### PR TITLE
Minor camera fixes and tweaks, for stable

### DIFF
--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -45,7 +45,13 @@
 	var/light_disabled = 0
 	var/alarm_on = 0
 
-	var/affected_by_emp_until = 0
+	var/emp_timer_id = null
+
+	/// The threshold that installed scanning modules need to met or exceed in order for the camera to see through walls.
+	var/const/XRAY_THRESHOLD = 2
+
+	/// The threshold that installed capacitors need to met or exceed in order for the camera to be immunie to EMP.
+	var/const/EMP_PROOF_THRESHOLD = 2
 
 /obj/machinery/camera/examine(mob/user)
 	. = ..()
@@ -95,23 +101,14 @@
 
 		invalidateCameraCache()
 	set_extension(src, /datum/extension/network_device/camera, null, null, null, TRUE, preset_channels, c_tag, cameranet_enabled, requires_connection)
+	RefreshParts()
 
 /obj/machinery/camera/Destroy()
 	set_status(0) //kick anyone viewing out
+	deltimer(emp_timer_id)
 	return ..()
 
 /obj/machinery/camera/Process()
-	if((stat & EMPED) && world.time >= affected_by_emp_until)
-		stat &= ~EMPED
-		cancelCameraAlarm()
-		update_icon()
-		update_coverage()
-
-		if (detectTime > 0)
-			var/elapsed = world.time - detectTime
-			if (elapsed > alarm_delay)
-				triggerAlarm()
-
 	if (stat & (EMPED))
 		return
 	if(!motion_sensor)
@@ -167,16 +164,30 @@
 		newTarget(AM)
 
 /obj/machinery/camera/emp_act(severity)
-	if(!(stat_immune & EMPED) && prob(100/severity))
-		if(!affected_by_emp_until || (world.time < affected_by_emp_until))
-			affected_by_emp_until = max(affected_by_emp_until, world.time + (90 SECONDS / severity))
-		else
-			stat |= EMPED
-			set_light(0)
-			triggerCameraAlarm()
-			update_icon()
-			update_coverage()
-			START_PROCESSING_MACHINE(src, MACHINERY_PROCESS_SELF)
+	if(stat_immune & EMPED)
+		return
+	if(prob(100 / severity))
+		stat |= EMPED
+		set_light(0)
+		triggerCameraAlarm()
+		update_icon()
+		update_coverage()
+
+		var/emp_length = 90 SECONDS / severity
+		emp_timer_id = addtimer(CALLBACK(src, PROC_REF(emp_expired)), emp_length, TIMER_UNIQUE | TIMER_OVERRIDE | TIMER_STOPPABLE)
+	..()
+
+/obj/machinery/camera/proc/emp_expired()
+	stat &= ~EMPED
+	cancelCameraAlarm()
+	update_icon()
+	update_coverage()
+
+	if (detectTime > 0)
+		var/elapsed = world.time - detectTime
+		if (elapsed > alarm_delay)
+			triggerAlarm()
+
 
 /obj/machinery/camera/bullet_act(var/obj/item/projectile/P)
 	take_damage(P.get_structure_damage())
@@ -263,25 +274,28 @@
 		update_coverage()
 
 /obj/machinery/camera/on_update_icon()
+	var/base_state = initial(icon_state)
+	if(total_component_rating_of_type(/obj/item/stock_parts/scanning_module) >= XRAY_THRESHOLD)
+		base_state = "xraycam"
 	if (!status || (stat & BROKEN))
-		icon_state = "[initial(icon_state)]1"
+		icon_state = "[base_state]1"
 	else if (stat & EMPED)
-		icon_state = "[initial(icon_state)]emp"
+		icon_state = "[base_state]emp"
 	else
-		icon_state = initial(icon_state)
+		icon_state = base_state
 
 /obj/machinery/camera/RefreshParts()
 	. = ..()
 	var/power_mult = 1
 	var/emp_protection = total_component_rating_of_type(/obj/item/stock_parts/capacitor)
-	if(emp_protection > 2)
-		stat_immune &= EMPED
+	if(emp_protection >= EMP_PROOF_THRESHOLD)
+		stat_immune |= EMPED
 	else
 		stat_immune &= ~EMPED
 	var/xray_rating = total_component_rating_of_type(/obj/item/stock_parts/scanning_module)
 	var/datum/extension/network_device/camera/camera_device = get_extension(src, /datum/extension/network_device/)
 	if(camera_device)
