### PR TITLE
Update colour code to use modern helpers

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ on:
 env:
   BYOND_MAJOR: "515"
   BYOND_MINOR: "1643"
-  SPACEMAN_DMM_VERSION: suite-1.8
+  SPACEMAN_DMM_VERSION: suite-1.9
 
 jobs:
   DreamChecker:

--- a/code/__defines/colors.dm
+++ b/code/__defines/colors.dm
@@ -236,3 +236,5 @@ var/global/list/telecomms_colours = list(
 #define COLOR_DARKMODE_TEXT "#a4bad6"
 
 #define COLORED_SQUARE(COLOR) "<span style='font-face: fixedsys; font-size: 14px; background-color: [COLOR]; color: [COLOR]'>___</span>"
+
+#define hsv(args...) rgb(args, space = COLORSPACE_HSV)

--- a/code/_helpers/game.dm
+++ b/code/_helpers/game.dm
@@ -292,7 +292,7 @@
 		if(1)
 			return colors[1]
 		if(2)
-			return BlendRGBasHSV(colors[1], colors[2], 0.5)
+			return BlendHSV(colors[1], colors[2], 0.5)
 	var/list/reds = list()
 	var/list/blues = list()
 	var/list/greens = list()

--- a/code/_helpers/matrices.dm
+++ b/code/_helpers/matrices.dm
@@ -191,7 +191,7 @@
 /// Converts RGB shorthands into RGBA matrices complete of constants rows (ergo a 20 keys list in byond).
 /proc/color_to_full_rgba_matrix(color)
 	if(istext(color))
-		var/list/L = ReadRGB(color)
+		var/list/L = rgb2num(color)
 		if(!L)
 			CRASH("Invalid/unsupported color format argument in color_to_full_rgba_matrix()")
 		return list(L[1]/255,0,0,0, 0,L[2]/255,0,0, 0,0,L[3]/255,0, 0,0,0,L.len>3?L[4]/255:1, 0,0,0,0)
@@ -202,7 +202,7 @@
 		if(3 to 5) // row-by-row hexadecimals
 			. = list()
 			for(var/a in 1 to L.len)
-				var/list/rgb = ReadRGB(L[a])
+				var/list/rgb = rgb2num(L[a])
 				for(var/b in rgb)
 					. += b/255
 				if(length(rgb) % 4) // RGB has no alpha instruction

--- a/code/game/objects/items/blades/_blade.dm
+++ b/code/game/objects/items/blades/_blade.dm
@@ -75,7 +75,7 @@
 				initial_tool_qualities[TOOL_HATCHET] = TOOL_QUALITY_MEDIOCRE
 		set_extension(src, /datum/extension/tool/variable/simple, initial_tool_qualities)
 
-	shine = istype(material) ? clamp((material.reflectiveness * 0.01) * 255, 10, (0.6 * ReadHSV(RGBtoHSV(material.color))[3])) : null
+	shine = istype(material) ? clamp((material.reflectiveness * 0.01) * 255, 10, (0.6 * rgb2num(material.color, COLORSPACE_HSV)[3])) : null
 	icon_state = ICON_STATE_WORLD
 	on_update_icon()
 

--- a/code/game/objects/structures/hand_cart.dm
+++ b/code/game/objects/structures/hand_cart.dm
@@ -20,7 +20,7 @@
 	underlays += "cart_wheel"
 	var/image/I = image(icon, "handcart_layer_north")
 	I.layer = STRUCTURE_LAYER + 0.02
-	I.color = BlendRGB(color, material.color, 0.5)
+	I.color = BlendHSV(color, material.color, 0.5)
 	add_overlay(I)
 	if(carrying)
 		var/image/CA = image(carrying.icon, carrying.icon_state)

--- a/code/game/turfs/walls/wall_natural_icon.dm
+++ b/code/game/turfs/walls/wall_natural_icon.dm
@@ -39,7 +39,7 @@
 		shine = exterior_wall_shine_cache[shine_cache_key]
 		if(isnull(shine))
 			// patented formula based on color's value (in HSV)
-			shine = clamp((material.reflectiveness * 0.01) * 255, 10, (0.6 * ReadHSV(RGBtoHSV(material.color))[3]))
+			shine = clamp((material.reflectiveness * 0.01) * 255, 10, (0.6 * rgb2num(material.color, COLORSPACE_HSV)[3]))
 			exterior_wall_shine_cache[shine_cache_key] = shine
 
 	var/new_icon

--- a/code/modules/integrated_electronics/subtypes/converters.dm
+++ b/code/modules/integrated_electronics/subtypes/converters.dm
@@ -411,8 +411,8 @@
 	var/hue = get_pin_data(IC_INPUT, 1)
 	var/saturation = get_pin_data(IC_INPUT, 2)
 	var/value = get_pin_data(IC_INPUT, 3)
-	if(isnum(hue)&&isnum(saturation)&&isnum(value))
-		result = HSVtoRGB(hsv(AngleToHue(hue),saturation,value))
+	if(isnum(hue) && isnum(saturation) && isnum(value))
+		result = hsv(hue, saturation, value)
 
 	set_pin_data(IC_OUTPUT, 1, result)
 	push_data()

--- a/code/modules/materials/_materials.dm
+++ b/code/modules/materials/_materials.dm
@@ -270,6 +270,8 @@ INITIALIZE_IMMEDIATE(/obj/effect/gas_overlay)
 	var/overdose = 0
 	var/scannable = 0 // Shows up on health analyzers.
 	var/color = COLOR_BEIGE
+	// How much variance in color do objects of this material have, in fraction of maximum brightness/hue.
+	var/color_variance = 0.04
 	var/color_weight = 1
 	var/cocktail_ingredient
 	var/defoliant
@@ -1087,7 +1089,7 @@ INITIALIZE_IMMEDIATE(/obj/effect/gas_overlay)
 	// Blend our extra_colour...
 	var/new_extra_color = newdata?[DATA_EXTRA_COLOR]
 	if(new_extra_color)
-		.[DATA_EXTRA_COLOR] = BlendRGBasHSV(new_extra_color, .[DATA_EXTRA_COLOR], new_fraction)
+		.[DATA_EXTRA_COLOR] = BlendHSV(new_extra_color, .[DATA_EXTRA_COLOR], new_fraction)
 
 /decl/material/proc/explosion_act(obj/item/chems/holder, severity)
 	SHOULD_CALL_PARENT(TRUE)


### PR DESCRIPTION
## Description of changes
Replaces some outdated icon/colour helper code with modern builtins and better-written code.
HSV colour strings are no more, instead they use HSV colour lists. This prevents unnecessary string tree operations and also allows it to work with the built-in colour procs.

## Why and what will this PR improve
Faster, better-written colour helper code.