### PR TITLE
More psionics subsystem priority define into psionics modpack

### DIFF
--- a/code/__defines/subsystem-priority.dm
+++ b/code/__defines/subsystem-priority.dm
@@ -45,7 +45,6 @@
 #define SS_PRIORITY_PROCESSING    95   // Generic datum processor. Replaces objects processor.
 #define SS_PRIORITY_PLANTS        90   // Plant processing, slow ticks.
 #define SS_PRIORITY_VINES         50   // Spreading vine effects.
-#define SS_PRIORITY_PSYCHICS      45   // Psychic complexus processing.
 #define SS_PRIORITY_AI            45   // Artificial Intelligence on mobs processing.
 #define SS_PRIORITY_NANO          40   // Updates to nanoui uis.
 #define SS_PRIORITY_TURF          30   // Radioactive walls/blob.

--- a/mods/content/psionics/_defines.dm
+++ b/mods/content/psionics/_defines.dm
@@ -20,3 +20,5 @@
 
 #define MAT_NULLGLASS  /decl/material/nullglass
 #define COLOR_NULLGLASS        "#ff6088"
+
+#define SS_PRIORITY_PSYCHICS      45 // Psychic complexus processing priority


### PR DESCRIPTION
Just moves a define into the modpack it's associated with. At some point I want to replace the priority system with dependency ordering like TG does, which should work fine here—we could even use UIDs to make it so it doesn't need compatibility patches. For now though, separation of code good woo woo.