### PR TITLE
Fix dev-branch bugs

### DIFF
--- a/code/_onclick/hud/screen/screen_drop.dm
+++ b/code/_onclick/hud/screen/screen_drop.dm
@@ -2,6 +2,8 @@
 	name       = "drop"
 	icon_state = "act_drop"
 	screen_loc = ui_drop_throw
+	use_supplied_ui_color = TRUE
+	use_supplied_ui_alpha = TRUE
 
 /obj/screen/drop/handle_click(mob/user, params)
 	if(user.client)

--- a/code/_onclick/hud/screen/screen_equip.dm
+++ b/code/_onclick/hud/screen/screen_equip.dm
@@ -1,6 +1,8 @@
 /obj/screen/equip
 	name       = "equip"
 	icon_state = "act_equip"
+	use_supplied_ui_color = TRUE
+	use_supplied_ui_alpha = TRUE
 
 /obj/screen/equip/handle_click(mob/user, params)
 	if(ishuman(user))

--- a/code/_onclick/hud/screen/screen_gun.dm
+++ b/code/_onclick/hud/screen/screen_gun.dm
@@ -2,6 +2,8 @@
 	icon = 'icons/mob/screen/styles/midnight/fire_intent.dmi'
 	dir = SOUTH
 	abstract_type = /obj/screen/gun
+	use_supplied_ui_color = TRUE
+	use_supplied_ui_alpha = TRUE
 	var/base_icon_state
 	var/toggle_flag
 

--- a/code/_onclick/hud/screen/screen_maneuver.dm
+++ b/code/_onclick/hud/screen/screen_maneuver.dm
@@ -2,6 +2,8 @@
 	name = "Prepare Maneuver"
 	icon_state = "maneuver_off"
 	screen_loc = ui_pull_resist
+	use_supplied_ui_color = TRUE
+	use_supplied_ui_alpha = TRUE
 
 /obj/screen/maneuver/handle_click(mob/user, params)
 	if(isliving(user))

--- a/code/_onclick/hud/screen/screen_resist.dm
+++ b/code/_onclick/hud/screen/screen_resist.dm
@@ -2,6 +2,8 @@
 	name       = "resist"
 	icon_state = "act_resist"
 	screen_loc = ui_pull_resist
+	use_supplied_ui_color = TRUE
+	use_supplied_ui_alpha = TRUE
 
 /obj/screen/resist/handle_click(mob/user, params)
 	if(isliving(user))

--- a/code/_onclick/hud/screen/screen_throw.dm
+++ b/code/_onclick/hud/screen/screen_throw.dm
@@ -2,6 +2,8 @@
 	name = "throw"
 	icon_state = "act_throw_off"
 	screen_loc = ui_drop_throw
+	use_supplied_ui_color = TRUE
+	use_supplied_ui_alpha = TRUE
 
 /obj/screen/throw_toggle/handle_click(mob/user, params)
 	if(!user.stat && isturf(user.loc) && !user.restrained())

--- a/code/_onclick/hud/screen/screen_toggle.dm
+++ b/code/_onclick/hud/screen/screen_toggle.dm
@@ -2,6 +2,8 @@
 	name = "toggle"
 	icon_state = "other"
 	screen_loc = ui_inventory
+	use_supplied_ui_color = TRUE
+	use_supplied_ui_alpha = TRUE
 
 /obj/screen/toggle/handle_click(mob/user, params)
 	if(!user.hud_used)

--- a/code/_onclick/hud/screen/screen_zone_selector.dm
+++ b/code/_onclick/hud/screen/screen_zone_selector.dm
@@ -2,6 +2,8 @@
 	name = "damage zone"
 	icon_state = "zone_sel_tail"
 	screen_loc = ui_zonesel
