### PR TITLE
Ambient Lighting: Multiple-source Ambience, Ambience Groups, and Reorg

### DIFF
--- a/code/__defines/lighting.dm
+++ b/code/__defines/lighting.dm
@@ -10,7 +10,8 @@
 #define LIGHTING_DARKNESS_ICON_STATE "black"	// icon_state used for lighting overlays with no luminosity.
 #define LIGHTING_TRANSPARENT_ICON_STATE "blank"
 
-#define LIGHTING_SOFT_THRESHOLD 0.001 // If the max of the lighting lumcounts of each spectrum drops below this, disable luminosity on the lighting overlays.
+// This is purely used as a threshold for 'is this turf probably dark' to avoid floating point nonsense.
+#define LIGHTING_SOFT_THRESHOLD 0.001
 #define LIGHTING_BLOCKED_FACTOR 0.5	// How much the range of a directional light will be reduced while facing a wall.
 
 // If defined, instant updates will be used whenever server load permits. Otherwise queued updates are always used.
@@ -19,6 +20,10 @@
 // mostly identical to below, but doesn't make sure T is valid first. Should only be used by lighting code.
 #define TURF_IS_DYNAMICALLY_LIT_UNSAFE(T) ((T:dynamic_lighting && T:loc:dynamic_lighting))
 #define TURF_IS_DYNAMICALLY_LIT(T) (isturf(T) && TURF_IS_DYNAMICALLY_LIT_UNSAFE(T))
+
+// Note: this does not imply the above, a turf can have ambient light without being dynamically lit.
+#define TURF_IS_AMBIENT_LIT_UNSAFE(T) (T:ambient_active)
+#define TURF_IS_AMBIENT_LIT(T) (isturf(T) && TURF_IS_AMBIENT_LIT_UNSAFE(T))
 
 // If I were you I'd leave this alone.
 #define LIGHTING_BASE_MATRIX \

--- a/code/modules/lighting/ambient_group.dm
+++ b/code/modules/lighting/ambient_group.dm
@@ -1,8 +1,8 @@
 #define BITWISE_MAX_BITS 24
 
 /// A bitmap of free ambience group indexes.
-var/ambience_group_free_bitmap = ~0
-var/ambience_group_map[BITWISE_MAX_BITS]
+var/global/ambience_group_free_bitmap = ~0
+var/global/ambience_group_map[BITWISE_MAX_BITS]
 
 /datum/ambience_group
 	var/global_index
@@ -19,24 +19,24 @@ var/ambience_group_map[BITWISE_MAX_BITS]
 		invalid = TRUE
 		return
 
-	ambience_group_map[global_index] = src
+	global.ambience_group_map[global_index] = src
 
 /datum/ambience_group/Destroy()
 	if (!invalid)
-		ambience_group_map[global_index] = null
-		ambience_group_free_bitmap |= (1 << global_index)
+		global.ambience_group_map[global_index] = null
+		global.ambience_group_free_bitmap |= (1 << global_index)
 	return ..()
 
 /datum/ambience_group/proc/allocate_index()
-	if (ambience_group_free_bitmap == 0)
+	if (global.ambience_group_free_bitmap == 0)
 		CRASH("Failed to allocate ambience_group: index bitmap is exhausted")
 
 	// Find the first free index in the bitmap.
 	var/index = 1
-	while (!(ambience_group_free_bitmap & (1 << index)) && index < BITWISE_MAX_BITS)
+	while (!(global.ambience_group_free_bitmap & (1 << index)) && index < BITWISE_MAX_BITS)
 		index += 1
 
-	ambience_group_free_bitmap &= ~(1 << index)
+	global.ambience_group_free_bitmap &= ~(1 << index)
 
 	return index
 
@@ -97,7 +97,7 @@ var/ambience_group_map[BITWISE_MAX_BITS]
 		var/remaining_groups = ambience_active_groups
 		for (var/i in 1 to BITWISE_MAX_BITS)
 			if (ambience_affecting_bitmap & (1 << i))
-				var/datum/ambience_group/group = ambience_group_map[i]
+				var/datum/ambience_group/group = global.ambience_group_map[i]
 				add_ambient_light_raw(-group.apparent_r, -group.apparent_g, -group.apparent_b)
 
 				remaining_groups -= 1
