### PR TITLE
Add breath-holding inspired by the Scavstation feature

### DIFF
--- a/maps/tradeship/tradeship.dm
+++ b/maps/tradeship/tradeship.dm
@@ -11,11 +11,12 @@
 	#include "../../mods/content/government/away_sites/icarus/icarus.dm"
 	#include "../../mods/content/corporate/away_sites/lar_maria/lar_maria.dm"
 
-	#include "../../mods/content/beekeeping/_beekeeping.dme"
 	#include "../../mods/content/mundane.dm"
 	#include "../../mods/content/scaling_descriptors.dm"
 
+	#include "../../mods/content/beekeeping/_beekeeping.dme"
 	#include "../../mods/content/bigpharma/_bigpharma.dme"
+	#include "../../mods/content/breath_holding/_breath_holding.dme"
 	#include "../../mods/content/corporate/_corporate.dme"
 	#include "../../mods/content/dungeon_loot/_dungeon_loot.dme"
 	#include "../../mods/content/government/_government.dme"

--- a/mods/content/breath_holding/_breath_holding.dme
+++ b/mods/content/breath_holding/_breath_holding.dme
@@ -1,0 +1,9 @@
+#ifndef CONTENT_PACK_BREATH_HOLDING
+#define CONTENT_PACK_BREATH_HOLDING
+// BEGIN_INCLUDE
+#include "breath_holding.dm"
+#include "living_overrides.dm"
+#include "living_verbs.dm"
+#include "lung_overrides.dm"
+// END_INCLUDE
+#endif

--- a/mods/content/breath_holding/breath_holding.dm
+++ b/mods/content/breath_holding/breath_holding.dm
@@ -1,0 +1,3 @@
+/decl/modpack/breath_holding
+	name = "Breath Holding"
+	desc = "Adds the ability for some mobs to hold their breath."

--- a/mods/content/breath_holding/living_overrides.dm
+++ b/mods/content/breath_holding/living_overrides.dm
@@ -1,0 +1,43 @@
+// override to make a held breath take priority
+/mob/living/get_breath(obj/item/organ/internal/lungs/lungs)
+	if(lungs?.holding_breath && lungs.held_breath)
+		return lungs.held_breath
+	return ..()
+
+// override that prevents getting a new breath if we already have one
+/mob/living/obtain_new_breath(obj/item/organ/internal/lungs/lungs)
+	if(lungs?.held_breath) // don't ever take a new breath if we have one held
+		return null
+	. = ..()
+	if(lungs?.holding_breath) // hold our current breath
+		lungs.held_breath = .
+
+/mob/living/handle_pre_breath(obj/item/organ/internal/lungs/lungs)
+	if((. = ..())) // something skipped breathing, so we can't breathe in or out
+		return
+	if(!lungs) // can't do any of this without lungs
+		return
+	if(stat != CONSCIOUS && lungs.holding_breath) // if you pass out from holding your breath too long, you should start breathing again
+		lungs.holding_breath = FALSE
+	// exhale the currently held breath if we're done not holding it anymore
+	if(lungs.held_breath && !lungs.holding_breath)
+		handle_post_breath(lungs.held_breath)
+
+/mob/living/handle_post_breath(datum/gas_mixture/breath)
+	var/decl/bodytype/root_bodytype = get_bodytype()
+	if(!root_bodytype?.breathing_organ)
+		return
+	var/obj/item/organ/internal/lungs/lungs = get_organ(root_bodytype.breathing_organ, /obj/item/organ/internal/lungs)
+	if(lungs?.holding_breath)
+		return // don't exhale if holding a breath
+	. = ..() // exhale our held breath
+	if(lungs)
+		lungs.held_breath = null // clear the old breath
+
+// OVERRIDE: can't sniff while holding your breath
+/mob/living/sniff_verb()
+	var/obj/item/organ/internal/lungs/breathe_organ = get_organ(get_bodytype().breathing_organ, /obj/item/organ/internal/lungs)
+	if(breathe_organ?.holding_breath)
+		to_chat(src, SPAN_WARNING("You can't sniff while holding your breath!"))
+		return
+	return ..()

--- a/mods/content/breath_holding/living_verbs.dm
+++ b/mods/content/breath_holding/living_verbs.dm
@@ -1,0 +1,9 @@
+/mob/living/proc/hold_breath()
+	set name = "Hold Breath"
+	set desc = "Hold your breath, or stop holding your breath."
+	set category = "IC"
+	set src = usr
+	if(!need_breathe())
+		return
+	var/obj/item/organ/internal/lungs/lungs = get_organ(get_bodytype().breathing_organ, /obj/item/organ/internal/lungs)
+	return lungs?.hold_breath()

--- a/mods/content/breath_holding/lung_overrides.dm
+++ b/mods/content/breath_holding/lung_overrides.dm
@@ -1,0 +1,39 @@
+/obj/item/organ/internal/lungs
+	var/can_hold_breath = TRUE
+	/// The breath currently being held.
+	var/datum/gas_mixture/held_breath = null
+	/// Whether or not to hold the next breath. If FALSE, any held breath (if it exists) will be exhaled. If TRUE, the next breath will be held.
+	var/holding_breath = FALSE
+
+/obj/item/organ/internal/lungs/do_uninstall(in_place, detach, ignore_children)
+	var/mob/living/prior_owner = owner
+	if(!(. = ..()))
+		return
+	if(istype(prior_owner) && !prior_owner.get_organ(BP_LUNGS))
+		prior_owner.verbs -= /mob/living/proc/hold_breath
+
+/obj/item/organ/internal/lungs/do_install(mob/living/human/target, obj/item/organ/external/affected, in_place)
+	. = ..()
+	if(istype(owner) && !QDELETED(owner) && can_hold_breath)
+		owner.verbs |= /mob/living/proc/hold_breath
+
+/obj/item/organ/internal/lungs/proc/hold_breath()
+	if(!can_hold_breath)
+		if(owner)
+			owner.verbs -= /mob/living/proc/hold_breath
+		return
+	// if there's ever a reason we should allow ownerless breath-holding this will have to be changed
+	if(!owner || owner.stat != CONSCIOUS)
+		return
+	if(!holding_breath)
+		owner.visible_message(SPAN_WARNING("\The [src] starts holding their breath!"), SPAN_WARNING("You start holding your breath!"))
+	else
+		owner.visible_message(SPAN_NOTICE("\The [src] starts breathing again."), SPAN_NOTICE("You stop holding your breath."))
+	holding_breath = !holding_breath
+	owner.try_breathe() // inhale/exhale immediately
+
+// OVERRIDE: Can't drown while holding your breath
+/obj/item/organ/internal/lungs/can_drown()
+	if(holding_breath && held_breath)
+		return FALSE
+	return ..()


### PR DESCRIPTION
## Description of changes
"Ports" breath-holding from Scavstation, except I completely rewrote it from scratch on accident.
Includes some foundational work that will need to be moved into other PRs on different branches.

TODO: Make holding your breath in vacuum a bad idea?

## Why and what will this PR improve
Prevents Scavstation merge skew.

## Authorship
Scavstation for the idea, but I rewrote almost every single line of code for the breath-holding feature in order to modpack it.

## Changelog
:cl:
add: Added a breath-holding modpack, which adds a 'Hold Breath' verb.
/:cl: