### PR TITLE
Fix pressure damage code hardcoding voidsuits to 1 atmosphere.

### DIFF
--- a/code/modules/mob/living/human/life.dm
+++ b/code/modules/mob/living/human/life.dm
@@ -88,13 +88,15 @@
 // Calculate how much of the environment pressure-difference affects the human.
 /mob/living/human/calculate_affecting_pressure(var/pressure)
 	var/pressure_difference
+	var/species_safe_pressure = species.get_safe_pressure(src)
 
+	pressure_difference = abs(pressure - species_safe_pressure)
 	// First get the absolute pressure difference.
-	if(pressure < ONE_ATMOSPHERE) // We are in an underpressure.
-		pressure_difference = ONE_ATMOSPHERE - pressure
+	/*if(pressure < species_safe_pressure) // We are in an underpressure.
+		pressure_difference = species_safe_pressure - pressure
 
 	else //We are in an overpressure or standard atmosphere.
-		pressure_difference = pressure - ONE_ATMOSPHERE
+		pressure_difference = pressure - species_safe_pressure*/
 
 	if(pressure_difference < 5) // If the difference is small, don't bother calculating the fraction.
 		pressure_difference = 0
@@ -107,10 +109,10 @@
 	// The difference is always positive to avoid extra calculations.
 	// Apply the relative difference on a standard atmosphere to get the final result.
 	// The return value will be the adjusted_pressure of the human that is the basis of pressure warnings and damage.
-	if(pressure < ONE_ATMOSPHERE)
-		return ONE_ATMOSPHERE - pressure_difference
+	if(pressure < species_safe_pressure)
+		return species_safe_pressure - pressure_difference
 	else
-		return ONE_ATMOSPHERE + pressure_difference
+		return species_safe_pressure + pressure_difference
 
 /mob/living/human/handle_impaired_vision()
 

--- a/code/modules/mob/living/human/life.dm
+++ b/code/modules/mob/living/human/life.dm
@@ -90,13 +90,8 @@
 	var/pressure_difference
 	var/species_safe_pressure = species.get_safe_pressure(src)
 
-	pressure_difference = abs(pressure - species_safe_pressure)
 	// First get the absolute pressure difference.
-	/*if(pressure < species_safe_pressure) // We are in an underpressure.
-		pressure_difference = species_safe_pressure - pressure
-
-	else //We are in an overpressure or standard atmosphere.
-		pressure_difference = pressure - species_safe_pressure*/
+	pressure_difference = abs(pressure - species_safe_pressure)
 
 	if(pressure_difference < 5) // If the difference is small, don't bother calculating the fraction.
 		pressure_difference = 0

--- a/code/modules/species/species.dm
+++ b/code/modules/species/species.dm
@@ -742,3 +742,6 @@ var/global/const/DEFAULT_SPECIES_HEALTH = 200
 		var/decl/background_category/background_cat = GET_DECL(cat_type)
 		if(background_cat.background_flags & background_flag)
 			return GET_DECL(default_background_info[cat_type])
+
+/decl/species/proc/get_safe_pressure()
+	return (warning_high_pressure + warning_low_pressure)/2


### PR DESCRIPTION
<!-- !! PLEASE, READ THIS !! -->
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/NebulaSS13/Nebula/blob/dev/CONTRIBUTING.md -->
<!-- If you're opening a pull request which changes A LOT of icon/map files: -->
<!-- Add [IDB IGNORE] (to ignore icon file changes) or [MDB IGNORE] (to ignore map file changes) in the PR title. -->
<!-- These tags prevent huge diffs from overloading IconDiffBot and MapDiffBot. -->

## Description of changes
<!-- Describe the pull request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Currently, for purposes of pressure damage calculation, wearing a voidsuit essentially tells the game that its wearer is experiencing 1 atmosphere of pressure. This is suboptimal for hypothetical species for whom 1atm is an unsafe pressure (for instance, Polaris' Zaddat). This changes the logic of the `calculate_affecting_pressure` proc to use, as its hardcoded baseline, the midpoint of `warning_high_pressure` and `warning_low_pressure`. This is technically a different number from before (by default it's (50+325)/2 = 187.5 kPa) but is simpler and less work to implement than e.g. specifically defining a safe pressure on a per-species basis. I have not changed anything else with `calculate_affecting_pressure` because messing with life.dm code this old scares me.

## Why and what will this PR improve
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Allows the ability for species that require high (or low) pressures to live to use voidsuits to exist in normal atmosphere.

## Authorship
<!-- Describe original authors of changes to credit them. -->
Myself.
## Changelog
:cl:
tweak: removed calculate_affecting_pressure() hardcoding
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->