@@ -113,7 +113,7 @@ var/ambience_group_map[BITWISE_MAX_BITS]
 		var/remaining_groups = ambience_active_groups
 		for (var/i in 1 to BITWISE_MAX_BITS)
 			if (ambience_affecting_bitmap & (1 << i))
-				var/datum/ambience_group/group = ambience_group_map[i]
+				var/datum/ambience_group/group = global.ambience_group_map[i]
 				add_ambient_light_raw(group.apparent_r, group.apparent_g, group.apparent_b)
 				remaining_groups -= 1
 

--- a/code/modules/lighting/ambient_group.dm
+++ b/code/modules/lighting/ambient_group.dm
@@ -1,0 +1,121 @@
+#define BITWISE_MAX_BITS 24
+
+/// A bitmap of free ambience group indexes.
+var/ambience_group_free_bitmap = ~0
+var/ambience_group_map[BITWISE_MAX_BITS]
+
+/datum/ambience_group
+	var/global_index
+	var/list/member_turfs_by_z = list()
+	var/apparent_r
+	var/apparent_g
+	var/apparent_b
+	var/invalid = FALSE
+	var/busy = FALSE
+
+/datum/ambience_group/New()
+	global_index = allocate_index()
+	if (!global_index)
+		invalid = TRUE
+		return
+
+	ambience_group_map[global_index] = src
+
+/datum/ambience_group/Destroy()
+	if (!invalid)
+		ambience_group_map[global_index] = null
+		ambience_group_free_bitmap |= (1 << global_index)
+	return ..()
+
+/datum/ambience_group/proc/allocate_index()
+	if (ambience_group_free_bitmap == 0)
+		CRASH("Failed to allocate ambience_group: index bitmap is exhausted")
+
+	// Find the first free index in the bitmap.
+	var/index = 1
+	while (!(ambience_group_free_bitmap & (1 << index)) && index < BITWISE_MAX_BITS)
+		index += 1
+
+	ambience_group_free_bitmap &= ~(1 << index)
+
+	return index
+
+/datum/ambience_group/proc/add_turf(turf/T)
+	set waitfor = FALSE
+
+	UNTIL(!busy)
+	if (T.z > member_turfs_by_z)
+		member_turfs_by_z.len = T.z
+
+	LAZYADD(member_turfs_by_z[T.z], T)
+	T.add_ambient_light_raw(apparent_r, apparent_g, apparent_b)
+	T.ambience_active_groups += 1
+
+/datum/ambience_group/proc/remove_turf(turf/T)
+	set waitfor = FALSE
+
+	UNTIL(!busy)
+	if (T.z > member_turfs_by_z.len)
+		CRASH("Attempt to remove member turf with Z greater than local max -- this turf is not a member")
+	T.add_ambient_light_raw(-apparent_r, -apparent_g, -apparent_b)
+	member_turfs_by_z[T.z] -= T
+	T.ambience_active_groups -= 1
+
+/datum/ambience_group/proc/set_ambient_light(color, multiplier)
+	var/list/new_parts = rgb2num(color)
+
+	var/dr = (new_parts[1] / 255) * multiplier - apparent_r
+	var/dg = (new_parts[2] / 255) * multiplier - apparent_g
+	var/db = (new_parts[3] / 255) * multiplier - apparent_b
+
+	if (round(dr/4, LIGHTING_ROUND_VALUE) == 0 && round(dg/4, LIGHTING_ROUND_VALUE) == 0 && round(db/4, LIGHTING_ROUND_VALUE) == 0)
+		// no-op
+		return
+
+	busy = TRUE
+
+	// Doing it ordered by zlev should ensure that it looks vaguely coherent mid-update regardless of turf insertion order.
+	for (var/zlev in 1 to member_turfs_by_z.len)
+		for (var/turf/T as anything in member_turfs_by_z[zlev])
+			T.add_ambient_light_raw(dr, dg, db)
+			CHECK_TICK
+
+	apparent_r += dr
+	apparent_g += dg
+	apparent_b += db
+
+	busy = FALSE
+
+/turf
+	/// A bitfield of which global ambience groups are affecting this turf.
+	var/tmp/ambience_affecting_bitmap = 0
+	/// A counter of how many ambience groups are affecting this turf, used to avoid pointlessly iterating the entire 24-bit bitfield.
+	var/tmp/ambience_active_groups = 0
+
+/turf/Destroy()
+	if (ambience_affecting_bitmap)
+		var/remaining_groups = ambience_active_groups
+		for (var/i in 1 to BITWISE_MAX_BITS)
+			if (ambience_affecting_bitmap & (1 << i))
+				var/datum/ambience_group/group = ambience_group_map[i]
+				add_ambient_light_raw(-group.apparent_r, -group.apparent_g, -group.apparent_b)
+
+				remaining_groups -= 1
+
+				if (!remaining_groups)
+					break
+
+	return ..()
+
+/turf/Initialize()
+	. = ..()
+	if (ambience_affecting_bitmap)
+		var/remaining_groups = ambience_active_groups
+		for (var/i in 1 to BITWISE_MAX_BITS)
+			if (ambience_affecting_bitmap & (1 << i))
+				var/datum/ambience_group/group = ambience_group_map[i]
+				add_ambient_light_raw(group.apparent_r, group.apparent_g, group.apparent_b)
+				remaining_groups -= 1
+
+				if (!remaining_groups)
+					break

