### PR TITLE
Add laser interaction to xenoarch crystal

### DIFF
--- a/code/modules/xenoarcheaology/artifacts/standalone/crystal.dm
+++ b/code/modules/xenoarcheaology/artifacts/standalone/crystal.dm
@@ -3,11 +3,13 @@
 	icon = 'icons/obj/xenoarchaeology.dmi'
 	icon_state = "ano70"
 	density = TRUE
+	var/base_state = null
+	var/energized = FALSE
 
 /obj/structure/crystal/Initialize()
 	. = ..()
 
-	icon_state = pick("ano70","ano80")
+	base_state = pick("ano7","ano8")
 
 	desc = pick(
 	"It shines faintly as it catches the light.",
@@ -15,6 +17,10 @@
 	"It seems to draw you inward as you look it at.",
 	"Something twinkles faintly as you look at it.",
 	"It's mesmerizing to behold.")
+
+/obj/structure/crystal/on_update_icon()
+	. = ..()
+	icon_state = "[base_state][energized ? 0 : 1]"
 
 /obj/structure/crystal/Destroy()
 	src.visible_message("<span class='warning'>[src] shatters!</span>")
@@ -33,6 +39,15 @@
 	return ..()
 
 /obj/structure/crystal/get_artifact_scan_data()
-	return "Crystal formation - pseudo-organic crystalline matrix, unlikely to have formed naturally. No known technology exists to synthesize this exact composition."
+	. = "Crystal formation - pseudo-organic crystalline matrix, unlikely to have formed naturally. No known technology exists to synthesize this exact composition."
+	if(energized)
+		. += " Stimulation of the inner crystal lattice has caused it to enter a metastable energy level, indicating potential uses in power storage and energy manipulation."
 
-//todo: laser_act
+// Placeholder functionality so that these do something
+/obj/structure/crystal/bullet_act(obj/item/projectile/the_bullet)
+	var/proj_damage = the_bullet.get_structure_damage()
+	if(!(the_bullet.damage_flags & DAM_LASER) || (proj_damage < 10) || energized)
+		return ..()
+	visible_message(SPAN_WARNING("\The [src] begins glowing..."))
+	energized = TRUE
+	update_icon()


### PR DESCRIPTION
actually implements that `//todo: laser_act` because it was bugging me and this file came up in my refactor roulette. untested, maybe needs an update_icon() call at the end of that initialize override 