### PR TITLE
Fix window jittering from fullscreen pref being reapplied unnecessarily

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -498,7 +498,7 @@ var/global/list/time_prefs_fixed = list()
 	if(!client)
 		return
 
-	if(client.get_preference_value(/datum/client_preference/fullscreen_mode) != PREF_OFF)
+	if(client.get_preference_value(/datum/client_preference/fullscreen_mode) != PREF_NO)
 		client.toggle_fullscreen(client.get_preference_value(/datum/client_preference/fullscreen_mode))
 
 /datum/preferences/proc/setup_preferences()


### PR DESCRIPTION
The fullscreen pref uses `PREF_NO` not `PREF_OFF`. I don't know how I didn't catch this sooner, it's been bothering me for ages.