### PR TITLE
reinf window fix

### DIFF
--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -638,8 +638,8 @@
 
 		if (ST.use(required_amount))
 			var/obj/structure/window/WD = new(loc, ST.material.type, ST.reinf_material?.type, dir_to_set, FALSE)
-			to_chat(user, SPAN_NOTICE("You place [WD]."))
-			WD.set_anchored(FALSE) // handles setting construction state for us
+			to_chat(user, SPAN_NOTICE("You place [WD].")) 
+			WD.set_anchored(TRUE) // handles setting construction state for us  // was orinigally FALSE but it caused bugs wth reinforced window which cannot then be pried out of frame
 		else
 			to_chat(user, SPAN_NOTICE("You do not have enough sheets."))
 			return


### PR DESCRIPTION
			WD.set_anchored(TRUE) // handles setting construction state for us // was orinigally FALSE but it caused bugs wth reinforced window which cannot then be pried out of frame

<!-- !! PLEASE, READ THIS !! -->
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/NebulaSS13/Nebula/blob/dev/CONTRIBUTING.md -->
<!-- If you're opening a pull request which changes A LOT of icon/map files: -->
<!-- Add [IDB IGNORE] (to ignore icon file changes) or [MDB IGNORE] (to ignore map file changes) in the PR title. -->
<!-- These tags prevent huge diffs from overloading IconDiffBot and MapDiffBot. -->

## Description of changes
<!-- Describe the pull request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Changed WD.set_anchored(FALSE) to WD.set_anchored(TRUE) because that state was causing issues with reinforced window not being able to be pried out of frame or deconstructed, being loked in wrong state. Since Window placed by crafting in hand is already achored normally this bring it into the same state and fixes issue. Tested it fixing both full tile and thin reinforced windows 
## Why and what will this PR improve
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
the bug has been plaguing our engineer players for long time now, forcing us to climb onto walls and built it there by hand, also made drones unable to install windows due to not being able to craft "in hand" this should solve it. 
## Authorship
<!-- Describe original authors of changes to credit them. -->
myself
## Changelog
:cl:

bugfix: Fixed reinforced window locked in wrong state when built directly on turf
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->