### PR TITLE
Adds Toggle Browser Inspect debug verb for debugging browsers

### DIFF
--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -218,6 +218,7 @@ var/global/list/admin_verbs_debug = list(
 	/datum/admins/proc/force_weather_state,
 	/datum/admins/proc/force_kill_weather,
 	/client/proc/force_reload_theme_css,
+	/client/proc/toggle_browser_inspect,
 	)
 
 var/global/list/admin_verbs_paranoid_debug = list(

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -512,3 +512,26 @@
 	. += "</ol>"
 
 	show_browser(usr, JOINTEXT(.), "window=dellog")
+
+/client/proc/toggle_browser_inspect()
+	set category = "Debug"
+	set name = "Toggle Browser Inspect"
+
+	#if DM_VERSION >= 516
+
+	var/list/browser_options = winget(src, null, "browser-options")
+
+	if(findtext(browser_options, "devtools") == TRUE)
+		// Disable the dev tools.
+		winset(src, null, list("browser-options" = "-devtools"))
+		message_admins("[key_name_admin(usr)] has disabled Browser Inspection.")
+	else
+		// Enable the dev tools.
+		winset(src, null, list("browser-options" = "+devtools"))
+		message_admins("[key_name_admin(usr)] has enabled Browser Inspection.")
+
+	#else
+
+	alert("Browser Inspection is not supported in this version of BYOND, please update to 516 or later.")
+
+	#endif

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -521,7 +521,7 @@
 
 	var/browser_options = winget(src, null, "browser-options")
 
-	if(findtext(browser_options, "devtools") == TRUE)
+	if(findtext(browser_options, "devtools"))
 		// Disable the dev tools.
 		winset(src, null, list("browser-options" = "-devtools"))
 		message_admins("[key_name_admin(usr)] has disabled Browser Inspection.")

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -519,7 +519,7 @@
 
 	#if DM_VERSION >= 516
 
-	var/list/browser_options = winget(src, null, "browser-options")
+	var/browser_options = winget(src, null, "browser-options")
 
 	if(findtext(browser_options, "devtools") == TRUE)
 		// Disable the dev tools.


### PR DESCRIPTION
## Description of changes
Implemented a debug verb for 516's webview2 devtools, allowing for nicer UI development.

## Why and what will this PR improve
Let people develop and test UIs with much more ease.

## Authorship
@Zandario

## Changelog
:cl:
admin: Added a "Toggle Browser Inspect" debug verb for debugging UIs
/:cl:
