### PR TITLE
Refactor species to use UID instead of name

### DIFF
--- a/code/__defines/mobs.dm
+++ b/code/__defines/mobs.dm
@@ -270,9 +270,6 @@
 #define CORPSE_CAN_REENTER             BITFLAG(0)
 #define CORPSE_CAN_RESPAWN             BITFLAG(1)
 
-#define SPECIES_HUMAN            "Human"
-#define SPECIES_MONKEY           "Monkey"
-
 #define SURGERY_CLOSED 0
 #define SURGERY_OPEN 1
 #define SURGERY_RETRACTED 2

--- a/code/_helpers/global_lists.dm
+++ b/code/_helpers/global_lists.dm
@@ -61,25 +61,6 @@ var/global/list/keybindings_by_name = list() // Replace this with just decl look
 			for(var/bound_key in instance.hotkey_keys)
 				global.hotkey_keybinding_list_by_key[bound_key] += list(instance.name)
 
-// This is all placeholder procs for an eventual PR to change them to use decls.
-var/global/list/all_species
-/proc/build_species_lists()
-	if(global.all_species)
-		return
-	global.all_species = list()
-	for(var/decl/species/species in decls_repository.get_decls_of_subtype_unassociated(/decl/species))
-		ASSERT(species.name) // all non-abstract species should have names
-		global.all_species[species.name] = species
-
-// TODO: Change species code to use decls instead of name keys. In that event, replace this with GET_DECL(species) I guess, or make it use UID instead of name?
-/proc/get_species_by_key(var/species_key)
-	build_species_lists()
-	. = global.all_species[species_key]
-// In the event of the above, this would be replaced with decls_repository.get_decls_of_subtype(/decl/species) or similar helpers.
-/proc/get_all_species()
-	build_species_lists()
-	. = global.all_species
-// In the event of the above, just make it add the typepath or UID instead of the name.
 /proc/get_playable_species()
 	var/static/list/_playable_species // A list of ALL playable species, whitelisted, latejoin or otherwise. (read: non-restricted)
 	if(!_playable_species)
@@ -87,5 +68,5 @@ var/global/list/all_species
 		for(var/decl/species/species in decls_repository.get_decls_of_subtype_unassociated(/decl/species))
 			if(species.spawn_flags & SPECIES_IS_RESTRICTED)
 				continue
-			_playable_species += species.name
+			_playable_species += species.uid
 	return _playable_species

--- a/code/_helpers/mobs.dm
+++ b/code/_helpers/mobs.dm
@@ -9,7 +9,7 @@
 
 /proc/random_name(gender, species)
 	if(species)
-		var/decl/species/current_species = get_species_by_key(species)
+		var/decl/species/current_species = decls_repository.get_decl_by_id(species)
 		if(current_species)
 			var/decl/background_detail/background = current_species.get_default_background_datum_by_flag(BACKGROUND_FLAG_NAMING)
 			if(background)

--- a/code/_onclick/hud/screen/screen_warning_oxygen.dm
+++ b/code/_onclick/hud/screen/screen_warning_oxygen.dm
@@ -23,7 +23,7 @@
 	var/datum/gas_mixture/environment = owner.loc?.return_air()
 	if(!environment)
 		return
-	var/decl/species/species = get_species_by_key(global.using_map.default_species)
+	var/decl/species/species = decls_repository.get_decl_by_id(global.using_map.default_species)
 	if(!species.breath_type || environment.gas[species.breath_type] > species.breath_pressure)
 		for(var/gas in species.poison_types)
 			if(environment.gas[gas])

--- a/code/datums/trading/_trader.dm
+++ b/code/datums/trading/_trader.dm
@@ -199,7 +199,7 @@
 	if(ishuman(user))
 		var/mob/living/human/H = user
 		if(H.species)
-			specific = H.species.name
+			specific = H.species.uid
 	else if(issilicon(user))
 		specific = TRADER_HAIL_SILICON_END
 	if(!speech["[TRADER_HAIL_START][specific]"])

--- a/code/datums/traits/prosthetics/prosthetic_limbs.dm
+++ b/code/datums/traits/prosthetics/prosthetic_limbs.dm
@@ -14,10 +14,8 @@
 	var/list/incompatible_with_limbs = list(BP_L_HAND)
 	var/model
 
-/decl/trait/prosthetic_limb/proc/get_base_model(var/species_name)
-	if(!species_name)
-		return /decl/bodytype/prosthetic/basic_human
-	var/decl/species/species = species_name ? get_species_by_key(species_name) : global.using_map.default_species
+/decl/trait/prosthetic_limb/proc/get_base_model(var/species_uid)
+	var/decl/species/species = decls_repository.get_decl_by_id(species_uid || global.using_map.default_species)
 	return species?.base_external_prosthetics_model
 
 /decl/trait/prosthetic_limb/get_chargen_name(datum/preferences/pref)
@@ -87,7 +85,7 @@
 			var/decl/bodytype/prosthetic/robot_model = GET_DECL(model)
 			if(!istype(robot_model))
 				return FALSE
-			var/decl/species/S = get_species_by_key(pref.species) || get_species_by_key(global.using_map.default_species)
+			var/decl/species/S = pref.get_species_decl()
 			var/decl/bodytype/B = S.get_bodytype_by_name(pref.bodytype)
 			if(!robot_model.check_can_install(apply_to_limb, target_bodytype = (check_bodytype || B.bodytype_category)))
 				return FALSE
@@ -114,7 +112,7 @@
 
 	// Robotize the selected limb.
 	if(. && apply_to_limb)
-		var/use_model = model || get_base_model(holder.get_species_name())
+		var/use_model = model || get_base_model(holder.get_species()?.uid)
 		var/obj/item/organ/external/E = GET_EXTERNAL_ORGAN(holder, apply_to_limb)
 		if(!istype(E))
 			var/list/organ_data = holder.should_have_limb(apply_to_limb)

--- a/code/game/gamemodes/endgame/ftl_jump/ftl_jump.dm
+++ b/code/game/gamemodes/endgame/ftl_jump/ftl_jump.dm
@@ -121,7 +121,7 @@
 /obj/effect/bluegoast/proc/blueswitch()
 	var/mob/living/human/H
 	if(ishuman(daddy))
-		H = new(get_turf(src), daddy.species.name, daddy.get_mob_snapshot(), daddy.get_bodytype())
+		H = new(get_turf(src), daddy.species.uid, daddy.get_mob_snapshot(), daddy.get_bodytype())
 		for(var/obj/item/entry in daddy.get_equipped_items(TRUE))
 			daddy.remove_from_mob(entry) //steals instead of copies so we don't end up with duplicates
 			H.equip_to_appropriate_slot(entry)

--- a/code/game/jobs/job/_job.dm
+++ b/code/game/jobs/job/_job.dm
@@ -235,13 +235,13 @@
 		to_chat(feedback, "<span class='boldannounce'>Wrong rank for [title]. Valid ranks in [prefs.branches[title]] are: [get_ranks(prefs.branches[title])].</span>")
 		return TRUE
 
-	var/decl/species/S = get_species_by_key(prefs.species)
+	var/decl/species/S = prefs.get_species_decl()
 	if(!is_species_allowed(S))
 		to_chat(feedback, "<span class='boldannounce'>Restricted species, [S], for [title].</span>")
 		return TRUE
 
-	if(LAZYACCESS(minimum_character_age, S.get_root_species_name()) && (prefs.get_character_age() < minimum_character_age[S.get_root_species_name()]))
-		to_chat(feedback, "<span class='boldannounce'>Not old enough. Minimum character age is [minimum_character_age[S.get_root_species_name()]].</span>")
+	if(LAZYACCESS(minimum_character_age, S.uid) && (prefs.get_character_age() < minimum_character_age[S.uid]))
+		to_chat(feedback, "<span class='boldannounce'>Not old enough. Minimum character age is [minimum_character_age[S.uid]].</span>")
 		return TRUE
 
 	if(!S.check_background(src, prefs))
@@ -379,17 +379,17 @@
 	if(!SSjobs.job_icons[title])
 		var/mob/living/human/dummy/mannequin/mannequin = get_mannequin("#job_icon")
 		if(mannequin)
-			var/decl/species/mannequin_species = get_species_by_key(global.using_map.default_species)
+			var/decl/species/mannequin_species = decls_repository.get_decl_by_id(global.using_map.default_species)
 			if(!is_species_allowed(mannequin_species))
 				// Don't just default to the first species allowed, pick one at random.
 				for(var/other_species in shuffle(get_playable_species()))
-					var/decl/species/other_species_decl = get_species_by_key(other_species)
+					var/decl/species/other_species_decl = decls_repository.get_decl_by_id(other_species)
 					if(is_species_allowed(other_species_decl))
 						mannequin_species = other_species_decl
 						break
 			if(!is_species_allowed(mannequin_species))
 				PRINT_STACK_TRACE("No allowed species allowed for job [title] ([type]), falling back to default!")
-			mannequin.change_species(mannequin_species.name)
+			mannequin.change_species(mannequin_species.uid)
 			dress_mannequin(mannequin)
 			mannequin.set_dir(SOUTH)
 			var/icon/preview_icon = getFlatIcon(mannequin)
@@ -411,7 +411,7 @@
 		reasons["Your branch of service does not allow it."] = TRUE
 	else if(!isnull(allowed_ranks) && (!caller.prefs.ranks[title] || !is_rank_allowed(caller.prefs.branches[title], caller.prefs.ranks[title])))
 		reasons["Your rank choice does not allow it."] = TRUE
-	var/decl/species/S = get_species_by_key(caller.prefs.species)
+	var/decl/species/S = caller.prefs.get_species_decl()
 	if(S)
 		if(!is_species_allowed(S))
 			reasons["Your species choice does not allow it."] = TRUE

--- a/code/game/jobs/server_whitelist.dm
+++ b/code/game/jobs/server_whitelist.dm
@@ -95,7 +95,7 @@ var/global/list/alien_whitelist = list()
 			return FALSE
 		if(!get_config_value(/decl/config/toggle/use_alien_whitelist) || !(S.spawn_flags & SPECIES_IS_WHITELISTED))
 			return TRUE
-		return whitelist_lookup(S.uid, M.ckey)
+		return whitelist_lookup(S.uid, M.ckey) || whitelist_lookup(S.name, M.ckey)
 
 	// Check for arbitrary text whitelisting.
 	return istext(species) ? whitelist_lookup(species, M.ckey) : FALSE

--- a/code/game/jobs/server_whitelist.dm
+++ b/code/game/jobs/server_whitelist.dm
@@ -63,8 +63,8 @@ var/global/list/alien_whitelist = list()
 			alien_whitelist[row["ckey"]] = list(row["race"])
 	return TRUE
 
-/proc/is_species_whitelisted(mob/M, var/species_name)
-	var/decl/species/S = get_species_by_key(species_name)
+/proc/is_species_whitelisted(mob/M, var/species_uid)
+	var/decl/species/S = decls_repository.get_decl_by_id(species_uid)
 	return is_alien_whitelisted(M, S)
 
 /proc/is_alien_whitelisted(mob/M, var/species)
@@ -95,7 +95,7 @@ var/global/list/alien_whitelist = list()
 			return FALSE
 		if(!get_config_value(/decl/config/toggle/use_alien_whitelist) || !(S.spawn_flags & SPECIES_IS_WHITELISTED))
 			return TRUE
-		return whitelist_lookup(S.get_root_species_name(M), M.ckey)
+		return whitelist_lookup(S.uid, M.ckey)
 
 	// Check for arbitrary text whitelisting.
 	return istext(species) ? whitelist_lookup(species, M.ckey) : FALSE

--- a/code/game/movietitles.dm
+++ b/code/game/movietitles.dm
@@ -102,17 +102,16 @@ var/global/list/end_titles
 		if(H.timeofdeath < 5 MINUTES) //no prespawned corpses
 			continue
 		if(H.isMonkey() && findtext(H.real_name,"[lowertext(H.species.name)]"))
-			monkies[H.species.name] += 1
+			monkies[H.species] += 1
 		else if(H.real_name)
 			corpses += H.real_name
-	for(var/spec in monkies)
-		var/decl/species/S = get_species_by_key(spec)
-		corpses += "[monkies[spec]] [lowertext(monkies[spec] > 1 ? S.name_plural : S.name)]"
+	for(var/decl/species/monkey_species in monkies)
+		corpses += "[monkies[monkey_species]] [lowertext(monkies[monkey_species] > 1 ? monkey_species.name_plural : monkey_species.name)]"
 	if(corpses.len)
 		titles += "<center>BASED ON REAL EVENTS<br>In memory of [english_list(corpses)].</center>"
 
 	var/list/staff = list("PRODUCTION STAFF:")
-	var/list/staffjobs = list("Coffe Fetcher", "Cameraman", "Angry Yeller", "Chair Operator", "Choreographer", "Historical Consultant", "Costume Designer", "Chief Editor", "Executive Assistant")
+	var/list/staffjobs = list("Coffee Fetcher", "Cameraman", "Angry Yeller", "Chair Operator", "Choreographer", "Historical Consultant", "Costume Designer", "Chief Editor", "Executive Assistant")
 	var/list/goodboys = list()
 	for(var/client/C)
 		if(!C.holder)
@@ -120,7 +119,7 @@ var/global/list/end_titles
 		if(C.holder.rights & (R_DEBUG|R_ADMIN))
 			var/list/all_backgrounds = decls_repository.get_decls_of_subtype(/decl/background_detail/heritage)
 			var/decl/background_detail/cult = all_backgrounds[pick(all_backgrounds)]
-			staff += "[uppertext(pick(staffjobs))] - [cult.get_random_name(pick(MALE, FEMALE))] a.k.a. '[C.key]'"
+			staff += "[uppertext(pick(staffjobs))] - [cult.get_random_name(C.gender)] a.k.a. '[C.key]'"
 		else if(C.holder.rights & R_MOD)
 			goodboys += "[C.key]"
 

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -233,6 +233,8 @@
 				delmob = TRUE
 
 		var/transform_key = replacetext(href_list["simplemake"], "_", " ")
+		// Nothing ever seems to pass species to any simplemake href links...
+		// TODO: Remove subspecies argument if it actually is defunct?
 		if(M.try_rudimentary_transform(transform_key, delmob, href_list["species"]))
 			log_and_message_admins("has used rudimentary transformation on [key_name_admin(M)]. Transforming to [transform_key]; deletemob=[delmob]")
 

--- a/code/modules/admin/view_variables/topic.dm
+++ b/code/modules/admin/view_variables/topic.dm
@@ -332,7 +332,7 @@
 			to_chat(usr, SPAN_WARNING("This can only be done to instances of type /mob/living/human"))
 			return
 
-		var/new_species = input("Please choose a new species.","Species",null) as null|anything in get_all_species()
+		var/decl/species/new_species = input("Please choose a new species.","Species",null) as null|anything in decls_repository.get_decls_of_subtype_unassociated(/decl/species)
 
 		if(!victim)
 			to_chat(usr, SPAN_WARNING("Mob doesn't exist anymore"))
@@ -341,7 +341,7 @@
 		if(!new_species)
 			return
 
-		if(victim.change_species(new_species))
+		if(victim.change_species(new_species.uid))
 			to_chat(usr, SPAN_NOTICE("Set species of \the [victim] to [victim.species]."))
 		else
 			to_chat(usr, SPAN_WARNING("Failed! Something went wrong."))

--- a/code/modules/awaymissions/corpse.dm
+++ b/code/modules/awaymissions/corpse.dm
@@ -63,7 +63,7 @@
 		else
 			M.randomize_skin_color()
 
-	var/decl/species/species_decl = get_species_by_key(species_choice)
+	var/decl/species/species_decl = decls_repository.get_decl_by_id(species_choice)
 	var/decl/bodytype/root_bodytype = M.get_bodytype()
 	var/update_hair = FALSE
 	if((spawn_flags & CORPSE_SPAWNER_RANDOM_HAIR_COLOR))

--- a/code/modules/blood/blood_types.dm
+++ b/code/modules/blood/blood_types.dm
@@ -20,7 +20,7 @@ var/global/list/blood_types_by_name
 	var/name
 	var/list/antigens
 	var/random_weighting = 1
-	var/antigen_category = SPECIES_MONKEY // Rhesus factor oh no
+	var/antigen_category = "Primate" // Rhesus factor oh no
 
 	var/splatter_name =   "blood"
 	var/splatter_desc =   "It's some blood. That's not supposed to be there."

--- a/code/modules/bodytype/_bodytype.dm
+++ b/code/modules/bodytype/_bodytype.dm
@@ -825,8 +825,7 @@ var/global/list/bodytypes_by_category = list()
 				to_chat(victim, SPAN_DANGER(pick(heat_discomfort_strings)))
 
 /decl/bodytype/proc/get_user_species_for_validation()
-	for(var/species_name in get_all_species())
-		var/decl/species/species = get_species_by_key(species_name)
+	for(var/decl/species/species as anything in decls_repository.get_decls_of_subtype_unassociated(/decl/species))
 		if(src in species.available_bodytypes)
 			return species
 

--- a/code/modules/bodytype/bodytype_helpers.dm
+++ b/code/modules/bodytype/bodytype_helpers.dm
@@ -38,7 +38,7 @@
 
 	// Markings used to be cleared outside of here, but it was always done before every call, so it was moved in here.
 	// remove invalid accessories for our new bodytype. don't clear the list directly as we did before, to preserve in the case of no default
-	var/decl/species/mob_species = get_species_by_key(pref.species)
+	var/decl/species/mob_species = pref.get_species_decl()
 	var/decl/bodytype/mob_bodytype = mob_species.get_bodytype_by_name(pref.bodytype) || mob_species.default_bodytype
 	for(var/acc_cat in pref.sprite_accessories)
 		if(!(acc_cat in mob_species.available_accessory_categories))

--- a/code/modules/bodytype/bodytype_prosthetic.dm
+++ b/code/modules/bodytype/bodytype_prosthetic.dm
@@ -60,8 +60,7 @@
 
 /decl/bodytype/prosthetic/get_user_species_for_validation()
 	if(bodytype_category)
-		for(var/species_name in get_all_species())
-			var/decl/species/species = get_species_by_key(species_name)
+		for(var/decl/species/species as anything in decls_repository.get_decls_of_subtype_unassociated(/decl/species))
 			for(var/decl/bodytype/bodytype_data in species.available_bodytypes)
 				if(bodytype_data.bodytype_category == bodytype_category)
 					return species

--- a/code/modules/client/preference_setup/background/01_species.dm
+++ b/code/modules/client/preference_setup/background/01_species.dm
@@ -6,11 +6,21 @@
 	sort_order = 1
 	var/hide_species = TRUE
 