+	use_supplied_ui_color = TRUE
+	use_supplied_ui_alpha = TRUE
 
 /obj/screen/zone_selector/handle_click(mob/user, params)
 	var/list/PL = params2list(params)

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -412,6 +412,16 @@
 		raise_event_non_global(/decl/observ/updated_icon)
 
 /**
+ * Update this atom's icon.
+ * If prior to SSicon_update's first flush, queues.
+ * Otherwise, updates instantly.
+ */
+/atom/proc/lazy_update_icon()
+	if(SSicon_update.init_state != SS_INITSTATE_NONE)
+		return update_icon()
+	queue_icon_update()
+
+/**
 	Update this atom's icon.
 
 	Usually queue_icon_update() or update_icon() should be used instead.

--- a/code/game/machinery/_machines_base/stock_parts/_stock_parts.dm
+++ b/code/game/machinery/_machines_base/stock_parts/_stock_parts.dm
@@ -86,7 +86,12 @@
 		if(ELECTROCUTE)
 			cause = "sparks"
 	visible_message(SPAN_WARNING("Something [cause] inside \the [machine]."), range = 2)
-	SetName("broken [name]")
+	update_name()
+
+/obj/item/stock_parts/update_name()
+	. = ..()
+	if(!is_functional())
+		SetName("broken [name]") // prepend 'broken' to the results
 
 /obj/item/stock_parts/proc/is_functional()
 	return (!can_take_damage()) || (current_health > 0)

--- a/code/game/objects/effects/misc.dm
+++ b/code/game/objects/effects/misc.dm
@@ -30,12 +30,12 @@
 	if(istype(wall))
 		wall.paint_color = color
 		wall.stripe_color = color
-		wall.update_icon()
+		wall.lazy_update_icon()
 	var/obj/structure/wall_frame/WF = locate() in loc
 	if(WF)
 		WF.paint_color = color
 		WF.stripe_color = color
-		WF.update_icon()
+		WF.lazy_update_icon()
 	qdel(src)
 
 /obj/effect/paint/pink

--- a/code/game/objects/items/__item.dm
+++ b/code/game/objects/items/__item.dm
@@ -1118,7 +1118,7 @@ modules/mob/living/human/life.dm if you die, you will be zoomed out.
 	for(var/equipped_slot in get_associated_equipment_slots())
 		wearer.update_equipment_overlay(equipped_slot, FALSE)
 	if(do_update_icon)
-		wearer.update_icon()
+		wearer.lazy_update_icon()
 	return TRUE
 
 /obj/item/proc/reconsider_client_screen_presence(var/client/client, var/slot)

--- a/code/game/objects/items/weapons/tanks/tanks.dm
+++ b/code/game/objects/items/weapons/tanks/tanks.dm
@@ -177,9 +177,6 @@ var/global/list/global/tank_gauge_cache = list()
 		if(wired)
 			to_chat(user, "<span class='notice'>You begin attaching the assembly to \the [src].</span>")
 			if(do_after(user, 50, src))
-				to_chat(user, "<span class='notice'>You finish attaching the assembly to \the [src].</span>")
-				global.bombers += "[key_name(user)] attached an assembly to a wired [src]. Temp: [air_contents.temperature-T0C]"
-				log_and_message_admins("attached an assembly to a wired [src]. Temp: [air_contents.temperature-T0C]", user)
 				assemble_bomb(used_item,user)
 			else
 				to_chat(user, "<span class='notice'>You stop attaching the assembly.</span>")
@@ -550,23 +547,26 @@ var/global/list/global/tank_gauge_cache = list()
 /obj/item/tankassemblyproxy/receive_signal()	//This is mainly called by the sensor through sense() to the holder, and from the holder to here.
 	tank.cause_explosion()	//boom (or not boom if you made shijwtty mix)
 
-/obj/item/tank/proc/assemble_bomb(used_item,user)	//Bomb assembly proc. This turns assembly+tank into a bomb
+/obj/item/tank/proc/assemble_bomb(used_item,mob/user)	//Bomb assembly proc. This turns assembly+tank into a bomb
 	var/obj/item/assembly_holder/S = used_item
-	var/mob/M = user
-	if(!S.secured)										//Check if the assembly is secured
-		return
 	if(isigniter(S.a_left) == isigniter(S.a_right))		//Check if either part of the assembly has an igniter, but if both parts are igniters, then fuck it
 		return
+	if(!S.secured)										//Check if the assembly is secured
+		to_chat(user, SPAN_NOTICE("\The [S] must be secured before attaching it to \the [src]!"))
+		return
 
-	if(!M.try_unequip(src))
+	if(!user.try_unequip(src))
 		return					//Remove the tank from your character,in case you were holding it
-	M.put_in_hands(src)			//Equips the bomb if possible, or puts it on the floor.
+	user.put_in_hands(src)			//Equips the bomb if possible, or puts it on the floor.
 
 	proxyassembly.assembly = S	//Tell the bomb about its assembly part
 	S.master = proxyassembly	//Tell the assembly about its new owner
-	S.forceMove(src)			//Move the assembly
+	user.remove_from_mob(S, src, FALSE) //Move the assembly and reset HUD layer/plane status
 
 	update_icon()
+	to_chat(user, "<span class='notice'>You finish attaching the assembly to \the [src].</span>")
+	global.bombers += "[key_name(user)] attached an assembly to a wired [src]. Temp: [air_contents.temperature-T0C]"
+	log_and_message_admins("attached an assembly to a wired [src]. Temp: [air_contents.temperature-T0C]", user)
 
 /obj/item/tank/proc/cause_explosion()	//This happens when a bomb is told to explode
 	var/obj/item/assembly_holder/assy = proxyassembly.assembly

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -9,7 +9,7 @@
 	var/rigged = 0
 
 /obj/structure/closet/crate/open(mob/user)
-	if((atom_flags & ATOM_FLAG_CLIMBABLE) && !opened && can_open(user))
+	if((atom_flags & ATOM_FLAG_CLIMBABLE) && LAZYLEN(climbers) && !opened && can_open(user))
 		object_shaken()
 	. = ..()
 	if(.)

--- a/code/game/turfs/floors/_floor.dm
+++ b/code/game/turfs/floors/_floor.dm
@@ -46,16 +46,9 @@
 	fill_to_zero_height() // try to refill turfs that act as fluid sources
 
 	if(floor_material || get_topmost_flooring())
-		update_from_flooring()
-		if(!ml)
-			for(var/direction in global.alldirs)
-				var/turf/target_turf = get_step_resolving_mimic(src, direction)
-				if(istype(target_turf))
-					if(TICK_CHECK) // not CHECK_TICK -- only queue if the server is overloaded
-						target_turf.queue_icon_update()
-					else
-						target_turf.update_icon()
-			update_icon()
+		update_from_flooring(skip_update = ml)
+		if(ml) // We skipped the update above to avoid updating our neighbors, but we need to update ourselves.
+			lazy_update_icon()
 
 
 /turf/floor/ChangeTurf(turf/N, tell_universe, force_lighting_update, keep_air, update_open_turfs_above, keep_height)

--- a/code/game/turfs/floors/floor_layers.dm
+++ b/code/game/turfs/floors/floor_layers.dm
@@ -250,8 +250,8 @@
 		qdel(print)
 
 	if(!skip_update)
-		update_icon()
+		lazy_update_icon()
 		for(var/dir in global.alldirs)
 			var/turf/neighbor = get_step_resolving_mimic(src, dir)
 			if(istype(neighbor))
-				neighbor.update_icon()
+				neighbor.lazy_update_icon()

--- a/code/game/turfs/walls/wall_icon.dm
+++ b/code/game/turfs/walls/wall_icon.dm
@@ -30,11 +30,11 @@
 				wall.other_connections = null
 				iterate_turfs += wall
 		for(var/turf/wall/wall as anything in iterate_turfs)
-			wall.update_icon()
+			wall.lazy_update_icon()
 	else
 		wall_connections = null
 		other_connections = null
-	update_icon()
+	lazy_update_icon()
 
 /turf/wall/proc/paint_wall(var/new_paint_color)
 	paint_color = new_paint_color

--- a/code/modules/admin/verbs/grief_fixers.dm
+++ b/code/modules/admin/verbs/grief_fixers.dm
@@ -13,9 +13,10 @@
 	sleep(10)
 	var/current_time = world.timeofday
 
-	var/list/steps = sortTim(decls_repository.get_decls_of_subtype_unassociated(/decl/atmos_grief_fix_step), /proc/cmp_decl_sort_value_asc)
+	var/list/steps = decls_repository.get_decls_of_subtype_unassociated(/decl/atmos_grief_fix_step)
+	steps = sortTim(steps.Copy(), /proc/cmp_decl_sort_value_asc)
 	var/step_count = length(steps)
-	for(var/step_index in 1 to length(step_count))
+	for(var/step_index in 1 to step_count)
 		var/decl/atmos_grief_fix_step/fix_step = steps[step_index]
 		to_chat(usr, "\[[step_index]/[step_count]\] - [fix_step.name].")
 		fix_step.act()

--- a/code/modules/multiz/level_data.dm
+++ b/code/modules/multiz/level_data.dm
@@ -224,7 +224,7 @@
 		return
 	var/area/A = change_area ? get_base_area_instance() : null
 	// We don't have to worry about the edge turfs because those are handled in build_border().
-	for(var/turf/T as anything in block(level_inner_min_x, level_inner_min_y, level_z, level_inner_max_x, level_inner_max_y, level_z))
+	for(var/turf/T as anything in Z_ALL_TURFS(level_z))
 		if(change_turf)
 			T = T.ChangeTurf(picked_turf)
 		if(change_area)

--- a/code/modules/nano/nanoui.dm
+++ b/code/modules/nano/nanoui.dm
@@ -520,7 +520,7 @@ nanoui is used to open and update nano browser uis
 			set_map_z_level(map_z)
 			map_update = 1
 
-	if ((src_object && src_object.Topic(href, href_list, state)) || map_update)
+	if (src_object && (src_object.Topic(href, href_list, state) || map_update))
 		SSnano.update_uis(src_object) // update all UIs attached to src_object
 
  /**


### PR DESCRIPTION
Fixes #4933 
Fixes #4908 
Fixes #4922 (maybe)
Fixes runtime-generated Z levels being empty (oops)
Fixes crates shaking excessively when opened
Fixes certain UI elements not having colors
Makes certain safe icon updates use the lazy-queueing we previously applied universally
Fixes the atmos grief fixer verb