### PR TITLE
Fix the prompt for being given an item defaulting to 'no'

### DIFF
--- a/code/modules/mob/living/living_give.dm
+++ b/code/modules/mob/living/living_give.dm
@@ -21,7 +21,7 @@
 		to_chat(usr, SPAN_WARNING("You can't give someone a grab."))
 		return
 	usr.visible_message(SPAN_NOTICE("\The [usr] holds out \the [I] to \the [target]."), SPAN_NOTICE("You hold out \the [I] to \the [target], waiting for them to accept it."))
-	if(alert(target,"[src] wants to give you \a [I]. Will you accept it?",,"No","Yes") == "No")
+	if(alert(target,"[src] wants to give you \a [I]. Will you accept it?",,"Yes","No") == "No")
 		target.visible_message(SPAN_NOTICE("\The [src] tried to hand \the [I] to \the [target], \
 		but \the [target] didn't want it."))
 		return


### PR DESCRIPTION
## Description of changes
Changes the default choice when being given an item to 'yes'.

## Why and what will this PR improve
This is what it was for 9 years and people in the Discord server voted for it also. Apparently, on staging/dev, it defaults to 'no' ever since the Polaris throw-mode give port.

![image](https://github.com/user-attachments/assets/7badc852-e5fb-4e26-9ddc-e72110e47342)