### PR TITLE
Make various non-user-visible code cleanup tweaks

### DIFF
--- a/code/__defines/maths.dm
+++ b/code/__defines/maths.dm
@@ -1,5 +1,5 @@
 // Macro functions.
-#define RAND_F(LOW, HIGH) (rand() * (HIGH - LOW) + LOW)
+#define RAND_F(LOW, HIGH) (rand() * ((HIGH) - (LOW)) + (LOW))
 
 // Float-aware floor and ceiling since round() will round upwards when given a second arg.
 #define NONUNIT_FLOOR(x, y)    (floor((x) / (y)) * (y))

--- a/code/modules/bodytype/bodytype_quadruped.dm
+++ b/code/modules/bodytype/bodytype_quadruped.dm
@@ -17,7 +17,7 @@
 		BP_R_FOOT = list("path" = /obj/item/organ/external/foot/right/quadruped)
 	)
 	var/rideable = TRUE
-	var/riding_offset = @"{'x':0,'y':0,'z':8}"
+	var/riding_offset = @'{"x":0,"y":0,"z":8}'
 
 /decl/bodytype/quadruped/apply_appearance(var/mob/living/human/H)
 	. = ..()

--- a/code/modules/emotes/definitions/tail.dm
+++ b/code/modules/emotes/definitions/tail.dm
@@ -1,6 +1,8 @@
 
 /decl/emote/visible/tail
 	abstract_type = /decl/emote/visible/tail
+	key = "tail"
+	emote_message_3p = "$USER$ waves $USER_THEIR$ tail."
 
 /decl/emote/visible/tail/mob_can_use(mob/living/user, assume_available = FALSE)
 	return istype(user) && ..()

--- a/code/modules/emotes/definitions/visible.dm
+++ b/code/modules/emotes/definitions/visible.dm
@@ -1,6 +1,5 @@
 /decl/emote/visible
-	key = "tail"
-	emote_message_3p = "$USER$ waves $USER_THEIR$ tail."
+	abstract_type = /decl/emote/visible
 	message_type = VISIBLE_MESSAGE
 
 /decl/emote/visible/scratch

--- a/code/modules/mob/living/simple_animal/_simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/_simple_animal.dm
@@ -10,7 +10,7 @@
 	mob_push_flags = MONKEY|SLIME|SIMPLE_ANIMAL
 
 	icon_state = ICON_STATE_WORLD
-	buckle_pixel_shift = @"{'x':0,'y':0,'z':8}"
+	buckle_pixel_shift = @'{"x":0,"y":0,"z":8}'
 
 	hud_used = /datum/hud/animal
 

--- a/code/modules/mob/living/simple_animal/passive/horse.dm
+++ b/code/modules/mob/living/simple_animal/passive/horse.dm
@@ -10,7 +10,7 @@
 	default_pixel_x       = -6
 	base_animal_type      = /mob/living/simple_animal/passive/horse
 	faction               = null
-	buckle_pixel_shift    = @"{'x':0,'y':0,'z':16}"
+	buckle_pixel_shift    = @'{"x":0,"y":0,"z":16}'
 	can_have_rider        = TRUE
 	max_rider_size        = MOB_SIZE_MEDIUM
 	ai                    = /datum/mob_controller/passive/horse

--- a/code/modules/random_map/noise/noise.dm
+++ b/code/modules/random_map/noise/noise.dm
@@ -61,48 +61,35 @@
 	var/hsize = round(input_size/2)
 
 	/*
-	(x,y+isize)----(x+hsize,y+isize)----(x+size,y+isize)
+	(x,y+isize)----(x+hsize,y+isize)----(x+isize,y+isize)
 	  |                 |                  |
 	  |                 |                  |
 	  |                 |                  |
-	(x,y+hsize)----(x+hsize,y+hsize)----(x+isize,y)
+	(x,y+hsize)----(x+hsize,y+hsize)----(x+isize,y+hsize)
 	  |                 |                  |
 	  |                 |                  |
 	  |                 |                  |
 	(x,y)----------(x+hsize,y)----------(x+isize,y)
 	*/
+	// Pre-halve them to prevent extra divisions.
+	var/topleft = map[TRANSLATE_COORD(x,y+isize)]/2
+	var/topright = map[TRANSLATE_COORD(x+isize,y+isize)]/2
+	var/bottomleft = map[TRANSLATE_COORD(x, y)]/2
+	var/bottomright = map[TRANSLATE_COORD(x+isize,y)]/2
+
 	// Central edge values become average of corners.
