### PR TITLE
Refactors stack recipe material validation

### DIFF
--- a/code/datums/repositories/decls.dm
+++ b/code/datums/repositories/decls.dm
@@ -144,6 +144,20 @@ var/global/repository/decls/decls_repository = new
 		. = get_decls(subtypesof(decl_prototype))
 		fetched_decl_subtypes[decl_prototype] = .
 
+/// Gets the path of any concrete (non-abstract) decl of the provided type.
+/// If decl_prototype is not abstract it will return that type.
+/// Otherwise, it returns the first (in compile order) non-abstract child of this type,
+/// or null otherwise.
+/// This doesn't respect DECL_FLAG_ALLOW_ABSTRACT_INIT, but that flag should probably be deprecated someday
+/// and replaced with a better solution to avoid instantiating abstract decls.
+/// This is mostly used for recipe validation in unit tests and such.
+/repository/decls/proc/get_first_concrete_decl_path_of_type(decl_prototype)
+	RETURN_TYPE(/decl)
+	. = fetched_decl_paths_by_type[decl_prototype]
+	if(!.)
+		. = get_decl_paths_of_type(decl_prototype)
+	return LAZYACCESS(., 1) // gets the first key (type) if it exists, else null if index is out of range
+
 /decl
 	abstract_type = /decl
 	var/uid

--- a/code/datums/vending/stored_item.dm
+++ b/code/datums/vending/stored_item.dm
@@ -82,7 +82,7 @@
 	for(var/atom/movable/thing in instances)
 		thing.forceMove(new_storing_obj)
 
-/datum/stored_items/proc/get_combined_matter(include_instances = TRUE)
+/datum/stored_items/proc/get_combined_matter(include_instances = TRUE, include_reagents = TRUE)
 	var/virtual_amount = amount - length(instances)
 	if(virtual_amount)
 		. = atom_info_repository.get_matter_for(item_path)?.Copy()
@@ -92,4 +92,4 @@
 		. = list()
 	if(include_instances)
 		for(var/atom/instance in instances)
-			. = MERGE_ASSOCS_WITH_NUM_VALUES(., instance.get_contained_matter())
+			. = MERGE_ASSOCS_WITH_NUM_VALUES(., instance.get_contained_matter(include_reagents))

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -435,13 +435,13 @@
  * Obj adds matter contents. Other overrides may add extra handling for things like material storage.
  * Most useful for calculating worth or deconstructing something along with its contents.
  */
-/atom/proc/get_contained_matter()
-	if(length(reagents?.reagent_volumes))
+/atom/proc/get_contained_matter(include_reagents = TRUE)
+	if(include_reagents && length(reagents?.reagent_volumes))
 		LAZYINITLIST(.)
 		for(var/decl/material/reagent as anything in reagents.reagent_volumes)
 			.[reagent.type] += floor(REAGENT_VOLUME(reagents, reagent) / REAGENT_UNITS_PER_MATERIAL_UNIT)
 	for(var/atom/contained_obj as anything in get_contained_external_atoms()) // machines handle component parts separately
-		. = MERGE_ASSOCS_WITH_NUM_VALUES(., contained_obj.get_contained_matter())
+		. = MERGE_ASSOCS_WITH_NUM_VALUES(., contained_obj.get_contained_matter(include_reagents))
 
 /// Return a list of all simulated atoms inside this one.
 /atom/proc/get_contained_external_atoms()

--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -96,11 +96,11 @@
 	LAZYREMOVE(., loaded_canisters)
 	LAZYREMOVE(., beaker)
 
-/obj/machinery/sleeper/get_contained_matter()
+/obj/machinery/sleeper/get_contained_matter(include_reagents = TRUE)
 	. = ..()
-	. = MERGE_ASSOCS_WITH_NUM_VALUES(., beaker.get_contained_matter())
+	. = MERGE_ASSOCS_WITH_NUM_VALUES(., beaker.get_contained_matter(include_reagents))
 	for(var/obj/canister in loaded_canisters)
-		. = MERGE_ASSOCS_WITH_NUM_VALUES(., canister.get_contained_matter())
+		. = MERGE_ASSOCS_WITH_NUM_VALUES(., canister.get_contained_matter(include_reagents))
 
 /obj/machinery/sleeper/Initialize(mapload, d = 0, populate_parts = TRUE)
 	. = ..()

--- a/code/game/machinery/_machines_base/machinery.dm
+++ b/code/game/machinery/_machines_base/machinery.dm
@@ -506,12 +506,12 @@ Class Procs:
 	LAZYREMOVE(., component_parts)
 
 // This only includes external atoms by default, so we need to add components back.