+// This must always return a decl, NEVER null.
+/datum/preferences/proc/get_species_decl()
+	RETURN_TYPE(/decl/species)
+	species ||= global.using_map.default_species
+	. = decls_repository.get_decl_by_id(species, validate_decl_type = FALSE)
+	if(!.)
+		species = global.using_map.default_species
+		return decls_repository.get_decl_by_id(species)
+
 /datum/category_item/player_setup_item/background/species/save_character(datum/pref_record_writer/writer)
 	writer.write("species", pref.species)
 
 /datum/category_item/player_setup_item/background/species/preload_character(datum/pref_record_reader/R)
-	pref.species = R.read("species")
+	var/decl/species/loaded_species = decls_repository.get_decl_by_id_or_var(R.read("species"), /decl/spawnpoint)
+	pref.species = loaded_species?.uid || decls_repository.get_decl_by_id(global.using_map.default_species)
 
 /datum/category_item/player_setup_item/background/species/sanitize_character()
 	. = ..()
@@ -18,9 +28,9 @@
 
 /datum/category_item/player_setup_item/background/species/proc/sanitize_species()
 
-	if(!pref.species || !get_species_by_key(pref.species))
+	if(!pref.species || !pref.get_species_decl())
 		pref.set_species(global.using_map.default_species)
-	var/decl/species/mob_species = get_species_by_key(pref.species)
+	var/decl/species/mob_species = pref.get_species_decl()
 	var/decl/bodytype/mob_bodytype = mob_species.get_bodytype_by_name(pref.bodytype) || mob_species.default_bodytype
 	var/decl/pronouns/pronouns = get_pronouns_by_gender(pref.gender)
 	if(!istype(pronouns) || !(pronouns in mob_species.available_pronouns))
@@ -33,13 +43,13 @@
 		pref.all_underwear.Cut()
 
 /datum/category_item/player_setup_item/background/species/content(var/mob/user)
-	var/decl/species/current_species = get_species_by_key(pref.species)
+	var/decl/species/current_species = pref.get_species_decl()
 	var/list/prefilter = get_playable_species()
 	var/list/playables = list()
 
 	for(var/s in prefilter)
 		if(!check_rights(R_ADMIN, 0) && get_config_value(/decl/config/toggle/use_alien_whitelist))
-			var/decl/species/checking_species = get_species_by_key(s)
+			var/decl/species/checking_species = decls_repository.get_decl_by_id(s)
 			if(!(checking_species.spawn_flags & SPECIES_CAN_JOIN))
 				continue
 			else if((checking_species.spawn_flags & SPECIES_IS_WHITELISTED) && !is_alien_whitelisted(preference_mob(),checking_species))
@@ -51,11 +61,11 @@
 	. += "<tr><td colspan=3><center><h3>Species</h3></center></td></tr>"
 	. += "<tr><td colspan=3><center>"
 	for(var/s in playables)
-		var/decl/species/list_species = get_species_by_key(s)
-		if(pref.species == list_species.name)
+		var/decl/species/list_species = decls_repository.get_decl_by_id(s)
+		if(pref.species == list_species.uid)
 			. += "<span class='linkOn'>[list_species.name]</span> "
 		else
-			. += "<a href='byond://?src=\ref[src];set_species=[list_species.name]'>[list_species.name]</a> "
+			. += "<a href='byond://?src=\ref[src];set_species=[list_species.uid]'>[list_species.name]</a> "
 	. += "</center><hr/></td></tr>"
 
 	. += "<tr>"
@@ -94,7 +104,7 @@
 		if(choice != pref.species)
 
 			if(!check_rights(R_ADMIN, 0) && get_config_value(/decl/config/toggle/use_alien_whitelist))
-				var/decl/species/new_species = get_species_by_key(choice)
+				var/decl/species/new_species = decls_repository.get_decl_by_id(choice)
 				if(!new_species)
 					return TOPIC_REFRESH
 				if(!(new_species.spawn_flags & SPECIES_CAN_JOIN))

--- a/code/modules/client/preference_setup/background/02_background.dm
+++ b/code/modules/client/preference_setup/background/02_background.dm
@@ -1,5 +1,5 @@
 #define GET_ALLOWED_VALUES(write_to, check_key) \
