### PR TITLE
Add check for panel opening to machinery unit test

### DIFF
--- a/code/game/machinery/_machines_base/machine_construction/airlock.dm
+++ b/code/game/machinery/_machines_base/machine_construction/airlock.dm
@@ -3,6 +3,28 @@
 	down_state = /decl/machine_construction/default/panel_open/door
 	var/hacking_state = /decl/machine_construction/default/panel_closed/door/hacking
 
+/decl/machine_construction/default/panel_closed/door/fail_test_state_transfer(obj/machinery/machine, mob/user)
+	var/static/obj/item/screwdriver/screwdriver = new
+	// Prevent access locks on doors from interfering with our interactions.
+	for(var/obj/item/stock_parts/access_lock/lock in machine.get_all_components_of_type(/obj/item/stock_parts/access_lock))
+		lock.locked = FALSE
+	// Test hacking state
+	if(!machine.attackby(screwdriver, user))
+		return "Machine [log_info_line(machine)] did not respond to attackby with screwdriver."
+	if(machine.construct_state.type != hacking_state)
+		return "Machine [log_info_line(machine)] had a construct_state of type [machine.construct_state.type] after screwdriver interaction (expected [hacking_state])."
+	// Do it again to reverse that state change.
+	if(!machine.attackby(screwdriver, user))
+		return "Machine [log_info_line(machine)] did not respond to attackby with screwdriver on a second try."
+	if(machine.construct_state != src)
+		return "Machine [log_info_line(machine)] had a construct_state of type [machine.construct_state.type] after screwdriver interaction (expected [type])."
+	// Now test the down state
+	var/obj/item/wrench/wrench = new
+	if(!machine.attackby(wrench, user))
+		return "Machine [log_info_line(machine)] did not respond to attackby with wrench."
+	if(machine.construct_state.type != down_state)
+		return "Machine [log_info_line(machine)] had a construct_state of type [machine.construct_state.type] after screwdriver interaction (expected [down_state])."
+
 /decl/machine_construction/default/panel_closed/door/attackby(obj/item/used_item, mob/user, obj/machinery/machine)
 	if(IS_SCREWDRIVER(used_item))
 		TRANSFER_STATE(hacking_state)

--- a/code/game/machinery/_machines_base/machine_construction/default.dm
+++ b/code/game/machinery/_machines_base/machine_construction/default.dm
@@ -13,6 +13,19 @@
 	visible_components = FALSE
 	locked = TRUE
 
+/decl/machine_construction/default/panel_closed/fail_unit_test(obj/machinery/machine)
+	if((. = ..()))
+		return
+	var/static/mob/living/human/user = new
+	return fail_test_state_transfer(machine, user)
+
+/decl/machine_construction/default/panel_closed/proc/fail_test_state_transfer(obj/machinery/machine, mob/user)
+	var/static/obj/item/screwdriver/screwdriver = new
+	if(!machine.attackby(screwdriver, user))
+		return "Machine [log_info_line(machine)] did not respond to attackby with screwdriver."
+	if(machine.construct_state.type != down_state)
+		return "Machine [log_info_line(machine)] had a construct_state of type [machine.construct_state.type] after screwdriver interaction (expected [down_state])."
+
 /decl/machine_construction/default/panel_closed/state_is_valid(obj/machinery/machine)
 	return !machine.panel_open
 

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -889,7 +889,7 @@ About the new airlock wires panel:
 		panel_open = TRUE
 		if(istype(construct_state, /decl/machine_construction/default/panel_closed))
 			var/decl/machine_construction/default/panel_closed/closed = construct_state
-			construct_state = closed.down_state
+			construct_state = GET_DECL(closed.down_state)
 			construct_state.validate_state(src)
 		if (secured_wires)
 			lock()

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -348,7 +348,7 @@
 		panel_open = FALSE
 		if(istype(construct_state, /decl/machine_construction/default/panel_open))
 			var/decl/machine_construction/default/panel_open/open = construct_state
-			construct_state = open.up_state
+			construct_state = GET_DECL(open.up_state)
 			construct_state.validate_state(src)
 		visible_message("The maintenance hatch of \the [src] closes.")
 		update_icon()

--- a/code/game/machinery/washing_machine.dm
+++ b/code/game/machinery/washing_machine.dm
@@ -112,6 +112,9 @@
 		to_chat(user, SPAN_WARNING("\The [src] is currently running."))
 		return TRUE
 