-/obj/machinery/get_contained_matter()
+/obj/machinery/get_contained_matter(include_reagents = TRUE)
 	. = ..()
 	var/list/component_types = types_of_component(/obj/item/stock_parts)
 	for(var/path in component_types)
 		for(var/obj/item/stock_parts/part in get_all_components_of_type(path))
-			var/list/part_costs = part.get_contained_matter()
+			var/list/part_costs = part.get_contained_matter(include_reagents)
 			for(var/key in part_costs)
 				.[key] += part_costs[key] * component_types[path]
 

--- a/code/game/machinery/_machines_base/stock_parts/building_material.dm
+++ b/code/game/machinery/_machines_base/stock_parts/building_material.dm
@@ -67,9 +67,9 @@
 	materials = null
 	..()
 
-/obj/item/stock_parts/building_material/get_contained_matter()
+/obj/item/stock_parts/building_material/get_contained_matter(include_reagents = TRUE)
 	. = ..()
 	for(var/obj/item/thing in materials)
-		var/list/costs = thing.get_contained_matter()
+		var/list/costs = thing.get_contained_matter(include_reagents)
 		for(var/key in costs)
 			.[key] += costs[key]

--- a/code/game/machinery/vending_deconstruction.dm
+++ b/code/game/machinery/vending_deconstruction.dm
@@ -38,12 +38,12 @@
 			return TRUE
 	. = ..()
 
-/obj/structure/vending_refill/get_contained_matter()
+/obj/structure/vending_refill/get_contained_matter(include_reagents = TRUE)
 	. = ..()
 	for(var/datum/stored_items/vending_products/record in product_records)
 		. = MERGE_ASSOCS_WITH_NUM_VALUES(., record.get_combined_matter(include_instances = FALSE))
 
-/obj/machinery/vending/get_contained_matter()
+/obj/machinery/vending/get_contained_matter(include_reagents = TRUE)
 	. = ..()
 	for(var/datum/stored_items/vending_products/record in product_records)
 		. = MERGE_ASSOCS_WITH_NUM_VALUES(., record.get_combined_matter(include_instances = FALSE))

--- a/code/game/machinery/wall_frames.dm
+++ b/code/game/machinery/wall_frames.dm
@@ -9,7 +9,7 @@
 	var/reverse = 0 //if resulting object faces opposite its dir (like light fixtures)
 	var/fully_construct = FALSE // Results in a machine with all parts auto-installed and ready to go if TRUE; if FALSE, the machine will spawn without removable expected parts
 
-/obj/item/frame/get_contained_matter()
+/obj/item/frame/get_contained_matter(include_reagents = TRUE)
 	. = ..()
 	if(fully_construct)
 		var/list/cost = atom_info_repository.get_matter_for(build_machine_type)

--- a/code/game/objects/__objs.dm
+++ b/code/game/objects/__objs.dm
@@ -293,7 +293,7 @@
 /obj/proc/WillContain()
 	return
 
-/obj/get_contained_matter()
+/obj/get_contained_matter(include_reagents = TRUE)
 	. = ..()
 	if(length(matter))
 		. = MERGE_ASSOCS_WITH_NUM_VALUES(., matter.Copy())

--- a/code/modules/augment/active/cyberbrain.dm
+++ b/code/modules/augment/active/cyberbrain.dm
@@ -79,11 +79,11 @@
 		if(os)
 			os.Process()
 
-/obj/item/organ/internal/augment/active/cyberbrain/get_contained_matter()
+/obj/item/organ/internal/augment/active/cyberbrain/get_contained_matter(include_reagents = TRUE)
 	. = ..()
 	var/datum/extension/assembly/assembly = get_extension(src, /datum/extension/assembly)
 	for(var/obj/part in assembly?.parts)
