### PR TITLE
Split human get_other_examine_strings() into separate handlers

### DIFF
--- a/code/__defines/mobs.dm
+++ b/code/__defines/mobs.dm
@@ -346,7 +346,10 @@ var/global/list/dexterity_levels = list(
 #define MOB_ICON_HAS_GIB_STATE       BITFLAG(5)
 #define MOB_ICON_HAS_DUST_STATE      BITFLAG(6)
 #define MOB_ICON_HAS_PARALYZED_STATE BITFLAG(7)
+
+// Additional pronoun sets.
 #define NEUTER_ANIMATE "animate singular neutral"
+#define SECOND_PERSON_SINGULAR "second person singular"
 
 // Equipment Overlays Indices //
 #define HO_CONDITION_LAYER  1

--- a/code/_helpers/cmp.dm
+++ b/code/_helpers/cmp.dm
@@ -86,6 +86,9 @@
 /proc/cmp_fusion_reaction_des(var/decl/fusion_reaction/A, var/decl/fusion_reaction/B)
 	return B.priority - A.priority
 
+/proc/cmp_human_examine_priority(decl/human_examination/a, decl/human_examination/b)
+	return a.priority - b.priority
+
 /proc/cmp_program(var/datum/computer_file/program/A, var/datum/computer_file/program/B)
 	return cmp_text_asc(A.filedesc, B.filedesc)
 

--- a/code/_macros.dm
+++ b/code/_macros.dm
@@ -174,6 +174,7 @@
 #define SPAN_PALEPINK(X)      SPAN_CLASS("font_palepink", X)
 #define SPAN_SINISTER(X)      SPAN_CLASS("sinister", X)
 #define SPAN_MODERATE(X)      SPAN_CLASS("moderate", X)
+#define SPAN_DEADSAY(X)       SPAN_CLASS("deadsay", X)
 // placeholders
 #define SPAN_GOOD(X)          SPAN_GREEN(X)
 #define SPAN_NEUTRAL(X)       SPAN_BLUE(X)

--- a/code/game/objects/structures/fountain.dm
+++ b/code/game/objects/structures/fountain.dm
@@ -85,6 +85,22 @@
 	used = TRUE
 	desc = "The water flows beautifully from the spout, but the water in the pool does not ripple."
 
+/mob/living/human
+	/// Used by the Fountain of Youth point of interest for on-examine messages.
+	var/became_older
+	/// Used by the Fountain of Youth point of interest for on-examine messages.
+	var/became_younger
+
+/decl/human_examination/fountain
+	priority = /decl/human_examination/graffiti::priority + 0.5 // just squeeze it in there
+
+/decl/human_examination/fountain/do_examine(mob/user, distance, mob/living/human/source, hideflags, decl/pronouns/pronouns)
+	. = list()
+	if(source.became_younger)
+		. += "[pronouns.He] look[pronouns.s] a lot younger than you remember."
+	if(source.became_older)
+		. += "[pronouns.He] look[pronouns.s] a lot older than you remember."
+
 /obj/structure/fountain/mundane
 	name                   = "fountain"
 	desc                   = "A beautifully constructed fountain."

--- a/code/modules/mob/examine.dm
+++ b/code/modules/mob/examine.dm
@@ -4,6 +4,11 @@
 		return GET_DECL(/decl/pronouns)
 	return get_pronouns()
 
+/mob/proc/get_visible_pronouns_for_viewer(mob/viewer, hideflags)
+	if(viewer == src)
+		return GET_DECL(/decl/pronouns/self)
+	return get_visible_pronouns(hideflags)
+
 /mob/proc/get_equipment_visibility()
 	. = 0
 	for(var/obj/item/thing in get_equipped_items(include_carried = FALSE))
@@ -46,7 +51,7 @@
 		hideflags |= HIDEEARS
 
 	// Show our equipment, held items, desc, etc.
-	var/decl/pronouns/pronouns = get_visible_pronouns(hideflags)
+	var/decl/pronouns/pronouns = get_visible_pronouns_for_viewer(user, hideflags) // handles second-person if src == user
 	var/list/examine_items = get_examined_worn_held_items(user, distance, infix, suffix, hideflags, pronouns)
 	if(length(examine_items))
 		. += examine_items

--- a/code/modules/mob/living/human/examine.dm
+++ b/code/modules/mob/living/human/examine.dm
@@ -1,158 +1,166 @@
 /mob/living/human/get_examine_header(mob/user, distance, infix, suffix, hideflags)
 	SHOULD_CALL_PARENT(FALSE)
-	. = list("<span class='info'>*---------*<br/>[user == src ? "You are" : "This is"] <EM>[name]</EM>")
+	. = list(SPAN_INFO("*---------*"))
+	var/list/mob_intro = "[user == src ? "You are" : "This is"] <EM>[name]</EM>"
 	if(!(hideflags & HIDEJUMPSUIT) || !(hideflags & HIDEFACE))
 		var/species_name = "\improper "
 		if(isSynthetic() && species.cyborg_noun)
 			species_name += "[species.cyborg_noun] [species.name]"
 		else
 			species_name += "[species.name]"
-		. += ", <b><font color='[species.get_species_flesh_color(src)]'>\a [species_name]!</font></b>[(user.can_use_codex() && SScodex.get_codex_entry(get_codex_value(user))) ?  SPAN_NOTICE(" \[<a href='byond://?src=\ref[SScodex];show_examined_info=\ref[src];show_to=\ref[user]'>?</a>\]") : ""]"
+		mob_intro += ", <b><font color='[species.get_species_flesh_color(src)]'>\a [species_name]!</font></b>[(user.can_use_codex() && SScodex.get_codex_entry(get_codex_value(user))) ?  SPAN_NOTICE(" \[<a href='byond://?src=\ref[SScodex];show_examined_info=\ref[src];show_to=\ref[user]'>?</a>\]") : ""]"
+	. += SPAN_INFO(JOINTEXT(mob_intro))
 	var/extra_species_text = species.get_additional_examine_text(src)
 	if(extra_species_text)
-		. += "<br>[extra_species_text]"
+		. += "[extra_species_text]"
 	var/show_descs = show_descriptors_to(user)
 	if(show_descs)
-		. += "<br><span class='info'>[jointext(show_descs, "<br>")]</span>"
+		. += SPAN_INFO(jointext(show_descs, "<br>"))
 	var/print_flavour = print_flavor_text()
 	if(print_flavour)
-		. += "<br/>*---------*"
-		. += "<br/>[print_flavour]"
-	. += "<br/>*---------*"
-	. = list(jointext(., null))
+		. += SPAN_INFO("*---------*")
+		. += SPAN_INFO("[print_flavour]")
+	. += SPAN_INFO("*---------*")
+	. = list(jointext(., "<br/>"))
 
-/mob/living/human/get_other_examine_strings(mob/user, distance, infix, suffix, hideflags, decl/pronouns/pronouns)
+/decl/human_examination/jitters/do_examine(mob/user, distance, mob/living/human/source, hideflags, decl/pronouns/pronouns)
+	var/jitteriness = GET_STATUS(source, STAT_JITTER)
+	switch(jitteriness)
+		if(300 to INFINITY)
+			return SPAN_DANGER("[pronouns.He] [pronouns.is] convulsing violently!")
+		if(200 to 300)
+			return SPAN_WARNING("[pronouns.He] [pronouns.is] extremely jittery.")
+		if(100 to 200)
+			return SPAN_WARNING("[pronouns.He] [pronouns.is] twitching ever so slightly.")
+		else
+			pass()
 
-	. = ..()
+/decl/human_examination/disfigured
+	priority = /decl/human_examination/jitters::priority + 1
 
-	var/self_examine = (user == src)
-	var/use_He    = self_examine ? "You"  : pronouns.He
-	var/use_he    = self_examine ? "you"  : pronouns.he
-	var/use_His   = self_examine ? "Your" : pronouns.His
-	var/use_his   = self_examine ? "your" : pronouns.his
-	var/use_is    = self_examine ? "are"  : pronouns.is
-	var/use_does  = self_examine ? "do"   : pronouns.does
-	var/use_has   = self_examine ? "have" : pronouns.has
-	var/use_him   = self_examine ? "you"  : pronouns.him
-	var/use_looks = self_examine ? "look" : "looks"
-
-	//Jitters
-	var/jitteriness = GET_STATUS(src, STAT_JITTER)
-	if(jitteriness >= 300)
-		. += "<span class='warning'><B>[use_He] [use_is] convulsing violently!</B></span>"
-	else if(jitteriness >= 200)
-		. += "<span class='warning'>[use_He] [use_is] extremely jittery.</span>"
-	else if(jitteriness >= 100)
-		. += "<span class='warning'>[use_He] [use_is] twitching ever so slightly.</span>"
-
+/decl/human_examination/disfigured/do_examine(mob/user, distance, mob/living/human/source, hideflags, decl/pronouns/pronouns)
 	//Disfigured face
-	if(!(hideflags & HIDEFACE)) //Disfigurement only matters for the head currently.
-		var/obj/item/organ/external/limb = GET_EXTERNAL_ORGAN(src, BP_HEAD)
-		if(limb && (limb.status & ORGAN_DISFIGURED)) //Check to see if we even have a head and if the head's disfigured.
-			if(limb.species) //Check to make sure we have a species
-				. += limb.species.disfigure_msg(src)
-			else //Just in case they lack a species for whatever reason.
-				. += "<span class='warning'>[use_His] face is horribly mangled!</span>"
+	if(hideflags & HIDEFACE) //Disfigurement only matters for the head currently.
+		return
+	var/obj/item/organ/external/limb = GET_EXTERNAL_ORGAN(source, BP_HEAD)
+	if(!limb || !(limb.status & ORGAN_DISFIGURED)) //Check to see if we even have a head and if the head's disfigured.
+		return
+	if(limb.species) //Check to make sure we have a species
+		return limb.species.disfigure_msg(source)
+	else //Just in case they lack a species for whatever reason.
+		return SPAN_WARNING("[pronouns.His] face is horribly mangled!")
 
-	//splints
-	for(var/organ in list(BP_L_LEG, BP_R_LEG, BP_L_ARM, BP_R_ARM))
-		var/obj/item/organ/external/limb = GET_EXTERNAL_ORGAN(src, organ)
-		if(limb && limb.splinted && limb.splinted.loc == limb)
-			. += "<span class='warning'>[use_He] [use_has] \a [limb.splinted] on [use_his] [limb.name]!</span>"
+/decl/human_examination/stat
+	priority = /decl/human_examination/disfigured::priority + 1
 
-	if (stat)
-		. += "<span class='warning'>[use_He] [use_is]n't responding to anything around [use_him] and seems to be unconscious.</span>"
-		if((stat == DEAD || is_asystole() || suffocation_counter) && distance <= 3)
-			. += "<span class='warning'>[use_He] [use_does] not appear to be breathing.</span>"
+/decl/human_examination/stat/do_examine(mob/user, distance, mob/living/human/source, hideflags, decl/pronouns/pronouns)
+	if (source.stat)
+		. = list(SPAN_WARNING("[pronouns.He] [pronouns.is]n't responding to anything around [pronouns.him] and seems to be unconscious."))
+		if((source.stat == DEAD || source.is_asystole() || source.suffocation_counter) && distance <= 3)
+			. += SPAN_WARNING("[pronouns.He] [pronouns.does] not appear to be breathing.")
 
-	var/datum/reagents/touching_reagents = get_contact_reagents()
+/decl/human_examination/contact_reagents
+	priority = /decl/human_examination/stat::priority + 1
+
+/decl/human_examination/contact_reagents/do_examine(mob/user, distance, mob/living/human/source, hideflags, decl/pronouns/pronouns)
+	var/datum/reagents/touching_reagents = source.get_contact_reagents()
 	if(touching_reagents?.total_volume >= 1)
 		var/saturation = touching_reagents.total_volume / touching_reagents.maximum_volume
 		if(saturation > 0.9)
-			. += "[use_He] [use_is] completely saturated."
+			. += "[pronouns.He] [pronouns.is] completely saturated."
 		else if(saturation > 0.6)
-			. += "[use_He] [use_is] looking half-drowned."
+			. += "[pronouns.He] [pronouns.is] looking half-drowned."
 		else if(saturation > 0.3)
-			. += "[use_He] [use_is] looking notably soggy."
+			. += "[pronouns.He] [pronouns.is] looking notably soggy."
 		else
-			. += "[use_He] [use_is] looking a bit soggy."
+			. += "[pronouns.He] [pronouns.is] looking a bit soggy."
 
-	var/fire_level = get_fire_intensity()
+/decl/human_examination/fire
+	priority = /decl/human_examination/contact_reagents::priority + 1
+
+/decl/human_examination/fire/do_examine(mob/user, distance, mob/living/human/source, hideflags, decl/pronouns/pronouns)
+	. = list()
+	var/fire_level = source.get_fire_intensity()
 	if(fire_level > 0)
-		. += "[use_He] [use_is] looking highly flammable!"
+		. += "[pronouns.He] [pronouns.is] looking highly flammable!"
 	else if(fire_level < 0)
-		. += "[use_He] [use_is] looking rather incombustible."
+		. += "[pronouns.He] [pronouns.is] looking rather incombustible."
 
-	if(is_on_fire())
-		. += "<span class='warning'>[use_He] [use_is] on fire!</span>"
+	if(source.is_on_fire())
+		. += SPAN_WARNING("[pronouns.He] [pronouns.is] on fire!")
 
-	var/ssd_msg = species.get_ssd(src)
-	if(ssd_msg && (!should_have_organ(BP_BRAIN) || has_brain()) && stat != DEAD)
-		if(!key)
-			. += "<span class='deadsay'>[use_He] [use_is] [ssd_msg]. It doesn't look like [use_he] [use_is] waking up anytime soon.</span>"
-		else if(!client)
-			. += "<span class='deadsay'>[use_He] [use_is] [ssd_msg].</span>"
+/decl/human_examination/ssd
+	priority = /decl/human_examination/fire::priority + 1
 
-	var/obj/item/organ/external/head/H = get_organ(BP_HEAD, /obj/item/organ/external/head)
+/decl/human_examination/ssd/do_examine(mob/user, distance, mob/living/human/source, hideflags, decl/pronouns/pronouns)
+	var/ssd_msg = source.species.get_ssd(source)
+	if(ssd_msg && (!source.should_have_organ(BP_BRAIN) || source.has_brain()) && source.stat != DEAD)
+		if(!source.key)
+			. += SPAN_DEADSAY("[pronouns.He] [pronouns.is] [ssd_msg]. It doesn't look like [pronouns.he] [pronouns.is] waking up anytime soon.")
+		else if(!source.client)
+			. += SPAN_DEADSAY("[pronouns.He] [pronouns.is] [ssd_msg].")
+
+// TODO: generalize and fold this into limb examine
+/decl/human_examination/graffiti
+	priority = /decl/human_examination/ssd::priority + 1
+
+/decl/human_examination/graffiti/do_examine(mob/user, distance, mob/living/human/source, hideflags, decl/pronouns/pronouns)
+	var/obj/item/organ/external/head/H = source.get_organ(BP_HEAD, /obj/item/organ/external/head)
 	if(istype(H) && H.forehead_graffiti && H.graffiti_style)
-		. += "<span class='notice'>[use_He] [use_has] \"[H.forehead_graffiti]\" written on [use_his] [H.name] in [H.graffiti_style]!</span>"
+		. += SPAN_NOTICE("[pronouns.He] [pronouns.has] \"[H.forehead_graffiti]\" written on [pronouns.his] [H.name] in [H.graffiti_style]!")
 
-	if(became_younger)
-		. += "[use_He] [use_looks] a lot younger than you remember."
-	if(became_older)
-		. += "[use_He] [use_looks] a lot older than you remember."
+/decl/human_examination/limb_examine
+	priority = /decl/human_examination/graffiti::priority + 1
 
+// This is still kind of a mess. TODO: /decl/organ_examination? lol
+/decl/human_examination/limb_examine/do_examine(mob/user, distance, mob/living/human/source, hideflags, decl/pronouns/pronouns)
+	. = list()
 	var/list/wound_flavor_text = list()
 	var/applying_pressure = ""
 	var/list/shown_objects = list()
 	var/list/hidden_bleeders = list()
 
-	var/decl/bodytype/root_bodytype = get_bodytype()
+	var/decl/bodytype/root_bodytype = source.get_bodytype()
 	for(var/organ_tag in root_bodytype.has_limbs)
-
 		var/list/organ_data = root_bodytype.has_limbs[organ_tag]
-		var/organ_descriptor = organ_data["descriptor"]
-		var/obj/item/organ/external/limb = GET_EXTERNAL_ORGAN(src, organ_tag)
+		var/obj/item/organ/external/limb = GET_EXTERNAL_ORGAN(source, organ_tag)
 
 		if(!limb)
-			wound_flavor_text[organ_descriptor] = "<b>[use_He] [use_is] missing [use_his] [organ_descriptor].</b>"
+			wound_flavor_text[organ_tag] = list(SPAN_DANGER("[pronouns.He] [pronouns.is] missing [pronouns.his] [organ_data["descriptor"]]."))
 			continue
 
-		wound_flavor_text[limb.name] = ""
+		wound_flavor_text[limb.organ_tag] = list()
 
-		if(limb.applied_pressure == src)
-			applying_pressure = "<span class='info'>[use_He] [use_is] applying pressure to [use_his] [limb.name].</span>"
+		if(limb.applied_pressure == source)
+			applying_pressure = SPAN_INFO("[pronouns.He] [pronouns.is] applying pressure to [pronouns.his] [limb.name].")
 
-		var/obj/item/clothing/hidden
-		for(var/slot in global.standard_clothing_slots)
-			var/obj/item/clothing/C = get_equipped_item(slot)
-			if(istype(C) && (C.body_parts_covered & limb.body_part))
-				hidden = C
-				break
+		var/obj/item/clothing/hidden = source.get_covering_equipped_item(limb.body_part)
 
-		if(hidden && user != src)
+		if(hidden && user != source)
 			if(limb.status & ORGAN_BLEEDING && !(hidden.item_flags & ITEM_FLAG_THICKMATERIAL)) //not through a spacesuit
 				if(!hidden_bleeders[hidden])
 					hidden_bleeders[hidden] = list()
-				hidden_bleeders[hidden] += limb.name
+				hidden_bleeders[hidden] += limb.organ_tag
 		else
-			if(!isSynthetic() && BP_IS_PROSTHETIC(limb) && (limb.parent && !BP_IS_PROSTHETIC(limb.parent)))
-				wound_flavor_text[limb.name] = "[use_He] [use_has] a [limb.name].\n"
+			// TODO: Make this just report if the bodytype is different than root and parent?
+			// That way a robotic right arm would show up but the hand attached to it wouldn't.
+			if(!source.isSynthetic() && BP_IS_PROSTHETIC(limb) && (limb.parent && !BP_IS_PROSTHETIC(limb.parent)))
+				wound_flavor_text[limb.organ_tag] += SPAN_WARNING("[pronouns.He] [pronouns.has] a [limb.name].")
 			var/wounddesc = limb.get_wounds_desc()
 			if(wounddesc != "nothing")
-				wound_flavor_text[limb.name] += "[use_He] [use_has] [wounddesc] on [use_his] [limb.name]."
+				wound_flavor_text[limb.organ_tag] += SPAN_WARNING("[pronouns.He] [pronouns.has] [wounddesc] on [pronouns.his] [limb.name].")
 		if(!hidden || distance <=1)
 			if(limb.is_dislocated())
-				wound_flavor_text[limb.name] += "[use_His] [limb.joint] is dislocated!<br>"
+				wound_flavor_text[limb.organ_tag] += SPAN_WARNING("[pronouns.His] [limb.joint] is dislocated!")
 			if(((limb.status & ORGAN_BROKEN) && limb.brute_dam > limb.min_broken_damage) || (limb.status & ORGAN_MUTATED))
-				wound_flavor_text[limb.name] += "[use_His] [limb.name] is dented and swollen!<br>"
+				wound_flavor_text[limb.organ_tag] += SPAN_WARNING("[pronouns.His] [limb.name] is dented and swollen!")
 			if(limb.status & ORGAN_DEAD)
 				if(BP_IS_PROSTHETIC(limb) || BP_IS_CRYSTAL(limb))
-					wound_flavor_text[limb.name] += "[use_His] [limb.name] is irrecoverably damaged!"
+					wound_flavor_text[limb.organ_tag] += SPAN_WARNING("[pronouns.His] [limb.name] is irrecoverably damaged!")
 				else
-					wound_flavor_text[limb.name] += "[use_His] [limb.name] is grey and necrotic!<br>"
+					wound_flavor_text[limb.organ_tag] += SPAN_WARNING("[pronouns.His] [limb.name] is grey and necrotic!")
 			else if((limb.brute_dam + limb.burn_dam) >= limb.max_damage && limb.germ_level >= INFECTION_LEVEL_TWO)
-				wound_flavor_text[limb.name] += "[use_His] [limb.name] is likely beyond saving, and has begun to decay!"
+				wound_flavor_text[limb.organ_tag] += SPAN_WARNING("[pronouns.His] [limb.name] is likely beyond saving, and has begun to decay!")
 
 		for(var/datum/wound/wound in limb.wounds)
 			var/list/embedlist = wound.embedded_objects
@@ -165,105 +173,138 @@
 					else if(!parsedembed.Find("multiple [embedded.name]"))
 						parsedembed.Remove(embedded.name)
 						parsedembed.Add("multiple "+embedded.name)
-				wound_flavor_text["[limb.name]"] += "The [wound.desc] on [use_his] [limb.name] has \a [english_list(parsedembed, and_text = " and a ", comma_text = ", a ")] sticking out of it!"
+				wound_flavor_text[limb.organ_tag] += SPAN_WARNING("The [wound.desc] on [pronouns.his] [limb.name] has \a [english_list(parsedembed, and_text = " and a ", comma_text = ", a ")] sticking out of it!")
+
+		if(limb.splinted && limb.splinted.loc == limb)
+			wound_flavor_text[limb.organ_tag] += SPAN_WARNING("[pronouns.He] [pronouns.has] \a [limb.splinted] on [pronouns.his] [limb.name]!")
+
 	for(var/hidden in hidden_bleeders)
-		wound_flavor_text[hidden] = "[use_He] [use_has] blood soaking through [hidden] around [use_his] [english_list(hidden_bleeders[hidden])]!"
+		wound_flavor_text[hidden] = SPAN_WARNING("[pronouns.He] [pronouns.has] blood soaking through [hidden] around [pronouns.his] [english_list(hidden_bleeders[hidden])]!")
 
-	. += "<span class='warning'>"
-	for(var/limb in wound_flavor_text)
-		. += wound_flavor_text[limb]
-	. += "</span>"
+	for(var/section in wound_flavor_text) // originally named limb, but can also include clothes
+		if(length(wound_flavor_text[section]))
+			. += jointext(wound_flavor_text[section], "<br>")
 
-	for(var/obj/implant in get_visible_implants(0))
+	if(applying_pressure)
+		. += applying_pressure
+
+	// TODO: move this into the limb for loop?
+	for(var/obj/implant in source.get_visible_implants(0))
 		if(implant in shown_objects)
 			continue
-		. += "<span class='danger'>[src] [use_has] \a [implant.name] sticking out of [use_his] flesh!</span>"
-	if(digitalcamo)
-		. += "[use_He] [use_is] repulsively uncanny!"
+		. += SPAN_DANGER("[source] [pronouns.has] \a [implant.name] sticking out of [pronouns.his] flesh!")
+
+/decl/human_examination/digicamo
+	priority = /decl/human_examination/limb_examine::priority + 1
+
+/decl/human_examination/digicamo/do_examine(mob/user, distance, mob/living/human/source, hideflags, decl/pronouns/pronouns)
+	if(source.digitalcamo)
+		return SPAN_WARNING("[pronouns.He] [pronouns.is] repulsively uncanny!")
+
+/decl/human_examination/hud
+	priority = /decl/human_examination/digicamo::priority + 1
+
+/decl/human_examination/hud/do_examine(mob/user, distance, mob/living/human/source, hideflags, decl/pronouns/pronouns)
+	var/perpname = source.get_authentification_name(source.get_face_name())
+	if(!perpname)
+		return
 
 	if(hasHUD(user, HUD_SECURITY))
-		var/perpname = "wot"
-		var/criminal = "None"
-
-		var/obj/item/card/id/check_id = GetIdCard()
-		if(istype(check_id))
-			perpname = check_id.registered_name
-		else
-			perpname = src.name
-
-		if(perpname)
-			var/datum/computer_network/network = user.getHUDnetwork(HUD_SECURITY)
-			if(network)
-				var/datum/computer_file/report/crew_record/R = network.get_crew_record_by_name(perpname)
-				if(R)
-					criminal = R.get_criminalStatus()
-
-				. += "<span class = 'deptradio'>Criminal status:</span> <a href='byond://?src=\ref[src];criminal=1'>\[[criminal]\]</a>"
-				. += "<span class = 'deptradio'>Security records:</span> <a href='byond://?src=\ref[src];secrecord=1'>\[View\]</a>"
+		var/datum/computer_network/network = user.getHUDnetwork(HUD_SECURITY)
+		if(network)
+			var/datum/computer_file/report/crew_record/R = network.get_crew_record_by_name(perpname)
+			LAZYINITLIST(.)
+			. += "<span class='deptradio'>Criminal status:</span> <a href='byond://?src=\ref[src];criminal=1'>\[[R?.get_criminalStatus() || "None"]\]</a>"
+			. += "<span class='deptradio'>Security records:</span> <a href='byond://?src=\ref[src];secrecord=1'>\[View\]</a>"
 
 	if(hasHUD(user, HUD_MEDICAL))
-		var/perpname = "wot"
-		var/medical = "None"
-
-		var/obj/item/card/id/check_id = GetIdCard()
-		if(istype(check_id))
-			perpname = check_id.registered_name
-		else
-			perpname = src.name
-
 		var/datum/computer_network/network = user.getHUDnetwork(HUD_MEDICAL)
 		if(network)
 			var/datum/computer_file/report/crew_record/R = network.get_crew_record_by_name(perpname)
-			if(R)
-				medical = R.get_status()
+			LAZYINITLIST(.)
+			. += "<span class='deptradio'>Physical status:</span> <a href='byond://?src=\ref[src];medical=1'>\[[R?.get_status() || "None"]\]</a>"
+			. += "<span class='deptradio'>Medical records:</span> <a href='byond://?src=\ref[src];medrecord=1'>\[View\]</a>"
 
-			. += "<span class = 'deptradio'>Physical status:</span> <a href='byond://?src=\ref[src];medical=1'>\[[medical]\]</a>"
-			. += "<span class = 'deptradio'>Medical records:</span> <a href='byond://?src=\ref[src];medrecord=1'>\[View\]</a>"
+/decl/human_examination/pose
+	priority = /decl/human_examination/hud::priority + 1
+	section_prefix = "*---------*"
 
+/decl/human_examination/pose/do_examine(mob/user, distance, mob/living/human/source, hideflags, decl/pronouns/pronouns)
+	if (!source.pose)
+		return
+	var/treated_pose = trim(source.handle_autopunctuation(source.pose))
+	// if the pose starts with is, are, do, does, or doesn't, apply basic verb correction
+	if(starts_with(treated_pose, "is ")) // if the pose starts with is
+		treated_pose = "[pronouns.is] [copytext(treated_pose, 1, 4)]"
+	if(starts_with(treated_pose, "are ")) // if the pose starts with are
+		treated_pose = "[pronouns.is] [copytext(treated_pose, 1, 5)]"
+	else if(starts_with(treated_pose, "does "))
+		treated_pose = "[pronouns.does] [copytext(treated_pose, 1, 6)]"
+	else if(starts_with(treated_pose, "do "))
+		treated_pose = "[pronouns.does] [copytext(treated_pose, 1, 4)]"
+	else if(starts_with(treated_pose, "doesn't "))
+		treated_pose = "[pronouns.does]n't [copytext(treated_pose, 1, 9)]"
+	else if(starts_with(treated_pose, "don't "))
+		treated_pose = "[pronouns.does]n't [copytext(treated_pose, 1, 7)]"
+	return "[pronouns.He] [source.handle_autopunctuation(source.pose)]"
+
+/decl/human_examination/comments
+	priority = /decl/human_examination/pose::priority + 99 // OOC info should show up pretty late.
+	section_prefix = "*---------*"
+	section_postfix = "*---------*" // this only applies if there is something after it
+
+/decl/human_examination/comments/do_examine(mob/user, distance, mob/living/human/source, hideflags, decl/pronouns/pronouns)
 	// Show IC/OOC info if available.
-	if(comments_record_id)
-		var/datum/character_information/comments = SScharacter_info.get_record(comments_record_id)
-		if(comments?.show_info_on_examine && (comments.ic_info || comments.ooc_info))
-			. += "*---------*"
-			if(comments.ic_info)
-				if(length(comments.ic_info) <= 40)
-					. += "<b>IC Info:</b>"
-					. += "&nbsp;&nbsp;&nbsp;&nbsp;[comments.ic_info]"
-				else
-					. += "<b>IC Info:</b>"
-					. += "&nbsp;&nbsp;&nbsp;&nbsp;[copytext_preserve_html(comments.ic_info,1,37)]... <a href='byond://?src=\ref[src];flavor_more=1'>More...</a>"
-			if(comments.ooc_info)
-				if(length(comments.ooc_info) <= 40)
-					. += "<b>OOC Info:</b>"
-					. += "&nbsp;&nbsp;&nbsp;&nbsp;[comments.ooc_info]"
-				else
-					. += "<b>OOC Info:</b>"
-					. += "&nbsp;&nbsp;&nbsp;&nbsp;[copytext_preserve_html(comments.ooc_info,1,37)]... <a href='byond://?src=\ref[src];flavor_more=1'>More...</a>"
+	if(!source.comments_record_id)
+		return
+	var/datum/character_information/comments = SScharacter_info.get_record(source.comments_record_id)
+	if(comments?.show_info_on_examine && (comments.ic_info || comments.ooc_info))
+		if(comments.ic_info)
+			if(length(comments.ic_info) <= 40)
+				. += "<b>IC Info:</b>"
+				. += "&nbsp;&nbsp;&nbsp;&nbsp;[comments.ic_info]"
+			else
+				. += "<b>IC Info:</b>"
+				. += "&nbsp;&nbsp;&nbsp;&nbsp;[copytext_preserve_html(comments.ic_info,1,37)]... <a href='byond://?src=\ref[source];flavor_more=1'>More...</a>"
+		if(comments.ooc_info)
+			if(length(comments.ooc_info) <= 40)
+				. += "<b>OOC Info:</b>"
+				. += "&nbsp;&nbsp;&nbsp;&nbsp;[comments.ooc_info]"
+			else
+				. += "<b>OOC Info:</b>"
+				. += "&nbsp;&nbsp;&nbsp;&nbsp;[copytext_preserve_html(comments.ooc_info,1,37)]... <a href='byond://?src=\ref[source];flavor_more=1'>More...</a>"
 
-	. += "*---------*</span>"
-	. += applying_pressure
+/mob/living/human/get_other_examine_strings(mob/user, distance, infix, suffix, hideflags, decl/pronouns/pronouns)
+	. = ..()
+	var/static/list/priority_examine_decls = sortTim(decls_repository.get_decls_of_subtype_unassociated(/decl/human_examination), /proc/cmp_human_examine_priority)
+	var/last_divider = null
+	for(var/decl/human_examination/examiner in priority_examine_decls)
+		var/adding_text = examiner.do_examine(user, distance, src, hideflags, pronouns)
+		if(!LAZYLEN(adding_text))
+			continue
+		if(last_divider) // insert the divider from the last entry
+			. += last_divider
+		else if(length(.)) // we already have prior entries, insert our prefix
+			. += examiner.section_prefix
+		. += adding_text
+		last_divider = examiner.section_postfix
 
-	if (pose)
-		if( findtext(pose,".",length(pose)) == 0 && findtext(pose,"!",length(pose)) == 0 && findtext(pose,"?",length(pose)) == 0 )
-			pose = addtext(pose,".") //Makes sure all emotes end with a period.
-		. += "[use_He] [pose]"
+/mob/living/human/examined_by(mob/user, distance, infix, suffix)
+	. = ..()
+	if(!stat || !ishuman(user) || user.incapacitated() || !Adjacent(user))
+		return
+	INVOKE_ASYNC(src, PROC_REF(check_heartbeat), user)
 
-	var/list/human_examines = decls_repository.get_decls_of_subtype(/decl/human_examination)
-	for(var/exam in human_examines)
-		var/decl/human_examination/examiner = human_examines[exam]
-		var/adding_text = examiner.do_examine(user, distance, src)
-		if(adding_text)
-			. += adding_text
-
-	// Foul, todo fix this
-	if(stat && ishuman(user) && !user.incapacitated() && Adjacent(user))
-		spawn(0)
-			user.visible_message("<b>\The [user]</b> checks \the [src]'s pulse.", "You check \the [src]'s pulse.")
-			if(do_after(user, 15, src))
-				if(get_pulse() == PULSE_NONE)
-					to_chat(user, "<span class='deadsay'>[use_He] [use_has] no pulse.</span>")
-				else
-					to_chat(user, "<span class='deadsay'>[use_He] [use_has] a pulse!</span>")
+/mob/living/human/proc/check_heartbeat(mob/living/human/user)
+	if(!stat || !ishuman(user) || user.incapacitated() || !Adjacent(user))
+		return
+	user.visible_message("<b>\The [user]</b> checks \the [src]'s pulse.", "You check \the [src]'s pulse.")
+	if(do_after(user, 1.5 SECONDS, src))
+		var/decl/pronouns/seen_pronouns = get_pronouns()
+		if(get_pulse() == PULSE_NONE)
+			to_chat(user, SPAN_DEADSAY("[seen_pronouns.He] [seen_pronouns.has] no pulse."))
+		else
+			to_chat(user, SPAN_DEADSAY("[seen_pronouns.He] [seen_pronouns.has] a pulse!"))
 
 //Helper procedure. Called by /mob/living/human/examined_by() and /mob/living/human/Topic() to determine HUD access to security and medical records.
 /proc/hasHUD(mob/M, hudtype)

--- a/code/modules/mob/living/human/human_attackhand.dm
+++ b/code/modules/mob/living/human/human_attackhand.dm
@@ -382,6 +382,7 @@
 		user.visible_message( \
 			SPAN_NOTICE("\The [user] starts applying pressure to \the [src]'s [organ.name]!"), \
 			SPAN_NOTICE("You start applying pressure to \the [src]'s [organ.name]!"))
+	// TODO: refactor applying pressure to use grabs instead? would probably require making grabs locked to the zone they were started on
 	spawn(0)
 		organ.applied_pressure = user
 

--- a/code/modules/mob/living/human/human_defines.dm
+++ b/code/modules/mob/living/human/human_defines.dm
@@ -49,9 +49,6 @@
 	var/obj/machinery/machine_visual
 	var/shock_stage
 	var/rounded_shock_stage
-	/// vars for fountain of youth examine lines
-	var/became_older
-	var/became_younger
 	/// var for caching last pain calc to avoid looping through organs over and over and over again
 	var/last_pain
 	var/vital_organ_missing_time

--- a/code/modules/mob/living/human/human_examine_decl.dm
+++ b/code/modules/mob/living/human/human_examine_decl.dm
@@ -1,4 +1,9 @@
 /decl/human_examination //This is essentially a stub-method for modpacks to be able to add onto the human examination stuff due to ... messy stuff.
+	var/priority = 0
+	/// If non-null, this is inserted before this entry if there is not already a postfix before it.
+	var/section_prefix = null
+	/// If non-null, this is inserted after this entry if there exist entries after it.
+	var/section_postfix = null
 
-/decl/human_examination/proc/do_examine(var/user, var/distance, var/source) //These can either return text, or should return nothing at all if you're doing to_chat()
+/decl/human_examination/proc/do_examine(mob/user, distance, mob/living/human/source, hideflags, decl/pronouns/pronouns) //These can either return text, or should return nothing at all if you're doing to_chat()
 	return

--- a/code/modules/pronouns/pronouns_second_person.dm
+++ b/code/modules/pronouns/pronouns_second_person.dm
@@ -1,0 +1,13 @@
+/decl/pronouns/self
+	name = SECOND_PERSON_SINGULAR
+	He   = "You"
+	he   = "you"
+	His  = "Your"
+	his  = "your"
+	him  = "you" // yourself? you?
+	has  = "have"
+	is   = "are"
+	does = "do"
+	self = "yourself"
+	s    = ""
+	es   = ""

--- a/mods/content/matchmaking/matchmaker.dm
+++ b/mods/content/matchmaking/matchmaker.dm
@@ -61,7 +61,12 @@
 		if(relation.holder == holder && relation.other && relation.other.holder == target && (relation.finalized || !finalized_only))
 			. += relation
 
-/decl/human_examination/matchmaking/do_examine(var/mob/living/user, var/distance, var/mob/living/source) //These can either return text, or should return nothing at all if you're doing to_chat()
+/decl/human_examination/matchmaking
+	// Show up after pose.
+	priority = /decl/human_examination/pose::priority + 1
+
+// These should return null, text, or a list of text strings.
+/decl/human_examination/matchmaking/do_examine(var/mob/living/user, var/distance, var/mob/living/human/source, hideflags, decl/pronouns/pronouns)
 	if(!istype(source) || !istype(user))
 		return
 	if(!source.mind || !user.mind || source.name != source.real_name)

--- a/nebula.dme
+++ b/nebula.dme
@@ -3594,6 +3594,7 @@
 #include "code\modules\pronouns\pronouns_female.dm"
 #include "code\modules\pronouns\pronouns_male.dm"
 #include "code\modules\pronouns\pronouns_neuter.dm"
+#include "code\modules\pronouns\pronouns_second_person.dm"
 #include "code\modules\radiation\radiation.dm"
 #include "code\modules\random_map\_random_map_setup.dm"
 #include "code\modules\random_map\random_map.dm"


### PR DESCRIPTION
unlike a bunch of my other PRs i made today, this one has been tested!

splits `/mob/living/human/get_other_examine_strings()` up into a bunch of human_examination decls. that system existed but was under-used.

priority is mostly as it currently is. some fountain of youth stuff was moved to go with the fountain of youth because i hate that code and want it to be as self contained as possible. as it stands it could even be a modpack i'm just too lazy to handle the repathing that'd likely need.

also adds a second-person singular pronoun set, and `get_pronouns_for_viewer()` that handles the case of src == viewer by returning second-person pronouns instead. honestly surprised none of that existed already.