### PR TITLE
Fix RPD dispensing uncolored colored pipes

### DIFF
--- a/code/game/objects/items/weapons/RPD.dm
+++ b/code/game/objects/items/weapons/RPD.dm
@@ -146,7 +146,7 @@ var/global/list/rpd_pipe_selection_skilled = list()
 				return
 			playsound(get_turf(user), 'sound/items/Deconstruct.ogg', 50, 1)
 
-		P.build(T, new/datum/fabricator_build_order(P, 1, list("slected_color" = pipe_colors[pipe_color])))
+		P.build(T, new/datum/fabricator_build_order(P, 1, list("selected_color" = pipe_colors[pipe_color])))
 		if(prob(20))
 			spark_at(src, amount = 5, holder = src)
 

--- a/code/modules/fabrication/designs/pipe/pipe_datum_base.dm
+++ b/code/modules/fabrication/designs/pipe/pipe_datum_base.dm
@@ -35,9 +35,9 @@
 			new_item.rotate_class = rotate_class
 			new_item.constructed_path = constructed_path
 		if(colorable)
-			new_item.color = order.get_data("selected_color", PIPE_COLOR_WHITE)
+			new_item.set_color(order.get_data("selected_color", PIPE_COLOR_WHITE))
 		else if (pipe_color != null)
-			new_item.color = pipe_color
+			new_item.set_color(pipe_color)
 		new_item.SetName(name)
 		if(desc)
 			new_item.desc = desc


### PR DESCRIPTION
Fixes a small issue where the RPD dispensed uncolored pipes no matter what color setting was chosen.  Hopefully this targets Staging this time.

<!-- !! PLEASE, READ THIS !! -->
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/NebulaSS13/Nebula/blob/dev/CONTRIBUTING.md -->
<!-- If you're opening a pull request which changes A LOT of icon/map files: -->
<!-- Add [IDB IGNORE] (to ignore icon file changes) or [MDB IGNORE] (to ignore map file changes) in the PR title. -->
<!-- These tags prevent huge diffs from overloading IconDiffBot and MapDiffBot. -->


## Description of changes
<!-- Describe the pull request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Fixes two small problems that prevented pipes dispensed by an RPD from having their color set properly.
/code/game/objects/items/weapons/RPD.dm - Line 149 had a typo in "selected_color" that caused the color not to be seen by the build() function.
/code/modules/fabrication/designs/pipe/pipe_datum_base.dm - Lines 38 and 40 set new_item.color directly, but then the color was being overridden with null due to there not being any paint_color ever specified. Changed to call .set_color() instead, which sets the paint_color variable.

## Why and what will this PR improve
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
The color setting on the RPD was useless, now it works correctly. Before, all pipes would come out as regular gray/white pipes, regardless of type. Now, Supply/Scrubber/Fuel pipes dispensed are their respective colors, and regular pipes respect the color selector.

## Authorship
<!-- Describe original authors of changes to credit them. -->
Typhin

## Changelog
:cl:
bugfix: RPD no longer ignores color setting, pipes get color set properly
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->