+	if((. = ..()))
+		return
+
 	// If the detergent port is open and the item is an open container, assume we're trying to fill the detergent port.
 	if(!(state & WASHER_STATE_CLOSED) && !((atom_flags & used_item.atom_flags) & ATOM_FLAG_OPEN_CONTAINER))
 		var/list/wash_whitelist = get_wash_whitelist()
@@ -141,8 +144,6 @@
 		else
 			to_chat(user, SPAN_NOTICE("\The [src] is full."))
 			return TRUE
-
-	return ..()
 
 /obj/machinery/washing_machine/physical_attack_hand(mob/user)
 	if(state & WASHER_STATE_RUNNING)

--- a/code/modules/hydroponics/trays/tray.dm
+++ b/code/modules/hydroponics/trays/tray.dm
@@ -497,7 +497,7 @@
 		to_chat(user, "You [anchored ? "wrench" : "unwrench"] \the [src].")
 		return TRUE
 
-	if(seed)
+	if(user.check_intent(I_FLAG_HARM) && seed)
 		var/force = used_item.expend_attack_force(user)
 		if(force)
 			user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)

--- a/code/modules/modular_computers/hardware/ai_slot.dm
+++ b/code/modules/modular_computers/hardware/ai_slot.dm
@@ -30,7 +30,7 @@
 			return TRUE
 		do_insert_ai(user, used_item)
 		return TRUE
-	if(IS_SCREWDRIVER(used_item))
+	if(stored_card && IS_SCREWDRIVER(used_item))
 		to_chat(user, "You manually remove \the [stored_card] from \the [src].")
 		do_eject_ai(user)
 		return TRUE
@@ -64,8 +64,9 @@
 	device.do_eject_ai(user)
 
 /obj/item/stock_parts/computer/ai_slot/proc/do_eject_ai(mob/user)
-	stored_card.dropInto(loc)
-	stored_card = null
+	if(stored_card)
+		stored_card.dropInto(loc)
+		stored_card = null
 
 	loc.verbs -= /obj/item/stock_parts/computer/ai_slot/verb/eject_ai
 

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -68,8 +68,6 @@ var/global/list/diversion_junctions = list()
 	return FALSE
 
 /obj/machinery/disposal/cannot_transition_to(state_path, mob/user)
-	if(mode > 0)
-		return SPAN_NOTICE("Turn off the pump first.")
 	if(contents.len > LAZYLEN(component_parts))
 		return SPAN_NOTICE("Eject the items first!")
 	return ..()
@@ -263,7 +261,7 @@ var/global/list/diversion_junctions = list()
 	if(isAI(user) && (href_list["handle"] || href_list["eject"]))
 		return min(STATUS_UPDATE, ..())
 	if(mode==-1 && !href_list["eject"]) // only allow ejecting if mode is -1
-		to_chat(user, "<span class='warning'>The disposal units power is disabled.</span>")
+		to_chat(user, "<span class='warning'>The disposal unit's power is disabled.</span>")
 		return min(STATUS_UPDATE, ..())
 	if(flushing)
 		return min(STATUS_UPDATE, ..())

--- a/code/modules/recycling/sortingmachinery.dm
+++ b/code/modules/recycling/sortingmachinery.dm
@@ -6,6 +6,8 @@
 	icon_state = "chute"
 	base_type = /obj/machinery/disposal/deliveryChute/buildable
 	frame_type = /obj/structure/disposalconstruct/machine/chute
+	// TODO: Convert attackby() override and c_mode vars to use construct states
+	construct_state = null
 
 	var/c_mode = 0
 

--- a/code/unit_tests/equipment_tests.dm
+++ b/code/unit_tests/equipment_tests.dm
@@ -55,10 +55,10 @@
 
 	for(var/storage_type in typesof(/obj))
 		var/obj/thing = storage_type
-		if(TYPE_IS_ABSTRACT(thing) || !ispath(initial(thing.storage), /datum/storage))
+		if(!TYPE_IS_SPAWNABLE(thing) || !ispath(initial(thing.storage), /datum/storage))
 			continue
 		thing = new thing //should be fine to put it in nullspace...
-		var/bad_msg = "[ascii_red]--------------- [thing.name] \[[thing.type] | [thing.storage]\]"
+		var/bad_msg = "[ascii_red]--------------- [thing.name] \[[thing.type] | [thing.storage || "NULL"]\]"
 		bad_tests += test_storage_capacity(thing.storage, bad_msg)
 
 	if(bad_tests)


### PR DESCRIPTION
## Description of changes
Adds a check to make sure opening machines' panels with a screwdriver works for those with an applicable construct_state.

## Why and what will this PR improve
Should catch issues like not being able to use a screwdriver on a biogenerator.

## Authorship
Me