--- a/code/modules/lighting/ambient_turf.dm
+++ b/code/modules/lighting/ambient_turf.dm
@@ -13,6 +13,7 @@
 	var/tmp/ambient_light_old_g = 0
 	var/tmp/ambient_light_old_b = 0
 
+/// Set the turf's self-ambience channel. This can only contain one value at a time, so it should generally only be used by the turf itself.
 /turf/proc/set_ambient_light(color, multiplier)
 	if (color == ambient_light && multiplier == ambient_light_multiplier)
 		return
@@ -22,6 +23,7 @@
 
 	update_ambient_light()
 
+/// Replace one ambient light with another. This is effectively a delta update, but it can be used to pretend that our one channel is doing color blending.
 /turf/proc/replace_ambient_light(old_color, new_color, old_multiplier, new_multiplier = 0)
 	if (!TURF_IS_AMBIENT_LIT_UNSAFE(src))
 		add_ambient_light(new_color, new_multiplier)
@@ -44,6 +46,7 @@
 
 	add_ambient_light_raw(dr, dg, db)
 
+/// Add an ambient light to the turf's self-channel. This is a delta update, retain your applied color if you want to be able to remove it later.
 /turf/proc/add_ambient_light(color, multiplier, update = TRUE)
 	if (!color)
 		return
@@ -58,6 +61,7 @@
 
 	add_ambient_light_raw(ambient_r, ambient_g, ambient_b, update)
 
+/// Directly manipulate the state of the self-ambience channel. Don't use unless you know what you're doing and how ambience works internally.
 /turf/proc/add_ambient_light_raw(lr, lg, lb, update = TRUE)
 	if (!lr && !lg && !lb)
 		if (!ambient_light_old_r || !ambient_light_old_g || !ambient_light_old_b)
@@ -92,12 +96,14 @@
 	for (var/datum/lighting_corner/C in corners)
 		C.update_ambient_lumcount(lr, lg, lb, !update)
 
+/// Wipe the entire self-ambience channel. This will preserve ambience from ambience groups.
 /turf/proc/clear_ambient_light()
 	if (ambient_light == null)
 		return
 
+	replace_ambient_light(ambient_light, COLOR_WHITE, ambient_light_multiplier, 0)
 	ambient_light = null
-	update_ambient_light()
+	ambient_light_multiplier = initial(ambient_light_multiplier)
 
 /turf/proc/update_ambient_light(no_corner_update = FALSE)
 	// These are deltas.

