### PR TITLE
Fix plural name for kobaloi species

### DIFF
--- a/mods/content/fantasy/datum/kobaloi/species.dm
+++ b/mods/content/fantasy/datum/kobaloi/species.dm
@@ -1,5 +1,6 @@
 /decl/species/kobaloi
 	name                = SPECIES_KOBALOI
+	name_plural         = SPECIES_KOBALOI
 	spawn_flags         = SPECIES_CAN_JOIN
 	preview_outfit      = null
 	description         = "Kobaloi are small, scaled and furred creatures that usually dwell in the quiet places of the world, \


### PR DESCRIPTION
## Description of changes
Makes the pluralization of "kobaloi" just "kobaloi" rather than "kobalois".

## Why and what will this PR improve
Should be kobaloi, not kobalois.