### PR TITLE
Fix savefile, footprints, and ambient lighting bugs

### DIFF
--- a/code/datums/daycycle/time_of_day.dm
+++ b/code/datums/daycycle/time_of_day.dm
@@ -24,7 +24,7 @@
 	name = "daytime"
 	announcement = "The sun rises over the horizon, beginning another day."
 	period = 0.4
-	power = 1
+	power = 0.8
 	color = COLOR_DAYLIGHT
 
 /datum/daycycle_period/sunset

--- a/code/game/turfs/flooring/flooring_mud.dm
+++ b/code/game/turfs/flooring/flooring_mud.dm
@@ -28,7 +28,7 @@
 	walker.add_walking_contaminant(force_material.type, rand(2,3))
 
 /decl/flooring/mud/can_show_coating_footprints(turf/target, decl/material/contaminant)
-	if(force_material.type == contaminant) // So we don't end up covered in a million footsteps that we provided.
+	if(force_material == contaminant) // So we don't end up covered in a million footsteps that we provided.
 		return FALSE
 	return ..()
 

--- a/code/game/turfs/flooring/flooring_snow.dm
+++ b/code/game/turfs/flooring/flooring_snow.dm
@@ -41,7 +41,7 @@
 	walker.add_walking_contaminant(force_material.type, rand(1, 2))
 
 /decl/flooring/snow/can_show_coating_footprints(turf/target, decl/material/contaminant)
-	if(force_material.type == contaminant) // So we don't end up covered in a million footsteps that we provided.
+	if(force_material == contaminant) // So we don't end up covered in a million footsteps that we provided.
 		return FALSE
 	return ..()
 

--- a/code/game/turfs/floors/floor_layers.dm
+++ b/code/game/turfs/floors/floor_layers.dm
@@ -5,16 +5,13 @@
 
 /turf/floor/proc/get_all_flooring()
 	. = list()
-	if(istype(_flooring))
-		. += _flooring
-	else if(ispath(_flooring))
-		. += GET_DECL(_flooring)
-	else if(islist(_flooring))
-		for(var/floor in _flooring)
-			if(ispath(floor))
-				_flooring += GET_DECL(floor)
-			else if(istype(floor, /decl/flooring))
-				_flooring += floor
+	if(_flooring)
+		if(islist(_flooring))
+			for(var/floor in _flooring)
+				. += RESOLVE_TO_DECL(floor)
+			_flooring = . // ensure the list elements are resolved
+		else
+			. += RESOLVE_TO_DECL(_flooring)
 	if(_base_flooring)
 		. += get_base_flooring()
 
@@ -22,15 +19,11 @@
 	return !isnull(_flooring)
 
 /turf/floor/proc/set_base_flooring(new_base_flooring, skip_update)
-	if(ispath(new_base_flooring, /decl/flooring))
-		new_base_flooring = GET_DECL(new_base_flooring)
-	else if(!istype(new_base_flooring, /decl/flooring))
-		new_base_flooring = null
+	// We can never have a null base flooring.
+	new_base_flooring = RESOLVE_TO_DECL(new_base_flooring || initial(_base_flooring) || /decl/flooring/plating)
 	if(_base_flooring == new_base_flooring)
 		return
 	_base_flooring = new_base_flooring
-	if(!_base_flooring) // We can never have a null base flooring.
-		_base_flooring = GET_DECL(initial(_base_flooring)) || GET_DECL(/decl/flooring/plating)
 	update_from_flooring(skip_update)
 
 /turf/floor/proc/get_base_flooring()
@@ -43,15 +36,14 @@
 	RETURN_TYPE(/decl/flooring)
 
 	if(isnull(_topmost_flooring))
-		var/flooring_length = length(_flooring)
-		if(flooring_length) // no need to check islist, length is only nonzero for lists and strings, and strings are invalid here
-			_topmost_flooring = _flooring[flooring_length]
-		else if(istype(_flooring, /decl/flooring))
-			_topmost_flooring = _flooring
-		else if(ispath(_flooring, /decl/flooring))
-			_topmost_flooring = GET_DECL(_flooring)
-		else
+		if(isnull(_flooring))
 			_topmost_flooring = FALSE
