### PR TITLE
A minor item.dm refactor and also pill bottle labeling.

### DIFF
--- a/code/game/objects/items/__item.dm
+++ b/code/game/objects/items/__item.dm
@@ -129,6 +129,7 @@
 	var/unwieldsound = 'sound/foley/tooldrop1.ogg'
 
 	var/base_name
+	var/base_desc
 
 	/// Can this object leak into water sources?
 	var/watertight = FALSE
@@ -196,6 +197,7 @@
 /obj/item/Initialize(var/ml, var/material_key)
 
 	base_name ||= name
+	base_desc ||= desc
 
 	if(isnull(current_health))
 		current_health = max_health //Make sure to propagate max_health to health var before material setup, for consistency

--- a/code/modules/clothing/gloves/jewelry/rings/_ring.dm
+++ b/code/modules/clothing/gloves/jewelry/rings/_ring.dm
@@ -11,12 +11,6 @@
 	var/can_fit_under_gloves = TRUE
 	var/can_inscribe         = TRUE
 	var/inscription
-	var/base_desc
-
-/obj/item/clothing/gloves/ring/Initialize()
-	if(desc)
-		base_desc = desc
-	. = ..()
 
 /obj/item/clothing/gloves/ring/get_decoration_icon(default_icon, obj/item/thing, on_mob = FALSE)
 	if(!on_mob && istype(thing, /obj/item/gemstone))

--- a/code/modules/posters/_poster.dm
+++ b/code/modules/posters/_poster.dm
@@ -130,9 +130,6 @@
 	_base_attack_force = 0
 	material = /decl/material/solid/organic/paper
 
-	///The description for the item/medium without any reference to the design.
-	//var/base_desc = "The poster comes with its own automatic adhesive mechanism, for easy pinning to any vertical surface."
-
 	///Type path to the /decl for the design on this poster. At runtime is changed for a reference to the decl
 	var/decl/poster_design/poster_design
 

--- a/code/modules/posters/_poster.dm
+++ b/code/modules/posters/_poster.dm
@@ -129,14 +129,17 @@
 	icon_state = "rolled_poster"
 	_base_attack_force = 0
 	material = /decl/material/solid/organic/paper
+
 	///The description for the item/medium without any reference to the design.
-	var/base_desc = "The poster comes with its own automatic adhesive mechanism, for easy pinning to any vertical surface."
+	//var/base_desc = "The poster comes with its own automatic adhesive mechanism, for easy pinning to any vertical surface."
+
 	///Type path to the /decl for the design on this poster. At runtime is changed for a reference to the decl
 	var/decl/poster_design/poster_design
 
 /obj/item/poster/Initialize(ml, material_key, var/given_poster_type = null)
 	//Init design
 	base_name ||= name
+	base_desc ||= desc
 	set_design(given_poster_type || poster_design || pick(decls_repository.get_decl_paths_of_subtype(/decl/poster_design)))
 	return ..(ml, material_key)
 

--- a/code/modules/posters/_poster.dm
+++ b/code/modules/posters/_poster.dm
@@ -135,10 +135,9 @@
 
 /obj/item/poster/Initialize(ml, material_key, var/given_poster_type = null)
 	//Init design
-	base_name ||= name
-	base_desc ||= desc
+	. = ..(ml, material_key)
 	set_design(given_poster_type || poster_design || pick(decls_repository.get_decl_paths_of_subtype(/decl/poster_design)))
-	return ..(ml, material_key)
+	return .
 
 /obj/item/poster/proc/set_design(var/decl/poster_design/_design_path)
 	if(ispath(_design_path, /decl))

--- a/code/modules/posters/_poster.dm
+++ b/code/modules/posters/_poster.dm
@@ -137,7 +137,6 @@
 	//Init design
 	. = ..(ml, material_key)
 	set_design(given_poster_type || poster_design || pick(decls_repository.get_decl_paths_of_subtype(/decl/poster_design)))
-	return .
 
 /obj/item/poster/proc/set_design(var/decl/poster_design/_design_path)
 	if(ispath(_design_path, /decl))

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -9,7 +9,6 @@
 	abstract_type = /obj/item/chems
 	watertight = TRUE
 
-	var/base_desc
 	var/amount_per_transfer_from_this = 5
 	var/possible_transfer_amounts = @"[5,10,15,25,30]"
 	var/volume = 30

--- a/code/modules/reagents/storage/pill_bottle.dm
+++ b/code/modules/reagents/storage/pill_bottle.dm
@@ -66,24 +66,11 @@
 	if(wrapper_color)
 		add_overlay(overlay_image(icon, "pillbottle_wrap", wrapper_color, RESET_COLOR))
 
-/obj/item/pill_bottle/proc/update_name_label()
-	if(!labeled_name)
-		name = base_name
-		desc = base_desc
-		return
-	else if(length(labeled_name) > 10)
-		var/short_label_name = copytext(labeled_name, 1, 11)
-		name = "[base_name] ([short_label_name]...)"
-	else
-		name = "[base_name] ([labeled_name])"
-	desc = "[base_desc] It is labeled \"[labeled_name]\"."
-
 /obj/item/pill_bottle/attackby(obj/item/used_item, mob/user)
 	if(IS_PEN(used_item))
-		var/decl/tool_archetype/pen/parch = GET_DECL(TOOL_PEN)
-
 		var/tmp_label = sanitize_safe(input(user, "Enter a label for [name]", "Label", labeled_name), MAX_NAME_LEN)
 		tmp_label = user.handle_writing_literacy(user, tmp_label)
