### PR TITLE
Fix get_other_examine_strings being expensive due to string ops

### DIFF
--- a/code/modules/mob/examine.dm
+++ b/code/modules/mob/examine.dm
@@ -28,7 +28,7 @@
 			. += SPAN_WARNING("[pronouns.He] [pronouns.is] [html_icon(buckled)] buckled to [buckled]!")
 
 /mob/proc/get_other_examine_strings(mob/user, distance, infix, suffix, hideflags, decl/pronouns/pronouns)
-	return
+	return list()
 
 // We add a default parameter here for hidden inventory flags.
 /mob/get_examine_header(mob/user, distance, infix, suffix, hideflags)


### PR DESCRIPTION
`..() = null`, `(null += string) == string`, `string += string` is expensive.

it already uses jointext and a length check, but length(string) is true if the string isn't empty and jointext(string) just returns the string. so it goes