### PR TITLE
Only show character creation blurb expand buttons if the blurb was cut off

### DIFF
--- a/code/modules/client/preference_setup/background/01_species.dm
+++ b/code/modules/client/preference_setup/background/01_species.dm
@@ -68,10 +68,12 @@
 	if(current_species.roleplay_summary)
 		desc = "[desc]<h3>Roleplaying Summary</h3><p>[current_species.roleplay_summary]</p>"
 
-	if(hide_species && length(desc) > 200)
+	var/was_hidden = hide_species && length(desc) > 200
+	if(was_hidden)
 		desc = "[copytext(desc, 1, 194)] <small>\[...\]</small>"
 	. += "<td width>[desc]</td>"
-	. += "<td width = '50px'><a href='?src=\ref[src];toggle_species_verbose=1'>[hide_species ? "Expand" : "Collapse"]</a></td>"
+	if(was_hidden)
+		. += "<td width = '50px'><a href='byond://?src=\ref[src];toggle_species_verbose=1'>[hide_species ? "Expand" : "Collapse"]</a></td>"
 
 	. += "</tr>"
 

--- a/code/modules/client/preference_setup/background/02_culture.dm
+++ b/code/modules/client/preference_setup/background/02_culture.dm
@@ -104,9 +104,11 @@
 		. += "<small>[culture_info["details"] || "No additional details."]</small>"
 		. += "</td><td>"
 		. += "[culture_info["body"] || "No description."]"
-		. += "</td><td width = '50px'>"
-		. += "<a href='?src=\ref[src];toggle_verbose_[token]=1'>[hidden[token] ? "Expand" : "Collapse"]</a>"
-		. += "</td></tr>"
+		. += "</td>"
+		// Only show the button to expand/hide if the text overflows the limit.
+		if(culture.is_long())
+			. += "<td width = '50px'><a href='?src=\ref[src];toggle_verbose_[token]=1'>[hidden[token] ? "Expand" : "Collapse"]</a></td>"
+		. += "</tr>"
 		. += "</table><hr>"
 
 	. = jointext(.,null)

--- a/code/modules/culture_descriptor/_culture.dm
+++ b/code/modules/culture_descriptor/_culture.dm
@@ -55,9 +55,12 @@
 /decl/cultural_info/proc/sanitize_cultural_name(new_name)
 	return sanitize_name(new_name)
 
+/decl/cultural_info/proc/is_long()
+	return length(get_text_body()) > 200
+
 /decl/cultural_info/proc/get_description(var/verbose = TRUE)
 	LAZYSET(., "details", jointext(get_text_details(), "<br>"))
-	if(verbose || length(get_text_body()) <= 200)
+	if(verbose || !is_long())
 		LAZYSET(., "body", get_text_body())
 	else
 		LAZYSET(., "body", "[copytext(get_text_body(), 1, 194)] <small>\[...\]</small>")


### PR DESCRIPTION
## Description of changes
![image](https://github.com/user-attachments/assets/92e700dd-714f-418a-8dc0-147c609c2a46)
The expand buttons are only shown for background blurbs that get cut off.

## Why and what will this PR improve
It felt weird for them to be always-visible.