+		else
+			var/flooring_length = length(_flooring)
+			if(flooring_length) // no need to check islist, length is only nonzero for lists and strings, and strings are invalid here
+				_topmost_flooring = RESOLVE_TO_DECL(_flooring[flooring_length])
+			else
+				_topmost_flooring = RESOLVE_TO_DECL(_flooring)
 	return _topmost_flooring || get_base_flooring()
 
 /turf/floor/proc/clear_flooring(skip_update = FALSE, place_product)
@@ -81,8 +73,7 @@
 		return
 
 	// Validate our input.
-	if(ispath(flooring))
-		flooring = GET_DECL(flooring)
+	flooring = RESOLVE_TO_DECL(flooring)
 	if(!istype(flooring))
 		return
 
@@ -145,14 +136,9 @@
 		if(islist(newflooring))
 			_flooring = list()
 			for(var/floor in UNLINT(newflooring))
-				if(ispath(floor))
-					floor = GET_DECL(floor)
-				if(istype(floor, /decl/flooring))
-					_flooring += floor
-		else if(ispath(newflooring))
-			_flooring = GET_DECL(newflooring)
-		else if(istype(newflooring))
-			_flooring = newflooring
+				_flooring += RESOLVE_TO_DECL(floor)
+		else if(newflooring)
+			_flooring = RESOLVE_TO_DECL(newflooring)
 		else
 			return FALSE
 
@@ -184,9 +170,8 @@
 		return
 
 	// We only want to work with references.
-	if(ispath(newflooring, /decl/flooring))
-		newflooring = GET_DECL(newflooring)
-	else if(!istype(newflooring, /decl/flooring))
+	newflooring = RESOLVE_TO_DECL(newflooring)
+	if(!newflooring)
 		return FALSE
 
 	// Check if the layer is already present.

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -864,7 +864,7 @@
 	if(IS_HOE(held) && can_dig_farm(held.material?.hardness))
 		LAZYADD(., /decl/interaction_handler/dig/farm)
 
-/// Contaminant may be the chemical type of the footprint being provided,
+/// Contaminant may be the chemical decl of the footprint being provided,
 /// or null if we just want to know if we support footprints, at all, ever.
 /turf/proc/can_show_coating_footprints(decl/material/contaminant)
 	return simulated

--- a/code/modules/client/preference_setup/background/01_species.dm
+++ b/code/modules/client/preference_setup/background/01_species.dm
@@ -19,7 +19,7 @@
 	writer.write("species", pref.species)
 
 /datum/category_item/player_setup_item/background/species/preload_character(datum/pref_record_reader/R)
-	var/decl/species/loaded_species = decls_repository.get_decl_by_id_or_var(R.read("species"), /decl/spawnpoint)
+	var/decl/species/loaded_species = decls_repository.get_decl_by_id_or_var(R.read("species"), /decl/species)
 	pref.species = loaded_species?.uid || decls_repository.get_decl_by_id(global.using_map.default_species)
 
 /datum/category_item/player_setup_item/background/species/sanitize_character()

--- a/code/modules/client/preference_setup/global/01_ui.dm
+++ b/code/modules/client/preference_setup/global/01_ui.dm
@@ -134,7 +134,7 @@ var/global/list/valid_icon_sizes = list(32, 48, 64, 96, 128)
 		var/UI_style_highlight_color_new = input(user, "Choose UI highlight color, dark colors are not recommended!", "Global Preference", pref.UI_style_highlight_color) as color|null
 		if(isnull(UI_style_highlight_color_new) || !CanUseTopic(user)) return TOPIC_NOACTION
 		pref.UI_style_highlight_color = UI_style_highlight_color_new
