### PR TITLE
Fix RPD dispensing uncolored pipes

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -532,3 +532,5 @@
 		appearance_flags &= ~remove_flags
 	return old_appearance != appearance_flags
 
+/atom/movable/proc/is_valid_merchant_pad_target()
+	return simulated

--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -45,7 +45,13 @@
 	var/light_disabled = 0
 	var/alarm_on = 0
 
-	var/affected_by_emp_until = 0
+	var/emp_timer_id = null
+
+	/// The threshold that installed scanning modules need to met or exceed in order for the camera to see through walls.
+	var/const/XRAY_THRESHOLD = 2
+
+	/// The threshold that installed capacitors need to met or exceed in order for the camera to be immunie to EMP.
+	var/const/EMP_PROOF_THRESHOLD = 2
 
 /obj/machinery/camera/examine(mob/user)
 	. = ..()
@@ -95,23 +101,14 @@
 
 		invalidateCameraCache()
 	set_extension(src, /datum/extension/network_device/camera, null, null, null, TRUE, preset_channels, c_tag, cameranet_enabled, requires_connection)
+	RefreshParts()
 
 /obj/machinery/camera/Destroy()
 	set_status(0) //kick anyone viewing out
+	deltimer(emp_timer_id)
 	return ..()
 
 /obj/machinery/camera/Process()
-	if((stat & EMPED) && world.time >= affected_by_emp_until)
-		stat &= ~EMPED
-		cancelCameraAlarm()
-		update_icon()
-		update_coverage()
-
-		if (detectTime > 0)
-			var/elapsed = world.time - detectTime
-			if (elapsed > alarm_delay)
-				triggerAlarm()
-
 	if (stat & (EMPED))
 		return
 	if(!motion_sensor)
@@ -167,16 +164,30 @@
 		newTarget(AM)
 
 /obj/machinery/camera/emp_act(severity)
-	if(!(stat_immune & EMPED) && prob(100/severity))
-		if(!affected_by_emp_until || (world.time < affected_by_emp_until))
-			affected_by_emp_until = max(affected_by_emp_until, world.time + (90 SECONDS / severity))
-		else
-			stat |= EMPED
-			set_light(0)
-			triggerCameraAlarm()
-			update_icon()
-			update_coverage()
-			START_PROCESSING_MACHINE(src, MACHINERY_PROCESS_SELF)
+	if(stat_immune & EMPED)
+		return
+	if(prob(100 / severity))
+		stat |= EMPED
+		set_light(0)
+		triggerCameraAlarm()
+		update_icon()
+		update_coverage()
+
+		var/emp_length = 90 SECONDS / severity
+		emp_timer_id = addtimer(CALLBACK(src, PROC_REF(emp_expired)), emp_length, TIMER_UNIQUE | TIMER_OVERRIDE | TIMER_STOPPABLE)
+	..()
+
+/obj/machinery/camera/proc/emp_expired()
+	stat &= ~EMPED
+	cancelCameraAlarm()
+	update_icon()
+	update_coverage()
+
+	if (detectTime > 0)
+		var/elapsed = world.time - detectTime
+		if (elapsed > alarm_delay)
+			triggerAlarm()
+
 
 /obj/machinery/camera/bullet_act(var/obj/item/projectile/P)
 	take_damage(P.get_structure_damage())
@@ -263,25 +274,28 @@
 		update_coverage()
 
 /obj/machinery/camera/on_update_icon()
+	var/base_state = initial(icon_state)
+	if(total_component_rating_of_type(/obj/item/stock_parts/scanning_module) >= XRAY_THRESHOLD)
+		base_state = "xraycam"
 	if (!status || (stat & BROKEN))
-		icon_state = "[initial(icon_state)]1"
+		icon_state = "[base_state]1"
 	else if (stat & EMPED)
-		icon_state = "[initial(icon_state)]emp"
+		icon_state = "[base_state]emp"
 	else
-		icon_state = initial(icon_state)
+		icon_state = base_state
 
 /obj/machinery/camera/RefreshParts()
 	. = ..()
 	var/power_mult = 1
 	var/emp_protection = total_component_rating_of_type(/obj/item/stock_parts/capacitor)
