### PR TITLE
Fix issues interacting with target stakes/dummies

### DIFF
--- a/code/game/objects/structures/target_stake.dm
+++ b/code/game/objects/structures/target_stake.dm
@@ -11,15 +11,22 @@
 	structure_flags     = STRUCTURE_FLAG_THROWN_DAMAGE
 	var/obj/item/training_dummy/dummy
 
+/obj/structure/target_stake/proc/set_dummy(obj/item/training_dummy/new_dummy)
+	dummy = new_dummy
+	if(dummy)
+		dummy.reset_offsets()
+	queue_icon_update()
+	queue_vis_contents_update()
+
 /obj/structure/target_stake/Destroy()
-	dummy = null
+	set_dummy(null)
 	. = ..()
 
 /obj/structure/target_stake/take_damage(damage, damage_type, damage_flags, inflicter, armor_pen, silent, do_update_health)
 	if(dummy)
 		. = dummy.take_damage(damage, damage_type, damage_flags, inflicter, armor_pen, silent, do_update_health)
 		if(QDELETED(dummy))
-			dummy = null
+			set_dummy(null)
 		update_icon()
 		return
 	return ..()
@@ -31,44 +38,32 @@
 	if(dummy)
 		dummy.dropInto(loc)
 		user.put_in_hands(dummy)
-		dummy = null
-		update_icon()
+		set_dummy(null)
 		return TRUE
 	return ..()
 
 /obj/structure/target_stake/attackby(obj/item/used_item, mob/user)
 	if(dummy?.repair_target_dummy(used_item, user))
 		return TRUE
+	if(user.check_intent(I_FLAG_HARM) && dummy?.attackby(used_item, user))
+		return TRUE
 	if(istype(used_item, /obj/item/training_dummy) && can_hold_dummy(user, used_item))
 		if(dummy)
 			to_chat(user, SPAN_WARNING("\The [src] is already holding \the [dummy]."))
 		else if(user.try_unequip(used_item, src))
-			dummy = used_item
+			set_dummy(used_item)
 			visible_message(SPAN_NOTICE("\The [user] places \the [dummy] onto \the [src]."))
-			update_icon()
 		return TRUE
 	return ..()
 
 /obj/structure/target_stake/Initialize(ml, _mat, _reinf_mat)
 	if(ispath(dummy))
-		dummy = new dummy(src)
+		set_dummy(new dummy(src))
 	. = ..()
-	update_icon()
 
-/obj/structure/target_stake/on_update_icon()
+/obj/structure/target_stake/get_vis_contents_to_add()
 	. = ..()
-	if(dummy)
-		// WTB way to stop vis_contents inheriting atom color
-		var/image/dummy_overlay = new /image
-		dummy_overlay.appearance = dummy
-		dummy_overlay.pixel_x = 0
-		dummy_overlay.pixel_y = 0
-		dummy_overlay.pixel_z = 0
-		dummy_overlay.pixel_w = 0
-		dummy_overlay.plane = FLOAT_PLANE
-		dummy_overlay.layer = FLOAT_LAYER
-		dummy_overlay.appearance_flags |= RESET_COLOR
-		add_overlay(dummy_overlay)
+	LAZYADD(., dummy)
 
 // Subtypes below.
 /obj/structure/target_stake/steel


### PR DESCRIPTION
## Description of changes
Makes target stakes/dummies use vis_contents for display. They... don't seem to inherit atom colour, I don't know what that was about. ~~If they did, then trays wouldn't work.~~ Oh, I guess items in trays have `RESET_COLOR`, so I should probably add that to target dummies...
Cleans up target stake attackby so that hitting it hits the dummy too. This was added before the vis_contents change and can probably be removed in light of that?
Makes setting `dummy` use a `set_dummy()` proc that centralises various updates.

## Why and what will this PR improve
I couldn't actually hit a target dummy when it was on a stake...