### PR TITLE
Fix standard jobs modpack assuming psionics modpack is included

### DIFF
--- a/mods/content/standard_jobs/jobs/medical.dm
+++ b/mods/content/standard_jobs/jobs/medical.dm
@@ -201,7 +201,6 @@
 		/datum/computer_file/program/suit_sensors,
 		/datum/computer_file/program/camera_monitor
 	)
-	give_psionic_implant_on_join = FALSE
 
 // Department-flavor IDs
 /obj/item/card/id/medical

--- a/mods/~compatibility/patches/psionics/psi_jobs.dm
+++ b/mods/~compatibility/patches/psionics/psi_jobs.dm
@@ -4,3 +4,7 @@
 	if(H.mind.role_alt_title == "Mentalist")
 		psi_faculties = list("[PSI_COERCION]" = PSI_RANK_OPERANT)
 	return ..()
+
+// Counselors can be psions without a control implant
+/datum/job/standard/counselor
+	give_psionic_implant_on_join = FALSE


### PR DESCRIPTION
## Description of changes
Separates out a fix from #4972.
A variable was referenced in the standard jobs modpack that only exists if the psionics modpack is also included. That variable override has been moved to the relevant compat patch.

## Why and what will this PR improve
The standard jobs modpack should work without psionics being included.

## Authorship
Me, in #4972.