--- a/code/modules/lighting/ambient_turf.dm
+++ b/code/modules/lighting/ambient_turf.dm
@@ -1,0 +1,118 @@
+/turf
+	/// If non-null, a hex RGB light color that should be applied to this turf.
+	var/ambient_light
+	/// The power of the above is multiplied by this. Setting too high may drown out normal lights on the same turf.
+	var/ambient_light_multiplier = 0.3
+
+	/// If this is TRUE, an above turf's ambient light is affecting this turf.
+	var/tmp/ambient_has_indirect = FALSE
+
+	// Record-keeping, do not touch -- that means you, admins.
+	var/tmp/ambient_active = FALSE	//! Do we have non-zero ambient light? Use [TURF_IS_AMBIENT_LIT] instead of reading this directly.
+	var/tmp/ambient_light_old_r = 0
+	var/tmp/ambient_light_old_g = 0
+	var/tmp/ambient_light_old_b = 0
+
+/turf/proc/set_ambient_light(color, multiplier)
+	if (color == ambient_light && multiplier == ambient_light_multiplier)
+		return
+
+	ambient_light = isnull(color) ? ambient_light : color
+	ambient_light_multiplier = isnull(multiplier) ? ambient_light_multiplier : multiplier
+
+	update_ambient_light()
+
+/turf/proc/replace_ambient_light(old_color, new_color, old_multiplier, new_multiplier = 0)
+	if (!TURF_IS_AMBIENT_LIT_UNSAFE(src))
+		add_ambient_light(new_color, new_multiplier)
+		return
+
+	ASSERT(!isnull(old_multiplier))	// omitting new_multiplier is allowed for removing light nondestructively
+
+	old_color ||= COLOR_WHITE
+	new_color ||= COLOR_WHITE
+
+	var/list/old_parts = rgb2num(old_color)
+	var/list/new_parts = rgb2num(new_color)
+
+	var/dr = (new_parts[1] / 255) * new_multiplier - (old_parts[1] / 255) * old_multiplier
+	var/dg = (new_parts[2] / 255) * new_multiplier - (old_parts[2] / 255) * old_multiplier
+	var/db = (new_parts[3] / 255) * new_multiplier - (old_parts[3] / 255) * old_multiplier
+
+	if (!dr && !dg && !db)
+		return
+
+	add_ambient_light_raw(dr, dg, db)
+
+/turf/proc/add_ambient_light(color, multiplier, update = TRUE)
+	if (!color)
+		return
+
+	multiplier ||= ambient_light_multiplier
+
+	var/list/ambient_parts = rgb2num(color)
+
+	var/ambient_r = (ambient_parts[1] / 255) * multiplier
+	var/ambient_g = (ambient_parts[2] / 255) * multiplier
+	var/ambient_b = (ambient_parts[3] / 255) * multiplier
+
+	add_ambient_light_raw(ambient_r, ambient_g, ambient_b, update)
+
+/turf/proc/add_ambient_light_raw(lr, lg, lb, update = TRUE)
+	if (!lr && !lg && !lb)
+		if (!ambient_light_old_r || !ambient_light_old_g || !ambient_light_old_b)
+			ambient_active = FALSE
+			SSlighting.total_ambient_turfs -= 1
+		return
+
+	if (!ambient_active)
+		SSlighting.total_ambient_turfs += 1
+		ambient_active = TRUE
+
+	// There are four corners per (lit) turf, we don't want to apply our light 4 times -- compensate by dividing by 4.
+	lr /= 4
+	lg /= 4
+	lb /= 4
+
+	lr = round(lr, LIGHTING_ROUND_VALUE)
+	lg = round(lg, LIGHTING_ROUND_VALUE)
+	lb = round(lb, LIGHTING_ROUND_VALUE)
+
+	ambient_light_old_r += lr
+	ambient_light_old_g += lg
+	ambient_light_old_b += lb
+
+	if (!corners || !lighting_corners_initialised)
+		if (TURF_IS_DYNAMICALLY_LIT_UNSAFE(src))
+			generate_missing_corners()
+		else
+			return
+
+	// This list can contain nulls on things like space turfs -- they only have their neighbors' corners.
+	for (var/datum/lighting_corner/C in corners)
+		C.update_ambient_lumcount(lr, lg, lb, !update)
+
+/turf/proc/clear_ambient_light()
+	if (ambient_light == null)
+		return
+
+	ambient_light = null
+	update_ambient_light()
+
+/turf/proc/update_ambient_light(no_corner_update = FALSE)
+	// These are deltas.
+	var/ambient_r = 0
+	var/ambient_g = 0
+	var/ambient_b = 0
+
+	if (ambient_light)
+		var/list/parts = rgb2num(ambient_light)
+		ambient_r = ((parts[1] / 255) * ambient_light_multiplier) - ambient_light_old_r
+		ambient_g = ((parts[2] / 255) * ambient_light_multiplier) - ambient_light_old_g
+		ambient_b = ((parts[3] / 255) * ambient_light_multiplier) - ambient_light_old_b
+	else
+		ambient_r = -ambient_light_old_r
+		ambient_g = -ambient_light_old_g
+		ambient_b = -ambient_light_old_b
+
+	add_ambient_light_raw(ambient_r, ambient_g, ambient_b, !no_corner_update)

