### PR TITLE
Fix issues with gases and breathing

### DIFF
--- a/code/game/objects/items/weapons/tanks/tanks.dm
+++ b/code/game/objects/items/weapons/tanks/tanks.dm
@@ -121,7 +121,7 @@ var/global/list/global/tank_gauge_cache = list()
 		icon = loc
 
 	if (istype(W, /obj/item/scanner/gas))
-		return TRUE
+		return FALSE // allow afterattack to proceed
 
 	if (istype(W,/obj/item/latexballon))
 		var/obj/item/latexballon/LB = W

--- a/code/modules/mob/living/simple_animal/_simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/_simple_animal.dm
@@ -499,6 +499,12 @@ var/global/list/simplemob_icon_bitflag_cache = list()
 	name = "quadruped animal"
 	bodytype_flag = 0
 	bodytype_category = "quadrupedal animal body"
+	// Simple animal bodies don't have limbs or organs, currently. If that changes, remove or modify these overrides.
+	// These overrides prevent unnecessary processing.
+	has_limbs = list()
+	has_organ = list()
+	// Simple animals go through a different breathing process (handle_environment) than mobs that use organs do.
+	breathing_organ = null
 
 /mob/living/simple_animal/get_base_telegraphed_melee_accuracy()
 	return telegraphed_melee_accuracy


### PR DESCRIPTION
## Description of changes
Flips a return value in tank attackby to allow gas scanner afterattack to run.
Makes it so that simple animal bodytypes don't have organs/limbs set (by default). This prevents Ian and other simplemobs from attempting the organ-based breathing path; their breathing is in `handle_environment()` instead.

## Why and what will this PR improve
Fixes tanks not being scannable with gas scanners.
Fixes simple_animals trying to use the organ breathing method and wasting processing time.

## Authorship
Me