### PR TITLE
Fix simple_animal natural weapons not working

### DIFF
--- a/code/_onclick/ai.dm
+++ b/code/_onclick/ai.dm
@@ -72,7 +72,7 @@
 	The below is only really for safety, or you can alter the way
 	it functions and re-insert it above.
 */
-/mob/living/silicon/ai/UnarmedAttack(atom/A)
+/mob/living/silicon/ai/ResolveUnarmedAttack(atom/A)
 	return A.attack_ai(src)
 
 /mob/living/silicon/ai/RangedAttack(atom/A, var/params)

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -187,8 +187,12 @@
 /mob/proc/UnarmedAttack(var/atom/A, var/proximity_flag)
 	return
 
-/mob/living/UnarmedAttack(var/atom/A, var/proximity_flag)
+/// Handles per-mob unarmed attack functionality after shared checks, e.g. maneuvers and abilities.
+/mob/living/proc/ResolveUnarmedAttack(var/atom/A)
+	return A.attack_hand(src)
 
+/mob/living/UnarmedAttack(var/atom/A, var/proximity_flag)
+	SHOULD_NOT_OVERRIDE(TRUE)
 	if(GAME_STATE < RUNLEVEL_GAME)
 		to_chat(src, "You cannot attack people before the game has started.")
 		return TRUE
@@ -204,11 +208,11 @@
 	// Special glove functions:
 	// If the gloves do anything, have them return 1 to stop
 	// normal attack_hand() here.
-	var/obj/item/clothing/gloves/G = get_equipped_item(slot_gloves_str) // not typecast specifically enough in defines
-	if(istype(G) && G.Touch(A,1))
+	var/obj/item/clothing/gloves/G = get_equipped_item(slot_gloves_str)
+	if(istype(G) && G.Touch(A, proximity_flag))
 		return TRUE
 
-	return A.attack_hand(src)
+	return ResolveUnarmedAttack(A)
 
 /*
 	Ranged unarmed attack:

--- a/code/_onclick/cyborg.dm
+++ b/code/_onclick/cyborg.dm
@@ -159,7 +159,7 @@
 	clicks, you can do so here, but you will have to
 	change attack_robot() above to the proper function
 */
-/mob/living/silicon/robot/UnarmedAttack(atom/A)
+/mob/living/silicon/robot/ResolveUnarmedAttack(atom/A)
 	return A.attack_robot(src)
 
 /mob/living/silicon/robot/RangedAttack(atom/A, var/params)

--- a/code/_onclick/other_mobs.dm
+++ b/code/_onclick/other_mobs.dm
@@ -51,7 +51,7 @@
 		return climb_up(A)
 
 	var/obj/item/clothing/gloves/G = get_equipped_item(slot_gloves_str)
-	if(istype(G) && G.Touch(A,0)) // for magic gloves
+	if(istype(G) && G.Touch(A, FALSE)) // for magic gloves
 		return TRUE
 
 	. = ..()
@@ -92,13 +92,8 @@
 /*
 	Animals
 */
-
-/mob/living/simple_animal/UnarmedAttack(var/atom/A, var/proximity)
-
-	. = ..()
-	if(.)
-		return
-
+/// Make unarmed attacks use natural weapons on harm intent.
+/mob/living/simple_animal/ResolveUnarmedAttack(atom/A)
 	var/attacking_with = get_natural_weapon()
 	if(a_intent == I_HELP || !attacking_with)
 		return A.attack_animal(src)

--- a/code/modules/mob/living/bot/cleanbot.dm
+++ b/code/modules/mob/living/bot/cleanbot.dm
@@ -56,7 +56,7 @@
 	if(get_turf(target) == src.loc)
 		UnarmedAttack(target, TRUE)
 
-/mob/living/bot/cleanbot/UnarmedAttack(var/obj/effect/decal/cleanable/decal, var/proximity)
+/mob/living/bot/cleanbot/ResolveUnarmedAttack(var/obj/effect/decal/cleanable/decal)
 	if(!istype(decal))
 		return TRUE
 

