### PR TITLE
Refactor syndie cigarettes to reduce code duplication

### DIFF
--- a/code/game/objects/items/weapons/storage/fancy/cigarettes.dm
+++ b/code/game/objects/items/weapons/storage/fancy/cigarettes.dm
@@ -167,76 +167,57 @@
 ////////////////////////////////////////////////////////////////////////////////
 // Syndie Cigs
 ////////////////////////////////////////////////////////////////////////////////
+/obj/item/box/fancy/cigarettes/covert
+	abstract_type = /obj/item/box/fancy/cigarettes/covert
+	/// (TYPEPATH) Used to reset the name and description of covert cigarette packs on init.
+	var/obj/item/box/fancy/cigarettes/disguised_as = /obj/item/box/fancy/cigarettes
+	/// (STRING) Part of a string appended to the description on init.
+	var/scribble = null
+
+/obj/item/box/fancy/cigarettes/covert/Initialize(ml, material_key)
+	. = ..()
+	if(ispath(disguised_as, /obj/item/box/fancy/cigarettes))
+		//Reset the name to the default cig pack. Done for codex reasons, since it indexes things by initial names
+		if(name == initial(name)) // allow mapped names to override it
+			SetName(disguised_as::name)
+		if(desc == initial(desc) && istext(scribble)) // ditto for mapped descs
+			desc = "[disguised_as::desc] '[scribble]' has been scribbled on it."
 
 // Flash Powder Pack
-/obj/item/box/fancy/cigarettes/flash_powder
+/obj/item/box/fancy/cigarettes/covert/flash_powder
 	name = "pack of flash powder laced Trans-Stellar Duty-frees"
+	disguised_as = /obj/item/box/fancy/cigarettes
+	scribble = "F"
 
-/obj/item/box/fancy/cigarettes/flash_powder/Initialize(ml, material_key)
-	. = ..()
-	//Reset the name to the default cig pack. Done for codex reasons, since it indexes things by initial names
-	var/obj/item/box/fancy/cigarettes/C = /obj/item/box/fancy/cigarettes
-	if(name == initial(name))
-		SetName(initial(C.name))
-	if(desc == initial(desc))
-		desc = "[initial(desc)] 'F' has been scribbled on it."
-
-/obj/item/box/fancy/cigarettes/flash_powder/populate_reagents()
+/obj/item/box/fancy/cigarettes/covert/flash_powder/populate_reagents()
 	var/max_storage_space = max(1, storage?.max_storage_space)
 	add_to_reagents(/decl/material/solid/metal/aluminium, max_storage_space)
 	add_to_reagents(/decl/material/solid/potassium,       max_storage_space)
 	add_to_reagents(/decl/material/solid/sulfur,          max_storage_space)
 
 //Chemsmoke Pack
-/obj/item/box/fancy/cigarettes/chemsmoke
+/obj/item/box/fancy/cigarettes/covert/chemsmoke
 	name = "pack of smoke powder laced Trans-Stellar Duty-frees"
+	scribble = "S"
 
-/obj/item/box/fancy/cigarettes/chemsmoke/Initialize(ml, material_key)
-	. = ..()
-	//Reset the name to the default cig pack. Done for codex reasons, since it indexes things by initial names
-	var/obj/item/box/fancy/cigarettes/C = /obj/item/box/fancy/cigarettes
-	if(name == initial(name))
-		SetName(initial(C.name))
-	if(desc == initial(desc))
-		desc = "[initial(desc)] 'S' has been scribbled on it."
-
-/obj/item/box/fancy/cigarettes/chemsmoke/populate_reagents()
+/obj/item/box/fancy/cigarettes/covert/chemsmoke/populate_reagents()
 	var/max_storage_space = max(1, storage?.max_storage_space)
 	add_to_reagents(/decl/material/solid/potassium,        max_storage_space)
 	add_to_reagents(/decl/material/liquid/nutriment/sugar, max_storage_space)
 	add_to_reagents(/decl/material/solid/phosphorus,       max_storage_space)
 
 //Mindbreak Pack (now called /decl/chemical_reaction/hallucinogenics)
-/obj/item/box/fancy/cigarettes/mindbreak
-	name = "pack of mindbreak toxin laced Trans-Stellar Duty-frees" //#TODO: maybe fix the lore for that?
+/obj/item/box/fancy/cigarettes/covert/mindbreak
+	name = "pack of hallucinogen-laced Trans-Stellar Duty-frees" //#TODO: maybe fix the lore for that?
+	scribble = "H"
 
-/obj/item/box/fancy/cigarettes/mindbreak/Initialize(ml, material_key)
-	. = ..()
-	//Reset the name to the default cig pack. Done for codex reasons, since it indexes things by initial names
-	var/obj/item/box/fancy/cigarettes/C = /obj/item/box/fancy/cigarettes
-	if(name == initial(name))
-		SetName(initial(C.name))
-	if(desc == initial(desc))
-		desc = "[initial(desc)] 'MB' has been scribbled on it." //#TODO: maybe fix the lore for that?
+/obj/item/box/fancy/cigarettes/covert/mindbreak/populate_reagents()
+	add_to_reagents(/decl/material/liquid/hallucinogenics, (3 * max(1, storage?.max_storage_space)))
 
-/obj/item/box/fancy/cigarettes/mindbreak/populate_reagents()
-	var/max_storage_space = max(1, storage?.max_storage_space)
-	add_to_reagents(/decl/material/solid/silicon,         max_storage_space)
-	add_to_reagents(/decl/material/liquid/fuel/hydrazine, max_storage_space)
-	add_to_reagents(/decl/material/liquid/antitoxins,     max_storage_space)
+//Tricord pack (now called 'regenerative serum')
+/obj/item/box/fancy/cigarettes/covert/tricord
+	name = "pack of regenerative serum-laced Trans-Stellar Duty-frees" //#TODO: maybe fix the lore for that?
+	scribble = "R"
 
-//Tricord pack (now called /decl/material/liquid/regenerator)
-/obj/item/box/fancy/cigarettes/tricord
-	name = "pack of tricordazine laced Trans-Stellar Duty-frees" //#TODO: maybe fix the lore for that?
-
-/obj/item/box/fancy/cigarettes/tricord/Initialize(ml, material_key)
-	. = ..()
-	//Reset the name to the default cig pack. Done for codex reasons, since it indexes things by initial names
-	var/obj/item/box/fancy/cigarettes/C = /obj/item/box/fancy/cigarettes
-	if(name == initial(name))
-		SetName(initial(C.name))
-	if(desc == initial(desc))
-		desc = "[initial(desc)] 'T' has been scribbled on it." //#TODO: maybe fix the lore for that?
-
-/obj/item/box/fancy/cigarettes/tricord/populate_reagents()
+/obj/item/box/fancy/cigarettes/covert/tricord/populate_reagents()
 	add_to_reagents(/decl/material/liquid/regenerator, (4 * max(1, storage?.max_storage_space)))

--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -126,10 +126,10 @@
 
 /obj/item/box/syndie_kit/cigarette/WillContain()
 	return list(
-		/obj/item/box/fancy/cigarettes/flash_powder = 2,
-		/obj/item/box/fancy/cigarettes/chemsmoke = 2,
-		/obj/item/box/fancy/cigarettes/mindbreak,
-		/obj/item/box/fancy/cigarettes/tricord,
+		/obj/item/box/fancy/cigarettes/covert/flash_powder = 2,
+		/obj/item/box/fancy/cigarettes/covert/chemsmoke = 2,
+		/obj/item/box/fancy/cigarettes/covert/mindbreak,
+		/obj/item/box/fancy/cigarettes/covert/tricord,
 		/obj/item/flame/fuelled/lighter/zippo/random,
 		)
 

--- a/maps/ministation/ministation-1.dmm
+++ b/maps/ministation/ministation-1.dmm
@@ -65,7 +65,7 @@
 	pixel_y = 24
 	},
 /obj/item/flashlight/lamp/green,
-/obj/item/box/fancy/cigarettes/tricord,
+/obj/item/box/fancy/cigarettes/covert/tricord,
 /turf/floor/carpet/blue,
 /area/ministation/medical)
 "at" = (

--- a/tools/map_migrations/9999_cigarettes.txt
+++ b/tools/map_migrations/9999_cigarettes.txt
@@ -1,0 +1,4 @@
+/obj/item/box/fancy/cigarettes/flash_powder : /obj/item/box/fancy/cigarettes/covert/flash_powder{@OLD}
+/obj/item/box/fancy/cigarettes/chemsmoke : /obj/item/box/fancy/cigarettes/covert/flash_powder{@OLD}
+/obj/item/box/fancy/cigarettes/mindbreak : /obj/item/box/fancy/cigarettes/covert/flash_powder{@OLD}
+/obj/item/box/fancy/cigarettes/tricord : /obj/item/box/fancy/cigarettes/covert/flash_powder{@OLD}


### PR DESCRIPTION
they had a lot of duplicated code, this moves it to a shared type. includes a map migration. currently untested :)
honestly this could probably be removed but i think the codex or uplink or something depends on the names being like this. shrug