-	if(emp_protection > 2)
-		stat_immune &= EMPED
+	if(emp_protection >= EMP_PROOF_THRESHOLD)
+		stat_immune |= EMPED
 	else
 		stat_immune &= ~EMPED
 	var/xray_rating = total_component_rating_of_type(/obj/item/stock_parts/scanning_module)
 	var/datum/extension/network_device/camera/camera_device = get_extension(src, /datum/extension/network_device/)
 	if(camera_device)
-		if(xray_rating > 2)
+		if(xray_rating >= XRAY_THRESHOLD)
 			camera_device.xray_enabled = TRUE
 			power_mult++
 		else

--- a/code/game/machinery/camera/presets.dm
+++ b/code/game/machinery/camera/presets.dm
@@ -33,33 +33,24 @@
 	requires_connection = FALSE
 
 // EMP
-
-/obj/machinery/camera/emp_proof/populate_parts(full_populate)
-	. = ..()
-	install_component(/obj/item/stock_parts/capacitor/adv, TRUE)
+/obj/machinery/camera/emp_proof
+	uncreated_component_parts = list(/obj/item/stock_parts/capacitor/adv = 1)
 
 // X-RAY
-
 /obj/machinery/camera/xray
-	icon_state = "xraycam" // Thanks to Krutchen for the icons.
-
-/obj/machinery/camera/xray/populate_parts(full_populate)
-	. = ..()
-	install_component(/obj/item/stock_parts/scanning_module/adv, TRUE)
+	uncreated_component_parts = list(/obj/item/stock_parts/scanning_module/adv = 1)
 
 // MOTION
-
-/obj/machinery/camera/motion/populate_parts(full_populate)
-	. = ..()
-	install_component(/obj/item/stock_parts/micro_laser, TRUE)
+/obj/machinery/camera/motion
+	uncreated_component_parts = list(/obj/item/stock_parts/micro_laser = 1)
 
 // ALL UPGRADES
-
-/obj/machinery/camera/all/populate_parts(full_populate)
-	. = ..()
-	install_component(/obj/item/stock_parts/capacitor/adv, TRUE)
-	install_component(/obj/item/stock_parts/scanning_module/adv, TRUE)
-	install_component(/obj/item/stock_parts/micro_laser, TRUE)
+/obj/machinery/camera/all
+	uncreated_component_parts = list(
+		/obj/item/stock_parts/capacitor/adv = 1,
+		/obj/item/stock_parts/scanning_module/adv = 1,
+		/obj/item/stock_parts/micro_laser = 1
+	)
 
 // AUTONAME left as a map stub
 /obj/machinery/camera/autoname

--- a/code/game/machinery/doors/_door.dm
+++ b/code/game/machinery/doors/_door.dm
@@ -253,7 +253,6 @@
 	else if(density)
 		do_animate("deny")
 
-	update_icon()
 	return TRUE
 
 /obj/machinery/door/proc/handle_repair(obj/item/I, mob/user)

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -438,18 +438,18 @@ About the new airlock wires panel:
 		if("opening")
 			set_airlock_overlays(AIRLOCK_OPENING)
 			flick("opening", src)//[stat ? "_stat":]
-			update_icon(AIRLOCK_OPEN)
+			addtimer(CALLBACK(src, TYPE_PROC_REF(/atom, update_icon), AIRLOCK_OPEN), 1 SECOND) // wait to update icon so the light doesn't go out too soon
 		if("closing")
 			set_airlock_overlays(AIRLOCK_CLOSING)
 			flick("closing", src)
-			update_icon(AIRLOCK_CLOSED)
+			addtimer(CALLBACK(src, TYPE_PROC_REF(/atom, update_icon), AIRLOCK_CLOSED), 1 SECOND) // wait to update icon so the light doesn't go out too soon
 		if("deny")
 			set_airlock_overlays(AIRLOCK_DENY)
 			if(density && arePowerSystemsOn())
 				flick("deny", src)
 				if(speaker)
 					playsound(loc, open_failure_access_denied, 50, 0)
