### PR TITLE
Fixes overmap trading hubs being uninteractable

### DIFF
--- a/code/modules/merchant/merchant_programs.dm
+++ b/code/modules/merchant/merchant_programs.dm
@@ -39,7 +39,7 @@
 
 /datum/computer_file/program/merchant/proc/get_available_hubs()
 	. = list()
-	var/turf/T = get_turf(holder)
+	var/turf/T = get_turf(holder.resolve())
 	for(var/datum/trade_hub/hub in SStrade.trade_hubs)
 		if(hub.is_accessible_from(T))
 			. |= hub


### PR DESCRIPTION
<!-- !! PLEASE, READ THIS !! -->
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/NebulaSS13/Nebula/blob/dev/CONTRIBUTING.md -->
<!-- If you're opening a pull request which changes A LOT of icon/map files: -->
<!-- Add [IDB IGNORE] (to ignore icon file changes) or [MDB IGNORE] (to ignore map file changes) in the PR title. -->
<!-- These tags prevent huge diffs from overloading IconDiffBot and MapDiffBot. -->

## Description of changes
<!-- Describe the pull request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Resolves the `holder` weakref, so that `get_turf()` is given the ingame computer's hard drive, thus `T` will be the computer's turf and not null, which makes overmap-based trade hubs correctly determine if they're in range or not, instead of always thinking they're out of range due to `T` being null.

## Why and what will this PR improve
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Overmap merchant hubs will function once more.

## Authorship
<!-- Describe original authors of changes to credit them. -->
Neerti