### PR TITLE
Readd missing can_be_shackled var to utility frames

### DIFF
--- a/mods/species/utility_frames/species_bodytypes.dm
+++ b/mods/species/utility_frames/species_bodytypes.dm
@@ -28,6 +28,7 @@
 			/decl/sprite_accessory/marking/frame/plating/head = "#8888cc"
 		)
 	)
+	can_be_shackled = TRUE
 
 /decl/bodytype/prosthetic/utility_frame/Initialize()
 	equip_adjust = list(


### PR DESCRIPTION
## Description of changes
4f96b4cc0bfe0d40577ba10fe0fc2c7bfdfe20a6 accidentally removed both places it was set rather than just removing the IFDEF on the frame one.

## Why and what will this PR improve
Fixes shackles for utility frames on the stable branch. The compatibility system will allow us to make the two modpacks separate again on the dev branch.