### PR TITLE
Revert "Force update_icon calls prior to first SSicon_update flush to queue"

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -398,18 +398,13 @@
 
 /**
 	Update this atom's icon.
-	If prior to the first SSicon_update flush (i.e. it's during init), icon updates are forced to queue instead.
-	This saves a lot of init time.
 
 	- Events: `updated_icon`
 */
 /atom/proc/update_icon()
 	SHOULD_CALL_PARENT(TRUE)
-	if(SSicon_update.init_state == SS_INITSTATE_NONE)
-		queue_icon_update()
-	else
-		on_update_icon()
-		RAISE_EVENT(/decl/observ/updated_icon, src)
+	on_update_icon()
+	RAISE_EVENT(/decl/observ/updated_icon, src)
 
 /**
 	Update this atom's icon.


### PR DESCRIPTION
## Description of changes
Causes ordering issues with human sprites and a lot of other things. Should probably make a separate helper to allow stuff to opt into queueing before init/while under load/etc.

## Why and what will this PR improve
Removes the spooky saw-wielding skeleton haunting character setup.

## Changelog
:cl:
del: Removed the saw-wielding spooky skeleton haunting character setup. No, really. This isn't a joke. It was there and then I removed it.
/:cl: