### PR TITLE
Fix window color and construction

### DIFF
--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -11,6 +11,7 @@
 	atom_flags = ATOM_FLAG_CHECKS_BORDER | ATOM_FLAG_CAN_BE_PAINTED
 	obj_flags = OBJ_FLAG_ROTATABLE | OBJ_FLAG_MOVES_UNSUPPORTED
 	alpha = 180
+	material_alteration = MAT_FLAG_ALTERATION_COLOR
 	material = /decl/material/solid/glass
 	rad_resistance_modifier = 0.5
 	atmos_canpass = CANPASS_PROC
@@ -38,10 +39,19 @@
 	connections = dirs_to_corner_states(dirs)
 	other_connections = dirs_to_corner_states(other_dirs)
 
-/obj/structure/window/update_materials(var/keep_health)
-	. = ..()
-	name = "[reinf_material ? "reinforced " : ""][material.solid_name] window"
-	desc = "A window pane made from [material.solid_name]."
+/obj/structure/window/update_material_name(override_name)
+	var/base_name = override_name || initial(name)
+	if(istype(material))
+		SetName("[reinf_material ? "reinforced " : ""][material.adjective_name] [base_name]")
+	else
+		SetName(base_name)
+
+/obj/structure/window/update_material_desc(var/override_desc)
+	if(istype(material))
+		var/reinf_string = istype(reinf_material) ? " reinforced with [reinf_material.use_name]" : null
+		desc = "A window pane made from [material.solid_name][reinf_string]."
+	else
+		..()
 
 /obj/structure/window/Initialize(var/ml, var/_mat, var/_reinf_mat, var/dir_to_set, var/anchored)
 	. = ..(ml, _mat, _reinf_mat)

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -7,7 +7,7 @@
 
 	color = GLASS_COLOR
 	layer = SIDE_WINDOW_LAYER
-	anchored = TRUE
+	anchored = FALSE // Base, non-premapped type should start unanchored.
 	atom_flags = ATOM_FLAG_CHECKS_BORDER | ATOM_FLAG_CAN_BE_PAINTED
 	obj_flags = OBJ_FLAG_ROTATABLE | OBJ_FLAG_MOVES_UNSUPPORTED
 	alpha = 180
@@ -23,7 +23,7 @@
 	var/const/CONSTRUCTION_STATE_NO_FRAME = 0
 	var/const/CONSTRUCTION_STATE_IN_FRAME = 1
 	var/const/CONSTRUCTION_STATE_FASTENED = 2
-	var/construction_state = CONSTRUCTION_STATE_FASTENED
+	var/construction_state = CONSTRUCTION_STATE_NO_FRAME
 	var/id
 	var/polarized = 0
 	var/basestate = "window"
@@ -60,6 +60,8 @@
 	if(. != INITIALIZE_HINT_QDEL)
 		if(!isnull(anchored))
 			set_anchored(anchored)
+			if(!anchored)
+				construction_state = CONSTRUCTION_STATE_NO_FRAME
 		if(!isnull(dir_to_set))
 			set_dir(dir_to_set)
 		if(is_fulltile())
@@ -482,6 +484,7 @@
 	..()
 
 /obj/structure/window/basic
+	anchored = TRUE // Premapped type, start anchored.
 	icon_state = "window"
 	color = GLASS_COLOR
 
@@ -496,6 +499,7 @@
 	name = "borosilicate window"
 	color = GLASS_COLOR_SILICATE
 	material = /decl/material/solid/glass/borosilicate
+	anchored = TRUE // Premapped type, start anchored.
 
 /obj/structure/window/borosilicate/full
 	dir = NORTHEAST
@@ -507,6 +511,8 @@
 	color = GLASS_COLOR_SILICATE
 	material = /decl/material/solid/glass/borosilicate
 	reinf_material = /decl/material/solid/metal/steel
+	anchored = TRUE // Premapped type, start anchored and fastened.
+	construction_state = CONSTRUCTION_STATE_FASTENED
 
 /obj/structure/window/borosilicate_reinforced/full
 	dir = NORTHEAST
@@ -517,6 +523,8 @@
 	icon_state = "rwindow"
 	material = /decl/material/solid/glass
 	reinf_material = /decl/material/solid/metal/steel
