### PR TITLE
Fix window spawners not blocking atmos

### DIFF
--- a/code/game/objects/structures/wallframe_spawner.dm
+++ b/code/game/objects/structures/wallframe_spawner.dm
@@ -4,6 +4,7 @@
 	icon_state = "wingrille"
 	density = TRUE
 	anchored = TRUE
+	atmos_canpass = CANPASS_NEVER
 	var/win_path = /obj/structure/window/basic/full
 	var/frame_path = /obj/structure/wall_frame/standard
 	var/grille_path = /obj/structure/grille

--- a/code/game/objects/structures/window_spawner.dm
+++ b/code/game/objects/structures/window_spawner.dm
@@ -9,6 +9,7 @@
 	icon_state = "wingrille"
 	density = TRUE
 	anchored = TRUE
+	atmos_canpass = CANPASS_NEVER
 	var/win_path = /obj/structure/window/basic
 	var/activated = FALSE
 	var/fulltile = FALSE


### PR DESCRIPTION
the `CanPass()` override on its own didn't do anything because of `atmos_canpass`, this fixes that. should fix some roundstart atmos weirdness potentially?