-	var/decl/species/S = get_species_by_key(pref.species); \
+	var/decl/species/S = pref.get_species_decl(); \
 	if(!S) { \
 		write_to = list(); \
 	} else if(S.force_background_info[check_key]) { \

--- a/code/modules/client/preference_setup/general/01_basic.dm
+++ b/code/modules/client/preference_setup/general/01_basic.dm
@@ -5,11 +5,7 @@
 	var/real_name						//our character's name
 	var/be_random_name = 0				//whether we are a random name every round
 
-// These two should always return a decl, NEVER null.
-/datum/preferences/proc/get_species_decl()
-	RETURN_TYPE(/decl/species)
-	return get_species_by_key(species || global.using_map.default_species)
-
+// This must always return a decl, NEVER null.
 /datum/preferences/proc/get_bodytype_decl()
 	RETURN_TYPE(/decl/bodytype)
 	var/decl/species/species_decl = get_species_decl()
@@ -54,7 +50,7 @@
 	if(!valid_spawn)
 		pref.spawnpoint = global.using_map.default_spawn
 
-	var/decl/species/S = get_species_by_key(pref.species) || get_species_by_key(global.using_map.default_species)
+	var/decl/species/S = pref.get_species_decl()
 	pref.be_random_name = sanitize_integer(pref.be_random_name, 0, 1, initial(pref.be_random_name))
 
 	var/decl/pronouns/pronouns
@@ -81,7 +77,7 @@
 	. += "<hr>"
 
 	. += "<b>Bodytype:</b> "
-	var/decl/species/S = get_species_by_key(pref.species)
+	var/decl/species/S = pref.get_species_decl()
 	for(var/decl/bodytype/B in S.available_bodytypes)
 		if(B.name == pref.bodytype)
 			. += "<span class='linkOn'>[capitalize(B.pref_name)]</span>"
@@ -105,7 +101,7 @@
 	. = jointext(.,null)
 
 /datum/category_item/player_setup_item/physical/basic/OnTopic(var/href,var/list/href_list, var/mob/user)
-	var/decl/species/S = get_species_by_key(pref.species)
+	var/decl/species/S = pref.get_species_decl()
 
 	if(href_list["rename"])
 		var/raw_name = input(user, "Choose your character's name:", "Character Name")  as text|null

--- a/code/modules/client/preference_setup/general/02_body.dm
+++ b/code/modules/client/preference_setup/general/02_body.dm
@@ -84,7 +84,7 @@
 
 /datum/category_item/player_setup_item/physical/body/save_character(datum/pref_record_writer/writer)
 
-	var/decl/species/mob_species = get_species_by_key(pref.species)
+	var/decl/species/mob_species = pref.get_species_decl()
 	var/list/save_accessories = list()
 	for(var/acc_cat in mob_species.available_accessory_categories)
 		if(!(acc_cat in pref.sprite_accessories))
@@ -109,10 +109,10 @@
 
 /datum/category_item/player_setup_item/physical/body/sanitize_character()
 
-	var/decl/species/mob_species = get_species_by_key(pref.species)
+	var/decl/species/mob_species = pref.get_species_decl()
 	if(!mob_species || (mob_species.spawn_flags & SPECIES_IS_RESTRICTED))
 		pref.species = global.using_map.default_species
-		mob_species = get_species_by_key(pref.species)
+		mob_species = pref.get_species_decl()
 	var/decl/bodytype/mob_bodytype = mob_species.get_bodytype_by_name(pref.bodytype) || mob_species.default_bodytype
 	if(mob_bodytype.appearance_flags & HAS_SKIN_COLOR)
 		pref.skin_colour = pref.skin_colour || mob_bodytype.base_color     || COLOR_BLACK
@@ -186,7 +186,7 @@
 /datum/category_item/player_setup_item/physical/body/content(var/mob/user)
 	. = list()
 
-	var/decl/species/mob_species = get_species_by_key(pref.species)
+	var/decl/species/mob_species = pref.get_species_decl()
 	var/decl/bodytype/mob_bodytype = mob_species.get_bodytype_by_name(pref.bodytype) || mob_species.default_bodytype
 	. += "Blood Type: <a href='byond://?src=\ref[src];blood_type=1'>[pref.blood_type]</a><br>"
 	. += "<a href='byond://?src=\ref[src];random=1'>Randomize Appearance</A><br>"
@@ -303,7 +303,7 @@
 
 /datum/category_item/player_setup_item/physical/body/OnTopic(var/href,var/list/href_list, var/mob/user)
 
-	var/decl/species/mob_species = get_species_by_key(pref.species)
+	var/decl/species/mob_species = pref.get_species_decl()
 	var/decl/bodytype/mob_bodytype = mob_species.get_bodytype_by_name(pref.bodytype) || mob_species.default_bodytype
 	if(href_list["set_descriptor"])
 
@@ -327,7 +327,7 @@
 	else if(href_list["blood_type"])
 		var/new_b_type = input(user, "Choose your character's blood type:", CHARACTER_PREFERENCE_INPUT_TITLE) as null|anything in mob_species.blood_types
 		if(new_b_type && CanUseTopic(user))
-			mob_species = get_species_by_key(pref.species)
+			mob_species = pref.get_species_decl()
 			if(new_b_type in mob_species.blood_types)
 				pref.blood_type = new_b_type
 				return TOPIC_REFRESH
@@ -436,7 +436,7 @@
 		if(!(mob_bodytype.appearance_flags & HAS_EYE_COLOR))
 			return TOPIC_NOACTION
 		var/new_eyes = input(user, "Choose your character's eye colour:", CHARACTER_PREFERENCE_INPUT_TITLE, pref.eye_colour) as color|null
-		mob_species = get_species_by_key(pref.species)
+		mob_species = pref.get_species_decl()
 		mob_bodytype = mob_species.get_bodytype_by_name(pref.bodytype) || mob_species.default_bodytype
 		if(new_eyes && (mob_bodytype.appearance_flags & HAS_EYE_COLOR) && CanUseTopic(user))
 			pref.eye_colour = new_eyes
@@ -446,7 +446,7 @@
 		if(!(mob_bodytype.appearance_flags & HAS_A_SKIN_TONE))
 			return TOPIC_NOACTION
 		var/new_s_tone = input(user, "Choose your character's skin-tone. Lower numbers are lighter, higher are darker. Range: 1 to [mob_bodytype.max_skin_tone()]", CHARACTER_PREFERENCE_INPUT_TITLE, (-pref.skin_tone) + 35) as num|null
-		mob_species = get_species_by_key(pref.species)
+		mob_species = pref.get_species_decl()
 		mob_bodytype = mob_species.get_bodytype_by_name(pref.bodytype) || mob_species.default_bodytype
 		if(new_s_tone && (mob_bodytype.appearance_flags & HAS_A_SKIN_TONE) && CanUseTopic(user))
 			pref.skin_tone = 35 - max(min(round(new_s_tone), mob_bodytype.max_skin_tone()), 1)
@@ -456,7 +456,7 @@
 		if(!(mob_bodytype.appearance_flags & HAS_SKIN_COLOR))
 			return TOPIC_NOACTION
 		var/new_skin = input(user, "Choose your character's skin colour: ", CHARACTER_PREFERENCE_INPUT_TITLE, pref.skin_colour) as color|null
-		mob_species = get_species_by_key(pref.species)
+		mob_species = pref.get_species_decl()
 		mob_bodytype = mob_species.get_bodytype_by_name(pref.bodytype) || mob_species.default_bodytype
 		if(new_skin && (mob_bodytype.appearance_flags & HAS_SKIN_COLOR) && CanUseTopic(user))
 			pref.skin_colour = new_skin

--- a/code/modules/client/preference_setup/occupation/occupation.dm
+++ b/code/modules/client/preference_setup/occupation/occupation.dm
@@ -150,7 +150,7 @@
 				var/help_link = "</td><td width = '10%' align = 'center'><a href='byond://?src=\ref[src];job_info=[title]'>?</a></td>"
 				lastJob = job
 
-				var/species_name = S.get_root_species_name()
+				var/species_uid = S.uid
 				var/bad_message = ""
 				if(job.total_positions == 0 && job.spawn_positions == 0)
 					bad_message = "<b>\[UNAVAILABLE]</b>"
@@ -159,8 +159,8 @@
 				else if(!job.player_old_enough(user.client))
 					var/available_in_days = job.available_in_days(user.client)
 					bad_message = "\[IN [(available_in_days)] DAYS]"
-				else if(LAZYACCESS(job.minimum_character_age, species_name) && user.client && (user.client.prefs.get_character_age() < job.minimum_character_age[species_name]))
-					bad_message = "\[MIN CHAR AGE: [job.minimum_character_age[species_name]]]"
+				else if(LAZYACCESS(job.minimum_character_age, species_uid) && user.client && (user.client.prefs.get_character_age() < job.minimum_character_age[species_uid]))
+					bad_message = "\[MIN CHAR AGE: [job.minimum_character_age[species_uid]]]"
 				else if(!job.is_species_allowed(S))
 					bad_message = "<b>\[SPECIES RESTRICTED]</b>"
 				else if(!S.check_background(job, user.client.prefs))

--- a/code/modules/client/preference_setup/occupation/skill_selection.dm
+++ b/code/modules/client/preference_setup/occupation/skill_selection.dm
@@ -87,7 +87,7 @@
 //Sets up skills_allocated
 /datum/preferences/proc/sanitize_skills(var/list/input)
 	. = list()
-	var/decl/species/S = get_species_by_key(species)
+	var/decl/species/S = get_species_decl()
 	for(var/job_name in SSjobs.titles_to_datums)
 		var/datum/job/job = SSjobs.get_by_title(job_name)
 		var/input_skills = list()

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -77,7 +77,7 @@ var/global/list/time_prefs_fixed = list()
 	gender = pick(MALE, FEMALE)
 	real_name = get_random_name()
 
-	var/decl/species/species = get_species_by_key(global.using_map.default_species)
+	var/decl/species/species = decls_repository.get_decl_by_id(global.using_map.default_species)
 	blood_type = pickweight(species.blood_types)
 
 	if(client)
@@ -358,7 +358,8 @@ var/global/list/time_prefs_fixed = list()
 	character.traits = null
 
 	var/decl/bodytype/new_bodytype = get_bodytype_decl()
-	if(species == character.get_species_name())
+	var/decl/species/character_species = character.get_species()
+	if(species == character_species.uid)
 		character.set_bodytype(new_bodytype)
 	else
 		character.change_species(species, new_bodytype)

--- a/code/modules/clothing/masks/miscellaneous.dm
+++ b/code/modules/clothing/masks/miscellaneous.dm
@@ -166,12 +166,12 @@
 	name = "human mask"
 	desc = "A rubber human mask."
 	icon = 'icons/clothing/mask/human.dmi'
-	var/species = SPECIES_HUMAN
+	var/species = /decl/species/human::uid
 
 /obj/item/clothing/mask/rubber/species/Initialize()
 	. = ..()
 	visible_name = species
-	var/decl/species/S = get_species_by_key(species)
+	var/decl/species/S = decls_repository.get_decl_by_id(species)
 	if(istype(S))
 		var/decl/background_detail/C = GET_DECL(S.default_background_info[/decl/background_category/heritage])
 		if(istype(C))

--- a/code/modules/codex/categories/category_species.dm
+++ b/code/modules/codex/categories/category_species.dm
@@ -4,10 +4,8 @@
 
 /decl/codex_category/species/Populate()
 
-	for(var/thing in get_all_species())
-		var/decl/species/species = get_species_by_key(thing)
+	for(var/decl/species/species as anything in decls_repository.get_decls_of_subtype_unassociated(/decl/species))
 		if(!species.hidden_from_codex)
-
 			var/entry_type = (species.secret_codex_info) ? /datum/codex_entry/scannable : /datum/codex_entry
 			var/datum/codex_entry/entry = new entry_type(
 				_display_name = "[species.name] (species)",

--- a/code/modules/crafting/stack_recipes/recipes_planks.dm
+++ b/code/modules/crafting/stack_recipes/recipes_planks.dm
@@ -104,7 +104,7 @@
 	abstract_type          = /decl/stack_recipe/planks/prosthetic
 	difficulty             = MAT_VALUE_EASY_DIY
 	category               = "prosthetics"
-	var/prosthetic_species = SPECIES_HUMAN
+	var/prosthetic_species = /decl/species/human::uid
 	var/prosthetic_model   = /decl/bodytype/prosthetic/wooden
 
 /decl/stack_recipe/planks/prosthetic/spawn_result(mob/user, location, amount, decl/material/mat, decl/material/reinf_mat, paint_color, spent_type, spent_amount = 1)

--- a/code/modules/events/ion_storm.dm
+++ b/code/modules/events/ion_storm.dm
@@ -142,14 +142,10 @@
 		return pick(players)
 	return default_if_none
 
-/datum/event/ionstorm/proc/get_random_species_name(var/default_if_none)
-	if(!default_if_none)
-		default_if_none = global.using_map.default_species
-	. = length(global.all_species) ? pick(global.all_species) : default_if_none
-	if(.)
-		var/decl/species/species = all_species[.]
-		if(species)
-			. = species.name_plural
+/datum/event/ionstorm/proc/get_random_species_name()
+	var/list/decl/species/all_species = decls_repository.get_decls_of_subtype_unassociated(/decl/species)
+	var/decl/species/species = pick(all_species) // this should never fail.
+	return species.name_plural
 
 /datum/event/ionstorm/proc/get_random_language(var/mob/living/silicon/S)
 	var/list/languages = S.speech_synthesizer_langs.Copy()

--- a/code/modules/fabrication/designs/robotics/designs_organs.dm
+++ b/code/modules/fabrication/designs/robotics/designs_organs.dm
@@ -20,7 +20,7 @@
 
 /datum/fabricator_recipe/robotics/organ/build(turf/location, datum/fabricator_build_order/order)
 	. = ..()
-	var/decl/species/species = get_species_by_key(order.get_data("species", global.using_map.default_species))
+	var/decl/species/species = decls_repository.get_decl_by_id(order.get_data("species", global.using_map.default_species))
 	for(var/obj/item/organ/internal/I in .)
 		I.set_species(species)
 		I.set_bodytype(species.base_internal_prosthetics_model)

--- a/code/modules/fabrication/designs/robotics/designs_prosthetics.dm
+++ b/code/modules/fabrication/designs/robotics/designs_prosthetics.dm
@@ -62,7 +62,7 @@
 		var/decl/bodytype/prosthetic/company = GET_DECL(model)
 		if(!istype(company))
 			return FALSE
-		var/decl/species/species = get_species_by_key(robofab.picked_prosthetic_species)
+		var/decl/species/species = decls_repository.get_decl_by_id(robofab.picked_prosthetic_species)
 		if(!istype(species))
 			return FALSE
 		var/obj/item/organ/target_limb = path
@@ -92,7 +92,7 @@
 /datum/fabricator_recipe/robotics/prosthetic/build(var/turf/location, var/datum/fabricator_build_order/order)
 	. = ..()
 	var/species_name = order.get_data("species", global.using_map.default_species)
-	var/decl/species/species = get_species_by_key(species_name)
+	var/decl/species/species = decls_repository.get_decl_by_id(species_name)
 	if(species)
 		for(var/obj/item/organ/external/E in .)
 			E.set_species(species_name)

--- a/code/modules/fabrication/fabricator_bioprinter.dm
+++ b/code/modules/fabrication/fabricator_bioprinter.dm
@@ -67,7 +67,7 @@
 	return list(
 		"real_name" = loaded_dna.real_name,
 		"UE"        = loaded_dna.unique_enzymes,
-		"species"   = loaded_dna.root_species.name,
+		"species"   = loaded_dna.root_species.uid,
 		"btype"     = loaded_dna.blood_type,
 	)
 

--- a/code/modules/maps/template_types/random_exoplanet/planetoid_data.dm
+++ b/code/modules/maps/template_types/random_exoplanet/planetoid_data.dm
@@ -489,7 +489,7 @@
 
 	//Adjust for species habitability
 	if(habitability_class == HABITABILITY_OKAY || habitability_class == HABITABILITY_IDEAL)
-		var/decl/species/S = global.get_species_by_key(global.using_map.default_species)
+		var/decl/species/S = decls_repository.get_decl_by_id(global.using_map.default_species)
 		if(habitability_class == HABITABILITY_IDEAL)
 			. = clamp(., S.default_bodytype.cold_discomfort_level + rand(1,5), S.default_bodytype.heat_discomfort_level - rand(1,5)) //Clamp between comfortable levels since we're ideal
 		else
@@ -501,7 +501,7 @@
 
 	//Adjust for species habitability
 	if(habitability_class == HABITABILITY_OKAY || habitability_class == HABITABILITY_IDEAL)
-		var/decl/species/S           = global.get_species_by_key(global.using_map.default_species)
+		var/decl/species/S           = decls_repository.get_decl_by_id(global.using_map.default_species)
 		var/breathed_min_pressure    = S.breath_pressure
 		var/safe_max_pressure        = S.get_hazard_high_pressure()
 		var/safe_min_pressure        = S.get_hazard_low_pressure()
@@ -550,7 +550,7 @@
 		blacklisted_flags |= XGM_GAS_CONTAMINANT
 
 		//Make sure temperature can't damage people on casual planets (Only when not forcing an atmosphere)
-		var/decl/species/S = global.get_species_by_key(global.using_map.default_species)
+		var/decl/species/S = decls_repository.get_decl_by_id(global.using_map.default_species)
 		var/lower_temp            = max(S.default_bodytype.cold_level_1, atmosphere_gen_temperature_min)
 		var/higher_temp           = min(S.default_bodytype.heat_level_1, atmosphere_gen_temperature_max)
 		var/breathed_gas          = S.breath_type

--- a/code/modules/mob/living/human/examine.dm
+++ b/code/modules/mob/living/human/examine.dm
@@ -3,7 +3,7 @@
 	if(!(hideflags & HIDEJUMPSUIT) || !(hideflags & HIDEFACE))
 		var/species_name = "\improper "
 		if(isSynthetic() && species.cyborg_noun)
-			species_name += "[species.cyborg_noun] [species.get_root_species_name(src)]"
+			species_name += "[species.cyborg_noun] [species.name]"
 		else
 			species_name += "[species.name]"
 		msg += ", <b><font color='[species.get_species_flesh_color(src)]'>\a [species_name]!</font></b>[(user.can_use_codex() && SScodex.get_codex_entry(get_codex_value(user))) ?  SPAN_NOTICE(" \[<a href='byond://?src=\ref[SScodex];show_examined_info=\ref[src];show_to=\ref[user]'>?</a>\]") : ""]"

--- a/code/modules/mob/living/human/human.dm
+++ b/code/modules/mob/living/human/human.dm
@@ -7,7 +7,7 @@
 	max_health = 150
 	var/embedded_flag	  //To check if we've need to roll for damage on movement while an item is imbedded in us.
 
-/mob/living/human/Initialize(mapload, species_name, datum/mob_snapshot/supplied_appearance)
+/mob/living/human/Initialize(mapload, species_uid, datum/mob_snapshot/supplied_appearance)
 
 	current_health = max_health
 	reset_hud_overlays()
@@ -479,20 +479,20 @@
 	update_eyes()
 	return TRUE
 
-/mob/proc/set_species(var/new_species_name, var/new_bodytype = null)
+/mob/proc/set_species(var/new_species_uid, var/new_bodytype = null)
 	return
 
 //set_species should not handle the entirety of initing the mob, and should not trigger deep updates
 //It focuses on setting up species-related data, without force applying them uppon organs and the mob's appearance.
 // For transforming an existing mob, look at change_species()
-/mob/living/human/set_species(var/new_species_name, var/new_bodytype = null)
-	if(!new_species_name)
-		CRASH("set_species on mob '[src]' was passed a null species name '[new_species_name]'!")
-	var/new_species = get_species_by_key(new_species_name)
-	if(species?.name == new_species_name)
+/mob/living/human/set_species(var/new_species_uid, var/new_bodytype = null)
+	if(!new_species_uid)
+		CRASH("set_species on mob '[src]' was passed a null species uid!")
+	var/decl/species/new_species = decls_repository.get_decl_by_id(new_species_uid)
+	if(species?.uid == new_species_uid)
 		return
 	if(!new_species)
-		CRASH("set_species on mob '[src]' was passed a bad species name '[new_species_name]'!")
+		CRASH("set_species on mob '[src]' was passed a bad species uid '[new_species_uid]'!")
 
 	//Handle old species transition
 	if(species)
@@ -586,7 +586,7 @@
 // Triggers deep update of limbs and hud
 /mob/living/human/proc/apply_species_appearance()
 	if(!species)
-		icon_state = lowertext(SPECIES_HUMAN)
+		icon_state = null // this used to set it to "human" but that's not even an icon state that exists, so
 	else
 		species.apply_appearance(src)
 
@@ -973,13 +973,13 @@
 		mind.name = newname
 
 //Human mob specific init code. Meant to be used only on init.
-/mob/living/human/proc/setup_human(species_name, datum/mob_snapshot/supplied_appearance)
+/mob/living/human/proc/setup_human(species_uid, datum/mob_snapshot/supplied_appearance)
 	if(supplied_appearance)
-		species_name = supplied_appearance.root_species.name
-	else if(!species_name)
-		species_name = global.using_map.default_species //Humans cannot exist without a species!
+		species_uid = supplied_appearance.root_species.uid
+	else if(!species_uid)
+		species_uid = global.using_map.default_species //Humans cannot exist without a species!
 
-	set_species(species_name, supplied_appearance?.root_bodytype)
+	set_species(species_uid, supplied_appearance?.root_bodytype)
 	var/decl/bodytype/root_bodytype = get_bodytype() // root bodytype is set in set_species
 	ASSERT((!supplied_appearance?.root_bodytype) || (root_bodytype == supplied_appearance.root_bodytype))
 	if(!get_skin_colour())
@@ -1016,7 +1016,7 @@
 		SetName(initial(name))
 
 //Runs last after setup and after the parent init has been executed.
-/mob/living/human/proc/post_setup(species_name, datum/mob_snapshot/supplied_appearance)
+/mob/living/human/proc/post_setup(species_uid, datum/mob_snapshot/supplied_appearance)
 	try_refresh_visible_overlays() //Do this exactly once per setup
 
 /mob/living/human/handle_flashed(var/flash_strength)

--- a/code/modules/mob/living/human/human_appearance.dm
+++ b/code/modules/mob/living/human/human_appearance.dm
@@ -21,10 +21,7 @@
 	if(!new_species)
 		return
 
-	if(species?.name == new_species)
-		return
-
-	if(!(new_species in get_all_species()))
+	if(species?.uid == new_species)
 		return
 
 	set_species(new_species, new_bodytype)
@@ -90,19 +87,17 @@
 
 /mob/living/human/proc/generate_valid_species(var/check_whitelist = 1, var/list/whitelist = list(), var/list/blacklist = list())
 	var/list/valid_species = new()
-	for(var/current_species_name in get_all_species())
-		var/decl/species/current_species = get_species_by_key(current_species_name)
-
+	for(var/decl/species/current_species as anything in decls_repository.get_decls_of_subtype_unassociated(/decl/species))
 		if(check_whitelist) //If we're using the whitelist, make sure to check it!
 			if((current_species.spawn_flags & SPECIES_IS_RESTRICTED) && !check_rights(R_ADMIN, 0, src))
 				continue
 			if(!is_alien_whitelisted(src, current_species))
 				continue
-		if(whitelist.len && !(current_species_name in whitelist))
+		if(whitelist.len && !(current_species.uid in whitelist))
 			continue
-		if(blacklist.len && (current_species_name in blacklist))
+		if(blacklist.len && (current_species.uid in blacklist))
 			continue
 
-		valid_species += current_species_name
+		valid_species += current_species.uid
 
 	return valid_species

--- a/code/modules/mob/living/human/human_presets.dm
+++ b/code/modules/mob/living/human/human_presets.dm
@@ -12,12 +12,12 @@
 		. = new /mob/living/human/dummy/mannequin()
 		mannequins[ckey] = .
 
-/mob/living/human/dummy/mannequin/Initialize(mapload, species_name, datum/mob_snapshot/supplied_appearance)
+/mob/living/human/dummy/mannequin/Initialize(mapload, species_uid, datum/mob_snapshot/supplied_appearance)
 	. = ..()
 	STOP_PROCESSING(SSmobs, src)
 	global.human_mob_list -= src
 
-/mob/living/human/dummy/selfdress/Initialize(mapload, species_name, datum/mob_snapshot/supplied_appearance)
+/mob/living/human/dummy/selfdress/Initialize(mapload, species_uid, datum/mob_snapshot/supplied_appearance)
 	..()
 	return INITIALIZE_HINT_LATELOAD
 
@@ -31,18 +31,18 @@
 /mob/living/human/corpse/get_death_message(gibbed)
 	return SKIP_DEATH_MESSAGE
 
-/mob/living/human/corpse/Initialize(mapload, species_name, datum/mob_snapshot/supplied_appearance, obj/abstract/landmark/corpse/corpse)
-	. = ..(mapload, species_name, supplied_appearance) // do not pass the corpse landmark
+/mob/living/human/corpse/Initialize(mapload, species_uid, datum/mob_snapshot/supplied_appearance, obj/abstract/landmark/corpse/corpse)
+	. = ..(mapload, species_uid, supplied_appearance) // do not pass the corpse landmark
 	var/decl/background_detail/background = get_background_datum_by_flag(BACKGROUND_FLAG_NAMING)
 	if(background)
-		var/newname = background.get_random_name(src, gender, species.name)
+		var/newname = background.get_random_name(src, gender, species.uid)
 		if(newname && newname != name)
 			real_name = newname
 			SetName(newname)
 			if(mind)
 				mind.name = real_name
 	if(corpse)
-		corpse.randomize_appearance(src, get_species_name())
+		corpse.randomize_appearance(src, get_species()?.uid)
 		corpse.equip_corpse_outfit(src)
 	return INITIALIZE_HINT_LATELOAD
 
@@ -71,8 +71,8 @@
 /mob/living/human/monkey
 	gender = PLURAL
 
-/mob/living/human/monkey/Initialize(mapload, species_name, datum/mob_snapshot/supplied_appearance)
+/mob/living/human/monkey/Initialize(mapload, species_uid, datum/mob_snapshot/supplied_appearance)
 	if(gender == PLURAL)
 		gender = pick(MALE, FEMALE)
-	species_name = SPECIES_MONKEY
+	species_uid = /decl/species/monkey::uid
 	. = ..()

--- a/code/modules/mob/living/human/npcs.dm
+++ b/code/modules/mob/living/human/npcs.dm
@@ -2,7 +2,7 @@
 	real_name = "Pun Pun"
 	gender = MALE
 
-/mob/living/human/monkey/punpun/Initialize(mapload, species_name, datum/mob_snapshot/supplied_appearance)
+/mob/living/human/monkey/punpun/Initialize(mapload, species_uid, datum/mob_snapshot/supplied_appearance)
 	..()
 	return INITIALIZE_HINT_LATELOAD
 
@@ -35,8 +35,8 @@
 	sensor.set_sensor_mode(VITALS_SENSOR_OFF)
 	attach_accessory(null, sensor)
 
-/mob/living/human/blank/Initialize(mapload, species_name, datum/mob_snapshot/supplied_appearance)
-	species_name = SPECIES_HUMAN
+/mob/living/human/blank/Initialize(mapload, species_uid, datum/mob_snapshot/supplied_appearance)
+	species_uid = /decl/species/human::uid
 	..()
 	return INITIALIZE_HINT_LATELOAD
 

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -427,7 +427,7 @@ default behaviour is:
 			continue
 		var/icon/DI
 		var/use_colour = (BP_IS_PROSTHETIC(O) ? SYNTH_BLOOD_COLOR : O.species.get_species_blood_color(src))
-		var/cache_index = "[O.damage_state]/[O.bodytype.uid]/[O.icon_state]/[use_colour]/[O.species.name]"
+		var/cache_index = "[O.damage_state]/[O.bodytype.uid]/[O.icon_state]/[use_colour]/[O.species.uid]"
 		if(!(cache_index in damage_icon_parts))
 			var/damage_overlay_icon = O.bodytype.get_damage_overlays(src)
 			if(check_state_in_icon(O.damage_state, damage_overlay_icon))

--- a/code/modules/mob/living/living_attackhand.dm
+++ b/code/modules/mob/living/living_attackhand.dm
@@ -103,8 +103,7 @@
 		uniform.add_fingerprint(user)
 
 	// They're SSD, so permanently asleep.
-	var/show_ssd = get_species_name()
-	if(show_ssd && ssd_check())
+	if(ssd_check() && get_species()?.get_ssd(src))
 		user.visible_message(
 			SPAN_NOTICE("\The [user] shakes \the [src] trying to wake [pronouns.him] up!"),
 			SPAN_NOTICE("You shake \the [src], but they do not respond...")

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -352,7 +352,7 @@ var/global/list/global/organ_rel_size = list(
 		if(istype(belt, /obj/item/gun) || istype(belt, /obj/item/energy_blade) || istype(belt, /obj/item/baton))
 			threatcount += 2
 
-		if(get_species_name() != global.using_map.default_species)
+		if(get_species()?.uid != global.using_map.default_species)
 			threatcount += 2
 
 	if(check_records || check_arrest)

--- a/code/modules/mob/mob_snapshot.dm
+++ b/code/modules/mob/mob_snapshot.dm
@@ -23,7 +23,7 @@
 	unique_enzymes = donor?.get_unique_enzymes()
 	fingerprint    = donor?.get_full_print(ignore_blockers = TRUE)
 
-	root_species   = donor?.get_species()  || get_species_by_key(global.using_map.default_species)
+	root_species   = donor?.get_species()  || decls_repository.get_decl_by_id(global.using_map.default_species)
 	root_bodytype  = donor?.get_bodytype() || root_species.default_bodytype
 
 	for(var/obj/item/organ/external/limb in donor?.get_external_organs())
@@ -61,9 +61,9 @@
 
 	if(istype(root_species) && root_species != target.get_species())
 		if(istype(root_bodytype))
-			target.set_species(root_species.name, root_bodytype)
+			target.set_species(root_species.uid, root_bodytype)
 		else
-			target.set_species(root_species.name)
+			target.set_species(root_species.uid)
 	else if(istype(root_bodytype) && target.get_bodytype() != root_bodytype)
 		target.set_bodytype(root_bodytype)
 

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -164,7 +164,7 @@ INITIALIZE_IMMEDIATE(/mob/new_player)
 		if(!SSjobs.check_general_join_blockers(src, job))
 			return FALSE
 
-		var/decl/species/S = get_species_by_key(client.prefs.species)
+		var/decl/species/S = client.prefs.get_species_decl()
 		if(!check_species_allowed(S))
 			return 0
 
@@ -361,7 +361,7 @@ INITIALIZE_IMMEDIATE(/mob/new_player)
 
 	var/decl/species/chosen_species
 	if(client.prefs.species)
-		chosen_species = get_species_by_key(client.prefs.species)
+		chosen_species = client.prefs.get_species_decl()
 
 	if(!spawn_turf)
 		var/datum/job/job = SSjobs.get_by_title(mind.assigned_role)
@@ -374,7 +374,7 @@ INITIALIZE_IMMEDIATE(/mob/new_player)
 		if(!check_species_allowed(chosen_species))
 			spawning = 0 //abort
 			return null
-		new_character = new(spawn_turf, chosen_species.name)
+		new_character = new(spawn_turf, chosen_species.uid)
 
 	if(!new_character)
 		new_character = new(spawn_turf)
@@ -427,11 +427,11 @@ INITIALIZE_IMMEDIATE(/mob/new_player)
 /mob/new_player/proc/check_species_allowed(var/decl/species/S, var/show_alert=1)
 	if(!S.is_available_for_join() && !has_admin_rights())
 		if(show_alert)
-			to_chat(src, alert("Your current species, [client.prefs.species], is not available for play."))
+			to_chat(src, alert("Your current species, [S.name], is not available for play."))
 		return 0
 	if(!is_alien_whitelisted(src, S))
 		if(show_alert)
-			to_chat(src, alert("You are currently not whitelisted to play [client.prefs.species]."))
+			to_chat(src, alert("You are currently not whitelisted to play [S.name_plural]."))
 		return 0
 	return 1
 
@@ -439,7 +439,7 @@ INITIALIZE_IMMEDIATE(/mob/new_player)
 	SHOULD_CALL_PARENT(FALSE)
 	var/decl/species/chosen_species
 	if(client.prefs.species)
-		chosen_species = get_species_by_key(client.prefs.species)
+		chosen_species = client.prefs.get_species_decl()
 	if(!chosen_species || !check_species_allowed(chosen_species, 0))
 		return global.using_map.default_species
 	return chosen_species.name

--- a/code/modules/mob/new_player/preferences_setup.dm
+++ b/code/modules/mob/new_player/preferences_setup.dm
@@ -96,7 +96,7 @@
 				else
 					permitted = TRUE
 
-				if(gear.whitelisted && !(mannequin.species.name in gear.whitelisted))
+				if(gear.whitelisted && !(mannequin.species.uid in gear.whitelisted))
 					permitted = FALSE
 
 				if(!permitted)

--- a/code/modules/modular_computers/file_system/reports/crew_record.dm
+++ b/code/modules/modular_computers/file_system/reports/crew_record.dm
@@ -61,7 +61,8 @@ var/global/arrest_security_status =  "Arrest"
 	set_gender(gender_term)
 	set_age(crewmember?.get_age() || 30)
 	set_status(global.default_physical_status)
-	set_species_name(crewmember ? crewmember.get_species_name() : global.using_map.default_species)
+	var/decl/species/default_species = decls_repository.get_decl_by_id(global.using_map.default_species)
+	set_species_name(crewmember ? crewmember.get_species_name() : default_species.name)
 	set_branch(crewmember ? (crewmember.char_branch && crewmember.char_branch.name) : "None")
 	set_rank(crewmember ? (crewmember.char_rank && crewmember.char_rank.name) : "None")
 

--- a/code/modules/nano/modules/human_appearance.dm
+++ b/code/modules/nano/modules/human_appearance.dm
@@ -14,6 +14,7 @@
 	src.whitelist = species_whitelist
 	src.blacklist = species_blacklist
 
+// FIXME: This doesn't currently handle arbitrary sprite accessory categories, so you can't select ears/tail/etc.
 /datum/nano_module/appearance_changer/Topic(ref, href_list, var/datum/topic_state/state = global.default_topic_state)
 	if(..())
 		return 1
@@ -80,13 +81,14 @@
 		return
 
 	var/list/data = host.initial_data()
-	data["specimen"] = owner.species.name
+	data["current_species_uid"] = owner.species.uid
 	data["gender"] = owner.gender
 	data["change_race"] = can_change(APPEARANCE_RACE)
 	if(data["change_race"])
 		var/species[0]
-		for(var/specimen in owner.generate_valid_species(check_whitelist, whitelist, blacklist))
-			species[++species.len] =  list("specimen" = specimen)
+		for(var/species_uid in owner.generate_valid_species(check_whitelist, whitelist, blacklist))
+			var/decl/species/candidate_species = decls_repository.get_decl_by_id(species_uid)
+			species[++species.len] =  list("uid" = species_uid, "name" = candidate_species.name)
 		data["species"] = species
 
 	data["change_gender"] = can_change(APPEARANCE_GENDER)

--- a/code/modules/organs/external/_external.dm
+++ b/code/modules/organs/external/_external.dm
@@ -135,7 +135,7 @@
 	if(owner)
 		LAZYREMOVE(owner.bad_external_organs, src)
 
-/obj/item/organ/external/set_species(specie_name)
+/obj/item/organ/external/set_species(species_uid)
 	_icon_cache_key = null
 	. = ..()
 	skin_blend = bodytype.limb_blend

--- a/code/modules/organs/external/_external_icons.dm
+++ b/code/modules/organs/external/_external_icons.dm
@@ -127,7 +127,7 @@ var/global/list/organ_icon_cache = list()
 
 /obj/item/organ/external/proc/get_icon_cache_key_components()
 
-	. = list("[icon_state]_[species.name]_[get_organ_appearance_bodytype()?.uid || "BAD_BODYTYPE"]_[render_alpha]_[icon]")
+	. = list("[icon_state]_[species.uid]_[get_organ_appearance_bodytype()?.uid || "BAD_BODYTYPE"]_[render_alpha]_[icon]")
 
 	// Skeletons don't care about most icon appearance stuff.
 	if(limb_flags & ORGAN_FLAG_SKELETAL)

--- a/code/modules/organs/internal/_internal.dm
+++ b/code/modules/organs/internal/_internal.dm
@@ -36,7 +36,7 @@
 	. = ..()
 	set_max_damage(absolute_max_damage)
 
-/obj/item/organ/internal/set_species(species_name)
+/obj/item/organ/internal/set_species(species_uid)
 	. = ..()
 	if(species.organs_icon)
 		icon = species.organs_icon

--- a/code/modules/organs/internal/brain.dm
+++ b/code/modules/organs/internal/brain.dm
@@ -45,7 +45,7 @@
 /obj/item/organ/internal/brain/getToxLoss()
 	return 0
 
-/obj/item/organ/internal/brain/set_species(species_name)
+/obj/item/organ/internal/brain/set_species(species_uid)
 	. = ..()
 	icon_state = "brain-prosthetic"
 	if(species)

--- a/code/modules/organs/internal/lungs.dm
+++ b/code/modules/organs/internal/lungs.dm
@@ -59,7 +59,7 @@
 /obj/item/organ/internal/lungs/proc/adjust_oxygen_deprivation(var/amount)
 	oxygen_deprivation = clamp(oxygen_deprivation + amount, 0, species.total_health)
 
-/obj/item/organ/internal/lungs/set_species(species_name)
+/obj/item/organ/internal/lungs/set_species(species_uid)
 	. = ..()
 	sync_breath_types()
 

--- a/code/modules/organs/internal/stomach.dm
+++ b/code/modules/organs/internal/stomach.dm
@@ -12,7 +12,7 @@
 	QDEL_NULL(ingested)
 	. = ..()
 
-/obj/item/organ/internal/stomach/set_species(species_name)
+/obj/item/organ/internal/stomach/set_species(species_uid)
 	if(species?.gluttonous)
 		verbs -= /obj/item/organ/internal/stomach/proc/throw_up
 	. = ..()

--- a/code/modules/organs/organ.dm
+++ b/code/modules/organs/organ.dm
@@ -126,7 +126,7 @@
 	if(species != organ_appearance.root_species)
 		if(organ_appearance.root_bodytype && organ_appearance.root_bodytype != bodytype)
 			bodytype = organ_appearance.root_bodytype // this lets us take advantage of set_bodytype being called in set_species
-		set_species(organ_appearance.root_species?.name || global.using_map.default_species)
+		set_species(organ_appearance.root_species?.uid || global.using_map.default_species)
 	else if(organ_appearance.root_bodytype && organ_appearance.root_bodytype != bodytype)
 		set_bodytype(organ_appearance.root_bodytype)
 
@@ -170,15 +170,15 @@
 	absolute_max_damage = floor(ndamage)
 	max_damage = absolute_max_damage
 
-/obj/item/organ/proc/set_species(specie_name)
+/obj/item/organ/proc/set_species(species_uid)
 	vital_to_owner = null // This generally indicates the owner mob is having species set, and this value may be invalidated.
-	if(istext(specie_name))
-		species = get_species_by_key(specie_name)
+	if(istext(species_uid))
+		species = decls_repository.get_decl_by_id(species_uid)
 	else
-		species = specie_name
+		species = species_uid
 	if(!species)
-		species = get_species_by_key(global.using_map.default_species)
-		PRINT_STACK_TRACE("Invalid species. Expected a valid species name as string, was: [log_info_line(specie_name)]")
+		species = decls_repository.get_decl_by_id(global.using_map.default_species)
+		PRINT_STACK_TRACE("Invalid species. Expected a valid species UID as string, was: [log_info_line(species_uid)]")
 
 	set_bodytype(bodytype || species.default_bodytype, override_material = material?.type)
 

--- a/code/modules/projectiles/projectile/change.dm
+++ b/code/modules/projectiles/projectile/change.dm
@@ -13,11 +13,11 @@
 	. = list()
 	if(!isrobot(M))
 		. += "robot"
-	for(var/t in get_all_species())
-		. += t
+	for(var/decl/species/species as anything in decls_repository.get_decls_of_subtype_unassociated(/decl/species))
+		. += species.uid
 	if(ishuman(M))
 		var/mob/living/human/H = M
-		. -= H.species.name
+		. -= H.species.uid
 
 /obj/item/projectile/change/proc/apply_transformation(var/mob/M, var/choice)
 
@@ -29,7 +29,7 @@
 		transfer_key_from_mob_to_mob(M, robot)
 		return robot
 
-	if(get_species_by_key(choice))
+	if(decls_repository.get_decl_by_id(choice))
 		var/mob/living/human/H = M
 		if(!istype(H))
 			H = new(get_turf(M))

--- a/code/modules/species/species.dm
+++ b/code/modules/species/species.dm
@@ -303,7 +303,7 @@ var/global/const/DEFAULT_SPECIES_HEALTH = 200
 		var/decl/sprite_accessory/accessory = GET_DECL(accessory_type)
 		// If this accessory is species restricted, add us to the list.
 		if(accessory.species_allowed)
-			accessory.species_allowed |= name
+			accessory.species_allowed |= uid
 		if(!isnull(accessory.body_flags_allowed))
 			for(var/decl/bodytype/bodytype in available_bodytypes)
 				accessory.body_flags_allowed |= bodytype.body_flags
@@ -320,7 +320,7 @@ var/global/const/DEFAULT_SPECIES_HEALTH = 200
 	for(var/accessory_type in disallow_specific_sprite_accessories)
 		var/decl/sprite_accessory/accessory = GET_DECL(accessory_type)
 		if(accessory.species_allowed)
-			accessory.species_allowed -= name
+			accessory.species_allowed -= uid
 		if(!isnull(accessory.body_flags_allowed))
 			for(var/decl/bodytype/bodytype in available_bodytypes)
 				accessory.body_flags_allowed &= ~bodytype.body_flags
@@ -386,9 +386,9 @@ var/global/const/DEFAULT_SPECIES_HEALTH = 200
 		var/decl/trait/trait = GET_DECL(trait_type)
 		if(!trait.validate_level(trait_level))
 			. += "invalid levels for species trait [trait_type]"
-		if(name in trait.blocked_species)
+		if(uid in trait.blocked_species)
 			. += "trait [trait.name] prevents this species from taking it"
-		if(trait.permitted_species && !(name in trait.permitted_species))
+		if(trait.permitted_species && !(uid in trait.permitted_species))
 			. += "trait [trait.name] does not permit this species to take it"
 
 	if(!length(blood_types))
@@ -707,10 +707,10 @@ var/global/const/DEFAULT_SPECIES_HEALTH = 200
 
 		// TODO: generate an icon based on all available bodytypes.
 
-		var/mob/living/human/dummy/mannequin/mannequin = get_mannequin("#species_[ckey(name)]")
+		var/mob/living/human/dummy/mannequin/mannequin = get_mannequin("#species_[ckey(uid)]")
 		if(mannequin)
 
-			mannequin.change_species(name) // handles species/bodytype init
+			mannequin.change_species(uid) // handles species/bodytype init
 			default_bodytype.customize_preview_mannequin(mannequin) // handles body colors/styles setup
 			customize_preview_mannequin(mannequin) // handles 'cultural' things like default outfit
 
@@ -724,7 +724,7 @@ var/global/const/DEFAULT_SPECIES_HEALTH = 200
 			preview_icon.Scale(preview_icon.Width() * 2, preview_icon.Height() * 2)
 			preview_icon_width = preview_icon.Width()
 			preview_icon_height = preview_icon.Height()
-			preview_icon_path = "species_preview_[ckey(name)].png"
+			preview_icon_path = "species_preview_[ckey(uid)].png"
 
 	return preview_icon
 

--- a/code/modules/species/species.dm
+++ b/code/modules/species/species.dm
@@ -5,6 +5,7 @@ var/global/const/DEFAULT_SPECIES_HEALTH = 200
 
 /decl/species
 	abstract_type = /decl/species
+	decl_flags = DECL_FLAG_MANDATORY_UID
 
 	// Descriptors and strings.
 	var/name

--- a/code/modules/species/species_getters.dm
+++ b/code/modules/species/species_getters.dm
@@ -28,9 +28,6 @@
 /decl/species/proc/get_radiation_mod(var/mob/living/human/H)
 	. = (H && H.isSynthetic() ? 0.5 : radiation_mod)
 
-/decl/species/proc/get_root_species_name(var/mob/living/human/H)
-	return name
-
 /decl/species/proc/get_bodytype_by_name(var/bodytype_name)
 	bodytype_name = trim(lowertext(bodytype_name))
 	if(!bodytype_name)

--- a/code/modules/species/station/human.dm
+++ b/code/modules/species/station/human.dm
@@ -1,8 +1,8 @@
 /decl/species/human
 	uid = "species_human"
-	name = SPECIES_HUMAN
+	name = "Human"
 	name_plural = "Humans"
-	primitive_form = SPECIES_MONKEY
+	primitive_form = /decl/species/monkey::uid
 	description = "A medium-sized creature prone to great ambition. If you are reading this, you are probably a human."
 	hidden_from_codex = FALSE
 	spawn_flags = SPECIES_CAN_JOIN
@@ -29,9 +29,6 @@
 		/decl/emote/exertion/synthetic,
 		/decl/emote/exertion/synthetic/creak
 	)
-
-/decl/species/human/get_root_species_name(var/mob/living/human/H)
-	return SPECIES_HUMAN
 
 /decl/species/human/get_ssd(var/mob/living/human/H)
 	if(H.stat == CONSCIOUS)

--- a/code/modules/species/station/human.dm
+++ b/code/modules/species/station/human.dm
@@ -1,4 +1,5 @@
 /decl/species/human
+	uid = "species_human"
 	name = SPECIES_HUMAN
 	name_plural = "Humans"
 	primitive_form = SPECIES_MONKEY

--- a/code/modules/species/station/monkey.dm
+++ b/code/modules/species/station/monkey.dm
@@ -1,4 +1,5 @@
 /decl/species/monkey
+	uid = "species_monkey"
 	name = SPECIES_MONKEY
 	name_plural = "Monkeys"
 	description = "Ook."

--- a/code/modules/species/station/monkey.dm
+++ b/code/modules/species/station/monkey.dm
@@ -1,6 +1,6 @@
 /decl/species/monkey
 	uid = "species_monkey"
-	name = SPECIES_MONKEY
+	name = "Monkey"
 	name_plural = "Monkeys"
 	description = "Ook."
 	codex_description = "Monkeys and other similar creatures tend to be found on science stations and vessels as \

--- a/code/modules/sprite_accessories/_accessory.dm
+++ b/code/modules/sprite_accessories/_accessory.dm
@@ -29,10 +29,8 @@
 	var/list/decl/bodytype/bodytypes_allowed
 	/// Restricted from specific bodytypes. null matches none
 	var/list/decl/bodytype/bodytypes_denied
-	/// Restrict some styles to specific root species names
-	var/list/species_allowed = list(SPECIES_HUMAN)
-	/// Restrict some styles to specific species names, irrespective of root species name
-	var/list/subspecies_allowed
+	/// Restrict some styles to specific species UIDs.
+	var/list/species_allowed = list(/decl/species/human::uid)
 	/// Restrict some styles to specific bodytype flags.
 	var/body_flags_allowed
 	/// Restrict some styles to specific bodytype flags.
@@ -90,9 +88,7 @@
 	if(species)
 		var/species_is_permitted = TRUE
 		if(species_allowed)
-			species_is_permitted = (species.get_root_species_name(owner) in species_allowed)
-		if(subspecies_allowed)
-			species_is_permitted = (species.name in subspecies_allowed)
+			species_is_permitted = (species.uid in species_allowed)
 		if(!species_is_permitted)
 			return FALSE
 	if(bodytype)

--- a/code/modules/sprite_accessories/cosmetics/_accessory_cosmetics.dm
+++ b/code/modules/sprite_accessories/cosmetics/_accessory_cosmetics.dm
@@ -12,7 +12,6 @@
 	bodytypes_allowed           = null
 	bodytypes_denied            = null
 	species_allowed             = null
-	subspecies_allowed          = null
 	bodytype_categories_allowed = null
 	bodytype_categories_denied  = null
 	body_flags_allowed          = null

--- a/code/modules/sprite_accessories/ears/_accessory_ears.dm
+++ b/code/modules/sprite_accessories/ears/_accessory_ears.dm
@@ -22,7 +22,6 @@
 	bodytypes_allowed           = null
 	bodytypes_denied            = null
 	species_allowed             = null
-	subspecies_allowed          = null
 	bodytype_categories_allowed = null
 	bodytype_categories_denied  = null
 	body_flags_allowed          = null

--- a/code/modules/sprite_accessories/facial/_accessory_facial.dm
+++ b/code/modules/sprite_accessories/facial/_accessory_facial.dm
@@ -39,7 +39,6 @@
 	bodytypes_allowed           = null
 	bodytypes_denied            = null
 	species_allowed             = null
-	subspecies_allowed          = null
 	bodytype_categories_allowed = null
 	bodytype_categories_denied  = null
 	body_flags_allowed          = null

--- a/code/modules/sprite_accessories/frills/_accessory_frills.dm
+++ b/code/modules/sprite_accessories/frills/_accessory_frills.dm
@@ -21,7 +21,6 @@
 	bodytypes_allowed           = null
 	bodytypes_denied            = null
 	species_allowed             = null
-	subspecies_allowed          = null
 	bodytype_categories_allowed = null
 	bodytype_categories_denied  = null
 	body_flags_allowed          = null

--- a/code/modules/sprite_accessories/hair/_accessory_hair.dm
+++ b/code/modules/sprite_accessories/hair/_accessory_hair.dm
@@ -43,7 +43,6 @@
 	bodytypes_allowed           = null
 	bodytypes_denied            = null
 	species_allowed             = null
-	subspecies_allowed          = null
 	bodytype_categories_allowed = null
 	bodytype_categories_denied  = null
 	body_flags_allowed          = null

--- a/code/modules/sprite_accessories/horns/_accessory_horns.dm
+++ b/code/modules/sprite_accessories/horns/_accessory_horns.dm
@@ -25,7 +25,6 @@
 	bodytypes_allowed           = null
 	bodytypes_denied            = null
 	species_allowed             = null
-	subspecies_allowed          = null
 	bodytype_categories_allowed = null
 	bodytype_categories_denied  = null
 	body_flags_allowed          = null

--- a/code/modules/sprite_accessories/tails/_accessory_tail.dm
+++ b/code/modules/sprite_accessories/tails/_accessory_tail.dm
@@ -37,7 +37,6 @@
 	bodytypes_allowed           = null
 	bodytypes_denied            = null
 	species_allowed             = null
-	subspecies_allowed          = null
 	bodytype_categories_allowed = null
 	bodytype_categories_denied  = null
 	body_flags_allowed          = null

--- a/code/modules/submaps/submap_job.dm
+++ b/code/modules/submaps/submap_job.dm
@@ -79,9 +79,9 @@
 	return TRUE
 
 /datum/job/submap/is_restricted(var/datum/preferences/prefs, var/feedback)
-	var/decl/species/S = get_species_by_key(prefs.species)
-	if(LAZYACCESS(minimum_character_age, S.get_root_species_name()) && (prefs.get_character_age() < minimum_character_age[S.get_root_species_name()]))
-		to_chat(feedback, "<span class='boldannounce'>Not old enough. Minimum character age is [minimum_character_age[S.get_root_species_name()]].</span>")
+	var/decl/species/S = prefs.get_species_decl()
+	if(LAZYACCESS(minimum_character_age, S.uid) && (prefs.get_character_age() < minimum_character_age[S.uid]))
+		to_chat(feedback, "<span class='boldannounce'>Not old enough. Minimum character age is [minimum_character_age[S.uid]].</span>")
 		return TRUE
 	if(LAZYLEN(whitelisted_species) && !(prefs.species in whitelisted_species))
 		to_chat(feedback, "<span class='boldannounce'>Your current species, [prefs.species], is not permitted as [title] on \a [owner.archetype.name].</span>")

--- a/code/modules/surgery/_surgery.dm
+++ b/code/modules/surgery/_surgery.dm
@@ -103,12 +103,12 @@ var/global/list/surgery_tool_exception_cache = list()
 		if(allowed_species)
 			. = FALSE
 			if(species)
-				for(var/species_name in allowed_species)
-					if(species.get_root_species_name(target) == species_name)
+				for(var/species_uid in allowed_species)
+					if(species.uid == species_uid)
 						return TRUE
 		if(species && disallowed_species)
-			for(var/species_name in disallowed_species)
-				if(species.get_root_species_name(target) == species_name)
+			for(var/species_uid in disallowed_species)
+				if(species.uid == species_uid)
 					return FALSE
 
 /decl/surgery_step/proc/get_skill_reqs(mob/living/user, mob/living/target, obj/item/tool, target_zone)

--- a/code/unit_tests/backgrounds.dm
+++ b/code/unit_tests/backgrounds.dm
@@ -6,90 +6,89 @@
 	var/list/all_background_tokens = global.using_map.get_background_categories()
 
 	var/fails = 0
-	for(var/species_name in get_all_species())
-		var/decl/species/species = get_species_by_key(species_name)
+	for(var/decl/species/species as anything in decls_repository.get_decls_of_subtype_unassociated(/decl/species))
 		if(!islist(species.default_background_info))
 			fails++
-			log_bad("Default background info for [species_name] is not a list.")
+			log_bad("Default background info for [species.type] is not a list.")
 		else
 			for(var/cat_type in species.default_background_info)
 				if(!(cat_type in all_background_tokens))
 					fails++
-					log_bad("Default background info for [species_name] contains invalid tag '[cat_type]'.")
+					log_bad("Default background info for [species.type] contains invalid tag '[cat_type]'.")
 				else
 					var/val = species.default_background_info[cat_type]
 					if(!val)
 						fails++
-						log_bad("Default background value '[val]' for [species_name] tag '[cat_type]' is null, must be a type.")
+						log_bad("Default background value '[val]' for [species.type] tag '[cat_type]' is null, must be a type.")
 					else if(istext(val))
 						fails++
-						log_bad("Default background value '[val]' for [species_name] tag '[cat_type]' is text, must be a type.")
+						log_bad("Default background value '[val]' for [species.type] tag '[cat_type]' is text, must be a type.")
 					else
 						var/decl/background_detail/background = GET_DECL(val)
 						if(!istype(background))
 							fails++
-							log_bad("Default background value '[val]' for [species_name] tag '[cat_type]' is not a valid background label.")
+							log_bad("Default background value '[val]' for [species.type] tag '[cat_type]' is not a valid background label.")
 						else if(background.category != cat_type)
 							fails++
-							log_bad("Default background value '[val]' for [species_name] tag '[cat_type]' does not match background datum category ([background.category] must equal [cat_type]).")
+							log_bad("Default background value '[val]' for [species.type] tag '[cat_type]' does not match background datum category ([background.category] must equal [cat_type]).")
 						else if(!background.description)
 							fails++
-							log_bad("Default background value '[val]' for [species_name] tag '[cat_type]' does not have a description set.")
+							log_bad("Default background value '[val]' for [species.type] tag '[cat_type]' does not have a description set.")
 
 		if(!islist(species.force_background_info))
 			fails++
-			log_bad("Forced background info for [species_name] is not a list.")
+			log_bad("Forced background info for [species.type] is not a list.")
 		else
 			for(var/cat_type in species.force_background_info)
 				if(!(cat_type in all_background_tokens))
 					fails++
-					log_bad("Forced background info for [species_name] contains invalid tag '[cat_type]'.")
+					log_bad("Forced background info for [species.type] contains invalid tag '[cat_type]'.")
 				else
 					var/val = species.force_background_info[cat_type]
 					if(!val)
 						fails++
-						log_bad("Forced background value for [species_name] tag '[cat_type]' is null, must be a type.")
+						log_bad("Forced background value for [species.type] tag '[cat_type]' is null, must be a type.")
 					else if(istext(val))
 						fails++
-						log_bad("Forced background value for [species_name] tag '[cat_type]' is text, must be a type.")
+						log_bad("Forced background value for [species.type] tag '[cat_type]' is text, must be a type.")
 					else
 						var/decl/background_detail/background = GET_DECL(val)
 						if(!istype(background))
 							fails++
-							log_bad("Forced background value '[val]' for [species_name] tag '[cat_type]' is not a valid background label.")
+							log_bad("Forced background value '[val]' for [species.type] tag '[cat_type]' is not a valid background label.")
 						else if(background.category != cat_type)
 							fails++
-							log_bad("Forced background value '[val]' for [species_name] tag '[cat_type]' does not match background datum category ([background.category] must equal [cat_type]).")
+							log_bad("Forced background value '[val]' for [species.type] tag '[cat_type]' does not match background datum category ([background.category] must equal [cat_type]).")
 						else if(!background.description)
 							fails++
-							log_bad("Forced background value '[val]' for [species_name] tag '[cat_type]' does not have a description set.")
+							log_bad("Forced background value '[val]' for [species.type] tag '[cat_type]' does not have a description set.")
 
 		if(!islist(species.available_background_info))
 			fails++
-			log_bad("Available background info for [species_name] is not a list.")
+			log_bad("Available background info for [species.type] is not a list.")
 		else
 			for(var/cat_type in all_background_tokens)
 				if(!islist(species.available_background_info[cat_type]))
 					fails++
-					log_bad("Available background info for [species_name] tag '[cat_type]' is invalid type, must be a list.")
+					log_bad("Available background info for [species.type] tag '[cat_type]' is invalid type, must be a list.")
 				else if(!LAZYLEN(species.available_background_info[cat_type]))
 					fails++
-					log_bad("Available background info for [species_name] tag '[cat_type]' is empty, must have at least one entry.")
+					log_bad("Available background info for [species.type] tag '[cat_type]' is empty, must have at least one entry.")
 				else
 					for(var/val in species.available_background_info[cat_type])
 						if(istext(val))
-							log_bad("Available background value '[val]' for [species_name] tag '[cat_type]' is text, must be a type.")
+							log_bad("Available background value '[val]' for [species.type] tag '[cat_type]' is text, must be a type.")
 						else
 							var/decl/background_detail/background = GET_DECL(val)
 							if(!istype(background))
 								fails++
-								log_bad("Available background value '[val]' for [species_name] tag '[cat_type]' is not a valid background label.")
+								log_bad("Available background value '[val]' for [species.type] tag '[cat_type]' is not a valid background label.")
 							else if(background.category != cat_type)
 								fails++
-								log_bad("Available background value '[val]' for [species_name] tag '[cat_type]' does not match background datum category ([background.category] must equal [cat_type]).")
+								log_bad("Available background value '[val]' for [species.type] tag '[cat_type]' does not match background datum category ([background.category] must equal [cat_type]).")
 							else if(!background.description)
 								fails++
-								log_bad("Available background value '[val]' for [species_name] tag '[cat_type]' does not have a description set.")
+								log_bad("Available background value '[val]' for [species.type] tag '[cat_type]' does not have a description set.")
 
 	if(fails > 0)
 		fail("[fails] invalid background value(s)")

--- a/code/unit_tests/clothing.dm
+++ b/code/unit_tests/clothing.dm
@@ -8,7 +8,8 @@
 	var/list/icon_states_checked = list()
 	var/list/reported_failures = list()
 
-	var/decl/species/default_species = get_species_by_key(SPECIES_HUMAN)
+	// TODO: Make this not hardcoded to humans, and test more than just the default bodytype.
+	var/decl/species/default_species = decls_repository.get_decl_by_id(/decl/species/human::uid)
 	var/decl/bodytype/default_bodytype = default_species.default_bodytype
 	var/state_base = default_bodytype.bodytype_category
 

--- a/code/unit_tests/equipment_tests.dm
+++ b/code/unit_tests/equipment_tests.dm
@@ -7,7 +7,7 @@
 	async = 1
 
 /datum/unit_test/vision_glasses/start_test()
-	subject = new(get_safe_turf(), SPECIES_HUMAN) // force human so default map species doesn't mess with anything
+	subject = new(get_safe_turf(), /decl/species/human::uid) // force human so default map species doesn't mess with anything
 	subject.equip_to_slot(new glasses_type(subject), slot_glasses_str)
 	return 1
 
@@ -150,7 +150,7 @@
 		failure_list += "[item] was equipped to [equipped_location] despite failing isEquipped (should not be equipped)."
 
 /datum/unit_test/equipment_slot_test/start_test()
-	var/mob/living/human/subject = new(get_safe_turf(), SPECIES_HUMAN) // force human so default map species doesn't mess with anything
+	var/mob/living/human/subject = new(get_safe_turf(), /decl/species/human::uid) // force human so default map species doesn't mess with anything
 	created_atoms |= subject
 	var/list/failures = list()
 

--- a/code/unit_tests/mob_tests.dm
+++ b/code/unit_tests/mob_tests.dm
@@ -29,7 +29,7 @@
 			continue
 		dummy_appearance.root_species  = species
 		dummy_appearance.root_bodytype = bodytype
-		var/mob/living/human/test_subject = new(T, species.name, dummy_appearance)
+		var/mob/living/human/test_subject = new(T, species.uid, dummy_appearance)
 		if(test_subject.need_breathe())
 			test_subject.apply_effect(20, STUN, 0)
 			var/obj/item/organ/internal/lungs/L = test_subject.get_organ(test_subject.get_bodytype().breathing_organ, /obj/item/organ/internal/lungs)
@@ -71,7 +71,7 @@
 		test_result["msg"] = "Unable to find a location to create test mob"
 		return test_result
 
-	var/mob/living/human/H = new mobtype(mobloc, SPECIES_HUMAN) // force human for testing
+	var/mob/living/human/H = new mobtype(mobloc, global.using_map.default_species) // force default species for testing
 
 	H.mind_initialize("TestKey[rand(0,10000)]")
 
@@ -282,8 +282,8 @@
 
 /datum/unit_test/mob_nullspace/start_test()
 	// Simply create one of each species type in nullspace
-	for(var/species_name in get_all_species())
-		var/test_subject = new/mob/living/human(null, species_name)
+	for(var/decl/species/species as anything in decls_repository.get_decls_of_subtype_unassociated(/decl/species))
+		var/test_subject = new/mob/living/human(null, species.uid)
 		test_subjects += test_subject
 	return TRUE
 
@@ -303,13 +303,24 @@
 
 /datum/unit_test/mob_organ_size/start_test()
 	var/failed = FALSE
-	for(var/species_name in get_all_species())
-		var/mob/living/human/H = new(null, species_name)
-		for(var/obj/item/organ/external/E in H.get_external_organs())
-			for(var/obj/item/organ/internal/I in E.internal_organs)
-				if(I.w_class > E.cavity_max_w_class)
-					failed = TRUE
-					log_bad("Internal organ [I] inside external organ [E] on species [species_name] was too large to fit.")
+	var/datum/mob_snapshot/dummy_appearance = new
+	for(var/decl/bodytype/bodytype in decls_repository.get_decls_of_subtype_unassociated(/decl/bodytype))
+		var/decl/species/species = bodytype.get_user_species_for_validation()
+		if(!species)
+			continue
+		dummy_appearance.root_species  = species
+		dummy_appearance.root_bodytype = bodytype
+		var/mob/living/human/test_subject = new(null, species.uid, dummy_appearance)
+		for(var/obj/item/organ/internal/organ in test_subject.get_internal_organs())
+			var/obj/item/organ/external/parent = GET_EXTERNAL_ORGAN(test_subject, organ.parent_organ)
+			if(!parent)
+				failed = TRUE
+				log_bad("Internal organ [organ] inside mob of species [species.type] lacked a parent organ (expected [organ.parent_organ])!")
+				continue
+			if(organ.w_class > parent.cavity_max_w_class)
+				failed = TRUE
+				log_bad("Internal organ [organ] inside external organ [parent] on species [species.type] was too large to fit.")
+	QDEL_NULL(dummy_appearance)
 	if(failed)
 		fail("A mob had an internal organ too large for its external organ.")
 	else

--- a/code/unit_tests/organ_tests.dm
+++ b/code/unit_tests/organ_tests.dm
@@ -123,7 +123,7 @@
 			continue
 		dummy_appearance.root_species  = species
 		dummy_appearance.root_bodytype = bodytype
-		var/mob/living/human/test_subject = new(null, species.name, dummy_appearance)
+		var/mob/living/human/test_subject = new(null, species.uid, dummy_appearance)
 
 		var/fail = 0
 		fail |= !check_internal_organs(test_subject, bodytype)
@@ -260,7 +260,7 @@
 			continue
 		dummy_appearance.root_species  = species
 		dummy_appearance.root_bodytype = bodytype
-		var/mob/living/human/test_subject = new(null, species.name, dummy_appearance)
+		var/mob/living/human/test_subject = new(null, species.uid, dummy_appearance)
 
 		for(var/O in test_subject.get_internal_organs())
 			if(!test_internal_organ(test_subject, O))

--- a/code/unit_tests/traders.dm
+++ b/code/unit_tests/traders.dm
@@ -45,7 +45,7 @@
 	var/list/all_species = decls_repository.get_decls_of_subtype(/decl/species)
 	for(var/species_type in all_species)
 		var/decl/species/species = all_species[species_type]
-		acceptable_additional_tokens |= "[TRADER_HAIL_START][species.name]"
+		acceptable_additional_tokens |= "[TRADER_HAIL_START][species.uid]"
 
 	var/list/failures = list()
 	for(var/trader_type in subtypesof(/datum/trader))

--- a/maps/shaded_hills/shaded_hills_map.dm
+++ b/maps/shaded_hills/shaded_hills_map.dm
@@ -1,6 +1,6 @@
 /datum/map/shaded_hills
 	default_liquid_fuel_type = /decl/material/liquid/oil
-	default_species = SPECIES_KOBALOI
+	default_species = /decl/species/kobaloi::uid
 	loadout_categories = list(
 		/decl/loadout_category/fantasy/clothing,
 		/decl/loadout_category/fantasy/utility

--- a/maps/~mapsystem/maps.dm
+++ b/maps/~mapsystem/maps.dm
@@ -136,7 +136,7 @@ var/global/const/MAP_HAS_RANK   = 2		//Rank system, also toggleable
 
 	var/list/station_departments = list()//Gets filled automatically depending on jobs allowed
 
-	var/default_species = SPECIES_HUMAN
+	var/default_species = /decl/species/human::uid
 
 	// Can this map be voted for by players?
 	var/votable = TRUE
@@ -564,7 +564,7 @@ var/global/const/MAP_HAS_RANK   = 2		//Rank system, also toggleable
 	if(!length(SSmapping.contact_levels))
 		log_error("[name] has no contact levels!")
 		. = FALSE
-	var/decl/species/default_species_decl = get_species_by_key(default_species)
+	var/decl/species/default_species_decl = decls_repository.get_decl_by_id(default_species)
 	if(default_species_decl.species_flags & SPECIES_IS_RESTRICTED)
 		log_error("[name]'s default species [default_species_decl.type] is set to restricted!")
 	if(default_species_decl.species_flags & SPECIES_IS_WHITELISTED)

--- a/mods/content/corporate/away_sites/lar_maria/lar_maria.dm
+++ b/mods/content/corporate/away_sites/lar_maria/lar_maria.dm
@@ -24,10 +24,10 @@
 
 ///////////////////////////////////crew and prisoners
 /obj/abstract/landmark/corpse/lar_maria
-	eye_colors_per_species = list(SPECIES_HUMAN = list(COLOR_RED))//red eyes
-	skin_tones_per_species = list(SPECIES_HUMAN = list(-15))
-	facial_styles_per_species = list(SPECIES_HUMAN = list(/decl/sprite_accessory/facial_hair/shaved))
-	genders_per_species = list(SPECIES_HUMAN = list(MALE))
+	eye_colors_per_species = list(/decl/species/human::uid = list(COLOR_RED))//red eyes
+	skin_tones_per_species = list(/decl/species/human::uid = list(-15))
+	facial_styles_per_species = list(/decl/species/human::uid = list(/decl/sprite_accessory/facial_hair/shaved))
+	genders_per_species = list(/decl/species/human::uid = list(MALE))
 
 /mob/living/simple_animal/hostile/lar_maria
 	name = "Lar Maria hostile mob"
@@ -83,10 +83,10 @@
 /obj/abstract/landmark/corpse/lar_maria/zhp_guard
 	name = "dead guard"
 	corpse_outfits = list(/decl/outfit/corpse/zhp_guard)
-	skin_tones_per_species = list(SPECIES_HUMAN = list(-15))
+	skin_tones_per_species = list(/decl/species/human::uid = list(-15))
 
 /obj/abstract/landmark/corpse/lar_maria/zhp_guard/dark
-	skin_tones_per_species = list(SPECIES_HUMAN = list(-115))
+	skin_tones_per_species = list(/decl/species/human::uid = list(-115))
 
 /decl/outfit/corpse/zhp_guard
 	name = "Dead ZHP guard"
@@ -161,9 +161,9 @@
 /obj/abstract/landmark/corpse/lar_maria/virologist_female
 	name = "dead virologist"
 	corpse_outfits = list(/decl/outfit/corpse/zhp_virologist_female)
-	hair_styles_per_species = list(SPECIES_HUMAN = list(/decl/sprite_accessory/hair/flair))
-	hair_colors_per_species = list(SPECIES_HUMAN = list("#ae7b48"))
-	genders_per_species = list(SPECIES_HUMAN = list(FEMALE))
+	hair_styles_per_species = list(/decl/species/human::uid = list(/decl/sprite_accessory/hair/flair))
+	hair_colors_per_species = list(/decl/species/human::uid = list("#ae7b48"))
+	genders_per_species = list(/decl/species/human::uid = list(FEMALE))
 
 /decl/outfit/corpse/zhp_virologist_female
 	name = "Dead female ZHP virologist"

--- a/mods/content/fantasy/_fantasy.dm
+++ b/mods/content/fantasy/_fantasy.dm
@@ -1,7 +1,3 @@
-#define SPECIES_KOBALOI "Kobaloi"
-#define SPECIES_HNOLL   "Hnoll"
-#define SPECIES_DVERGR  "Dvergr"
-
 #define BODYTYPE_KOBALOI "reptomammalian body"
 #define BODYTYPE_HNOLL   "hyenoid body"
 #define BODYTYPE_DVERGR  "small humanoid body"

--- a/mods/content/fantasy/datum/hnoll/markings.dm
+++ b/mods/content/fantasy/datum/hnoll/markings.dm
@@ -2,7 +2,7 @@
 /decl/sprite_accessory/hair/hnoll
 	name = "Hnoll Rattail"
 	icon_state = "hair_rattail"
-	species_allowed = list(SPECIES_HNOLL)
+	species_allowed = list(/decl/species/hnoll::uid)
 	icon = 'mods/content/fantasy/icons/hnoll/hair.dmi'
 	color_blend = ICON_MULTIPLY
 	uid = "acc_hair_hnoll_rattail"
@@ -135,7 +135,7 @@
 /decl/sprite_accessory/facial_hair/hnoll
 	name = "Hnoll Sideburns"
 	icon_state = "facial_sideburns"
-	species_allowed = list(SPECIES_HNOLL)
+	species_allowed = list(/decl/species/hnoll::uid)
 	icon = 'mods/content/fantasy/icons/hnoll/facial.dmi'
 	color_blend = ICON_MULTIPLY
 	uid = "acc_fhair_hnoll_sideburns"
@@ -169,7 +169,7 @@
 	name = "Hnoll Nose"
 	icon_state = "nose"
 	icon = 'mods/content/fantasy/icons/hnoll/markings.dmi'
-	species_allowed = list(SPECIES_HNOLL)
+	species_allowed = list(/decl/species/hnoll::uid)
 	body_parts = list(BP_HEAD)
 	color_blend = ICON_MULTIPLY
 	uid = "acc_marking_hnoll_nose"

--- a/mods/content/fantasy/datum/hnoll/species.dm
+++ b/mods/content/fantasy/datum/hnoll/species.dm
@@ -12,6 +12,7 @@
 	)
 
 /decl/species/hnoll
+	uid                 = "species_hnoll"
 	name                = SPECIES_HNOLL
 	name_plural         = "Hnoll"
 	description         = "The hnoll are thickly-furred, powerfully built bipeds with a notable resemblance to the steppe \

--- a/mods/content/fantasy/datum/hnoll/species.dm
+++ b/mods/content/fantasy/datum/hnoll/species.dm
@@ -13,7 +13,7 @@
 
 /decl/species/hnoll
 	uid                 = "species_hnoll"
-	name                = SPECIES_HNOLL
+	name                = "Hnoll"
 	name_plural         = "Hnoll"
 	description         = "The hnoll are thickly-furred, powerfully built bipeds with a notable resemblance to the steppe \
 	hyenas that often decorate their coinage and art. The oldest hnoll cultures make their home on the Grass Ocean and the \

--- a/mods/content/fantasy/datum/kobaloi/markings.dm
+++ b/mods/content/fantasy/datum/kobaloi/markings.dm
@@ -6,7 +6,7 @@
 	abstract_type    = /decl/sprite_accessory/marking/kobaloi
 	icon             = 'mods/content/fantasy/icons/kobaloi/markings.dmi'
 	color_blend      = ICON_MULTIPLY
-	species_allowed  = list(SPECIES_KOBALOI)
+	species_allowed  = list(/decl/species/kobaloi::uid)
 	body_parts       = list(BP_HEAD)
 	mask_to_bodypart = FALSE
 

--- a/mods/content/fantasy/datum/kobaloi/species.dm
+++ b/mods/content/fantasy/datum/kobaloi/species.dm
@@ -1,7 +1,7 @@
 /decl/species/kobaloi
 	uid                 = "species_kobaloi"
-	name                = SPECIES_KOBALOI
-	name_plural         = SPECIES_KOBALOI
+	name                = "Kobaloi"
+	name_plural         = "Kobaloi"
 	spawn_flags         = SPECIES_CAN_JOIN
 	preview_outfit      = null
 	description         = "Kobaloi are small, scaled and furred creatures that usually dwell in the quiet places of the world, \

--- a/mods/content/fantasy/datum/kobaloi/species.dm
+++ b/mods/content/fantasy/datum/kobaloi/species.dm
@@ -1,4 +1,5 @@
 /decl/species/kobaloi
+	uid                 = "species_kobaloi"
 	name                = SPECIES_KOBALOI
 	name_plural         = SPECIES_KOBALOI
 	spawn_flags         = SPECIES_CAN_JOIN

--- a/mods/content/xenobiology/_xenobiology.dm
+++ b/mods/content/xenobiology/_xenobiology.dm
@@ -1,9 +1,8 @@
 #define isslime(X) istype(X, /mob/living/slime)
-#define SPECIES_GOLEM "Golem"
 
 /decl/modpack/xenobiology
 	name = "Xenobiology"
 
 /decl/modpack/xenobiology/initialize()
 	. = ..()
-	SSmodpacks.default_submap_blacklisted_species += SPECIES_GOLEM
+	SSmodpacks.default_submap_blacklisted_species += /decl/species/golem::uid

--- a/mods/content/xenobiology/slime/items.dm
+++ b/mods/content/xenobiology/slime/items.dm
@@ -99,7 +99,7 @@
 	visible_message(SPAN_WARNING("A craggy humanoid figure coalesces into being!"))
 
 	var/mob/living/human/G = new(src.loc)
-	G.set_species(SPECIES_GOLEM)
+	G.set_species(/decl/species/golem::uid)
 	G.key = ghost.key
 
 	var/obj/item/implant/translator/natural/I = new()

--- a/mods/content/xenobiology/species/golem.dm
+++ b/mods/content/xenobiology/species/golem.dm
@@ -11,7 +11,7 @@
 
 /decl/species/golem
 	uid = "species_golem"
-	name = SPECIES_GOLEM
+	name = "Golem"
 	name_plural = "Golems"
 	hidden_from_codex = TRUE
 

--- a/mods/content/xenobiology/species/golem.dm
+++ b/mods/content/xenobiology/species/golem.dm
@@ -10,6 +10,7 @@
 	uid = "bodytype_crystalline_golem"
 
 /decl/species/golem
+	uid = "species_golem"
 	name = SPECIES_GOLEM
 	name_plural = "Golems"
 	hidden_from_codex = TRUE

--- a/mods/gamemodes/heist/special_role.dm
+++ b/mods/gamemodes/heist/special_role.dm
@@ -55,5 +55,5 @@
 	return 1
 
 /decl/special_role/raider/equip_role(var/mob/living/human/player)
-	default_outfit = LAZYACCESS(outfits_per_species, player.species.name) || initial(default_outfit)
+	default_outfit = LAZYACCESS(outfits_per_species, player.species.uid) || initial(default_outfit)
 	. = ..()

--- a/mods/species/adherent/_adherent.dm
+++ b/mods/species/adherent/_adherent.dm
@@ -3,7 +3,6 @@
 #define BP_JETS         "maneuvering jets"
 #define BP_COOLING_FINS "cooling fins"
 
-#define SPECIES_ADHERENT  "Adherent"
 #define BODYTYPE_ADHERENT "adherent body"
 
 /decl/modpack/adherent
@@ -11,8 +10,8 @@
 
 /decl/modpack/adherent/pre_initialize()
 	..()
-	SSmodpacks.default_submap_whitelisted_species |= SPECIES_ADHERENT
+	SSmodpacks.default_submap_whitelisted_species |= /decl/species/adherent::uid
 
-/mob/living/human/adherent/Initialize(mapload, species_name, datum/mob_snapshot/supplied_appearance)
-	species_name = SPECIES_ADHERENT
+/mob/living/human/adherent/Initialize(mapload, species_uid, datum/mob_snapshot/supplied_appearance)
+	species_uid = /decl/species/adherent::uid
 	. = ..()

--- a/mods/species/adherent/datum/species.dm
+++ b/mods/species/adherent/datum/species.dm
@@ -11,6 +11,7 @@
 	)
 
 /decl/species/adherent
+	uid = "species_adherent"
 	name = SPECIES_ADHERENT
 	name_plural = "Adherents"
 	base_external_prosthetics_model = null

--- a/mods/species/adherent/datum/species.dm
+++ b/mods/species/adherent/datum/species.dm
@@ -12,7 +12,7 @@
 
 /decl/species/adherent
 	uid = "species_adherent"
-	name = SPECIES_ADHERENT
+	name = "Adherent"
 	name_plural = "Adherents"
 	base_external_prosthetics_model = null
 

--- a/mods/species/ascent/ascent.dm
+++ b/mods/species/ascent/ascent.dm
@@ -1,7 +1,3 @@
-#define SPECIES_MANTID_ALATE   "Kharmaan Alate"
-#define SPECIES_MANTID_GYNE    "Kharmaan Gyne"
-#define SPECIES_MANTID_NYMPH   "Kharmaan Nymph"
-
 #define BODYTYPE_MANTID_SMALL "small mantid body"
 #define BODYTYPE_MANTID_LARGE "large mantid body"
 
@@ -14,8 +10,6 @@
 ##_thing/ascent/name = _name; \
 ##_thing/ascent/desc = "Some kind of strange alien " + _desc + " technology."; \
 ##_thing/ascent/color = COLOR_PURPLE;
-
-#define ALL_ASCENT_SPECIES list(SPECIES_MANTID_ALATE, SPECIES_MANTID_GYNE)
 
 /decl/modpack/ascent
 	name = "The Ascent"

--- a/mods/species/ascent/datum/antagonist.dm
+++ b/mods/species/ascent/datum/antagonist.dm
@@ -21,21 +21,22 @@
 	if(ishuman(player.current))
 		var/mob/living/human/H = player.current
 		H.set_gyne_lineage(lineage) // This makes all antag ascent have the same lineage on get_random_name.
-		if(!leader && is_species_whitelisted(player.current, SPECIES_MANTID_GYNE))
+		var/species_uid = H.get_species()?.uid
+		if(!leader && is_species_whitelisted(player.current, /decl/species/mantid/gyne::uid))
 			leader = player
-			if(H.species.get_root_species_name() != SPECIES_MANTID_GYNE)
-				H.set_species(SPECIES_MANTID_GYNE)
+			if(species_uid != /decl/species/mantid/gyne::uid)
+				H.set_species(/decl/species/mantid/gyne::uid)
 			H.set_gender(FEMALE)
 		else
-			if(H.species.get_root_species_name() != SPECIES_MANTID_ALATE)
-				H.set_species(SPECIES_MANTID_ALATE)
+			if(species_uid != /decl/species/mantid::uid)
+				H.set_species(/decl/species/mantid::uid)
 			H.set_gender(MALE)
 		var/decl/background_detail/heritage/ascent/background = GET_DECL(/decl/background_detail/heritage/ascent)
 		H.real_name = background.get_random_name(H, H.gender)
 		H.name = H.real_name
 
 /decl/special_role/hunter/equip_role(var/mob/living/human/player)
-	if(player?.species.get_root_species_name(player) == SPECIES_MANTID_GYNE)
+	if(player?.get_species()?.uid == /decl/species/mantid::uid)
 		rig_type = /obj/item/rig/mantid/gyne
 	else
 		rig_type = initial(rig_type)

--- a/mods/species/ascent/datum/languages.dm
+++ b/mods/species/ascent/datum/languages.dm
@@ -12,8 +12,8 @@
 	shorthand = "KV"
 	machine_understands = FALSE
 	var/list/correct_mouthbits = list(
-		SPECIES_MANTID_ALATE,
-		SPECIES_MANTID_GYNE
+		/decl/species/mantid::uid,
+		/decl/species/mantid/gyne::uid
 	)
 
 /decl/language/mantid/can_be_spoken_properly_by(var/mob/speaker)
@@ -24,7 +24,7 @@
 		return SPEECH_RESULT_GOOD
 	if(ishuman(speaker))
 		var/mob/living/human/H = speaker
-		if(H.species.name in correct_mouthbits)
+		if(H.species.uid in correct_mouthbits)
 			return SPEECH_RESULT_GOOD
 	return SPEECH_RESULT_MUDDLED
 
@@ -74,7 +74,7 @@
 		return TRUE
 	else if(ishuman(speaker))
 		var/mob/living/human/H = speaker
-		return (H.species.name == SPECIES_MANTID_ALATE || H.species.name == SPECIES_MANTID_GYNE)
+		return istype(H.get_species(), /decl/species/mantid)
 	return FALSE
 
 /decl/language/mantid/worldnet

--- a/mods/species/ascent/datum/species.dm
+++ b/mods/species/ascent/datum/species.dm
@@ -25,7 +25,7 @@
 
 /decl/species/mantid
 	uid =                    "species_mantid_alate"
-	name =                   SPECIES_MANTID_ALATE
+	name =                   "Kharmaan Alate"
 	name_plural =            "Kharmaan Alates"
 	show_ssd =               "quiescent"
 	hidden_from_codex =      TRUE
@@ -92,8 +92,7 @@
 
 /decl/species/mantid/gyne
 	uid =         "species_mantid_gyne"
-
-	name =        SPECIES_MANTID_GYNE
+	name =        "Kharmaan Gyne"
 	name_plural = "Kharmaan Gynes"
 
 	available_bodytypes = list(/decl/bodytype/crystalline/mantid/gyne)

--- a/mods/species/ascent/datum/species.dm
+++ b/mods/species/ascent/datum/species.dm
@@ -24,7 +24,7 @@
 	splatter_colour = "#660066"
 
 /decl/species/mantid
-
+	uid =                    "species_mantid_alate"
 	name =                   SPECIES_MANTID_ALATE
 	name_plural =            "Kharmaan Alates"
 	show_ssd =               "quiescent"
@@ -91,6 +91,7 @@
 	return
 
 /decl/species/mantid/gyne
+	uid =         "species_mantid_gyne"
 
 	name =        SPECIES_MANTID_GYNE
 	name_plural = "Kharmaan Gynes"

--- a/mods/species/ascent/datum/traits.dm
+++ b/mods/species/ascent/datum/traits.dm
@@ -1,9 +1,8 @@
 /decl/trait/build_references()
 	. = ..()
 	LAZYINITLIST(blocked_species)
-	blocked_species |= SPECIES_MANTID_ALATE
-	blocked_species |= SPECIES_MANTID_GYNE
-	blocked_species |= SPECIES_MANTID_NYMPH
+	blocked_species |= /decl/species/mantid::uid
+	blocked_species |= /decl/species/mantid/gyne::uid
 
 /decl/trait/ascent
 	abstract_type = /decl/trait/ascent
@@ -12,9 +11,8 @@
 	. = ..()
 	blocked_species = null
 	permitted_species = list(
-		SPECIES_MANTID_ALATE,
-		SPECIES_MANTID_GYNE,
-		SPECIES_MANTID_NYMPH
+		/decl/species/mantid::uid,
+		/decl/species/mantid/gyne::uid
 	)
 
 // Modifies the exosuit that you spawn with.

--- a/mods/species/ascent/effects/razorweb.dm
+++ b/mods/species/ascent/effects/razorweb.dm
@@ -32,8 +32,8 @@
 	var/image/gleam
 	var/image/web
 	var/static/species_immunity_list = list(
-		SPECIES_MANTID_ALATE   = TRUE,
-		SPECIES_MANTID_GYNE    = TRUE
+		/decl/species/mantid::uid      = TRUE,
+		/decl/species/mantid/gyne::uid = TRUE
 	)
 
 /obj/effect/razorweb/Destroy()
@@ -133,7 +133,7 @@
 	var/mob/living/human/H
 	if(ishuman(L))
 		H = L
-		if(species_immunity_list[H.species.name])
+		if(species_immunity_list[H.species.uid])
 			return
 
 	if(!silent)

--- a/mods/species/ascent/items/id_control.dm
+++ b/mods/species/ascent/items/id_control.dm
@@ -8,7 +8,7 @@
 
 /obj/item/card/id/ascent/GetAccess()
 	var/mob/living/human/H = loc
-	if(istype(H) && !(H.species.name in ALL_ASCENT_SPECIES))
+	if(istype(H) && !istype(H.get_species(), /decl/species/mantid))
 		. = list()
 	else
 		. = ..()

--- a/mods/species/ascent/items/rig.dm
+++ b/mods/species/ascent/items/rig.dm
@@ -41,7 +41,7 @@
 		/obj/item/rig_module/maneuvering_jets
 		)
 	req_access = list(access_ascent)
-	var/mantid_caste = SPECIES_MANTID_ALATE
+	var/mantid_caste = /decl/species/mantid::uid
 
 // Renamed blade.
 /obj/item/rig_module/mounted/energy_blade/mantid
@@ -209,7 +209,7 @@
 		ARMOR_BIO = ARMOR_BIO_SHIELDED,
 		ARMOR_RAD = ARMOR_RAD_SHIELDED
 	)
