### PR TITLE
Make 'put hands in pockets' emote require having pockets

### DIFF
--- a/code/modules/emotes/definitions/visible.dm
+++ b/code/modules/emotes/definitions/visible.dm
@@ -308,6 +308,15 @@
 	check_restraints = TRUE
 	emote_message_3p = "$USER$ shoves $USER_THEIR$ hands in $USER_THEIR$ pockets."
 
+/decl/emote/visible/pocket/mob_can_use(mob/living/user, assume_available)
+	. = ..()
+	if(!.)
+		return
+	// You need a uniform to have pockets.
+	var/datum/inventory_slot/check_slot = user.get_inventory_slot_datum(slot_w_uniform_str)
+	if(!check_slot?.get_equipped_item())
+		return FALSE
+
 /decl/emote/visible/rsalute
 	key = "rsalute"
 	check_restraints = TRUE


### PR DESCRIPTION
## Description of changes
Makes the 'put hands in pockets' emote require having pockets.

## Why and what will this PR improve
Consistency with the pocket slot, mostly.

## Changelog
:cl:
tweak: You must now be wearing a uniform to use the 'shove your hands in your pockets' emote.
/:cl: