### PR TITLE
Fix the skybox becoming blank after a full HUD reset

### DIFF
--- a/code/_onclick/hud/hud.dm
+++ b/code/_onclick/hud/hud.dm
@@ -15,7 +15,6 @@
 		hud_used = new hud_type(src)
 	else
 		hud_used = new /datum/hud(src)
-	refresh_lighting_master()
 
 /datum/hud
 	var/mob/mymob

--- a/code/modules/mob/login.dm
+++ b/code/modules/mob/login.dm
@@ -90,8 +90,6 @@
 
 	hud_reset(TRUE)
 
-	client.update_skybox(1)
-
 	if(istype(machine))
 		machine.on_user_login(src)
 
@@ -103,9 +101,9 @@
 		client.screen = list()	//remove hud items just in case
 		client.set_right_click_menu_mode(shift_to_open_context_menu)
 		InitializeHud()
-	else
-		refresh_lighting_master()
 
+	refresh_lighting_master()
+	client.update_skybox(full_reset) // readd to client.screen if we cleared it
 	refresh_client_images()
 	reload_fullscreen() // Reload any fullscreen overlays this mob has.
 	add_click_catcher()


### PR DESCRIPTION
## Description of changes
Does a skybox rebuild after `hud_reset(TRUE)`.

## Why and what will this PR improve
We had random issues with mobs losing their skybox for a while. This was apparently caused by full HUD resets not doing a skybox rebuild after which meant it wasn't in `client.screen`. Full HUD resets are caused by, among other things, `set_species()` and `change_species()`. If either were called on a mob that already had a client it would break the skybox, which is particularly an issue for antags/admin intervention, and it would remain that way until the mob changes Z-level.