-			update_icon(AIRLOCK_CLOSED)
+			addtimer(CALLBACK(src, TYPE_PROC_REF(/atom, update_icon), AIRLOCK_CLOSED), 1 SECOND) // wait to update icon so the light doesn't go out too soon
 		if("emag")
 			set_airlock_overlays(AIRLOCK_EMAG)
 			if(density && arePowerSystemsOn())

--- a/code/game/objects/items/weapons/RPD.dm
+++ b/code/game/objects/items/weapons/RPD.dm
@@ -146,7 +146,7 @@ var/global/list/rpd_pipe_selection_skilled = list()
 				return
 			playsound(get_turf(user), 'sound/items/Deconstruct.ogg', 50, 1)
 
-		P.build(T, new/datum/fabricator_build_order(P, 1, list("slected_color" = pipe_colors[pipe_color])))
+		P.build(T, new/datum/fabricator_build_order(P, 1, list("selected_color" = pipe_colors[pipe_color])))
 		if(prob(20))
 			spark_at(src, amount = 5, holder = src)
 

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -364,3 +364,8 @@
 
 /obj/proc/get_blend_objects()
 	return
+
+/obj/is_valid_merchant_pad_target()
+	if(anchored)
+		return FALSE
+	return ..()

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -498,7 +498,7 @@ var/global/list/time_prefs_fixed = list()
 	if(!client)
 		return
 
-	if(client.get_preference_value(/datum/client_preference/fullscreen_mode) != PREF_OFF)
+	if(client.get_preference_value(/datum/client_preference/fullscreen_mode) != PREF_NO)
 		client.toggle_fullscreen(client.get_preference_value(/datum/client_preference/fullscreen_mode))
 
 /datum/preferences/proc/setup_preferences()

--- a/code/modules/fabrication/designs/pipe/pipe_datum_base.dm
+++ b/code/modules/fabrication/designs/pipe/pipe_datum_base.dm
@@ -35,9 +35,9 @@
 			new_item.rotate_class = rotate_class
 			new_item.constructed_path = constructed_path
 		if(colorable)
-			new_item.color = order.get_data("selected_color", PIPE_COLOR_WHITE)
+			new_item.set_color(order.get_data("selected_color", PIPE_COLOR_WHITE))
 		else if (pipe_color != null)
-			new_item.color = pipe_color
+			new_item.set_color(pipe_color)
 		new_item.SetName(name)
 		if(desc)
 			new_item.desc = desc

--- a/code/modules/mechs/mech.dm
+++ b/code/modules/mechs/mech.dm
@@ -249,3 +249,8 @@
 // Override this to avoid triggering the ancient vore code.
 /mob/living/exosuit/relaymove(mob/living/user, direction)
 	return
+
+/mob/living/exosuit/is_valid_merchant_pad_target()
+	if(current_user)
+		return FALSE
+	return ..()

--- a/code/modules/merchant/merchant_machinery.dm
+++ b/code/modules/merchant/merchant_machinery.dm
@@ -25,10 +25,8 @@
 		. += a
 
 /obj/machinery/merchant_pad/proc/is_valid_target(atom/movable/thing)
+	if(!istype(thing))
+		return FALSE
 	if(thing == src)
 		return FALSE
-	if(!isobj(thing) && !isliving(thing))
-		return FALSE
-	if(thing.anchored || !thing.simulated)
-		return FALSE
-	return TRUE
+	return thing.is_valid_merchant_pad_target()

--- a/code/modules/merchant/merchant_machinery.dm
+++ b/code/modules/merchant/merchant_machinery.dm
@@ -12,7 +12,7 @@
 /obj/machinery/merchant_pad/proc/get_target()
 	var/turf/T = get_turf(src)
 	for(var/a in T)
-		if(a == src || (!istype(a,/obj) && !isliving(a)) || istype(a,/obj/effect))
+		if(!is_valid_target(a))
 			continue
 		return a
 
@@ -20,6 +20,15 @@
 	. = list()
 	var/turf/T = get_turf(src)
 	for(var/a in T)