-		if(xray_rating > 2)
+		if(xray_rating >= XRAY_THRESHOLD)
 			camera_device.xray_enabled = TRUE
 			power_mult++
 		else

--- a/code/game/machinery/camera/presets.dm
+++ b/code/game/machinery/camera/presets.dm
@@ -33,33 +33,24 @@
 	requires_connection = FALSE
 
 // EMP
-
-/obj/machinery/camera/emp_proof/populate_parts(full_populate)
-	. = ..()
-	install_component(/obj/item/stock_parts/capacitor/adv, TRUE)
+/obj/machinery/camera/emp_proof
+	uncreated_component_parts = list(/obj/item/stock_parts/capacitor/adv = 1)
 
 // X-RAY
-
 /obj/machinery/camera/xray
-	icon_state = "xraycam" // Thanks to Krutchen for the icons.
-
-/obj/machinery/camera/xray/populate_parts(full_populate)
-	. = ..()
-	install_component(/obj/item/stock_parts/scanning_module/adv, TRUE)
+	uncreated_component_parts = list(/obj/item/stock_parts/scanning_module/adv = 1)
 
 // MOTION
-
-/obj/machinery/camera/motion/populate_parts(full_populate)
-	. = ..()
-	install_component(/obj/item/stock_parts/micro_laser, TRUE)
+/obj/machinery/camera/motion
+	uncreated_component_parts = list(/obj/item/stock_parts/micro_laser = 1)
 
 // ALL UPGRADES
-
-/obj/machinery/camera/all/populate_parts(full_populate)
-	. = ..()
-	install_component(/obj/item/stock_parts/capacitor/adv, TRUE)
-	install_component(/obj/item/stock_parts/scanning_module/adv, TRUE)
-	install_component(/obj/item/stock_parts/micro_laser, TRUE)
+/obj/machinery/camera/all
+	uncreated_component_parts = list(
+		/obj/item/stock_parts/capacitor/adv = 1,
+		/obj/item/stock_parts/scanning_module/adv = 1,
+		/obj/item/stock_parts/micro_laser = 1
+	)
 
 // AUTONAME left as a map stub
 /obj/machinery/camera/autoname


### PR DESCRIPTION
<!-- !! PLEASE, READ THIS !! -->
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/NebulaSS13/Nebula/blob/dev/CONTRIBUTING.md -->
<!-- If you're opening a pull request which changes A LOT of icon/map files: -->
<!-- Add [IDB IGNORE] (to ignore icon file changes) or [MDB IGNORE] (to ignore map file changes) in the PR title. -->
<!-- These tags prevent huge diffs from overloading IconDiffBot and MapDiffBot. -->
For some reason the the cherry-pick / force push didn't work so here's another PR. Old PR was #5002.


## Description of changes
<!-- Describe the pull request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
This was supposed to be a quick and easy fix for mapped in x-ray cameras not actually becoming x-ray cameras, but I stumbled into some more bugs, so I fixed them as well.
List of all changes:
- Changes the component rating threshold for cameras becoming x-ray cameras, or EMP proof, from `> 2` to `>= 2`, since the mapped in emp proof and x-ray cameras could not meet those thresholds with the parts they start with. They can now reach the thresholds with one adv component, which is how I remembered how it worked on other non-Neb codebases.
- Removed a few magic numbers, in favor of some consts.
- Somewhat refactors camera EMP code, to actually function, and use timers and callbacks instead of checking in `Process()`.
- A camera which becomes capable of being an x-ray camera by adding components will have its sprite changed to the x-ray camera one, instead of that sprite only being applied to mapped in x-ray cameras.
- Mapped in camera variants (emp proof, x-ray, motion, and the 'all' camera which has all three) changed to use uncreated components instead.

## Why and what will this PR improve
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Mapped in special cameras will work as advertised, and cameras can be EMPed again.

## Authorship
<!-- Describe original authors of changes to credit them. -->
Neerti

## Changelog
:cl:
tweak: X-ray cameras made in-round will show the same sprite as mapped in x-ray cameras.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->