### PR TITLE
Fix for Biogenerator issue #4953

### DIFF
--- a/code/game/machinery/biogenerator.dm
+++ b/code/game/machinery/biogenerator.dm
@@ -81,6 +81,9 @@
 
 /obj/machinery/biogenerator/attackby(var/obj/item/used_item, var/mob/user)
 
+	if(panel_open || IS_SCREWDRIVER(used_item))
+		return ..()
+
 	if(processing)
 		if((. = component_attackby(used_item, user)))
 			return


### PR DESCRIPTION
Fixes biogenerators not allowing parts/tools to build/repair as mentioned in issue #4953

<!-- !! PLEASE, READ THIS !! -->
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/NebulaSS13/Nebula/blob/dev/CONTRIBUTING.md -->
<!-- If you're opening a pull request which changes A LOT of icon/map files: -->
<!-- Add [IDB IGNORE] (to ignore icon file changes) or [MDB IGNORE] (to ignore map file changes) in the PR title. -->
<!-- These tags prevent huge diffs from overloading IconDiffBot and MapDiffBot. -->

## Description of changes
<!-- Describe the pull request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Adds a check at the start of `/obj/machinery/biogenerator/attackby(var/obj/item/used_item, var/mob/user)` to allow normal maintenance to be done while the panel is open, and the screwdriver to open the panel when it is closed.

```
	if(panel_open || IS_SCREWDRIVER(used_item))
		return ..()
```

## Why and what will this PR improve
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Currently, biogenerators cannot be built or repaired.  If a mapped one is damaged, it's dead for the rest of the round.  If a new one is desired, there is no way to construct it.  That is not great, so this makes biogenerators act properly.

## Authorship
<!-- Describe original authors of changes to credit them. -->
Typhin

## Changelog
:cl:
bugfix: Allows parts/screwdrivers to be used on biogenerators
code: Adds a check for if panel is open, or if item used is a screwdriver
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->