+
 		var/label_length = length(tmp_label)
 		if(label_length > 50)
 			to_chat(user, "<span class='notice'>The label can be at most 50 characters long.</span>")
@@ -92,9 +79,13 @@
 				to_chat(user, "<span class='notice'>You set the label.</span>")
 			else
 				to_chat(user, "<span class='notice'>You set the label to \"[tmp_label]\".</span>")
+
+			var/decl/tool_archetype/pen/parch = GET_DECL(TOOL_PEN)
 			if(parch.decrement_uses(user, used_item, max(round(label_length / 25, 1), 1)) <= 0)
 				parch.warn_out_of_ink(user, used_item)
-			labeled_name = tmp_label
-			update_name_label()
+
+			var/datum/extension/labels/lext = get_or_create_extension(src, /datum/extension/labels)
+			lext.RemoveAllLabels()
+			attach_label(null, null, tmp_label)
 		return TRUE
 	return ..()

--- a/code/modules/reagents/storage/pill_bottle.dm
+++ b/code/modules/reagents/storage/pill_bottle.dm
@@ -78,17 +78,22 @@
 		name = "[base_name] ([labeled_name])"
 	desc = "[base_desc] It is labeled \"[labeled_name]\"."
 
-/obj/item/pill_bottle/attackby(obj/item/W, mob/user)
-	if(istype(W, /obj/item/pen) || istype(W, /obj/item/flashlight/pen))
+/obj/item/pill_bottle/attackby(obj/item/used_item, mob/user)
+	if(IS_PEN(used_item))
+		var/decl/tool_archetype/pen/parch = GET_DECL(TOOL_PEN)
+
 		var/tmp_label = sanitize_safe(input(user, "Enter a label for [name]", "Label", labeled_name), MAX_NAME_LEN)
-		if(length(tmp_label) > 50)
+		tmp_label = user.handle_writing_literacy(user, tmp_label)
+		var/label_length = length(tmp_label)
+		if(label_length > 50)
 			to_chat(user, "<span class='notice'>The label can be at most 50 characters long.</span>")
-		else if(length(tmp_label) > 10)
-			to_chat(user, "<span class='notice'>You set the label.</span>")
-			labeled_name = tmp_label
-			update_name_label()
-		else
-			to_chat(user, "<span class='notice'>You set the label to \"[tmp_label]\".</span>")
+		else 
+			if(label_length > 10)
+				to_chat(user, "<span class='notice'>You set the label.</span>")
+			else
+				to_chat(user, "<span class='notice'>You set the label to \"[tmp_label]\".</span>")
+			if(parch.decrement_uses(user, used_item, max(round(label_length / 25, 1), 1)) <= 0)
+				parch.warn_out_of_ink(user, used_item)
 			labeled_name = tmp_label
 			update_name_label()
 		return TRUE

--- a/code/modules/reagents/storage/pill_bottle.dm
+++ b/code/modules/reagents/storage/pill_bottle.dm
@@ -65,3 +65,31 @@
 	. = ..()
 	if(wrapper_color)
 		add_overlay(overlay_image(icon, "pillbottle_wrap", wrapper_color, RESET_COLOR))
+
+/obj/item/pill_bottle/proc/update_name_label()
+	if(!labeled_name)
+		name = base_name
+		desc = base_desc
+		return
+	else if(length(labeled_name) > 10)
+		var/short_label_name = copytext(labeled_name, 1, 11)
+		name = "[base_name] ([short_label_name]...)"
+	else
+		name = "[base_name] ([labeled_name])"
+	desc = "[base_desc] It is labeled \"[labeled_name]\"."
+
+/obj/item/pill_bottle/attackby(obj/item/W, mob/user)
+	if(istype(W, /obj/item/pen) || istype(W, /obj/item/flashlight/pen))
+		var/tmp_label = sanitize_safe(input(user, "Enter a label for [name]", "Label", labeled_name), MAX_NAME_LEN)
+		if(length(tmp_label) > 50)
+			to_chat(user, "<span class='notice'>The label can be at most 50 characters long.</span>")
+		else if(length(tmp_label) > 10)
+			to_chat(user, "<span class='notice'>You set the label.</span>")
+			labeled_name = tmp_label
+			update_name_label()
+		else
+			to_chat(user, "<span class='notice'>You set the label to \"[tmp_label]\".</span>")
+			labeled_name = tmp_label
+			update_name_label()
+		return TRUE
+	return ..()


### PR DESCRIPTION
<!-- !! PLEASE, READ THIS !! -->
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/NebulaSS13/Nebula/blob/dev/CONTRIBUTING.md -->
<!-- If you're opening a pull request which changes A LOT of icon/map files: -->
<!-- Add [IDB IGNORE] (to ignore icon file changes) or [MDB IGNORE] (to ignore map file changes) in the PR title. -->
<!-- These tags prevent huge diffs from overloading IconDiffBot and MapDiffBot. -->

## Description of changes
While implementing pill bottle labeling, I noticed that the property `base_desc` (for storing what the original description is for items whose descriptions are frequently modified) had been implemented in multiple separate locations in the code, and decided I would rather refactor that into the base `_item.dm` class rather than continue to add redundant implementations of the same property, so I did.

## Why and what will this PR improve
You can now write on pill bottles with pens and such. It's an exact copy paste of the code from Polaris and works fine, and the relevant functionality for posters and rings should be unaffected as well. Future items that have descriptions that can change will be able to just reference `base_desc` like they can reference the `base_name` that currently exists.

## Authorship
Myself.

## Changelog
:cl:
add: Writing on pill bottles
refactor: Refactored base_desc into item base class
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->