--- a/code/modules/mob/living/bot/farmbot.dm
+++ b/code/modules/mob/living/bot/farmbot.dm
@@ -141,7 +141,7 @@
 	makeStep(target_path)
 	return
 
-/mob/living/bot/farmbot/UnarmedAttack(var/atom/A, var/proximity)
+/mob/living/bot/farmbot/ResolveUnarmedAttack(var/atom/A)
 	if(busy)
 		return TRUE
 

--- a/code/modules/mob/living/bot/floorbot.dm
+++ b/code/modules/mob/living/bot/floorbot.dm
@@ -128,7 +128,7 @@
 
 	return emagged || (amount && (my_turf.is_floor_damaged() || (improvefloors && !my_turf.has_flooring())))
 
-/mob/living/bot/floorbot/UnarmedAttack(var/atom/A, var/proximity)
+/mob/living/bot/floorbot/ResolveUnarmedAttack(var/atom/A)
 	if(busy)
 		return TRUE
 

--- a/code/modules/mob/living/bot/medibot.dm
+++ b/code/modules/mob/living/bot/medibot.dm
@@ -95,7 +95,7 @@
 				last_newpatient_speak = world.time
 			break
 
-/mob/living/bot/medbot/UnarmedAttack(var/mob/living/human/target, var/proximity)
+/mob/living/bot/medbot/ResolveUnarmedAttack(var/mob/living/human/target)
 	if(!on || !istype(target))
 		return FALSE
 

--- a/code/modules/mob/living/bot/mulebot.dm
+++ b/code/modules/mob/living/bot/mulebot.dm
@@ -193,7 +193,7 @@
 		return
 	..()
 
-/mob/living/bot/mulebot/UnarmedAttack(var/turf/T)
+/mob/living/bot/mulebot/ResolveUnarmedAttack(var/turf/T)
 	if(T == src.loc)
 		unload(dir)
 

--- a/code/modules/mob/living/bot/secbot.dm
+++ b/code/modules/mob/living/bot/secbot.dm
@@ -194,7 +194,7 @@
 		return BP_CHEST
 	return ..()
 
-/mob/living/bot/secbot/UnarmedAttack(var/mob/M, var/proximity)
+/mob/living/bot/secbot/ResolveUnarmedAttack(var/mob/M)
 	if(!istype(M))
 		return FALSE
 

--- a/code/modules/mob/living/human/human_attackhand.dm
+++ b/code/modules/mob/living/human/human_attackhand.dm
@@ -428,7 +428,7 @@
 			to_chat(src, SPAN_NOTICE(summary))
 	attack_selector?.update_icon()
 
-/mob/living/human/UnarmedAttack(atom/A, proximity_flag)
+/mob/living/human/ResolveUnarmedAttack(atom/A)
 	// Hackfix for humans trying to attack someone without hands.
 	// Dexterity ect. should be checked in these procs regardless,
 	// but unarmed attacks that don't require hands should still

--- a/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
+++ b/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
@@ -27,7 +27,7 @@
 		body.visible_message(SPAN_DANGER("\The [body] gets an evil-looking gleam in [pronouns.his] eye."))
 
 /datum/mob_controller/aggressive/goat/proc/find_edible_atom(list/targets)
-	// TODO: add /obj/structure/flora here and in goat/UnarmedAttack()
+	// TODO: add /obj/structure/flora here and in goat/ResolveUnarmedAttack()
 	var/atom/maybe_food = locate(/obj/effect/vine) in targets
 	if(!istype(maybe_food))
 		for(var/obj/machinery/portable_atmospherics/hydroponics/tray in targets)
@@ -74,25 +74,24 @@
 	. = ..()
 	set_extension(src, /datum/extension/milkable/goat)
 
-/mob/living/simple_animal/hostile/goat/UnarmedAttack(var/atom/A, var/proximity)
+/mob/living/simple_animal/hostile/goat/ResolveUnarmedAttack(var/atom/A)
 	var/was_food = FALSE
