### PR TITLE
Allow staging to compile on 516

### DIFF
--- a/code/controllers/hooks.dm
+++ b/code/controllers/hooks.dm
@@ -29,10 +29,10 @@
 		error("Invalid hook '/hook/[hook]' called.")
 		return 0
 
-	var/caller = new hook_path
+	var/hook_caller = new hook_path
 	var/status = 1
 	for(var/P in typesof("[hook_path]/proc"))
-		if(!call(caller, P)(arglist(args)))
+		if(!call(hook_caller, P)(arglist(args)))
 			error("Hook '[P]' failed or runtimed.")
 			status = 0
 

--- a/code/datums/mind/mind.dm
+++ b/code/datums/mind/mind.dm
@@ -152,8 +152,8 @@
 
 	if(href_list["add_goal"])
 
-		var/mob/caller = locate(href_list["add_goal_caller"])
-		if(caller && caller == current) can_modify = TRUE
+		var/mob/goal_caller = locate(href_list["add_goal_caller"])
+		if(goal_caller && goal_caller == current) can_modify = TRUE
 
 		if(can_modify)
 			if(is_admin)
@@ -171,8 +171,8 @@
 	if(href_list["abandon_goal"])
 		var/datum/goal/goal = get_goal_from_href(href_list["abandon_goal"])
 
-		var/mob/caller = locate(href_list["abandon_goal_caller"])
-		if(caller && caller == current) can_modify = TRUE
+		var/mob/goal_caller = locate(href_list["abandon_goal_caller"])
+		if(goal_caller && goal_caller == current) can_modify = TRUE
 
 		if(goal && can_modify)
 			if(usr == current)
@@ -186,8 +186,8 @@
 	if(href_list["reroll_goal"])
 		var/datum/goal/goal = get_goal_from_href(href_list["reroll_goal"])
 
-		var/mob/caller = locate(href_list["reroll_goal_caller"])
-		if(caller && caller == current) can_modify = TRUE
+		var/mob/goal_caller = locate(href_list["reroll_goal_caller"])
+		if(goal_caller && goal_caller == current) can_modify = TRUE
 
 		if(goal && (goal in goals) && can_modify)
 			qdel(goal)

--- a/code/modules/admin/view_variables/topic.dm
+++ b/code/modules/admin/view_variables/topic.dm
@@ -599,9 +599,9 @@
 			href_list["datumrefresh"] = href_list["mobToDamage"]
 
 	else if(href_list["call_proc"])
-		var/datum/callee = locate(href_list["call_proc"])
-		if(istype(callee) || istype(callee, /client)) // can call on clients too, not just datums
-			callproc_targetpicked(1, callee)
+		var/datum/proc_callee = locate(href_list["call_proc"])
+		if(istype(proc_callee) || istype(proc_callee, /client)) // can call on clients too, not just datums
+			callproc_targetpicked(1, proc_callee)
 	else if(href_list["addaura"])
 		if(!check_rights(R_DEBUG|R_ADMIN|R_FUN))	return
 		var/mob/living/victim = locate(href_list["addaura"])


### PR DESCRIPTION
Renames some vars so that staging compiles on 516. These weren't included when the staging period was reset last November because they were in https://github.com/NebulaSS13/Nebula/pull/4655/files. We don't have `/proc/sign(x)` on staging so it's just these vars.