--- a/code/modules/lighting/lighting_overlay.dm
+++ b/code/modules/lighting/lighting_overlay.dm
@@ -77,7 +77,7 @@
 		ca = corners[1] || dummy_lighting_corner
 
 	var/max = max(cr.cache_mx, cg.cache_mx, cb.cache_mx, ca.cache_mx)
-	luminosity = max > LIGHTING_SOFT_THRESHOLD
+	luminosity = max > 0
 
 	var/rr = cr.cache_r
 	var/rg = cr.cache_g

--- a/code/modules/lighting/lighting_turf.dm
+++ b/code/modules/lighting/lighting_turf.dm
@@ -1,9 +1,5 @@
 /turf
 	var/dynamic_lighting = TRUE
-	/// If non-null, a hex RGB light color that should be applied to this turf.
-	var/ambient_light
-	/// The power of the above is multiplied by this. Setting too high may drown out normal lights on the same turf.
-	var/ambient_light_multiplier = 0.3
 	luminosity = 1
 
 	var/tmp/lighting_corners_initialised = FALSE
@@ -15,118 +11,6 @@
 	var/tmp/list/datum/lighting_corner/corners
 	/// Not to be confused with opacity, this will be TRUE if there's any opaque atom on the tile.
 	var/tmp/has_opaque_atom = FALSE