-	if(proximity)
-		if(prob(30))
-			if(istype(A, /obj/effect/vine))
-				var/obj/effect/vine/SV = A
-				SV.die_off(1)
+	if(prob(30))
+		if(istype(A, /obj/effect/vine))
+			var/obj/effect/vine/SV = A
+			SV.die_off(1)
+			was_food = TRUE
+		else if(istype(A, /obj/machinery/portable_atmospherics/hydroponics))
+			var/obj/machinery/portable_atmospherics/hydroponics/tray = A
+			if(tray.seed)
 				was_food = TRUE
-			else if(istype(A, /obj/machinery/portable_atmospherics/hydroponics))
-				var/obj/machinery/portable_atmospherics/hydroponics/tray = A
-				if(tray.seed)
-					was_food = TRUE
-					tray.die()
-					if(!QDELETED(tray))
-						tray.remove_dead(silent = TRUE) // this will qdel invisible trays
-		if(was_food)
-			visible_message(SPAN_NOTICE("\The [src] eats \the [A]."))
-
-	return was_food ? TRUE :..()
+				tray.die()
+				if(!QDELETED(tray))
+					tray.remove_dead(silent = TRUE) // this will qdel invisible trays
+	if(was_food)
+		visible_message(SPAN_NOTICE("\The [src] eats \the [A]."))
+		return TRUE
+	return ..()
 
 /mob/living/simple_animal/cow
 	name = "cow"

--- a/mods/content/xenobiology/slime/slime_click.dm
+++ b/mods/content/xenobiology/slime/slime_click.dm
@@ -1,7 +1,7 @@
 /mob/living/slime/RestrainedClickOn(var/atom/A)
 	return FALSE
 
-/mob/living/slime/UnarmedAttack(var/atom/A, var/proximity)
+/mob/living/slime/ResolveUnarmedAttack(var/atom/A)
 
 	. = ..()
 	if(.)

--- a/mods/mobs/borers/mob/borer/borer_attacks.dm
+++ b/mods/mobs/borers/mob/borer/borer_attacks.dm
@@ -1,9 +1,9 @@
-/mob/living/simple_animal/borer/UnarmedAttack(atom/A, proximity)
+/mob/living/simple_animal/borer/ResolveUnarmedAttack(atom/A)
 
 	if(host)
 		return TRUE // We cannot click things outside of our host.
 
-	if(!isliving(A) || a_intent != I_GRAB || stat || !proximity)
+	if(!isliving(A) || a_intent != I_GRAB || stat)
 		return ..()
 
 	if(!can_use_borer_ability(requires_host_value = FALSE, check_last_special = FALSE))

--- a/mods/mobs/dionaea/mob/nymph_attacks.dm
+++ b/mods/mobs/dionaea/mob/nymph_attacks.dm
@@ -1,4 +1,4 @@
-/mob/living/simple_animal/alien/diona/UnarmedAttack(var/atom/A)
+/mob/living/simple_animal/alien/diona/ResolveUnarmedAttack(var/atom/A)
 
 	if(incapacitated())
 		return ..()

--- a/mods/species/ascent/mobs/nymph/nymph_attacks.dm
+++ b/mods/species/ascent/mobs/nymph/nymph_attacks.dm
@@ -1,4 +1,4 @@
-/mob/living/simple_animal/alien/kharmaan/UnarmedAttack(var/atom/A)
+/mob/living/simple_animal/alien/kharmaan/ResolveUnarmedAttack(var/atom/A)
 
 	. = ..()
 	if(.)


### PR DESCRIPTION
## Description of changes
Separates out UnarmedAttack so that we can have mobs that override just the part after all the checks, i.e. replace or add onto the base `A.attack_hand(src)` call.

## Why and what will this PR improve
Fixes https://github.com/ScavStation/ScavStation/issues/1251.

## Authorship
Me