-		if(a == src || (!istype(a,/obj) && !isliving(a)) || istype(a,/obj/effect))
+		if(!is_valid_target(a))
 			continue
 		. += a
+
+/obj/machinery/merchant_pad/proc/is_valid_target(atom/movable/thing)
+	if(thing == src)
+		return FALSE
+	if(!isobj(thing) && !isliving(thing))
+		return FALSE
+	if(thing.anchored || !thing.simulated)
+		return FALSE
+	return TRUE

--- a/code/modules/mob/living/living_genetics.dm
+++ b/code/modules/mob/living/living_genetics.dm
@@ -30,7 +30,7 @@
 		LAZYDISTINCTADD(_genetic_conditions, condition)
 		if(temporary_time)
 			// TODO: some kind of world.time key or parameter so overlapping calls don't remove each other.
-			addtimer(CALLBACK(src, TYPE_PROC_REF(/mob/living, remove_genetic_condition)), temporary_time)
+			addtimer(CALLBACK(src, TYPE_PROC_REF(/mob/living, remove_genetic_condition), condition_type), temporary_time)
 		queue_genetic_condition_update()
 		return TRUE
 	return FALSE

--- a/mods/mobs/dionaea/mob/gestalt/gestalt_movement.dm
+++ b/mods/mobs/dionaea/mob/gestalt/gestalt_movement.dm
@@ -6,8 +6,7 @@
 	. = ..()
 	if(AM && can_roll_up_atom(AM) && AM.Adjacent(src))
 		var/turf/stepping = AM.loc
-		roll_up_atom(AM)
-		if(stepping)
+		if(roll_up_atom(AM) && stepping)
 			step_towards(src, stepping)
 
 

--- a/mods/mobs/dionaea/mob/gestalt/gestalt_nymph.dm
+++ b/mods/mobs/dionaea/mob/gestalt/gestalt_nymph.dm
@@ -11,13 +11,14 @@
 
 /obj/structure/diona_gestalt/proc/roll_up_atom(var/mob/living/simple_animal/alien/diona/chirp, var/silent)
 	if(!istype(chirp))
-		return
+		return FALSE
 	if(!silent)
 		visible_message("<span class='notice'>\The [chirp] is engulfed by \the [src].</span>")
 	if(isdiona(chirp))
 		nymphs[chirp] = TRUE
 		queue_icon_update()
 	chirp.forceMove(src)
+	return TRUE
 
 /obj/structure/diona_gestalt/proc/shed_atom(var/atom/movable/shedding, var/silent, var/forcefully)
 


### PR DESCRIPTION
<!-- !! PLEASE, READ THIS !! -->
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/NebulaSS13/Nebula/blob/dev/CONTRIBUTING.md -->
<!-- If you're opening a pull request which changes A LOT of icon/map files: -->
<!-- Add [IDB IGNORE] (to ignore icon file changes) or [MDB IGNORE] (to ignore map file changes) in the PR title. -->
<!-- These tags prevent huge diffs from overloading IconDiffBot and MapDiffBot. -->

## Description of changes
<!-- Describe the pull request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Fixes two small problems that prevented pipes dispensed by an RPD from having their color set properly.
/code/game/objects/items/weapons/RPD.dm - Line 149 had a typo in "selected_color" that caused the color not to be seen by the build() function.
/code/modules/fabrication/designs/pipe/pipe_datum_base.dm - Lines 38 and 40 set new_item.color directly, but then the color was being overridden with null due to there not being any paint_color ever specified.  Changed to call .set_color() instead, which sets the paint_color variable.

## Why and what will this PR improve
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
The color setting on the RPD was useless, now it works correctly.  Before, all pipes would come out as regular gray/white pipes, regardless of type.  Now, Supply/Scrubber/Fuel pipes dispensed are their respective colors, and regular pipes respect the color selector.  

## Authorship
<!-- Describe original authors of changes to credit them. -->
Typhin

## Changelog
:cl:
bugfix: RPD now dispenses colored pipes like it should
code: /code/game/objects/items/weapons/RPD.dm and /code/modules/fabrication/designs/pipe/pipe_datum_base.dm
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->