-	map[TRANSLATE_COORD(x+hsize,y+isize)] = round((\
-		map[TRANSLATE_COORD(x,y+isize)] +          \
-		map[TRANSLATE_COORD(x+isize,y+isize)] \
-		)/2)
-
-	map[TRANSLATE_COORD(x+hsize,y)] = round((  \
-		map[TRANSLATE_COORD(x,y)] +            \
-		map[TRANSLATE_COORD(x+isize,y)]   \
-		)/2)
-
-	map[TRANSLATE_COORD(x,y+hsize)] = round((  \
-		map[TRANSLATE_COORD(x,y+isize)] + \
-		map[TRANSLATE_COORD(x,y)]              \
-		)/2)
-
-	map[TRANSLATE_COORD(x+isize,y+hsize)] = round((  \
-		map[TRANSLATE_COORD(x+isize,y+isize)] + \
-		map[TRANSLATE_COORD(x+isize,y)]        \
-		)/2)
+	map[TRANSLATE_COORD(x+hsize,y+isize)] = round(topleft + topright) // top = topleft + topright
+	map[TRANSLATE_COORD(x+hsize,y)] = round(bottomleft + bottomright) // bottom = bottomleft + bottomright
+	map[TRANSLATE_COORD(x,y+hsize)] = round(topleft + bottomleft) // left = topleft + bottomleft
+	map[TRANSLATE_COORD(x+isize,y+hsize)] = round(topright + bottomright) // right = topright + bottomright
 
 	// Centre value becomes the average of all other values + possible random variance.
 	var/current_cell = TRANSLATE_COORD(x+hsize,y+hsize)
-	map[current_cell] = round(( \
-		map[TRANSLATE_COORD(x+hsize,y+isize)] + \
-		map[TRANSLATE_COORD(x+hsize,y)] + \
-		map[TRANSLATE_COORD(x,y+hsize)] + \
-		map[TRANSLATE_COORD(x+isize,y)] \
-		)/4)
+	// yes, this is equivalent to the prior averaging. it just avoids more list indexing
+	map[current_cell] = round(round(topleft+topright)/4 + round(bottomleft + bottomright)/4 + round(topleft + bottomleft)/4 + round(topright + bottomright)/4)
 
 	if(prob(random_variance_chance))
-		map[current_cell] *= (rand(1,2)==1 ? (1.0-random_element) : (1.0+random_element))
+		map[current_cell] *= (prob(50) ? (1.0-random_element) : (1.0+random_element))
 		map[current_cell] = max(0,min(cell_range,map[current_cell]))
 
  	// Recurse until size is too small to subdivide.
@@ -116,42 +103,46 @@
 
 /datum/random_map/noise/cleanup()
 	for(var/i = 1 to smoothing_iterations)
-		var/list/next_map[limit_x*limit_y]
+		// var/list/next_map[limit_x*limit_y]
 		// simple box blur from http://amritamaz.net/blog/understanding-box-blur
 		// basically: we do two very fast one-dimensional blurs
 		var/total
 		for(var/y = 1 to limit_y) // for each row
 			// init window for x=1
 			// for a blur with a radius >1 use a for loop instead and replace 2 with the real count
-			var/cellone = map[TRANSLATE_COORD(1, y)]
-			var/celltwo = map[TRANSLATE_COORD(2, y)]
+			var/first_coord = TRANSLATE_COORD(1, y)
+			var/second_coord = TRANSLATE_COORD(2, y)
+			var/cellone = map[first_coord]
+			var/celltwo = map[second_coord]
 			total = cellone + celltwo
-			next_map[TRANSLATE_COORD(1, y)] = round(total / 2)
+			map[first_coord] = round(total / 2)
 			// hardcoding x=2 also, to lower checks in the loop
 			// larger radius would need to also cover all x < 1 + blur_radius
 			total += map[TRANSLATE_COORD(3, y)]
-			next_map[TRANSLATE_COORD(2, y)] = round(total / 3)
+			map[second_coord] = round(total / 3)
 			for(var/x = 3 to limit_x-1) // should technically be 2 + blur_radius to limit_x - blur_radius
 				total -= map[TRANSLATE_COORD(x-2, y)] // x - blur_radius - 1
 				total += map[TRANSLATE_COORD(x+1, y)] // x + blur_radius
-				next_map[TRANSLATE_COORD(x, y)] = round(total / 3) // should technically be 2*blur_radius+1
+				map[TRANSLATE_COORD(x, y)] = round(total / 3) // should technically be 2*blur_radius+1
 		// now do the same in the x axis
-		map = next_map.Copy()
+		// map = next_map.Copy()
 		for(var/x = 1 to limit_x)
 			// see comments above
-			var/cellone = map[TRANSLATE_COORD(x, 1)]
-			var/celltwo = map[TRANSLATE_COORD(x, 2)]
+			var/first_coord = TRANSLATE_COORD(x, 1)
+			var/second_coord = TRANSLATE_COORD(x, 2)
+			var/cellone = map[first_coord]
+			var/celltwo = map[second_coord]
 			total = cellone + celltwo