-		. = MERGE_ASSOCS_WITH_NUM_VALUES(., part.get_contained_matter())
+		. = MERGE_ASSOCS_WITH_NUM_VALUES(., part.get_contained_matter(include_reagents))
 
 /*
  *

--- a/code/modules/crafting/stack_recipes/_recipe.dm
+++ b/code/modules/crafting/stack_recipes/_recipe.dm
@@ -23,9 +23,6 @@
 	var/gender
 	/// Object path to the desired product.
 	var/result_type
-	/// Object path to use in unit testing; leave null to use result_type instead.
-	/// Useful for items that require a material to Initialize() correctly as testing tries to use a null material.
-	var/test_result_type
 	/// Amount of matter units needed for this recipe. If null, generates from result matter.
 	var/req_amount
 	/// Time it takes for this recipe to be crafted (not including skill and tool modifiers). If null, generates from product w_class and difficulty.
@@ -77,6 +74,10 @@
 	var/required_material                = MATERIAL_REQUIRED
 	/// Can this recipe use a reinforced material? Set to type for a specific material.
 	var/required_reinforce_material      = MATERIAL_FORBIDDEN
+
+	/// In cases where required_material is MATERIAL_REQUIRED and not a typepath,
+	/// this is the material type used for setup, validation, and tests.
+	var/validation_material
 
 	/// Minimum material wall support value.
 	var/required_wall_support_value
@@ -131,17 +132,29 @@
 	else if(!ispath(result_type, expected_product_type))
 		. += "result type [result_type || "NULL"] is not subtype of expected product type [expected_product_type || "NULL"]"
 
-	if(isnull(required_material) || required_material == MATERIAL_FORBIDDEN)
-		if(!isnull(required_wall_support_value))
-			. += "null required material but non-null wall support value"
-		if(!isnull(required_integrity))
-			. += "null required material but non-null integrity value"
-		if(!isnull(required_max_opacity))
-			. += "null required material but non-null max opacity value"
-		if(!isnull(required_min_hardness))
-			. += "null required material but non-null min hardness value"
-		if(!isnull(required_max_hardness))
-			. += "null required material but non-null max hardness value"
+	switch(required_material)
+		if(null)
+			. += "null required material value is deprecated, use MATERIAL_FORBIDDEN"
+		if(MATERIAL_FORBIDDEN)
+			if(!isnull(validation_material))
+				. += "material is forbidden but non-null validation material"
+			if(!isnull(required_wall_support_value))
+				. += "material is forbidden but non-null wall support value"
+			if(!isnull(required_integrity))
+				. += "material is forbidden but non-null integrity value"
+			if(!isnull(required_max_opacity))
+				. += "material is forbidden but non-null max opacity value"
+			if(!isnull(required_min_hardness))
+				. += "material is forbidden but non-null min hardness value"
+			if(!isnull(required_max_hardness))
+				. += "material is forbidden but non-null max hardness value"
+		if(MATERIAL_REQUIRED)
+			if(isnull(validation_material))
+				. += "material is required but validation material was null"
+			else
+				var/list/material_failures = get_missing_material_properties(RESOLVE_TO_DECL(validation_material))
+				if(LAZYLEN(material_failures))
+					. += "validation material is [english_list(material_failures)]" // 'material is too soft, too opaque, and unable to support enough weight'
 
 	if(recipe_skill && !isnull(difficulty))
 		var/decl/skill/used_skill = GET_DECL(recipe_skill)
@@ -235,6 +248,21 @@
 
 	. = JOINTEXT(.)
 
+/// Returns a list of descriptive error strings e.g. "too soft/hard/opaque" if material properties are not satisfied.
+/decl/stack_recipe/proc/get_missing_material_properties(decl/material/mat)
+	ASSERT(mat)
+	// Check if the material has the appropriate properties.
+	if(!isnull(required_wall_support_value) && mat.wall_support_value < required_wall_support_value)
+		LAZYADD(., "unable to support enough weight")
+	if(!isnull(required_integrity) && mat.integrity < required_integrity)
+		LAZYADD(., "too weak")
+	if(!isnull(required_min_hardness) && mat.hardness < required_min_hardness)
+		LAZYADD(., "too soft")
+	if(!isnull(required_max_hardness) && mat.hardness > required_max_hardness)
+		LAZYADD(., "too hard")
+	if(!isnull(required_max_opacity) && mat.opacity > required_max_opacity)
+		LAZYADD(., "too opaque")
+
 /decl/stack_recipe/proc/can_be_made_from(stack_type, tool_type, decl/material/mat, decl/material/reinf_mat)
 
 	// Early checks to avoid letting recipes make themselves.
@@ -259,17 +287,8 @@
 		return FALSE
 
 	// Check if the material has the appropriate properties.
-	if(mat)
-		if(!isnull(required_wall_support_value) && mat.wall_support_value < required_wall_support_value)
-			return FALSE
-		if(!isnull(required_integrity) && mat.integrity < required_integrity)
-			return FALSE
-		if(!isnull(required_min_hardness) && mat.hardness < required_min_hardness)
-			return FALSE
-		if(!isnull(required_max_hardness) && mat.hardness > required_max_hardness)
-			return FALSE
-		if(!isnull(required_max_opacity) && mat.opacity > required_max_opacity)
-			return FALSE
+	if(mat && length(get_missing_material_properties(mat)))
+		return FALSE
 
 	// Check if they're using the right tool.
 	if(required_tool)
@@ -325,7 +344,8 @@
 	if(result_type && isnull(req_amount))
 		req_amount = 0
 		var/list/materials
-		materials = atom_info_repository.get_matter_for((test_result_type || result_type), (ispath(required_material) ? required_material : null))
+		var/decl/material/validation_material_path = ispath(required_material) ? decls_repository.get_first_concrete_decl_path_of_type(required_material) : validation_material
+		materials = atom_info_repository.get_matter_for(result_type, validation_material_path)
 		for(var/mat in materials)
 			req_amount += round(materials[mat])
 		req_amount = ceil(req_amount*crafting_extra_cost_factor)

--- a/code/modules/crafting/stack_recipes/recipes_bricks.dm
+++ b/code/modules/crafting/stack_recipes/recipes_bricks.dm
@@ -9,6 +9,7 @@
 		/obj/item/stack/material/log,
 		/obj/item/stack/material/lump
 	)
+	validation_material        = /decl/material/solid/stone/basalt
 	category                   = "structures"
 
 /decl/stack_recipe/bricks/cup
@@ -121,6 +122,7 @@
 	result_type                = /turf/wall/brick
 	craft_stack_types          = /obj/item/stack/material/brick
 	difficulty                 = MAT_VALUE_HARD_DIY
+	validation_material        = /decl/material/solid/stone/basalt
 
 /decl/stack_recipe/turfs/wall/brick/shutter
 	name                       = "shuttered brick wall"
@@ -129,8 +131,8 @@
 /decl/stack_recipe/turfs/floor/brick
 	name                       = "cobblestone path"
 	result_type                = /turf/floor/path
-	expected_product_type      = /turf/floor/path
 	craft_stack_types          = /obj/item/stack/material/brick
+	validation_material        = /decl/material/solid/stone/basalt
 
 /decl/stack_recipe/turfs/floor/brick/herringbone
 	name                       = "herringbone path"

--- a/code/modules/crafting/stack_recipes/recipes_cardstock.dm
+++ b/code/modules/crafting/stack_recipes/recipes_cardstock.dm
@@ -1,6 +1,7 @@
 /decl/stack_recipe/cardstock
 	abstract_type     = /decl/stack_recipe/cardstock
 	craft_stack_types = /obj/item/stack/material/cardstock
+	validation_material = /decl/material/solid/organic/cardboard
 	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE // not exactly high-tech, but donuts etc are not medieval
 
 /decl/stack_recipe/cardstock/box

--- a/code/modules/crafting/stack_recipes/recipes_grass.dm
+++ b/code/modules/crafting/stack_recipes/recipes_grass.dm
@@ -3,7 +3,10 @@
 	craft_stack_types           = /obj/item/stack/material/bundle
 	category                    = "woven items"
 	forbidden_craft_stack_types = null
+	validation_material         = /decl/material/solid/organic/plantmatter/grass/dry
 
+// TODO: make this check a material property. tensile strength? dryness?
+// literally anything but a direct type equality check please
 /decl/stack_recipe/woven/can_be_made_from(stack_type, tool_type, decl/material/mat, decl/material/reinf_mat)
 	if((istype(mat) ? mat.type : mat) == /decl/material/solid/organic/plantmatter/grass)
 		return FALSE

--- a/code/modules/crafting/stack_recipes/recipes_hardness.dm
+++ b/code/modules/crafting/stack_recipes/recipes_hardness.dm
@@ -1,6 +1,7 @@
 /decl/stack_recipe/hardness
 	abstract_type     = /decl/stack_recipe/hardness
 	required_min_hardness = MAT_VALUE_FLEXIBLE + 10
+	validation_material = DEFAULT_FURNITURE_MATERIAL
 
 /decl/stack_recipe/hardness/improvised_armour
 	result_type       = /obj/item/clothing/suit/armor/crafted
@@ -73,21 +74,6 @@
 
 /decl/stack_recipe/hardness/mortar
 	result_type = /obj/item/chems/glass/mortar
-
-/decl/stack_recipe/ring
-	result_type       = /obj/item/clothing/gloves/ring
-
-/decl/stack_recipe/ring_thin
-	name              = "ring, thin"
-	result_type       = /obj/item/clothing/gloves/ring/thin
-
-/decl/stack_recipe/ring_thick
-	name              = "ring, thick"
-	result_type       = /obj/item/clothing/gloves/ring/thick
-
-/decl/stack_recipe/ring_split
-	name              = "ring, split"
-	result_type       = /obj/item/clothing/gloves/ring/split
 
 /decl/stack_recipe/hardness/clipboard
 	result_type       = /obj/item/clipboard

--- a/code/modules/crafting/stack_recipes/recipes_items.dm
+++ b/code/modules/crafting/stack_recipes/recipes_items.dm
@@ -38,3 +38,21 @@
 			bundles += bundle
 		bundle.merge(paper)
 	return bundles
+
+// These don't check hardness so that you can make them out of clay and fire them, I guess?
+// They used to be in the hardness-based recipes file but aren't now.
+/decl/stack_recipe/ring
+	result_type         = /obj/item/clothing/gloves/ring
+	validation_material = /decl/material/solid/metal/silver
+
+/decl/stack_recipe/ring/thin
+	name                = "ring, thin"
+	result_type         = /obj/item/clothing/gloves/ring/thin
+
+/decl/stack_recipe/ring/thick
+	name                = "ring, thick"
+	result_type         = /obj/item/clothing/gloves/ring/thick
+
+/decl/stack_recipe/ring/split
+	name                = "ring, split"
+	result_type         = /obj/item/clothing/gloves/ring/split

--- a/code/modules/crafting/stack_recipes/recipes_logs.dm
+++ b/code/modules/crafting/stack_recipes/recipes_logs.dm
@@ -2,6 +2,7 @@
 	abstract_type               = /decl/stack_recipe/logs
 	craft_stack_types           = /obj/item/stack/material/log
 	forbidden_craft_stack_types = /obj/item/stack/material/ore
+	validation_material         = /decl/material/solid/organic/wood/oak
 
 /decl/stack_recipe/logs/travois
 	result_type                 = /obj/structure/travois
@@ -12,6 +13,7 @@
 	result_type                 = /turf/wall/log
 	craft_stack_types           = /obj/item/stack/material/log
 	forbidden_craft_stack_types = /obj/item/stack/material/ore
+	validation_material         = /decl/material/solid/organic/wood/oak
 	difficulty                  = MAT_VALUE_HARD_DIY
 
 /decl/stack_recipe/turfs/wall/logs/shutter

--- a/code/modules/crafting/stack_recipes/recipes_opacity.dm
+++ b/code/modules/crafting/stack_recipes/recipes_opacity.dm
@@ -9,6 +9,7 @@
 		/obj/item/stack/material/sheet,
 		/obj/item/stack/material/panel
 	)
+	validation_material         = /decl/material/solid/glass
 
 /decl/stack_recipe/opacity/fullwindow
 	name                 = "full-tile window"

--- a/code/modules/crafting/stack_recipes/recipes_panels.dm
+++ b/code/modules/crafting/stack_recipes/recipes_panels.dm
@@ -2,6 +2,7 @@
 	abstract_type     = /decl/stack_recipe/panels
 	craft_stack_types = /obj/item/stack/material/panel
 	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
+	validation_material = /decl/material/solid/organic/plastic
 
 /decl/stack_recipe/panels/bag
 	result_type       = /obj/item/bag/flimsy

--- a/code/modules/crafting/stack_recipes/recipes_planks.dm
+++ b/code/modules/crafting/stack_recipes/recipes_planks.dm
@@ -1,6 +1,7 @@
 /decl/stack_recipe/planks
 	abstract_type          = /decl/stack_recipe/planks
 	craft_stack_types      = /obj/item/stack/material/plank
+	validation_material    = /decl/material/solid/organic/wood/oak
 
 /decl/stack_recipe/planks/sandals
 	result_type            = /obj/item/clothing/shoes/sandal

--- a/code/modules/crafting/stack_recipes/recipes_reinforced.dm
+++ b/code/modules/crafting/stack_recipes/recipes_reinforced.dm
@@ -1,9 +1,10 @@
 /decl/stack_recipe/reinforced
-	abstract_type     = /decl/stack_recipe/reinforced
-	craft_stack_types = /obj/item/stack/material/sheet/reinforced
-	one_per_turf      = TRUE
-	difficulty        = MAT_VALUE_HARD_DIY
+	abstract_type               = /decl/stack_recipe/reinforced
+	craft_stack_types           = /obj/item/stack/material/sheet/reinforced
+	one_per_turf                = TRUE
+	difficulty                  = MAT_VALUE_HARD_DIY
 	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
+	validation_material         = /decl/material/solid/metal/plasteel
 
 /decl/stack_recipe/reinforced/ai_core
 	result_type       = /obj/structure/aicore

--- a/code/modules/crafting/stack_recipes/recipes_rods.dm
+++ b/code/modules/crafting/stack_recipes/recipes_rods.dm
@@ -10,6 +10,7 @@
 	difficulty                  = MAT_VALUE_HARD_DIY
 	available_to_map_tech_level = MAP_TECH_LEVEL_MEDIEVAL
 	category                    = "structures"
+	validation_material         = /decl/material/solid/metal/steel
 
 /decl/stack_recipe/rods/stick
 	result_type                 = /obj/item/stick

--- a/code/modules/crafting/stack_recipes/recipes_soft.dm
+++ b/code/modules/crafting/stack_recipes/recipes_soft.dm
@@ -9,6 +9,7 @@
 	)
 	required_min_hardness       = 0
 	required_max_hardness       = MAT_VALUE_SOFT
+	validation_material         = /decl/material/solid/clay
 	crafting_extra_cost_factor  = 1 // No wastage for just resculpting materials.
 
 /decl/stack_recipe/soft/teapot
@@ -42,13 +43,11 @@
 	name                        = "brick"
 	name_plural                 = "bricks"
 	result_type                 = /obj/item/stack/material/brick
-	test_result_type            = /obj/item/stack/material/brick/clay
 
 /decl/stack_recipe/soft/bar
 	name                        = "bar"
 	name_plural                 = "bars"
 	result_type                 = /obj/item/stack/material/bar
-	test_result_type            = /obj/item/stack/material/bar/wax
 
 /decl/stack_recipe/soft/stack/spawn_result(mob/user, location, amount, decl/material/mat, decl/material/reinf_mat, paint_color, spent_type, spent_amount = 1)
 	var/obj/item/stack/S = ..()
@@ -68,13 +67,11 @@
 	name                        = "large lump"
 	name_plural                 = "large lumps"
 	result_type                 = /obj/item/stack/material/lump/large
-	test_result_type            = /obj/item/stack/material/lump/large/clay
 
 /decl/stack_recipe/soft/stack/small_lump
 	name                        = "small lump"
 	name_plural                 = "small lumps"
 	result_type                 = /obj/item/stack/material/lump
-	test_result_type            = /obj/item/stack/material/lump/clay
 
 /decl/stack_recipe/soft/crucible
 	result_type = /obj/item/chems/crucible

--- a/code/modules/crafting/stack_recipes/recipes_stacks.dm
+++ b/code/modules/crafting/stack_recipes/recipes_stacks.dm
@@ -112,6 +112,7 @@
 	abstract_type = /decl/stack_recipe/tile/panels
 	craft_stack_types = /obj/item/stack/material/panel
 	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
+	validation_material = /decl/material/solid/organic/plastic
 
 /decl/stack_recipe/tile/panels/floor
 	result_type       = /obj/item/stack/tile/floor_white

--- a/code/modules/crafting/stack_recipes/recipes_textiles.dm
+++ b/code/modules/crafting/stack_recipes/recipes_textiles.dm
@@ -6,6 +6,7 @@
 	difficulty                 = null // Autoset from material difficulty
 	crafting_extra_cost_factor = 1.5 // measure twice, cut once; material is lost. todo: produce scraps?
 	abstract_type              = /decl/stack_recipe/textiles
+	validation_material        = /decl/material/solid/organic/cloth
 
 /decl/stack_recipe/textiles/rug
 	result_type                = /obj/structure/rug/crafted
@@ -62,6 +63,7 @@
 
 /decl/stack_recipe/textiles/leather
 	abstract_type         = /decl/stack_recipe/textiles/leather
+	validation_material   = /decl/material/solid/organic/leather
 	craft_stack_types     = /obj/item/stack/material/skin
 	category              = "clothing"
 
@@ -105,6 +107,7 @@
 
 /decl/stack_recipe/textiles/cloth
 	abstract_type         = /decl/stack_recipe/textiles/cloth
+	validation_material   = /decl/material/solid/organic/cloth
 	craft_stack_types     = /obj/item/stack/material/bolt
 	category              = "clothing"
 
@@ -141,6 +144,7 @@
 /decl/stack_recipe/textiles/fur
 	abstract_type         = /decl/stack_recipe/textiles/fur
 	craft_stack_types     = /obj/item/stack/material/skin/pelt
+	validation_material   = /decl/material/solid/organic/skin/fur
 
 /decl/stack_recipe/textiles/fur/bedding
 	difficulty                 = MAT_VALUE_EASY_DIY

--- a/code/modules/fabrication/_fabricator.dm
+++ b/code/modules/fabrication/_fabricator.dm
@@ -230,6 +230,6 @@
 	return pipe_colors //override with null for hex color selections
 
 // Our stored_material is just the right format to be added to the matter list.
-/obj/machinery/fabricator/get_contained_matter()
+/obj/machinery/fabricator/get_contained_matter(include_reagents = TRUE)
 	. = ..()
 	. = MERGE_ASSOCS_WITH_NUM_VALUES(., stored_material)

--- a/code/modules/mob/living/living_organs.dm
+++ b/code/modules/mob/living/living_organs.dm
@@ -11,10 +11,10 @@
 /mob/living/proc/has_internal_organs()
 	return LAZYLEN(get_internal_organs()) > 0
 
-/mob/living/get_contained_matter()
+/mob/living/get_contained_matter(include_reagents = TRUE)
 	. = ..()
 	for(var/obj/item/organ in get_organs())
-		. = MERGE_ASSOCS_WITH_NUM_VALUES(., organ.get_contained_matter())
+		. = MERGE_ASSOCS_WITH_NUM_VALUES(., organ.get_contained_matter(include_reagents))
 
 //Can be called when we want to add an organ in a detached state or an attached state.
 /mob/living/proc/add_organ(var/obj/item/organ/O, var/obj/item/organ/external/affected = null, var/in_place = FALSE, var/update_icon = TRUE, var/detached = FALSE, var/skip_health_update = FALSE)

--- a/code/modules/modular_computers/computers/modular_computer/core.dm
+++ b/code/modules/modular_computers/computers/modular_computer/core.dm
@@ -4,11 +4,11 @@
 	if(assembly)
 		LAZYREMOVE(., assembly.parts)
 
-/obj/item/modular_computer/get_contained_matter()
+/obj/item/modular_computer/get_contained_matter(include_reagents = TRUE)
 	. = ..()
 	var/datum/extension/assembly/assembly = get_extension(src, /datum/extension/assembly)
 	for(var/obj/part in assembly?.parts)
-		. = MERGE_ASSOCS_WITH_NUM_VALUES(., part.get_contained_matter())
+		. = MERGE_ASSOCS_WITH_NUM_VALUES(., part.get_contained_matter(include_reagents))
 
 /obj/item/modular_computer/Process()
 	var/datum/extension/assembly/assembly = get_extension(src, /datum/extension/assembly)

--- a/code/modules/projectiles/ammunition.dm
+++ b/code/modules/projectiles/ammunition.dm
@@ -176,7 +176,7 @@
 		stored_ammo += new ammo_type(src)
 	contents_initialized = TRUE
 
-/obj/item/ammo_magazine/get_contained_matter()
+/obj/item/ammo_magazine/get_contained_matter(include_reagents = TRUE)
 	. = ..()
 	if(!lazyload_contents || contents_initialized || !ammo_type || !initial_ammo)
 		return

--- a/code/modules/tools/components/recipes.dm
+++ b/code/modules/tools/components/recipes.dm
@@ -7,6 +7,7 @@
 		/obj/item/stack/material/lump,
 		/obj/item/stack/material/plank
 	)
+	validation_material         = /decl/material/solid/stone/basalt
 
 /decl/stack_recipe/tool/handle
 	abstract_type               = /decl/stack_recipe/tool/handle
@@ -16,6 +17,7 @@
 		/obj/item/stack/material/rods,
 		/obj/item/stack/material/bone
 	)
+	validation_material         = /decl/material/solid/organic/bone
 
 /decl/stack_recipe/tool/handle/long
 	result_type                 = /obj/item/tool_component/handle/long

--- a/code/unit_tests/materials.dm
+++ b/code/unit_tests/materials.dm
@@ -12,31 +12,50 @@
 	var/list/stack_types = list(null)
 	var/list/tool_types = list(null)
 
-	var/list/all_recipes = decls_repository.get_decls_of_subtype(/decl/stack_recipe)
-	for(var/recipe_type in all_recipes)
-		var/decl/stack_recipe/recipe = all_recipes[recipe_type]
+	var/list/all_recipes = decls_repository.get_decls_of_subtype_unassociated(/decl/stack_recipe)
+	for(var/decl/stack_recipe/recipe in all_recipes)
 		if(recipe.required_tool)
 			tool_types |= recipe.required_tool
 		if(recipe.craft_stack_types)
 			stack_types |= recipe.craft_stack_types
 
 	// Force config to be the most precise recipes possible.
+	// This first one doesn't actually work because it's applied on decl init...
 	var/decl/config/config = GET_DECL(/decl/config/toggle/on/stack_crafting_uses_types)
 	config.set_value(TRUE)
 	config = GET_DECL(/decl/config/toggle/stack_crafting_uses_tools)
 	config.set_value(TRUE)
 
 	var/list/test_materials = list(
-		GET_DECL(/decl/material/solid/organic/wood),
+		GET_DECL(/decl/material/solid/organic/wood/oak),
 		GET_DECL(/decl/material/solid/organic/plastic),
 		GET_DECL(/decl/material/solid/organic/meat),
+		GET_DECL(/decl/material/solid/organic/cloth/linen),
+		GET_DECL(/decl/material/solid/organic/leather),
+		GET_DECL(/decl/material/solid/organic/plantmatter/grass/dry),
+		GET_DECL(/decl/material/solid/organic/paper),
 		GET_DECL(/decl/material/solid/metal/steel),
 		GET_DECL(/decl/material/solid/metal/plasteel),
 		GET_DECL(/decl/material/solid/metal/gold),
+		GET_DECL(/decl/material/solid/metal/aluminium),
+		GET_DECL(/decl/material/solid/organic/wax),
 		GET_DECL(/decl/material/solid/glass),
-		GET_DECL(/decl/material/solid/stone/sandstone),
-		GET_DECL(/decl/material/solid/clay)
+		GET_DECL(/decl/material/solid/stone/basalt),
+		GET_DECL(/decl/material/solid/clay),
 	)
+
+	// Add validation materials if not already present
+	// (this is especially useful for modpacked recipes/materials, like nullglass)
+	for(var/decl/stack_recipe/the_recipe in all_recipes)
+		if(ispath(the_recipe.required_material))
+			var/decl/material/the_validation_material = the_recipe.required_material
+			if(TYPE_IS_ABSTRACT(the_validation_material))
+				the_validation_material = decls_repository.get_first_concrete_decl_path_of_type(the_recipe.required_material)
+			test_materials |= GET_DECL(the_validation_material)
+			continue
+		if(the_recipe.validation_material)
+			test_materials |= GET_DECL(the_recipe.validation_material)
+			continue
 
 	// This is obscene, but completeness requires it.
 	for(var/stack_type in stack_types)
@@ -51,21 +70,19 @@
 
 					// Handle the actual validation.
 					for(var/decl/stack_recipe/recipe as anything in recipes)
-						var/test_type = recipe.test_result_type || recipe.result_type
-						if(!test_type || ispath(test_type, /turf)) // Cannot exist without a loc and doesn't have matter, cannot assess here.
+						if(!recipe.result_type || ispath(recipe.result_type, /turf)) // Cannot exist without a loc and doesn't have matter, cannot assess here.
 							continue
 						var/list/results = recipe.spawn_result(null, null, 1, material, reinforced, null)
 						var/atom/product = LAZYACCESS(results, 1)
 						var/list/failed = list()
 						if(!product)
 							failed += "no product returned"
-						else if(!istype(product, recipe.expected_product_type))
-							failed += "unexpected product type returned ([product.type])"
+						else if(!istype(product, recipe.result_type))
+							failed += "unexpected product type, got '[product.type]' (expected '[recipe.result_type]')"
 						else if(isobj(product))
 							var/list/product_matter = list()
 							for(var/obj/product_obj in results)
-								product_matter = MERGE_ASSOCS_WITH_NUM_VALUES(product_matter, product_obj.get_contained_matter())
-							LAZYINITLIST(product_matter) // For the purposes of the following tests not runtiming.
+								product_matter = MERGE_ASSOCS_WITH_NUM_VALUES(product_matter, product_obj.get_contained_matter(include_reagents = FALSE))
 							if(!material && !reinforced)
 								if(length(product_matter))
 									failed += "unsupplied material types"
@@ -87,6 +104,8 @@
 							passed_designs += recipe
 						if(!QDELETED(product))
 							qdel(product)
+						CHECK_TICK
+					CHECK_TICK
 
 	if(failed_count)
 		fail("[failed_count] crafting recipes had inconsistent output materials: [jointext(failed_designs, "\n")].")


### PR DESCRIPTION
built on top of #5029

- removes `test_result_type`, replaces it with `validation_material`, which is now required if any material is required but not specified as a particular type
- checks that the validation material can pass the hardness/etc requirements for its recipe
- adds `get_first_concrete_decl_path_of_type()` to take a generic abstract material type like `/decl/material/solid/organic/wood` and return some valid non-abstract subtype. this is useful for validation mostly
- allows `get_contained_matter()` to exclude reagents, though we should probably change that at some point, particularly like. when food is refactored to use matter/matter is refactored to use reagent datums, so you can just bite chunks out of the hay and not need to add extra reagents
- removes some `expected_product_type` overrides that didn't make sense, this should really only be turf/obj/etc and used in validate() to avoid "someone made a non-turf recipe create a turf" or vice versa.
- adds CHECK_TICKs to the material matter unit test because it kept freezing daemon