-		return TOPIC_REFRESH
+		. = TOPIC_REFRESH
 
 	else if(href_list["select_alpha"])
 		var/UI_style_alpha_new = input(user, "Select UI alpha (transparency) level, between 50 and 255.", "Global Preference", pref.UI_style_alpha) as num|null

--- a/code/modules/lighting/lighting_turf.dm
+++ b/code/modules/lighting/lighting_turf.dm
@@ -64,15 +64,8 @@
 	if (abs(ambient_r + ambient_g + ambient_b) == 0)
 		return
 
-	// Unlit turfs will have corners if they have a lit neighbor -- don't generate corners for them, but do update them if they're there.
-	if (!corners)
-		var/force_build_corners = FALSE
-		for (var/turf/T as anything in RANGE_TURFS(src, 1))
-			if (TURF_IS_DYNAMICALLY_LIT_UNSAFE(T))
-				force_build_corners = TRUE
-				break
-
-		if (force_build_corners || TURF_IS_DYNAMICALLY_LIT_UNSAFE(src))
+	if (!corners || !lighting_corners_initialised)
+		if (TURF_IS_DYNAMICALLY_LIT_UNSAFE(src))
 			generate_missing_corners()
 		else
 			return

--- a/code/modules/lighting/lighting_turf.dm
+++ b/code/modules/lighting/lighting_turf.dm
@@ -28,10 +28,8 @@
 	if (color == ambient_light && multiplier == ambient_light_multiplier)
 		return
 
-	ambient_light = color || ambient_light
-	ambient_light_multiplier = multiplier || ambient_light_multiplier
-	if (!ambient_light_multiplier)
-		ambient_light_multiplier = initial(ambient_light_multiplier)
+	ambient_light = isnull(color) ? ambient_light : color
+	ambient_light_multiplier = isnull(multiplier) ? ambient_light_multiplier : multiplier
 
 	update_ambient_light()
 
@@ -48,7 +46,7 @@
 	var/ambient_g = 0
 	var/ambient_b = 0
 
-	if (ambient_light)
+	if (ambient_light && ambient_light_multiplier) // If either of these are false-y we can use the simplier path and avoid calculations
 		ambient_r = round(((HEX_RED(ambient_light)   / 255) * ambient_light_multiplier)/4 - ambient_light_old_r, LIGHTING_ROUND_VALUE)
 		ambient_g = round(((HEX_GREEN(ambient_light) / 255) * ambient_light_multiplier)/4 - ambient_light_old_g, LIGHTING_ROUND_VALUE)
 		ambient_b = round(((HEX_BLUE(ambient_light)  / 255) * ambient_light_multiplier)/4 - ambient_light_old_b, LIGHTING_ROUND_VALUE)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1571,21 +1571,21 @@ default behaviour is:
 	if(!use_move_trail)
 		return
 
-	var/decl/material/contaminant_type = source.coating.reagent_volumes[1] // take [1] instead of primary reagent to match what remove_any will probably remove
-	if(!T.can_show_coating_footprints(contaminant_type))
+	var/decl/material/contaminant = source.coating.reagent_volumes[1] // take [1] instead of primary reagent to match what remove_any will probably remove
+	if(!T.can_show_coating_footprints(contaminant))
 		return
 	/// An associative list of DNA unique enzymes -> blood type. Used by forensics, mostly.
 	var/list/bloodDNA = list()
 	var/track_color
-	var/list/source_data = REAGENT_DATA(source.coating, contaminant_type)
+	var/list/source_data = REAGENT_DATA(source.coating, contaminant)
 	if(source_data && source_data[DATA_BLOOD_DNA] && source_data[DATA_BLOOD_TYPE])
 		bloodDNA = list(source_data[DATA_BLOOD_DNA] = source_data[DATA_BLOOD_TYPE])
 	track_color = source.coating.get_color()
-	T.AddTracks(use_move_trail, bloodDNA, dir, 0, track_color, contaminant_type) // Coming
+	T.AddTracks(use_move_trail, bloodDNA, dir, 0, track_color, contaminant.type) // Coming
 	if(isturf(old_loc))
 		var/turf/old_turf = old_loc