+	anchored = TRUE // Premapped type, start anchored and fastened.
+	construction_state = CONSTRUCTION_STATE_FASTENED
 
 /obj/structure/window/reinforced/full
 	dir = NORTHEAST
@@ -538,6 +546,7 @@
 	basestate = "w"
 	reinf_basestate = "w"
 	dir = NORTHEAST
+	anchored = TRUE // Premapped type, start anchored.
 
 /obj/structure/window/reinforced/polarized
 	name = "electrochromic window"
@@ -629,27 +638,26 @@
 	if (!ST.can_use(required_amount))
 		to_chat(user, SPAN_NOTICE("You do not have enough sheets."))
 		return
-	for(var/obj/structure/window/WINDOW in loc)
-		if(WINDOW.dir == dir_to_set)
+	for(var/obj/structure/window/existing_window in loc)
+		if(existing_window.dir == dir_to_set)
 			to_chat(user, SPAN_NOTICE("There is already a window facing this way there."))
 			return
-		if(WINDOW.is_fulltile() && (dir_to_set & (dir_to_set - 1))) //two fulltile windows
+		if(existing_window.is_fulltile() && (dir_to_set & (dir_to_set - 1))) //two fulltile windows
 			to_chat(user, SPAN_NOTICE("There is already a window there."))
 			return
 	to_chat(user, SPAN_NOTICE("You start placing the window."))
-	if(do_after(user,20))
-		for(var/obj/structure/window/WINDOW in loc)
-			if(WINDOW.dir == dir_to_set)//checking this for a 2nd time to check if a window was made while we were waiting.
+	if(do_after(user, 2 SECONDS))
+		for(var/obj/structure/window/existing_window in loc)
+			if(existing_window.dir == dir_to_set)//checking this for a 2nd time to check if a window was made while we were waiting.
 				to_chat(user, SPAN_NOTICE("There is already a window facing this way there."))
 				return
-			if(WINDOW.is_fulltile() && (dir_to_set & (dir_to_set - 1)))
+			if(existing_window.is_fulltile() && (dir_to_set & (dir_to_set - 1)))
 				to_chat(user, SPAN_NOTICE("There is already a window there."))
 				return
 
 		if (ST.use(required_amount))
 			var/obj/structure/window/WD = new(loc, ST.material.type, ST.reinf_material?.type, dir_to_set, FALSE)
 			to_chat(user, SPAN_NOTICE("You place [WD]."))
-			WD.set_anchored(FALSE) // handles setting construction state for us
 		else
 			to_chat(user, SPAN_NOTICE("You do not have enough sheets."))
 			return

--- a/code/modules/crafting/stack_recipes/recipes_opacity.dm
+++ b/code/modules/crafting/stack_recipes/recipes_opacity.dm
@@ -25,7 +25,7 @@
 				return FALSE
 
 /decl/stack_recipe/opacity/fullwindow/spawn_result(mob/user, location, amount, decl/material/mat, decl/material/reinf_mat, paint_color, spent_type, spent_amount = 1)
-	. = list(new result_type(user?.loc, MATERIAL_RECIPE_PARAMS, SOUTHWEST, TRUE))
+	. = list(new result_type(user?.loc, MATERIAL_RECIPE_PARAMS, SOUTHWEST, FALSE))
 	if(paint_color)
 		for(var/obj/structure/window/window in .)
 			window.set_color(paint_color)
@@ -45,9 +45,9 @@
 				return FALSE
 
 /decl/stack_recipe/opacity/borderwindow/spawn_result(mob/user, location, amount, decl/material/mat, decl/material/reinf_mat, paint_color, spent_type, spent_amount = 1)
-	. = list(new result_type(user?.loc, MATERIAL_RECIPE_PARAMS, user?.dir, TRUE))
-	if(paint_color)
-		for(var/obj/structure/window/window in .)
+	. = list(new result_type(user?.loc, MATERIAL_RECIPE_PARAMS, user?.dir, FALSE))
+	for(var/obj/structure/window/window in .)
+		if(paint_color)
 			window.set_color(paint_color)
 
 /decl/stack_recipe/opacity/windoor


### PR DESCRIPTION
Fixes reinforced windows being in an uninteractable state when constructed.
Fixes windows not using material color.
Fixes windows not respecting name/desc material alteration flags.