### PR TITLE
Fix hotplates failing to show the boiling overlay on pots

### DIFF
--- a/code/modules/food/cooking/cooking_vessels/pot.dm
+++ b/code/modules/food/cooking/cooking_vessels/pot.dm
@@ -25,16 +25,20 @@
 	. = ..()
 
 /obj/item/chems/cooking_vessel/pot/ProcessAtomTemperature()
+	var/prior_temperature = temperature
 	. = ..()
+	// to avoid issues with it cooling down in ..() and reheating the same tick, we use the highest of the two
+	// todo: just prevent the cooling instead, for a less-hacky solution
+	var/use_temperature = max(temperature, prior_temperature)
 
 	// Largely ignore return value so we don't skip this update on the final time we temperature process.
-	if(temperature != last_boil_temp)
+	if(use_temperature != last_boil_temp)
 
-		last_boil_temp = temperature
+		last_boil_temp = use_temperature
 		var/next_boil_status = FALSE
 		for(var/reagent_type in reagents?.reagent_volumes)
 			var/decl/material/reagent = GET_DECL(reagent_type)
-			if(!isnull(reagent.boiling_point) && temperature >= reagent.boiling_point)
+			if(!isnull(reagent.boiling_point) && use_temperature >= reagent.boiling_point)
 				next_boil_status = TRUE
 				break
 

--- a/code/modules/reagents/heat_sources/_heat_source.dm
+++ b/code/modules/reagents/heat_sources/_heat_source.dm
@@ -83,9 +83,8 @@
 
 		// Hackery to heat pots placed onto a hotplate without also grilling/baking stuff.
 		if(isturf(loc))
-			var/datum/gas_mixture/environment = loc.return_air()
 			for(var/obj/item/chems/cooking_vessel/pot in loc.get_contained_external_atoms())
-				pot.fire_act(environment, temperature, 500)
+				pot.handle_external_heating(temperature, src)
 
 		return TRUE // Don't kill this processing loop unless we're not powered.
 	. = ..()


### PR DESCRIPTION
## Description of changes
Makes hotplates use handle_external_heating directly rather than fire_act, so that their manual heating coefficient is applied, which should speed heating up ~6x.
Also makes the boiling overlay check the temperature pre- and post-parent-call and use the highest, meaning briefly dropping under the boiling temperature due to cooling in `..()` and then back up the next tick (in time for pot `Process()` to handle cooking) won't make the boiling overlay fail to show. Basically as long as it's hot enough to boil either before or after the parent call, we'll show the overlay. This means it'll show for a tick longer while cooling down but that's not a big deal compared to "never showing if it's just on the edge".

## Why and what will this PR improve
Fixes #4801.