-	mantid_caste = SPECIES_MANTID_GYNE
+	mantid_caste = /decl/species/mantid/gyne::uid
 	initial_modules = list(
 		/obj/item/rig_module/vision/thermal,
 		/obj/item/rig_module/ai_container,
@@ -231,7 +231,7 @@
 	if(!. || slot != slot_back_str || !mantid_caste)
 		return
 	var/decl/species/my_species = user?.get_species()
-	if(my_species?.get_root_species_name(user) != mantid_caste)
+	if(my_species?.uid != mantid_caste)
 		to_chat(user, SPAN_WARNING("Your species cannot wear \the [src]."))
 		return FALSE
 

--- a/mods/species/ascent/machines/magnetotron.dm
+++ b/mods/species/ascent/machines/magnetotron.dm
@@ -24,7 +24,7 @@
 		display_message("No biological signature detected in [src].")
 		return TRUE
 
-	if(target.get_species_name() != SPECIES_MANTID_ALATE)
+	if(target.get_species()?.uid != /decl/species/mantid::uid)
 		display_message("Invalid biological signature detected. Safety mechanisms engaged, only alates may undergo metamorphosis.")
 		return TRUE
 
@@ -46,7 +46,7 @@
 		target.visible_message(SPAN_NOTICE("[target] molts away their shell, emerging as a new gyne."))
 		spark_at(src, cardinal_only = TRUE)
 		ADJ_STATUS(target, STAT_STUN, 6)
-		target.change_species(SPECIES_MANTID_GYNE)
+		target.change_species(/decl/species/mantid/gyne::uid)
 		new /obj/effect/temp_visual/emp_burst(loc)
 		for(var/obj/item/organ/external/E in target.get_external_organs())
 			if(prob(60))
@@ -59,7 +59,7 @@
 
 /obj/machinery/ascent_magnetotron/proc/get_total_gynes()
 	for(var/mob/living/human/H in global.living_mob_list_)
-		if(H.get_species_name() == SPECIES_MANTID_GYNE)
+		if(H.get_species()?.uid == /decl/species/mantid/gyne::uid)
 			. += 1
 
 /obj/item/stock_parts/circuitboard/ascent_magnetotron

--- a/mods/species/ascent/machines/ship_machines.dm
+++ b/mods/species/ascent/machines/ship_machines.dm
@@ -164,7 +164,7 @@ MANTIDIFY(/obj/item/chems/chem_disp_cartridge, "canister", "chemical storage")
 		return ..()
 	if(ishuman(user))
 		var/mob/living/human/H = user
-		if(!(H.species.name in ALL_ASCENT_SPECIES))
+		if(!istype(H.get_species(), /decl/species/mantid))
 			to_chat(H, SPAN_WARNING("You have no idea how to use \the [src]."))
 			return TRUE
 	else if(!isascentdrone(user))

--- a/mods/species/ascent/mobs/insectoid_egg.dm
+++ b/mods/species/ascent/mobs/insectoid_egg.dm
@@ -95,7 +95,7 @@ var/global/default_gyne
 	if(!current_health || maturity != 100 || hatched || hatching)
 		return
 
-	var/mob/living/simple_animal/alien/kharmaan/new_nymph = new(src, SPECIES_MANTID_NYMPH) // Spawn in the egg.
+	var/mob/living/simple_animal/alien/kharmaan/new_nymph = new(src) // Spawn in the egg.
 	new_nymph.lastarea = get_area(src)
 	new_nymph.key = C.ckey
 	new_nymph.real_name = "[random_id(/decl/species/mantid, 10000, 99999)] [lineage]"

--- a/mods/species/ascent/mobs/nymph/nymph_life.dm
+++ b/mods/species/ascent/mobs/nymph/nymph_life.dm
@@ -41,7 +41,7 @@
 	visible_message("\icon[src] [src] begins to shimmy and shake out of its old skin.")
 	if(molt == 5)
 		if(do_after(src, 10 SECONDS, src, FALSE))
-			var/mob/living/human/H = new(get_turf(src), SPECIES_MANTID_ALATE)
+			var/mob/living/human/H = new(get_turf(src), /decl/species/mantid::uid)
 			H.set_gyne_lineage(get_gyne_lineage())
 			H.real_name = "[random_id(/decl/species/mantid, 10000, 99999)] [H.get_gyne_name()]"
 			H.nutrition = nutrition * 0.25 // Homgry after molt.

--- a/mods/species/drakes/_drakes.dm
+++ b/mods/species/drakes/_drakes.dm
@@ -1,4 +1,3 @@
-#define SPECIES_GRAFADREKA            "Grafadreka"
 #define BODYTYPE_GRAFADREKA           "drake body"
 #define BODYTYPE_GRAFADREKA_HATCHLING "hatchling drake body"
 #define BP_DRAKE_GIZZARD              "drake gizzard"
@@ -6,7 +5,6 @@
 /decl/modpack/grafadreka
 	name = "Grafadreka Species"
 
-/mob/living/human/grafadreka/Initialize(mapload, species_name, datum/mob_snapshot/supplied_appearance)
-	// fantasy modpack overrides drake name, so can't use the #define
-	var/decl/species/grafadreka/drakes = GET_DECL(/decl/species/grafadreka)
-	. = ..(mapload, drakes.name)
+/mob/living/human/grafadreka/Initialize(mapload, species_uid, datum/mob_snapshot/supplied_appearance)
+	species_uid = /decl/species/grafadreka::uid
+	. = ..()

--- a/mods/species/drakes/species.dm
+++ b/mods/species/drakes/species.dm
@@ -1,4 +1,5 @@
 /decl/species/grafadreka
+	uid = "species_grafadreka"
 	name = SPECIES_GRAFADREKA
 	name_plural = SPECIES_GRAFADREKA
 	description = "The reclusive grafadreka (Icelandic, lit. 'digging dragon'), also known as the snow drake, is a large reptillian pack predator similar in size and morphology to old Earth hyenas. \

--- a/mods/species/drakes/species.dm
+++ b/mods/species/drakes/species.dm
@@ -1,7 +1,7 @@
 /decl/species/grafadreka
 	uid = "species_grafadreka"
-	name = SPECIES_GRAFADREKA
-	name_plural = SPECIES_GRAFADREKA
+	name = "Grafadreka"
+	name_plural = "Grafadreka"
 	description = "The reclusive grafadreka (Icelandic, lit. 'digging dragon'), also known as the snow drake, is a large reptillian pack predator similar in size and morphology to old Earth hyenas. \
 	They commonly dig shallow dens in dirt, snow or foliage, sometimes using them for concealment prior to an ambush. \
 	Biological cousins to the elusive kururak, they have heavy, low-slung bodies and powerful jaws suited to hunting land prey rather than fishing. \

--- a/mods/species/drakes/species_bodytypes.dm
+++ b/mods/species/drakes/species_bodytypes.dm
@@ -262,7 +262,7 @@
 	icon            = 'mods/species/drakes/icons/markings.dmi'
 	icon_state      = "spines"
 	uid             = "acc_marking_drake_spines"
-	species_allowed = list(SPECIES_GRAFADREKA)
+	species_allowed = list(/decl/species/grafadreka::uid)
 	color_blend     = ICON_MULTIPLY
 	body_parts      = list(
 		BP_CHEST,

--- a/mods/species/neoavians/_neoavians.dm
+++ b/mods/species/neoavians/_neoavians.dm
@@ -1,4 +1,3 @@
-#define SPECIES_AVIAN            "Neo-Avian"
 #define BODYTYPE_AVIAN           "avian body"
 #define BODY_EQUIP_FLAG_AVIAN          BITFLAG(6)
 
@@ -7,4 +6,4 @@
 
 /decl/modpack/neoavians/pre_initialize()
 	..()
-	SSmodpacks.default_submap_whitelisted_species |= SPECIES_AVIAN
+	SSmodpacks.default_submap_whitelisted_species |= /decl/species/neoavian::uid

--- a/mods/species/neoavians/datum/accessory.dm
+++ b/mods/species/neoavians/datum/accessory.dm
@@ -3,7 +3,7 @@
 	name = "Avian Plumage"
 	icon_state = "avian_default"
 	icon = 'mods/species/neoavians/icons/hair.dmi'
-	species_allowed = list(SPECIES_AVIAN)
+	species_allowed = list(/decl/species/neoavian::uid)
 	color_blend = ICON_MULTIPLY
 	uid = "acc_hair_avian_plumage"
 
@@ -124,7 +124,7 @@
 	icon_state = "beak"
 	body_parts = list(BP_HEAD)
 	icon = 'mods/species/neoavians/icons/markings.dmi'
-	species_allowed = list(SPECIES_AVIAN)
+	species_allowed = list(/decl/species/neoavian::uid)
 	color_blend = ICON_MULTIPLY
 	uid = "acc_marking_avian_beak"
 

--- a/mods/species/neoavians/datum/loadout.dm
+++ b/mods/species/neoavians/datum/loadout.dm
@@ -2,7 +2,7 @@
 	name = "Avian"
 
 /decl/loadout_option/avian
-	whitelisted = list(SPECIES_AVIAN)
+	whitelisted = list(/decl/species/neoavian::uid)
 	category = /decl/loadout_category/avian
 	abstract_type = /decl/loadout_option/avian
 

--- a/mods/species/neoavians/datum/species.dm
+++ b/mods/species/neoavians/datum/species.dm
@@ -16,6 +16,7 @@
 	meat_type = /obj/item/food/butchery/meat/chicken
 
 /decl/species/neoavian
+	uid = "species_avian"
 	name = SPECIES_AVIAN
 	name_plural = "Neo-Avians"
 	description = "Avian species, largely crows, magpies and other corvids, were among the first sophonts uplifted to aid in colonizing Mars. \

--- a/mods/species/neoavians/datum/species.dm
+++ b/mods/species/neoavians/datum/species.dm
@@ -17,7 +17,7 @@
 
 /decl/species/neoavian
 	uid = "species_avian"
-	name = SPECIES_AVIAN
+	name = "Neo-Avian"
 	name_plural = "Neo-Avians"
 	description = "Avian species, largely crows, magpies and other corvids, were among the first sophonts uplifted to aid in colonizing Mars. \
 	These days they are more commonly found pursuing their own careers and goals on the fringes of human space or around their adopted homeworld \

--- a/mods/species/random_species/_random_species.dm
+++ b/mods/species/random_species/_random_species.dm
@@ -1,8 +1,6 @@
-#define SPECIES_ALIEN "Humanoid"
-
 /decl/modpack/random_species
 	name = "Random Alien Species"
 
 /decl/modpack/random_species/initialize()
 	. = ..()
-	SSmodpacks.default_submap_blacklisted_species += SPECIES_ALIEN
+	SSmodpacks.default_submap_blacklisted_species += /decl/species/alium::uid

--- a/mods/species/random_species/aliumizer.dm
+++ b/mods/species/random_species/aliumizer.dm
@@ -13,19 +13,19 @@
 	var/decl/species/species = user.get_species()
 	if(!species)
 		return TRUE
-	if(species.name == SPECIES_ALIEN)
-		to_chat(user, SPAN_WARNING("You're already a [SPECIES_ALIEN]."))
+	if(species.uid == /decl/species/alium::uid)
+		to_chat(user, SPAN_WARNING("You're already an alien."))
 		return TRUE
 	if(alert("Are you sure you want to be an alien?", "Mom Look I'm An Alien!", "Yes", "No") == "No")
-		to_chat(user, SPAN_NOTICE("<b>You are now a [SPECIES_ALIEN]!</b>"))
+		to_chat(user, SPAN_NOTICE("<b>You are now an alien!</b>"))
 		return TRUE
-	if(species.name == SPECIES_ALIEN) //no spamming it to get free implants
+	if(species.uid == /decl/species/alium::uid) //no spamming it to get free implants
 		return TRUE
 	to_chat(user, "You're now an alien humanoid of some undiscovered species. Make up what lore you want, no one knows a thing about your species! You can check info about your traits with Check Species Info verb in IC tab.")
 	to_chat(user, "You can't speak any other languages by default. You can use translator implant that spawns on top of this monolith - it will give you knowledge of any language if you hear it enough times.")
 	var/mob/living/human/H = user
 	new /obj/item/implanter/translator(get_turf(src))
-	H.change_species(SPECIES_ALIEN)
+	H.change_species(/decl/species/alium::uid)
 	var/decl/background_detail/background = H.get_background_datum_by_flag(BACKGROUND_FLAG_NAMING)
 	H.fully_replace_character_name(background.get_random_name(H, H.gender))
 	H.rename_self("Humanoid Alien", 1)

--- a/mods/species/random_species/random_species_species.dm
+++ b/mods/species/random_species/random_species_species.dm
@@ -1,4 +1,5 @@
 /decl/species/alium
+	uid = "species_random_alien"
 	name = SPECIES_ALIEN
 	name_plural = "Humanoids"
 	description = "Some alien humanoid species, unknown to humanity. How exciting."

--- a/mods/species/random_species/random_species_species.dm
+++ b/mods/species/random_species/random_species_species.dm
@@ -1,6 +1,6 @@
 /decl/species/alium
 	uid = "species_random_alien"
-	name = SPECIES_ALIEN
+	name = "Humanoid"
 	name_plural = "Humanoids"
 	description = "Some alien humanoid species, unknown to humanity. How exciting."
 	rarity_value = 5

--- a/mods/species/serpentid/datum/species.dm
+++ b/mods/species/serpentid/datum/species.dm
@@ -20,7 +20,7 @@
 
 /decl/species/serpentid
 	uid = "species_serpentid"
-	name = SPECIES_SERPENTID
+	name = "Serpentid"
 	name_plural = "Serpentids"
 	spawn_flags = SPECIES_IS_RESTRICTED
 

--- a/mods/species/serpentid/datum/species.dm
+++ b/mods/species/serpentid/datum/species.dm
@@ -19,6 +19,7 @@
 	bone_type         = null
 
 /decl/species/serpentid
+	uid = "species_serpentid"
 	name = SPECIES_SERPENTID
 	name_plural = "Serpentids"
 	spawn_flags = SPECIES_IS_RESTRICTED

--- a/mods/species/serpentid/serpentid.dm
+++ b/mods/species/serpentid/serpentid.dm
@@ -1,3 +1,2 @@
-#define SPECIES_SERPENTID     "Serpentid"
 #define BODYTYPE_SNAKE        "snakelike body"
 #define BODY_EQUIP_FLAG_SNAKE BITFLAG(12)

--- a/mods/species/skrell/_skrell.dm
+++ b/mods/species/skrell/_skrell.dm
@@ -1,5 +1,3 @@
-#define SPECIES_SKRELL "Skrell"
-
 /decl/modpack/skrell
 	name = "Skrell Species"
 	tabloid_headlines = list(
@@ -9,8 +7,8 @@
 
 /decl/modpack/skrell/pre_initialize()
 	..()
-	SSmodpacks.default_submap_whitelisted_species |= SPECIES_SKRELL
+	SSmodpacks.default_submap_whitelisted_species |= /decl/species/skrell::uid
 
-/mob/living/human/skrell/Initialize(mapload, species_name, datum/mob_snapshot/supplied_appearance)
-	species_name = SPECIES_SKRELL
+/mob/living/human/skrell/Initialize(mapload, species_uid, datum/mob_snapshot/supplied_appearance)
+	species_uid = /decl/species/skrell::uid
 	. = ..()

--- a/mods/species/skrell/datum/accessory.dm
+++ b/mods/species/skrell/datum/accessory.dm
@@ -2,7 +2,7 @@
 	name = "Kanin - Very Short Headtails"
 	icon = 'mods/species/skrell/icons/body/hair.dmi'
 	icon_state = "very_short"
-	species_allowed = list(SPECIES_SKRELL)
+	species_allowed = list(/decl/species/skrell::uid)
 	uid = "acc_hair_skrell_veryshort"
 
 /decl/sprite_accessory/hair/skrell/raskin

--- a/mods/species/skrell/datum/species.dm
+++ b/mods/species/skrell/datum/species.dm
@@ -4,6 +4,7 @@
 	bone_material = /decl/material/solid/organic/bone/cartilage
 
 /decl/species/skrell
+	uid = "species_skrell"
 	name = SPECIES_SKRELL
 	name_plural = SPECIES_SKRELL
 

--- a/mods/species/skrell/datum/species.dm
+++ b/mods/species/skrell/datum/species.dm
@@ -5,8 +5,8 @@
 
 /decl/species/skrell
 	uid = "species_skrell"
-	name = SPECIES_SKRELL
-	name_plural = SPECIES_SKRELL
+	name = "Skrell"
+	name_plural = "Skrell"
 
 	available_bodytypes = list(
 		/decl/bodytype/skrell

--- a/mods/species/skrell/gear/gear_ears.dm
+++ b/mods/species/skrell/gear/gear_ears.dm
@@ -4,7 +4,7 @@
 
 /obj/item/clothing/ears/skrell/mob_can_equip(mob/user, slot, disable_warning = FALSE, force = FALSE, ignore_equipped = FALSE)
 	. = ..()
-	if(. && user?.get_species_name() != SPECIES_SKRELL)
+	if(. && user?.get_species()?.uid != /decl/species/skrell::uid)
 		return FALSE
 
 /obj/item/clothing/ears/skrell/band
@@ -43,7 +43,7 @@
 /decl/loadout_option/ears/skrell
 	name = "skrell headtail accessory selection"
 	category = /decl/loadout_category/ears
-	whitelisted = list(SPECIES_SKRELL)
+	whitelisted = list(/decl/species/skrell::uid)
 	path = /obj/item/clothing/ears/skrell
 	loadout_flags = GEAR_HAS_COLOR_SELECTION | GEAR_HAS_SUBTYPE_SELECTION
 	uid = "gear_accessory_skrell"

--- a/mods/species/skrell/gear/gear_head.dm
+++ b/mods/species/skrell/gear/gear_head.dm
@@ -14,7 +14,7 @@
 
 /obj/item/clothing/head/helmet/space/void/skrell/mob_can_equip(mob/user, slot, disable_warning = FALSE, force = FALSE, ignore_equipped = FALSE)
 	. = ..()
-	if(. && user?.get_species_name() != SPECIES_SKRELL)
+	if(. && user?.get_species()?.uid != /decl/species/skrell::uid)
 		return FALSE
 
 /obj/item/clothing/head/helmet/space/void/skrell/black
@@ -27,5 +27,5 @@
 
 /obj/item/clothing/head/helmet/skrell/mob_can_equip(mob/user, slot, disable_warning = FALSE, force = FALSE, ignore_equipped = FALSE)
 	. = ..()
-	if(. && user?.get_species_name() != SPECIES_SKRELL)
+	if(. && user?.get_species()?.uid != /decl/species/skrell::uid)
 		return FALSE

--- a/mods/species/skrell/gear/gear_mask.dm
+++ b/mods/species/skrell/gear/gear_mask.dm
@@ -1,7 +1,7 @@
 /decl/loadout_option/mask/skrell
 	name = "skrellian gill cover"
 	path = /obj/item/clothing/mask/gas/skrell
-	whitelisted = list(SPECIES_SKRELL)
+	whitelisted = list(/decl/species/skrell::uid)
 	uid = "gear_mask_skrell"
 
 /obj/item/clothing/mask/gas/skrell
@@ -13,5 +13,5 @@
 
 /obj/item/clothing/mask/gas/skrell/mob_can_equip(mob/user, slot, disable_warning = FALSE, force = FALSE, ignore_equipped = FALSE)
 	. = ..()
-	if(. && user?.get_species_name() != SPECIES_SKRELL)
+	if(. && user?.get_species()?.uid != /decl/species/skrell::uid)
 		return FALSE

--- a/mods/species/tajaran/_tajaran.dm
+++ b/mods/species/tajaran/_tajaran.dm
@@ -1,5 +1,4 @@
 #define LANGUAGE_TAJARAN       "Siik'maas"
-#define SPECIES_TAJARAN        "Tajara"
 #define BODYTYPE_TAJARAN       "felinoid body"
 
 /decl/modpack/tajaran
@@ -10,10 +9,10 @@
 
 /decl/modpack/tajaran/pre_initialize()
 	..()
-	SSmodpacks.default_submap_whitelisted_species |= SPECIES_TAJARAN
+	SSmodpacks.default_submap_whitelisted_species |= /decl/species/tajaran::uid
 
-/mob/living/human/tajaran/Initialize(mapload, species_name, datum/mob_snapshot/supplied_appearance)
-	. = ..(species_name = SPECIES_TAJARAN)
+/mob/living/human/tajaran/Initialize(mapload, species_uid, datum/mob_snapshot/supplied_appearance)
+	. = ..(species_uid = /decl/species/tajaran::uid)
 
 /obj/item
 	var/_tajaran_onmob_icon

--- a/mods/species/tajaran/datum/accessory.dm
+++ b/mods/species/tajaran/datum/accessory.dm
@@ -2,7 +2,7 @@
 /decl/sprite_accessory/hair/taj
 	name = "Tajaran Rattail"
 	icon_state = "hair_rattail"
-	species_allowed = list(SPECIES_TAJARAN)
+	species_allowed = list(/decl/species/tajaran::uid)
 	icon = 'mods/species/tajaran/icons/hair.dmi'
 	color_blend = ICON_MULTIPLY
 	uid = "acc_hair_taj_rattail"
@@ -135,7 +135,7 @@
 /decl/sprite_accessory/facial_hair/taj
 	name = "Tajaran Sideburns"
 	icon_state = "facial_sideburns"
-	species_allowed = list(SPECIES_TAJARAN)
+	species_allowed = list(/decl/species/tajaran::uid)
 	icon = 'mods/species/tajaran/icons/facial.dmi'
 	color_blend = ICON_MULTIPLY
 	uid = "acc_fhair_taj_sideburns"
@@ -169,7 +169,7 @@
 	name = "Tajaran Nose"
 	icon_state = "nose"
 	icon = 'mods/species/tajaran/icons/markings.dmi'
-	species_allowed = list(SPECIES_TAJARAN)
+	species_allowed = list(/decl/species/tajaran::uid)
 	body_parts = list(BP_HEAD)
 	color_blend = ICON_MULTIPLY
 	uid = "acc_marking_taj_nose"

--- a/mods/species/tajaran/datum/species.dm
+++ b/mods/species/tajaran/datum/species.dm
@@ -13,7 +13,7 @@
 
 /decl/species/tajaran
 	uid = "species_tajaran"
-	name = SPECIES_TAJARAN
+	name = "Tajara"
 	name_plural = "Tajaran"
 	base_external_prosthetics_model = null
 

--- a/mods/species/tajaran/datum/species.dm
+++ b/mods/species/tajaran/datum/species.dm
@@ -12,6 +12,7 @@
 	)
 
 /decl/species/tajaran
+	uid = "species_tajaran"
 	name = SPECIES_TAJARAN
 	name_plural = "Tajaran"
 	base_external_prosthetics_model = null

--- a/mods/species/tritonian/_tritonian.dm
+++ b/mods/species/tritonian/_tritonian.dm
@@ -1,4 +1,2 @@
-#define SPECIES_TRITONIAN "Tritonian"
-
 /decl/modpack/tritonians
 	name = "Tritonian Species"

--- a/mods/species/tritonian/datum/species.dm
+++ b/mods/species/tritonian/datum/species.dm
@@ -1,4 +1,5 @@
 /decl/species/human/tritonian
+	uid = "species_tritonian"
 	name = SPECIES_TRITONIAN
 	name_plural = "Tritonians"
 	description = "A human-derived genotype designed for colonizing aquatic worlds."

--- a/mods/species/tritonian/datum/species.dm
+++ b/mods/species/tritonian/datum/species.dm
@@ -1,6 +1,6 @@
 /decl/species/human/tritonian
 	uid = "species_tritonian"
-	name = SPECIES_TRITONIAN
+	name = "Tritonian"
 	name_plural = "Tritonians"
 	description = "A human-derived genotype designed for colonizing aquatic worlds."
 

--- a/mods/species/unathi/_unathi.dm
+++ b/mods/species/unathi/_unathi.dm
@@ -1,4 +1,3 @@
-#define SPECIES_UNATHI "Unathi"
 #define LANGUAGE_LIZARD "Sinta'unathi"
 
 /decl/modpack/unathi
@@ -11,8 +10,8 @@
 
 /decl/modpack/unathi/pre_initialize()
 	..()
-	SSmodpacks.default_submap_whitelisted_species |= SPECIES_UNATHI
+	SSmodpacks.default_submap_whitelisted_species |= /decl/species/unathi::uid
 
-/mob/living/human/unathi/Initialize(mapload, species_name, datum/mob_snapshot/supplied_appearance)
-	species_name = SPECIES_UNATHI
+/mob/living/human/unathi/Initialize(mapload, species_uid, datum/mob_snapshot/supplied_appearance)
+	species_uid = /decl/species/unathi::uid
 	. = ..()

--- a/mods/species/unathi/datum/species.dm
+++ b/mods/species/unathi/datum/species.dm
@@ -16,6 +16,7 @@
 	skin_material = /decl/material/solid/organic/skin/lizard
 
 /decl/species/unathi
+	uid = "species_unathi"
 	name = SPECIES_UNATHI
 	name_plural = SPECIES_UNATHI
 	butchery_data = /decl/butchery_data/humanoid/unathi

--- a/mods/species/unathi/datum/species.dm
+++ b/mods/species/unathi/datum/species.dm
@@ -17,8 +17,8 @@
 
 /decl/species/unathi
 	uid = "species_unathi"
-	name = SPECIES_UNATHI
-	name_plural = SPECIES_UNATHI
+	name = "Unathi"
+	name_plural = "Unathi"
 	butchery_data = /decl/butchery_data/humanoid/unathi
 
 	available_bodytypes = list(

--- a/mods/species/unathi/datum/sprite_accessory.dm
+++ b/mods/species/unathi/datum/sprite_accessory.dm
@@ -2,7 +2,7 @@
 	name = "Lizard Horns"
 	icon = 'mods/species/unathi/icons/horns.dmi'
 	icon_state = "horns"
-	species_allowed = list(SPECIES_UNATHI)
+	species_allowed = list(/decl/species/unathi::uid)
 	color_blend = ICON_MULTIPLY
 	accessory_flags = HAIR_VERY_SHORT
 	uid = "acc_hair_una_horns"
@@ -71,7 +71,7 @@
 	name = "Lizard Frills Aqua"
 	icon = 'mods/species/unathi/icons/frills.dmi'
 	icon_state = "frills_aqua"
-	species_allowed = list(SPECIES_UNATHI)
+	species_allowed = list(/decl/species/unathi::uid)
 	color_blend = ICON_MULTIPLY
 	accessory_flags = HAIR_VERY_SHORT
 	uid = "acc_hair_una_aqua"

--- a/mods/species/utility_frames/_utility_frames.dm
+++ b/mods/species/utility_frames/_utility_frames.dm
@@ -1,5 +1,3 @@
-#define SPECIES_FRAME "Utility Frame"
-
 /decl/modpack/utility_frames
 	name = "Utility Frames"
 	dreams = list("a utility frame", "rogue machine servitors")

--- a/mods/species/utility_frames/markings.dm
+++ b/mods/species/utility_frames/markings.dm
@@ -2,7 +2,7 @@
 	name = "Frame Department Stripe"
 	icon_state = "single_stripe"
 	body_parts = list(BP_CHEST)
-	species_allowed = list(SPECIES_FRAME)
+	species_allowed = list(/decl/species/utility_frame::uid)
 	icon = 'mods/species/utility_frames/icons/markings.dmi'
 	color_blend = ICON_MULTIPLY
 	uid = "acc_marking_frame_stripe"

--- a/mods/species/utility_frames/species.dm
+++ b/mods/species/utility_frames/species.dm
@@ -10,6 +10,7 @@
 	)
 
 /decl/species/utility_frame
+	uid =                   "species_frame"
 	name =                  SPECIES_FRAME
 	name_plural =           "Utility Frames"
 	description =           "Simple AI-driven robots are used for many menial or repetitive tasks in human space."

--- a/mods/species/utility_frames/species.dm
+++ b/mods/species/utility_frames/species.dm
@@ -11,7 +11,7 @@
 
 /decl/species/utility_frame
 	uid =                   "species_frame"
-	name =                  SPECIES_FRAME
+	name =                  "Utility Frame"
 	name_plural =           "Utility Frames"
 	description =           "Simple AI-driven robots are used for many menial or repetitive tasks in human space."
 	cyborg_noun = null

--- a/mods/species/utility_frames/traits.dm
+++ b/mods/species/utility_frames/traits.dm
@@ -1,6 +1,6 @@
 /decl/trait/build_references()
 	. = ..()
-	LAZYDISTINCTADD(blocked_species, SPECIES_FRAME)
+	LAZYDISTINCTADD(blocked_species, /decl/species/utility_frame::uid)
 
 /decl/trait/utility_frame
 	abstract_type = /decl/trait/utility_frame
@@ -8,7 +8,7 @@
 /decl/trait/utility_frame/build_references()
 	. = ..()
 	blocked_species = null
-	permitted_species = list(SPECIES_FRAME)
+	permitted_species = list(/decl/species/utility_frame::uid)
 
 // Cosmetic/armour changes, different models of limb
 /decl/trait/utility_frame/customisation

--- a/mods/species/vox/_vox.dm
+++ b/mods/species/vox/_vox.dm
@@ -1,4 +1,3 @@
-#define SPECIES_VOX        "Vox"
 #define BODYTYPE_VOX       "reptoavian body"
 #define BODYTYPE_VOX_LARGE "large reptoavian body"
 #define BP_HINDTONGUE      "hindtongue"
@@ -10,10 +9,10 @@
 	credits_crew_names = list("THE VOX")
 	credits_topics = list("VOX RITUAL DUELS", "NECK MARKINGS", "ANCIENT SUPERCOMPUTERS")
 
-/mob/living/human/vox/Initialize(mapload, species_name, datum/mob_snapshot/supplied_appearance)
+/mob/living/human/vox/Initialize(mapload, species_uid, datum/mob_snapshot/supplied_appearance)
 	SET_HAIR_STYLE(src, /decl/sprite_accessory/hair/vox/short, TRUE)
 	SET_HAIR_COLOR(src, COLOR_BEASTY_BROWN, TRUE)
-	species_name = SPECIES_VOX
+	species_uid = /decl/species/vox::uid
 	. = ..()
 
 /datum/follow_holder/voxstack

--- a/mods/species/vox/datum/accessories.dm
+++ b/mods/species/vox/datum/accessories.dm
@@ -2,7 +2,7 @@
 	name = "Long Vox Quills"
 	icon = 'mods/species/vox/icons/body/soldier/hair.dmi'
 	icon_state = "vox_longquills"
-	species_allowed = list(SPECIES_VOX)
+	species_allowed = list(/decl/species/vox::uid)
 	uid = "acc_hair_vox_longquills"
 
 /decl/sprite_accessory/hair/vox/get_accessory_icon(obj/item/organ/external/organ)
@@ -30,7 +30,7 @@
 	name = "Vox Neck Markings"
 	icon_state = "neck_markings"
 	body_parts = list(BP_HEAD)
-	species_allowed = list(SPECIES_VOX)
+	species_allowed = list(/decl/species/vox::uid)
 	icon = 'mods/species/vox/icons/body/soldier/markings.dmi'
 	color_blend = ICON_MULTIPLY
 	uid = "acc_markings_vox_neck"

--- a/mods/species/vox/datum/species.dm
+++ b/mods/species/vox/datum/species.dm
@@ -21,8 +21,8 @@
 
 /decl/species/vox
 	uid = "species_vox"
-	name = SPECIES_VOX
-	name_plural = SPECIES_VOX
+	name = "Vox"
+	name_plural = "Vox"
 	base_external_prosthetics_model = /decl/bodytype/prosthetic/vox/crap
 
 	default_emotes = list(

--- a/mods/species/vox/datum/species.dm
+++ b/mods/species/vox/datum/species.dm
@@ -20,6 +20,7 @@
 	transfusion_fail_reagent = /decl/material/gas/ammonia
 
 /decl/species/vox
+	uid = "species_vox"
 	name = SPECIES_VOX
 	name_plural = SPECIES_VOX
 	base_external_prosthetics_model = /decl/bodytype/prosthetic/vox/crap

--- a/mods/species/vox/datum/species_bodytypes.dm
+++ b/mods/species/vox/datum/species_bodytypes.dm
@@ -147,6 +147,7 @@
 /decl/bodytype/vox/stanchion
 	name                = "stanchion voxform"
 	bodytype_category   = BODYTYPE_VOX_LARGE
+	// TODO: should the extra big guys really have the same bodytype equip flags as the little guys?
 	blood_overlays      = 'mods/species/vox/icons/body/stanchion/blood_overlays.dmi'
 	damage_overlays     = 'mods/species/vox/icons/body/stanchion/damage_overlays.dmi'
 	icon_base           = 'mods/species/vox/icons/body/stanchion/body.dmi'

--- a/mods/species/vox/datum/trader.dm
+++ b/mods/species/vox/datum/trader.dm
@@ -61,17 +61,17 @@
 
 /datum/trader/ship/vox/New()
 	speech[TRADER_HAIL_SILICON] = "Hello metal thing! You trade metal for things?"
-	speech[TRADER_HAIL_START + SPECIES_HUMAN] = "Hello hueman! Kiikikikiki! " + TRADER_TOKEN_MOB + " trade with us, yes? Good!"
-	visited_vox_speech[TRADER_HAIL_START + SPECIES_HUMAN] = "Friend of it is friend of all Shoal! " + TRADER_TOKEN_MOB + " you trade now!"
-	visited_vox_speech[TRADER_HAIL_START + SPECIES_VOX] = "SKREEEE! May the Shoal make this trade good, " + TRADER_TOKEN_MOB + "!"
+	speech[TRADER_HAIL_START + /decl/species/human::uid] = "Hello hueman! Kiikikikiki! " + TRADER_TOKEN_MOB + " trade with us, yes? Good!"
+	visited_vox_speech[TRADER_HAIL_START + /decl/species/human::uid] = "Friend of it is friend of all Shoal! " + TRADER_TOKEN_MOB + " you trade now!"
+	visited_vox_speech[TRADER_HAIL_START + /decl/species/vox::uid] = "SKREEEE! May the Shoal make this trade good, " + TRADER_TOKEN_MOB + "!"
 	..()
 
 /datum/trader/ship/vox/hail(var/mob/user)
 	if(ishuman(user))
 		var/mob/living/human/H = user
 		if(H.species)
-			switch(H.species.name)
-				if(SPECIES_VOX)
+			switch(H.species.uid)
+				if(/decl/species/vox::uid)
 					disposition = 1000
 					hailed_vox = TRUE
 					speech = visited_vox_speech
@@ -88,5 +88,5 @@
 		. *= 2
 
 /datum/trader/ship/clothingshop/New()
-	speech[TRADER_HAIL_START + SPECIES_VOX] = "Well hello, sir! I don't believe we have any clothes that fit you... but you can still look!"
+	speech[TRADER_HAIL_START + /decl/species/vox::uid] = "Well hello, sir! I don't believe we have any clothes that fit you... but you can still look!"
 	..()

--- a/mods/species/vox/datum/traits.dm
+++ b/mods/species/vox/datum/traits.dm
@@ -1,6 +1,6 @@
 /decl/trait/build_references()
 	. = ..()
-	LAZYDISTINCTADD(blocked_species, SPECIES_VOX)
+	LAZYDISTINCTADD(blocked_species, /decl/species/vox::uid)
 
 /decl/trait/vox
 	abstract_type = /decl/trait/vox
@@ -8,7 +8,7 @@
 /decl/trait/vox/build_references()
 	. = ..()
 	blocked_species = null
-	permitted_species = list(SPECIES_VOX)
+	permitted_species = list(/decl/species/vox::uid)
 
 // Bonuses or maluses to skills/checks/actions.
 /decl/trait/vox/psyche

--- a/mods/species/vox/gear/gun_slugsling.dm
+++ b/mods/species/vox/gear/gun_slugsling.dm
@@ -24,7 +24,7 @@
 		var/mob/living/L = AM
 		if(L.get_bodytype()?.bodytype_flag & BODY_EQUIP_FLAG_VOX)
 			return FALSE
-		if(L.faction == SPECIES_VOX)
+		if(L.faction == /mob/living/simple_animal/hostile/slug/vox::faction)
 			return FALSE
 		squish()
 
@@ -33,6 +33,9 @@
 	new /mob/living/simple_animal/hostile/slug(get_turf(src))
 	playsound(src.loc,'sound/effects/attackblob.ogg',100, 1)
 	qdel(src)
+
+/mob/living/simple_animal/hostile/slug/vox
+	faction = "Vox"
 
 //a slug sling basically launches a small egg that hatches (either on a person or on the floor), releasing a terrible blood thirsty monster.
 //Balanced due to the non-spammy nature of the gun, as well as the frailty of the creatures.

--- a/mods/species/vox/organs_vox.dm
+++ b/mods/species/vox/organs_vox.dm
@@ -185,7 +185,7 @@
 
 /obj/item/organ/internal/voxstack/get_examine_strings(mob/user, distance, infix, suffix)
 	. = ..()
-	var/user_vox = user.get_species_name() == SPECIES_VOX // TODO use bodytype flags instead so subspecies are included
+	var/user_vox = istype(user.get_species(), /decl/species/vox)
 	if (istype(backup))
 		var/owner_viable = find_dead_player(stored_ckey, TRUE)
 		if (user_vox)

--- a/mods/~compatibility/patches/heist_vox.dm
+++ b/mods/~compatibility/patches/heist_vox.dm
@@ -1,6 +1,6 @@
 /decl/special_role/raider/Initialize()
 	. = ..()
-	LAZYSET(outfits_per_species, SPECIES_VOX, /decl/outfit/vox_raider)
+	LAZYSET(outfits_per_species, /decl/species/vox::uid, /decl/outfit/vox_raider)
 
 // The following mirror is ~special~.
 /obj/structure/mirror/raider
@@ -15,7 +15,7 @@
 
 	var/decl/species/my_species = user?.get_species()
 	var/decl/special_role/raider/raiders = GET_DECL(/decl/special_role/raider)
-	if(!istype(user) || !user.mind || !raiders.is_antagonist(user.mind) || !my_species || my_species.name == SPECIES_VOX || !is_alien_whitelisted(user, SPECIES_VOX))
+	if(!istype(user) || !user.mind || !raiders.is_antagonist(user.mind) || !my_species || my_species.uid == /decl/species/vox::uid || !is_alien_whitelisted(user, /decl/species/vox::uid))
 		return ..()
 
 	var/choice = input("Do you wish to become a vox of the Shoal? This is not reversible.") as null|anything in list("No","Yes")
@@ -23,7 +23,7 @@
 		return TRUE
 
 	var/decl/outfit/outfit = GET_DECL(/decl/outfit/vox_raider)
-	var/mob/living/human/vox/vox = new(get_turf(src), SPECIES_VOX)
+	var/mob/living/human/vox/vox = new(get_turf(src), /decl/species/vox::uid)
 	outfit.equip_outfit(vox)
 	if(user.mind)
 		user.mind.transfer_to(vox)

--- a/nano/templates/appearance_changer.tmpl
+++ b/nano/templates/appearance_changer.tmpl
@@ -5,7 +5,7 @@
         </div>
         <div class="itemContentWide">
             {{for data.species}}
-                {{:helper.link(value.specimen, null, { 'race' : value.specimen}, null, data.specimen == value.specimen ? 'selected' : null)}}
+                {{:helper.link(value.name, null, { 'race' : value.uid}, null, data.current_species_uid == value.uid ? 'selected' : null)}}
             {{/for}}
         </div>
     </div>


### PR DESCRIPTION
## Description of changes
Makes species use uid instead of name.
I tested it in-game and also was pretty thorough with my code analysis, checking all the uses of `name` on species.
~~Aside from one instance where a skeleton stand wielding a surgical saw (no, really) showed up instead of my character in the character setup menu until I triggered a refresh, it was fine.~~ I had to revert the icon update queueing during init to fix that, it turns out it was just the most obvious manifestation of some pretty insidious ordering issues this brought to the surface. Oh well.

Also removes get_root_species_name and associated (unused) subspecies support. Whoever readds it, if they do, really needs to think through how it'd work with all the new systems and such and whether or not bodytypes would be more applicable.

Depends on #4876.

## Why and what will this PR improve
Decouples species name and species UID. Modernises species stuff overall, really. This is also a step towards things like runtime-created random/custom species, by choosing to use UID. (At some point, if we really want to commit to supporting that, we would need to replace all the species istypes with flags or dedicated vars, too.)