### PR TITLE
Centralize flash behavior and add flash burn support.

### DIFF
--- a/code/game/machinery/flasher.dm
+++ b/code/game/machinery/flasher.dm
@@ -71,30 +71,7 @@
 			continue
 
 		var/flash_time = strength
-		if(isliving(viewer))
-			if(viewer.eyecheck() > FLASH_PROTECTION_NONE)
-				continue
-			if(ishuman(viewer))
-				var/mob/living/human/H = viewer
-				flash_time = round(H.get_flash_mod() * flash_time)
-				if(flash_time <= 0)
-					return
-				var/vision_organ_tag = H.get_vision_organ_tag()
-				if(vision_organ_tag)
-					var/obj/item/organ/internal/organ = GET_INTERNAL_ORGAN(H, vision_organ_tag)
-					if(organ && organ.is_bruised() && prob(organ.get_organ_damage() + 50))
-						H.flash_eyes()
-						organ.adjust_organ_damage(rand(1, 5))
-
-		if(!viewer.is_blind())
-			do_flash(viewer, flash_time)
-
-/obj/machinery/flasher/proc/do_flash(var/mob/living/victim, var/flash_time)
-	victim.flash_eyes()
-	ADJ_STATUS(victim, STAT_BLURRY, flash_time)
-	ADJ_STATUS(victim, STAT_CONFUSE, flash_time + 2)
-	SET_STATUS_MAX(victim, STAT_STUN, flash_time / 2)
-	SET_STATUS_MAX(victim, STAT_WEAK, 3)
+		viewer.handle_flashed(flash_time)
 
 /obj/machinery/flasher/emp_act(severity)
 	if(stat & (BROKEN|NOPOWER))

--- a/code/game/machinery/flasher.dm
+++ b/code/game/machinery/flasher.dm
@@ -86,6 +86,7 @@
 	desc = "A portable flashing device. Wrench to activate and deactivate. Cannot detect slow movements."
 	icon_state = "pflash1"
 	icon = 'icons/obj/machines/flash_portable.dmi'
+	directional_offset = @'{"NORTH":{"y":0}, "SOUTH":{"y":0}, "EAST":{"x":0}, "WEST":{"x":0}}'
 	strength = 8
 	anchored = FALSE
 	base_state = "pflash"

--- a/code/modules/bodytype/_bodytype.dm
+++ b/code/modules/bodytype/_bodytype.dm
@@ -239,6 +239,8 @@ var/global/list/bodytypes_by_category = list()
 	var/eye_blend                   = ICON_ADD
 	/// Stun from blindness modifier.
 	var/eye_flash_mod               = 1
+	//how much damage to take from being flashed (if any)
+	var/eye_flash_burn              = 0
 
 	// Bodytype temperature damage thresholds.
 	/// Cold damage level 1 below this point. -30 Celsium degrees

--- a/code/modules/mechs/equipment/combat.dm
+++ b/code/modules/mechs/equipment/combat.dm
@@ -347,30 +347,4 @@
 			var/obj/item/cell/cell = owner.get_cell()
 			cell.use(active_power_use * CELLRATE)
 
-			var/protection = O.eyecheck()
-			if(protection >= FLASH_PROTECTION_MAJOR)
-				return
-
-			if(protection >= FLASH_PROTECTION_MODERATE)
-				flash_time /= 2
-
-			if(ishuman(O))
-				var/mob/living/human/H = O
-				flash_time = round(H.get_flash_mod() * flash_time)
-				if(flash_time <= 0)
-					return
-
-			if(!O.is_blind())
-				O.flash_eyes(FLASH_PROTECTION_MAJOR - protection)
-				SET_STATUS_MAX(O, STAT_BLURRY, flash_time)
-				SET_STATUS_MAX(O, STAT_CONFUSE, (flash_time + 2))
-
-				if(isanimal(O)) //Hit animals a bit harder
-					SET_STATUS_MAX(O, STAT_STUN, flash_time)
-				else
-					SET_STATUS_MAX(O, STAT_STUN, (flash_time / 2))
-
-				if(flash_time > 3)
-					O.drop_held_items()
-				if(flash_time > 5)
-					SET_STATUS_MAX(O, STAT_WEAK, 2)
+			O.handle_flashed(flash_time)

