### PR TITLE
Supply shuttle ignores non-dense obstacles.

### DIFF
--- a/code/controllers/subsystems/supply.dm
+++ b/code/controllers/subsystems/supply.dm
@@ -117,7 +117,7 @@ SUBSYSTEM_DEF(supply)
 				continue
 			var/occupied = 0
 			for(var/atom/A in T.contents)
-				if(!A.simulated)
+				if(!A.simulated || !A.density)
 					continue
 				occupied = 1
 				break


### PR DESCRIPTION
Fix is care of @Typhin, I am just committing it.

Cargo shuttle was picking up dirt and effect decals as obstacles to spawning cargo, ending up becoming unusable if dirt covers the entire shuttle bed.

Fixes #4769.