-	/// If this is TRUE, an above turf's ambient light is affecting this turf.
-	var/tmp/ambient_has_indirect = FALSE
-
-	// Record-keeping, do not touch -- that means you, admins.
-	var/tmp/ambient_active = FALSE	//! Do we have non-zero ambient light? Use [TURF_IS_AMBIENT_LIT] instead of reading this directly.
-	var/tmp/ambient_light_old_r = 0
-	var/tmp/ambient_light_old_g = 0
-	var/tmp/ambient_light_old_b = 0
-
-/turf/proc/set_ambient_light(color, multiplier)
-	if (color == ambient_light && multiplier == ambient_light_multiplier)
-		return
-
-	ambient_light = isnull(color) ? ambient_light : color
-	ambient_light_multiplier = isnull(multiplier) ? ambient_light_multiplier : multiplier
-
-	update_ambient_light()
-
-/turf/proc/replace_ambient_light(old_color, new_color, old_multiplier, new_multiplier = 0)
-	if (!TURF_IS_AMBIENT_LIT_UNSAFE(src))
-		add_ambient_light(new_color, new_multiplier)
-		return
-
-	ASSERT(!isnull(old_multiplier))	// omitting new_multiplier is allowed for removing light nondestructively
-
-	old_color ||= COLOR_WHITE
-	new_color ||= COLOR_WHITE
-
-	var/list/old_parts = rgb2num(old_color)
-	var/list/new_parts = rgb2num(new_color)
-
-	var/dr = (new_parts[1] / 255) * new_multiplier - (old_parts[1] / 255) * old_multiplier
-	var/dg = (new_parts[2] / 255) * new_multiplier - (old_parts[2] / 255) * old_multiplier
-	var/db = (new_parts[3] / 255) * new_multiplier - (old_parts[3] / 255) * old_multiplier
-
-	if (!dr && !dg && !db)
-		return
-
-	add_ambient_light_raw(dr, dg, db)
-
-/turf/proc/add_ambient_light(color, multiplier, update = TRUE)
-	if (!color)
-		return
-
-	multiplier ||= ambient_light_multiplier
-
-	var/list/ambient_parts = rgb2num(color)
-
-	var/ambient_r = (ambient_parts[1] / 255) * multiplier
-	var/ambient_g = (ambient_parts[2] / 255) * multiplier
-	var/ambient_b = (ambient_parts[3] / 255) * multiplier
-
-	add_ambient_light_raw(ambient_r, ambient_g, ambient_b, update)
-
-/turf/proc/add_ambient_light_raw(lr, lg, lb, update = TRUE)
-	if (!lr && !lg && !lb)
-		if (!ambient_light_old_r || !ambient_light_old_g || !ambient_light_old_b)
-			ambient_active = FALSE
-			SSlighting.total_ambient_turfs -= 1
-		return
-
-	if (!ambient_active)
-		SSlighting.total_ambient_turfs += 1
-		ambient_active = TRUE
-
-	// There are four corners per (lit) turf, we don't want to apply our light 4 times -- compensate by dividing by 4.
-	lr /= 4
-	lg /= 4
-	lb /= 4
-
-	lr = round(lr, LIGHTING_ROUND_VALUE)
-	lg = round(lg, LIGHTING_ROUND_VALUE)
-	lb = round(lb, LIGHTING_ROUND_VALUE)
-
-	ambient_light_old_r += lr
-	ambient_light_old_g += lg
-	ambient_light_old_b += lb
-
-	if (!corners || !lighting_corners_initialised)
-		if (TURF_IS_DYNAMICALLY_LIT_UNSAFE(src))
-			generate_missing_corners()
-		else
-			return
-
-	// This list can contain nulls on things like space turfs -- they only have their neighbors' corners.
-	for (var/datum/lighting_corner/C in corners)
-		C.update_ambient_lumcount(lr, lg, lb, !update)
-
-/turf/proc/clear_ambient_light()
-	if (ambient_light == null)
-		return
-
-	ambient_light = null
-	update_ambient_light()
-
-/turf/proc/update_ambient_light(no_corner_update = FALSE)
-	// These are deltas.
-	var/ambient_r = 0
-	var/ambient_g = 0
-	var/ambient_b = 0
-
-	if (ambient_light)
-		var/list/parts = rgb2num(ambient_light)
-		ambient_r = ((parts[1] / 255) * ambient_light_multiplier) - ambient_light_old_r
-		ambient_g = ((parts[2] / 255) * ambient_light_multiplier) - ambient_light_old_g
-		ambient_b = ((parts[3] / 255) * ambient_light_multiplier) - ambient_light_old_b
-	else
-		ambient_r = -ambient_light_old_r
-		ambient_g = -ambient_light_old_g
-		ambient_b = -ambient_light_old_b
-
-	add_ambient_light_raw(ambient_r, ambient_g, ambient_b, !no_corner_update)
 
 // Causes any affecting light sources to be queued for a visibility update, for example a door got opened.
 /turf/proc/reconsider_lights()

--- a/code/modules/lighting/lighting_turf.dm
+++ b/code/modules/lighting/lighting_turf.dm
@@ -12,14 +12,14 @@
 	/// Not to be confused with opacity, this will be TRUE if there's any opaque atom on the tile.
 	var/tmp/has_opaque_atom = FALSE
 
-// Causes any affecting light sources to be queued for a visibility update, for example a door got opened.
+/// Causes any affecting light sources to be queued for a visibility update, for example a door got opened.
 /turf/proc/reconsider_lights()
 	var/datum/light_source/L
 	for (var/thing in affecting_lights)
 		L = thing
 		L.vis_update()
 
-// Forces a lighting update. Reconsider lights is preferred when possible.
+/// Forces a lighting update. Reconsider lights is preferred when possible.
 /turf/proc/force_update_lights()
 	var/datum/light_source/L
 	for (var/thing in affecting_lights)
@@ -78,7 +78,7 @@
 
 #define SCALE(targ,min,max) (targ - min) / (max - min)
 
-// Used to get a scaled lumcount.
+/// Returns a lumcount (average intensity of color channels) scaled between minlum and maxlum.
 /turf/proc/get_lumcount(minlum = 0, maxlum = 1)
 	if (!lighting_overlay)
 		return 0.5