--- a/code/modules/mechs/equipment/combat.dm
+++ b/code/modules/mechs/equipment/combat.dm
@@ -317,23 +317,7 @@
 
 	for (var/mob/living/O in oviewers(flash_range, owner))
 		if(istype(O))
-			var/protection = O.eyecheck()
-			if(protection >= FLASH_PROTECTION_MODERATE)
-				return
-
-			if(protection >= FLASH_PROTECTION_MINOR)
-				flash_time /= 2
-
-			if(ishuman(O))
-				var/mob/living/human/H = O
-				flash_time = round(H.get_flash_mod() * flash_time)
-				if(flash_time <= 0)
-					return
-
-			if(!O.is_blind())
-				O.flash_eyes(FLASH_PROTECTION_MODERATE - protection)
-				SET_STATUS_MAX(O, STAT_BLURRY, flash_time)
-				SET_STATUS_MAX(O, STAT_CONFUSE, (flash_time + 2))
+			O.handle_flashed(flash_time)
 
 /obj/item/mech_equipment/flash/attack_self(mob/user)
 	. = ..()

--- a/code/modules/mechs/equipment/combat.dm
+++ b/code/modules/mechs/equipment/combat.dm
@@ -317,7 +317,7 @@
 
 	for (var/mob/living/O in oviewers(flash_range, owner))
 		if(istype(O))
-			O.handle_flashed(flash_time)
+			O.handle_flashed(flash_time, do_stun = FALSE)
 
 /obj/item/mech_equipment/flash/attack_self(mob/user)
 	. = ..()

--- a/code/modules/mob/living/human/human.dm
+++ b/code/modules/mob/living/human/human.dm
@@ -1019,7 +1019,7 @@
 /mob/living/human/proc/post_setup(species_uid, datum/mob_snapshot/supplied_appearance)
 	try_refresh_visible_overlays() //Do this exactly once per setup
 
-/mob/living/human/handle_flashed(var/flash_strength)
+/mob/living/human/handle_flashed(var/flash_strength, do_stun = FALSE)
 	var/safety = eyecheck()
 	if(safety < FLASH_PROTECTION_MODERATE)
 		flash_strength = round(get_flash_mod() * flash_strength)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -869,6 +869,14 @@ default behaviour is:
 			return I.get_flash_mod()
 	return get_bodytype()?.eye_flash_mod
 
+/mob/living/proc/get_flash_burn()
+	var/vision_organ_tag = get_vision_organ_tag()
+	if(vision_organ_tag)
+		var/obj/item/organ/internal/eyes/I = get_organ(vision_organ_tag, /obj/item/organ/internal/eyes)
+		if(I)
+			return I.get_flash_burn()
+	return get_bodytype()?.eye_flash_burn
+
 /mob/living/proc/eyecheck()
 	var/total_protection = flash_protection
 	if(should_have_organ(BP_EYES))
@@ -1692,6 +1700,7 @@ default behaviour is:
 /mob/living/handle_flashed(var/flash_strength)
 
 	var/safety = eyecheck()
+	var/flash_burn = get_flash_burn()
 	if(safety >= FLASH_PROTECTION_MODERATE || flash_strength <= 0) // May be modified by human proc.
 		return FALSE
 
@@ -1699,6 +1708,9 @@ default behaviour is:
 	SET_STATUS_MAX(src, STAT_STUN, (flash_strength / 2))
 	SET_STATUS_MAX(src, STAT_BLURRY, flash_strength)
 	SET_STATUS_MAX(src, STAT_CONFUSE, (flash_strength + 2))
+
+	if(flash_burn > 0)
+		apply_damage(flash_strength * flash_burn/5, BURN, BP_HEAD, used_weapon = "Photon burns")
 	if(flash_strength > 3)
 		drop_held_items()
 	if(flash_strength > 5)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1697,15 +1697,18 @@ default behaviour is:
 		return range * range - 0.333
 	return range
 