-			next_map[TRANSLATE_COORD(x, 1)] = round(total / 2)
+			map[first_coord] = round(total / 2)
 			// hardcoding x=2 also, to lower checks in the loop
 			// larger radius would need to also cover all x < 1 + blur_radius
 			total += map[TRANSLATE_COORD(x, 3)]
-			next_map[TRANSLATE_COORD(x, 2)] = round(total / 3)
+			map[second_coord] = round(total / 3)
 			for(var/y = 3 to limit_y-1)
 				total -= map[TRANSLATE_COORD(x, y-2)]
 				total += map[TRANSLATE_COORD(x, y+1)]
-				next_map[TRANSLATE_COORD(x, y)] = round(total / 3)
-		map = next_map
+				map[TRANSLATE_COORD(x, y)] = round(total / 3)
+		// map = next_map
 		CHECK_TICK
 
 	if(smooth_single_tiles)

--- a/code/modules/random_map/random_map.dm
+++ b/code/modules/random_map/random_map.dm
@@ -104,14 +104,15 @@ var/global/list/map_count = list()
 	if(!user)
 		user = world
 
-	var/dat = "<code>+------+<br>"
+	var/dat = list("<code>+------+<br>")
 	for(var/x = 1, x <= limit_x, x++)
 		for(var/y = 1, y <= limit_y, y++)
 			var/current_cell = TRANSLATE_COORD(x,y)
 			if(current_cell)
 				dat += get_map_char(map[current_cell])
 		dat += "<br>"
-	to_chat(user, "[dat]+------+</code>")
+	dat += "+------+</code>"
+	to_chat(user, JOINTEXT(dat))
 
 /datum/random_map/proc/set_map_size()
 	map = list()
@@ -189,8 +190,7 @@ var/global/list/map_count = list()
 			return wall_type
 
 /datum/random_map/proc/get_additional_spawns(var/value, var/turf/T)
-	if(value == DOOR_CHAR)
-		new /obj/machinery/door/airlock(T)
+	// e.g. if(value == DOOR_CHAR) new /obj/machinery/door/airlock(T)
 
 /datum/random_map/proc/cleanup()
 	return

--- a/code/modules/reagents/reagent_containers/drinkingglass/extras.dm
+++ b/code/modules/reagents/reagent_containers/drinkingglass/extras.dm
@@ -46,6 +46,7 @@
 	return TRUE
 
 /obj/item/glass_extra
+	abstract_type = /obj/item/glass_extra
 	name = "generic glass addition"
 	desc = "This goes on a glass."
 	var/glass_addition

--- a/code/unit_tests/json.dm
+++ b/code/unit_tests/json.dm
@@ -37,6 +37,12 @@
 	var/list/failures
 	var/list/json_to_check
 
+	for(var/atom/movable/subtype as anything in typesof(/obj))
+		if(TYPE_IS_ABSTRACT(subtype))
+			continue
+		var/check_json = subtype::buckle_pixel_shift
+		if(istext(check_json))
+			LAZYSET(json_to_check, "[subtype].buckle_pixel_shift", check_json)
 	for(var/subtype in typesof(/obj))
 		var/obj/test = subtype
 		var/check_json = initial(test.directional_offset)
@@ -67,6 +73,15 @@
 		var/check_json = initial(test.possible_transfer_amounts)
 		if(!isnull(check_json))
 			LAZYSET(json_to_check, "[subtype].possible_transfer_amounts", check_json)
+	for(var/mob/subtype as anything in typesof(/mob))
+		if(TYPE_IS_ABSTRACT(subtype))
+			continue
+	var/list/quadruped_bodytypes = decls_repository.get_decls_of_subtype(/decl/bodytype/quadruped)
+	for(var/quad_bodytype_path in quadruped_bodytypes)
+		var/decl/bodytype/quadruped/quad_bodytype = quadruped_bodytypes[quad_bodytype_path]
+		var/check_json = quad_bodytype.riding_offset
+		if(istext(check_json))
+			LAZYSET(json_to_check, "[quad_bodytype_path].riding_offset", check_json)
 	var/list/prefabs = decls_repository.get_decls_of_subtype(/decl/prefab/ic_assembly)
 	for(var/assembly_path in prefabs)
 		var/decl/prefab/ic_assembly/assembly = prefabs[assembly_path]


### PR DESCRIPTION
## Description of changes
Fixes some math issues with `RAND_F` I encountered due to order-of-operation issues with macro argument expansion.
Adds some overlooked JSON variables to the JSON unit test.
Makes `/decl/emote/visible` abstract and moves its key and default message onto `/decl/emote/visible/tail`.
Cleans up and optimises noisemap code.
Removes code that caused noisemaps to randomly spawn airlocks if a cell was a certain value. No, really. What??
Sets `abstract_type` on `glass_extra`.

## Why and what will this PR improve
Fixes some non-user-visible issues, or issues not exposed by existing upstream code. Also optimises stuff.