### PR TITLE
Fix bugs with carpets

### DIFF
--- a/code/game/objects/items/stacks/tiles/tile_types.dm
+++ b/code/game/objects/items/stacks/tiles/tile_types.dm
@@ -271,6 +271,7 @@
  * Carpets
  */
 /obj/item/stack/tile/carpet
+	build_type = /obj/item/stack/tile/carpet
 	name = "brown carpet"
 	singular_name = "brown carpet"
 	desc = "A piece of brown carpet."
@@ -292,6 +293,7 @@
 	amount = 50
 
 /obj/item/stack/tile/carpet/blue
+	build_type = /obj/item/stack/tile/carpet/blue
 	name = "blue carpet"
 	desc = "A piece of blue and gold carpet."
 	singular_name = "blue carpet"
@@ -301,6 +303,7 @@
 	amount = 50
 
 /obj/item/stack/tile/carpet/blue2
+	build_type = /obj/item/stack/tile/carpet/blue2
 	name = "pale blue carpet"
 	desc = "A piece of blue and pale blue carpet."
 	singular_name = "pale blue carpet"
@@ -311,6 +314,7 @@
 	amount = 50
 
 /obj/item/stack/tile/carpet/blue3
+	build_type = /obj/item/stack/tile/carpet/blue3
 	name = "sea blue carpet"
 	desc = "A piece of blue and green carpet."
 	singular_name = "sea blue carpet"
@@ -321,6 +325,7 @@
 	amount = 50
 
 /obj/item/stack/tile/carpet/magenta
+	build_type = /obj/item/stack/tile/carpet/magenta
 	name = "magenta carpet"
 	desc = "A piece of magenta carpet."
 	singular_name = "magenta carpet"
@@ -331,6 +336,7 @@
 	amount = 50
 
 /obj/item/stack/tile/carpet/purple
+	build_type = /obj/item/stack/tile/carpet/purple
 	name = "purple carpet"
 	desc = "A piece of purple carpet."
 	singular_name = "purple carpet"
@@ -341,6 +347,7 @@
 	amount = 50
 
 /obj/item/stack/tile/carpet/orange
+	build_type = /obj/item/stack/tile/carpet/orange
 	name = "orange carpet"
 	desc = "A piece of orange carpet."
 	singular_name = "orange carpet"
@@ -351,6 +358,7 @@
 	amount = 50
 
 /obj/item/stack/tile/carpet/green
+	build_type = /obj/item/stack/tile/carpet/green
 	name = "green carpet"
 	desc = "A piece of green carpet."
 	singular_name = "green carpet"
@@ -371,6 +379,7 @@
 	amount = 50
 
 /obj/item/stack/tile/carpet/rustic
+	build_type = /obj/item/stack/tile/carpet/rustic
 	name = "rustic carpet"
 	desc = "A piece of simple, rustic carpeting."
 	singular_name = "rustic carpet"

--- a/code/game/objects/items/stacks/tiles/tile_types.dm
+++ b/code/game/objects/items/stacks/tiles/tile_types.dm
@@ -286,7 +286,7 @@
 /obj/item/stack/tile/carpet/on_update_icon()
 	. = ..()
 	if(detail_color)
-		set_overlays(overlay_image(icon, "[icon_state]-detail", detail_color, RESET_COLOR))
+		add_overlay(overlay_image(icon, "[icon_state]_detail", detail_color, RESET_COLOR))
 
 /obj/item/stack/tile/carpet/fifty
 	amount = 50

--- a/code/game/turfs/floors/floor_attackby.dm
+++ b/code/game/turfs/floors/floor_attackby.dm
@@ -47,7 +47,12 @@
 	for(var/decl/flooring/F as anything in decls_repository.get_decls_of_subtype_unassociated(/decl/flooring))
 		if(!F.build_type)
 			continue
-		if((ispath(S.type, F.build_type) || ispath(S.build_type, F.build_type)) && (isnull(F.build_material) || S.material?.type == F.build_material))
+		// If S.build_type is set, we expect an exact match. Otherwise, we do
+		// an ispath on S.type. This is a shitty way to disambiguate carpet
+		// types because they're in the ugly position of "same material, built
+		// with a subtype" whereas with everything else, material + type
+		// disambiguates well enough.
+		if((S.build_type ? S.build_type == F.build_type : ispath(S.type, F.build_type)) && (isnull(F.build_material) || S.material?.type == F.build_material))
 			use_flooring = F
 			break
 	if(!use_flooring)


### PR DESCRIPTION
Fixes #4951.

- The detail state had the wrong name, it used a `-` instead of a `_`.
- Since carpets no longer use separate colored cloth material types, they overlap. Should maybe unit test for that.