@@ -95,7 +95,7 @@
 
 #undef SCALE
 
-// Can't think of a good name, this proc will recalculate the has_opaque_atom variable.
+/// Can't think of a good name, this proc will recalculate the has_opaque_atom variable.
 /turf/proc/recalc_atom_opacity()
 #ifdef AO_USE_LIGHTING_OPACITY
 	var/old = has_opaque_atom

--- a/mods/content/supermatter/endgame_cascade/universe.dm
+++ b/mods/content/supermatter/endgame_cascade/universe.dm
@@ -70,14 +70,18 @@
 // TODO: Should this be changed to use the actual ambient lights system...?
 /datum/universal_state/supermatter_cascade/OverlayAndAmbientSet()
 	spawn(0)
-		for(var/datum/lighting_corner/L in SSlighting.lighting_corners)
+		// TODO: dear god anything but this
+		for(var/datum/lighting_corner/L)
 			if(isAdminLevel(L.z))
 				L.update_lumcount(1,1,1)
 			else
 				L.update_lumcount(0.0, 0.4, 1)
 
+			CHECK_TICK
+
 		for(var/turf/space/T)
 			OnTurfChange(T)
+			CHECK_TICK
 
 /datum/universal_state/supermatter_cascade/proc/MiscSet()
 	for (var/obj/machinery/firealarm/alm in SSmachines.machinery)

--- a/nebula.dme
+++ b/nebula.dme
@@ -2680,6 +2680,7 @@
 #include "code\modules\keybindings\movement.dm"
 #include "code\modules\keybindings\setup.dm"
 #include "code\modules\lighting\_lighting_defs.dm"
+#include "code\modules\lighting\ambient_turf.dm"
 #include "code\modules\lighting\lighting_area.dm"
 #include "code\modules\lighting\lighting_atom.dm"
 #include "code\modules\lighting\lighting_corner.dm"

--- a/nebula.dme
+++ b/nebula.dme
@@ -2680,6 +2680,7 @@
 #include "code\modules\keybindings\movement.dm"
 #include "code\modules\keybindings\setup.dm"
 #include "code\modules\lighting\_lighting_defs.dm"
+#include "code\modules\lighting\ambient_group.dm"
 #include "code\modules\lighting\ambient_turf.dm"
 #include "code\modules\lighting\lighting_area.dm"
 #include "code\modules\lighting\lighting_atom.dm"

--- a/test/check-paths.sh
+++ b/test/check-paths.sh
@@ -34,7 +34,7 @@ exactly 10 "/turf text paths" '"/turf'
 exactly 1 "world<< uses" 'world\s*<<'
 exactly 75 "'in world' uses" '\s+\bin world\b(?=\s*$|\s*//|\s*\))' -P
 exactly 1 "world.log<< uses" 'world.log\s*<<'
-exactly 18 "<< uses" '(?<![<\\])<<(?!<)' -P
+exactly 23 "<< uses" '(?<![<\\])<<(?!<)' -P
 exactly 1 "direct_output uses" '\bdirect_output\('
 exactly 3 ">> uses" '(?<![>\\])>>(?!>)' -P
 exactly 0 "incorrect indentations" '^( {4,})' -P


### PR DESCRIPTION
This updates the ambience code to the newest revision (with multiple-source support), as well as finally adding ambience groups.

A turf can be a member of multiple ambience groups at once, and will sum the light applied by all of them. There is a hard limit of 24 ambience groups in the world at once, but ambience groups can be deleted to free up their index.

The turf's own ambience is treated as a separate channel that will be blended with ambience groups. Clearing it out will not clear out ambience group applied lighting. It's intended that this channel is only used by the turf itself, but this is not enforced.

Other changes:
- There is now a hook to temporarily suspend instant lighting updates when doing bulk updates. This is stack based, multiple items can call this and updates will only resume when all locks are released.
- `LIGHTING_SOFT_THRESHOLD` is now mostly dead, it wasn't really doing anything in the first place.
- The global lighting corner has been removed since nothing really used it. The supermatter cascade is currently using a hack workaround as it _did_ use this list, but it should be changed to use ambient lighting at some point, likely a special global channel.