### PR TITLE
Remove unused, unincluded DM file in gamemode modpack directory

### DIFF
--- a/mods/gamemodes/gamemode.dm
+++ b/mods/gamemodes/gamemode.dm
@@ -1,2 +1,0 @@
-/decl/configuration_category/gamemode
-	abstract_type = /decl/configuration_category/gamemode


### PR DESCRIPTION
## Description of changes
Removes a file with only an abstract type definition that never got included or used.

## Why and what will this PR improve
Now every bare DM file in the second level of the mods folder is a modpack! Hooray.

## Authorship
Me