### PR TITLE
Fix staging branch issues

### DIFF
--- a/code/game/objects/items/blades/axe_fire.dm
+++ b/code/game/objects/items/blades/axe_fire.dm
@@ -1,6 +1,7 @@
 /obj/item/bladed/axe/fire
 	name                = "fire axe"
 	icon                = 'icons/obj/items/bladed/fireaxe.dmi'
+	icon_state          = ICON_STATE_WORLD
 	desc                = "Truly, the weapon of a madman. Who would think to fight fire with an axe?"
 	material_alteration = MAT_FLAG_ALTERATION_NAME
 	guard_material      = /decl/material/solid/organic/plastic

--- a/code/game/objects/items/devices/boombox.dm
+++ b/code/game/objects/items/devices/boombox.dm
@@ -2,8 +2,7 @@
 	name = "boombox"
 	desc = "A device used to emit rhythmic sounds, colloquialy refered to as a 'boombox'. It's in a retro style (massive), and absolutely unwieldy."
 	icon = 'icons/obj/items/device/boombox.dmi'
-	icon_state = "off"
-	item_state = "boombox"
+	icon_state = ICON_STATE_WORLD
 	_base_attack_force = 7
 	w_class = ITEM_SIZE_HUGE //forbid putting something that emits loud sounds forever into a backpack
 	origin_tech = @'{"magnets":2,"combat":1}'

--- a/code/game/objects/items/weapons/dice.dm
+++ b/code/game/objects/items/weapons/dice.dm
@@ -76,8 +76,8 @@
 
 /obj/item/dice/d100
 	name = "d100"
-	desc = "A dice with ten sides. This one is for the tens digit."
-	icon_state = "d10010"
+	desc = "A die with ten sides. This one is for the tens digit."
+	icon_state = "d10001"
 	sides = 10
 
 /obj/item/dice/d100/roll_die()

--- a/code/game/objects/items/weapons/material/swords.dm
+++ b/code/game/objects/items/weapons/material/swords.dm
@@ -20,7 +20,7 @@
 	_base_attack_force = 15
 	var/draw_handle = TRUE
 
-/obj/item/edge/set_edge(new_edge)
+/obj/item/sword/set_edge(new_edge)
 	. = ..()
 	if(. && !edge)
 		attack_verb = list("attacked", "stabbed", "jabbed", "smacked", "prodded")

--- a/code/game/objects/items/weapons/melee/baseball_bat.dm
+++ b/code/game/objects/items/weapons/melee/baseball_bat.dm
@@ -2,6 +2,7 @@
 	name                       = "bat"
 	desc                       = "HOME RUN!"
 	icon                       = 'icons/obj/items/weapon/bat.dmi'
+	icon_state                 = ICON_STATE_WORLD
 	w_class                    = ITEM_SIZE_LARGE
 	can_be_twohanded             = TRUE
 	pickup_sound               = 'sound/foley/scrape1.ogg'

--- a/code/game/turfs/flooring/_flooring.dm
+++ b/code/game/turfs/flooring/_flooring.dm
@@ -188,12 +188,6 @@ var/global/list/flooring_cache = list()
 	if(target.icon_state != target.floor_icon_state_override)
 		target.icon_state = target.floor_icon_state_override
 
-	if(color)
-		target.color = color
-	else if(!can_paint || isnull(target.paint_color))
-		var/decl/material/use_material = target.get_material()
-		target.color = use_material?.color
-
 	var/edge_layer = (icon_edge_layer != FLOOR_EDGE_NONE) ? target.layer + icon_edge_layer : target.layer
 	var/list/edge_overlays = list()
 	var/has_border = 0

--- a/code/modules/emotes/definitions/audible_slap.dm
+++ b/code/modules/emotes/definitions/audible_slap.dm
@@ -18,8 +18,8 @@
 
 /decl/emote/audible/slap/do_extra(atom/user, atom/target)
 	. = ..()
-	if(ismob(user))
-		var/mob/user_mob = user
-		var/obj/item/clothing/mask/smokable/cig = user_mob.get_equipped_item(slot_wear_mask_str)
+	var/mob/victim_mob = target || user
+	if(ismob(victim_mob))
+		var/obj/item/clothing/mask/smokable/cig = victim_mob.get_equipped_item(slot_wear_mask_str)
 		if(istype(cig))
-			user_mob.try_unequip(cig, user.loc)
+			victim_mob.try_unequip(cig)

--- a/code/modules/projectiles/guns/launcher/bows/bow_interaction.dm
+++ b/code/modules/projectiles/guns/launcher/bows/bow_interaction.dm
@@ -93,6 +93,15 @@
 	if(string)
 		to_chat(user, SPAN_WARNING("\The [src] is already strung."))
 		return TRUE
+	// check to make sure it fits
+	var/datum/storage/loc_storage = loc.storage
+	if(loc_storage)
+		if(strung_w_class > loc_storage.max_w_class)
+			to_chat(user, SPAN_WARNING("\The [src] can't fit in \the [loc] when strung, take it out first!"))
+			return TRUE
+		if((loc_storage.storage_space_used() - w_class + strung_w_class) > loc_storage.max_storage_space)
+			to_chat(user, SPAN_WARNING("\The [loc] is too full to fit \the [src] when strung, make some room!"))
+			return TRUE
 	if(user.try_unequip(new_string, src))
 		set_string(new_string)
 		if(user)


### PR DESCRIPTION
## Description of changes
Adds a check when stringing a bow: if the bow's loc is a storage item the storage item must be able to fit the strung bow.
Removes code that overwrites `color` for `/turf/floor` since it's redundant in light of `get_color()`.
Makes the slap emote unequip the target's worn face-slot smokable item rather than the user's.
Adds default/map preview icon states for items that lack them.
Removes a nonexistent `/obj/item/edge` type accidentally created via a typo.

## Why and what will this PR improve
Prevents stringing a bow inside a storage item that can't fit the strung bow.
Fixes get_color() for floors not determining the colour of the floor.
Fixes slapping someone causing your own cigarette to fly out of your mouth.
Fixes certain items having broken/missing icon states in the map editor.
Fixes a `/set_edge` override being defined on the wrong type.