### PR TITLE
Fixes inability to sell to merchants due to overly eager telepads

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -532,3 +532,5 @@
 		appearance_flags &= ~remove_flags
 	return old_appearance != appearance_flags
 
+/atom/movable/proc/is_valid_merchant_pad_target()
+	return simulated

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -364,3 +364,8 @@
 
 /obj/proc/get_blend_objects()
 	return
+
+/obj/is_valid_merchant_pad_target()
+	if(anchored)
+		return FALSE
+	return ..()

--- a/code/modules/mechs/mech.dm
+++ b/code/modules/mechs/mech.dm
@@ -249,3 +249,8 @@
 // Override this to avoid triggering the ancient vore code.
 /mob/living/exosuit/relaymove(mob/living/user, direction)
 	return
+
+/mob/living/exosuit/is_valid_merchant_pad_target()
+	if(current_user)
+		return FALSE
+	return ..()

--- a/code/modules/merchant/merchant_machinery.dm
+++ b/code/modules/merchant/merchant_machinery.dm
@@ -25,10 +25,8 @@
 		. += a
 
 /obj/machinery/merchant_pad/proc/is_valid_target(atom/movable/thing)
+	if(!istype(thing))
+		return FALSE
 	if(thing == src)
 		return FALSE
-	if(!isobj(thing) && !isliving(thing))
-		return FALSE
-	if(thing.anchored || !thing.simulated)
-		return FALSE
-	return TRUE
+	return thing.is_valid_merchant_pad_target()

--- a/code/modules/merchant/merchant_machinery.dm
+++ b/code/modules/merchant/merchant_machinery.dm
@@ -12,7 +12,7 @@
 /obj/machinery/merchant_pad/proc/get_target()
 	var/turf/T = get_turf(src)
 	for(var/a in T)
-		if(a == src || (!istype(a,/obj) && !isliving(a)) || istype(a,/obj/effect))
+		if(!is_valid_target(a))
 			continue
 		return a
 
@@ -20,6 +20,15 @@
 	. = list()
 	var/turf/T = get_turf(src)
 	for(var/a in T)
-		if(a == src || (!istype(a,/obj) && !isliving(a)) || istype(a,/obj/effect))
+		if(!is_valid_target(a))
 			continue
 		. += a
+
+/obj/machinery/merchant_pad/proc/is_valid_target(atom/movable/thing)
+	if(thing == src)
+		return FALSE
+	if(!isobj(thing) && !isliving(thing))
+		return FALSE
+	if(thing.anchored || !thing.simulated)
+		return FALSE
+	return TRUE


### PR DESCRIPTION
<!-- !! PLEASE, READ THIS !! -->
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/NebulaSS13/Nebula/blob/dev/CONTRIBUTING.md -->
<!-- If you're opening a pull request which changes A LOT of icon/map files: -->
<!-- Add [IDB IGNORE] (to ignore icon file changes) or [MDB IGNORE] (to ignore map file changes) in the PR title. -->
<!-- These tags prevent huge diffs from overloading IconDiffBot and MapDiffBot. -->

## Description of changes
<!-- Describe the pull request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Merchants currently cannot be sold to, because the merchant pad tries to sell anything on top of it, including immobile machines mounted on the walls, and in Tradeship's case, a job spawn point.
The merchants don't want a fire alarm or a `/obj/abstract/landmark/start` and so you can't sell anything. This bug affects `stable`, `staging`, and `dev`, and this PR fixes it by excluding unsimulated objects and anchored objects, and removes a bit of copypasta on the side.

## Why and what will this PR improve
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Merchants can be sold to once again.

## Authorship
<!-- Describe original authors of changes to credit them. -->
Neerti