-/mob/living/handle_flashed(var/flash_strength)
+/mob/living/handle_flashed(var/flash_strength, do_stun = TRUE)
 
 	var/safety = eyecheck()
 	var/flash_burn = get_flash_burn()
-	if(safety >= FLASH_PROTECTION_MODERATE || flash_strength <= 0) // May be modified by human proc.
+	var/flash_mod = get_flash_mod()
+
+	if(safety >= FLASH_PROTECTION_MODERATE || flash_strength <= 0 || flash_mod <= 0) // May be modified by human proc.
 		return FALSE
 
 	flash_eyes(FLASH_PROTECTION_MODERATE - safety)
-	SET_STATUS_MAX(src, STAT_STUN, (flash_strength / 2))
+	if(do_stun)
+		SET_STATUS_MAX(src, STAT_STUN, (flash_strength / 2))
 	SET_STATUS_MAX(src, STAT_BLURRY, flash_strength)
 	SET_STATUS_MAX(src, STAT_CONFUSE, (flash_strength + 2))
 
@@ -1715,6 +1718,7 @@ default behaviour is:
 		drop_held_items()
 	if(flash_strength > 5)
 		SET_STATUS_MAX(src, STAT_WEAK, 2)
+	return TRUE
 
 /mob/living/verb/showoff()
 	set name = "Show Held Item"

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -415,7 +415,7 @@
 	if(os)
 		os.Process()
 
-/mob/living/silicon/handle_flashed(var/flash_strength)
+/mob/living/silicon/handle_flashed(var/flash_strength, do_stun = FALSE)
 	SET_STATUS_MAX(src, STAT_PARA, flash_strength)
 	SET_STATUS_MAX(src, STAT_WEAK, flash_strength)
 	return TRUE

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1156,7 +1156,7 @@
 
 	return FALSE
 
-/mob/proc/handle_flashed(var/flash_strength)
+/mob/proc/handle_flashed(var/flash_strength, do_stun = FALSE)
 	return FALSE
 
 /mob/proc/do_flash_animation()

--- a/code/modules/organs/internal/eyes.dm
+++ b/code/modules/organs/internal/eyes.dm
@@ -22,6 +22,9 @@
 /obj/item/organ/internal/eyes/proc/get_flash_mod()
 	return bodytype.eye_flash_mod
 
+/obj/item/organ/internal/eyes/proc/get_flash_burn()
+	return bodytype.eye_flash_burn
+
 /obj/item/organ/internal/eyes/proc/get_darksight_range()
 	return bodytype.eye_darksight_range
 


### PR DESCRIPTION
<!-- !! PLEASE, READ THIS !! -->
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/NebulaSS13/Nebula/blob/dev/CONTRIBUTING.md -->
<!-- If you're opening a pull request which changes A LOT of icon/map files: -->
<!-- Add [IDB IGNORE] (to ignore icon file changes) or [MDB IGNORE] (to ignore map file changes) in the PR title. -->
<!-- These tags prevent huge diffs from overloading IconDiffBot and MapDiffBot. -->

## Description of changes
<!-- Describe the pull request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
While poking around for a port of Polaris' Zaddat race, I noticed that the race has a feature where they take mild burn damage to the head from being flashed. This lead me to find out that currently, the functionality for handheld flashes, mech-mounted flashes and static flashers is implemented separately (and slightly differently) for each one. This PR consolidates them all to call `mob/living/handle_flashed()` instead, and adds support for a bodytype-specific `eye_flash_burn` modifier (default 0). The new behavior isn't a 100% 1:1 match of how the flasher and mech-flash function currently, but I don't really see a reason for those behaviors to be significantly different from a more powerful regular flash anyways.
Also fixes portable flashers having the same sprite offset as wall flashers.

## Why and what will this PR improve
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Future modification of flash behavior will be easily unified since it's all in one place now. In addition, bodytypes with eyes that take burn damage from flashes are made possible.

## Authorship
<!-- Describe original authors of changes to credit them. -->
Myself.

## Changelog
:cl:
add: added support for burn damage from flashes
refactor: centralized flash functionality
bugfix: fixed portable flasher sprite offset
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->