-		if(old_turf.can_show_coating_footprints(contaminant_type))
-			old_turf.AddTracks(use_move_trail, bloodDNA, 0, dir, track_color, contaminant_type) // Going
+		if(old_turf.can_show_coating_footprints(contaminant))
+			old_turf.AddTracks(use_move_trail, bloodDNA, 0, dir, track_color, contaminant.type) // Going
 	source.remove_coating(1)
 	update_equipment_overlay(slot_shoes_str)
 

--- a/maps/shaded_hills/areas/_areas.dm
+++ b/maps/shaded_hills/areas/_areas.dm
@@ -36,5 +36,5 @@
 	)
 	description = "Birds and insects call from the grasses, and a cool wind gusts from across the river."
 	area_blurb_category = /area/shaded_hills/outside
-	interior_ambient_light_modifier = -0.3
+	interior_ambient_light_modifier = -0.4
 	area_flags = AREA_FLAG_EXTERNAL | AREA_FLAG_IS_BACKGROUND

--- a/maps/shaded_hills/areas/downlands.dm
+++ b/maps/shaded_hills/areas/downlands.dm
@@ -23,7 +23,7 @@
 
 /area/shaded_hills/inn/porch
 	name = "\improper Inn Porch"
-	interior_ambient_light_modifier = -0.3 // night is pitch-black on the porch
+	interior_ambient_light_modifier = -0.4 // night is pitch-black on the porch
 	sound_env = FOREST
 
 /area/shaded_hills/stable
@@ -42,7 +42,7 @@
 
 /area/shaded_hills/farmhouse/porch
 	name = "\improper Farmhouse Porch"
-	interior_ambient_light_modifier = -0.3 // night is pitch-black on the porch
+	interior_ambient_light_modifier = -0.4 // night is pitch-black on the porch
 	sound_env = FOREST
 
 /area/shaded_hills/slaughterhouse
@@ -68,7 +68,7 @@
 
 /area/shaded_hills/general_store/porch
 	name = "\improper General Store Porch"
-	interior_ambient_light_modifier = -0.3 // night is pitch-black on the porch
+	interior_ambient_light_modifier = -0.4 // night is pitch-black on the porch
 	sound_env = FOREST
 
 /area/shaded_hills/shrine

--- a/maps/shaded_hills/shaded_hills_define.dm
+++ b/maps/shaded_hills/shaded_hills_define.dm
@@ -43,6 +43,7 @@
 		"rock"  = /turf/floor/rock/basalt::color,
 		"brick" = /turf/wall/brick/sandstone::color
 	)
+	default_ui_style = /decl/ui_style/underworld
 
 /decl/backpack_outfit/sack
 	is_default = TRUE

--- a/mods/content/fantasy/submaps/_submaps.dm
+++ b/mods/content/fantasy/submaps/_submaps.dm
@@ -43,7 +43,7 @@
 		'sound/effects/wind/wind_4_2.ogg',
 		'sound/effects/wind/wind_5_1.ogg'
 	)
-	interior_ambient_light_modifier = -0.3
+	interior_ambient_light_modifier = -0.4
 	area_flags = AREA_FLAG_EXTERNAL | AREA_FLAG_IS_BACKGROUND
 
 /area/fantasy/outside/point_of_interest


### PR DESCRIPTION
## Description of changes
- Fixes a typo in legacy savefile loading that prevented species (saved as name) being loaded properly.
- Fix footprints breaking from being passed instances instead of typepaths.
- Partially reverts a change to lighting code done in commit e1a1d93d0594d26f21e6712a11beb28b1b121aec, and re-enables some commented code that existed prior to that commit. Now the code is on par with CitRP's ambient lights prior to ambience groups.

## Why and what will this PR improve
- Saves made prior to the species UID migration now load species properly.
- Muddy footprints no longer runtime out the ass.
- Random tiles on Shaded Hills are no longer missing lighting corners.