### PR TITLE
Fix mob snapshot not tracking skin color or tone

### DIFF
--- a/code/modules/mob/living/human/human.dm
+++ b/code/modules/mob/living/human/human.dm
@@ -1122,8 +1122,10 @@
 		return //no feet no footsteps
 	return TRUE
 
-/mob/living/human/get_skin_tone(value)
-	return skin_tone
+/mob/living/human/get_skin_tone()
+	if(get_bodytype()?.appearance_flags & HAS_A_SKIN_TONE)
+		return skin_tone
+	return null
 
 /mob/living/human/set_skin_tone(value)
 	skin_tone = value

--- a/code/modules/mob/living/human/human_appearance.dm
+++ b/code/modules/mob/living/human/human_appearance.dm
@@ -7,7 +7,9 @@
 	AC.ui_interact(user, state = state)
 
 /mob/living/human/get_skin_colour()
-	return _skin_colour
+	if(get_bodytype()?.appearance_flags & HAS_SKIN_COLOR)
+		return _skin_colour
+	return null
 
 /mob/living/human/set_skin_colour(var/new_color, var/skip_update = FALSE)
 	if((. = ..()))

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1359,7 +1359,7 @@
 /mob/proc/set_skin_tone(value)
 	return
 
-/mob/proc/get_skin_tone(value)
+/mob/proc/get_skin_tone()
 	return
 
 /mob/proc/force_update_limbs()

--- a/code/modules/mob/mob_snapshot.dm
+++ b/code/modules/mob/mob_snapshot.dm
@@ -21,6 +21,8 @@
 	eye_color      = donor?.get_eye_colour() || COLOR_BLACK
 	blood_type     = donor?.get_blood_type()
 	unique_enzymes = donor?.get_unique_enzymes()
+	skin_color     = donor?.get_skin_colour()
+	skin_tone      = donor?.get_skin_tone()
 	fingerprint    = donor?.get_full_print(ignore_blockers = TRUE)
 
 	root_species   = donor?.get_species()  || get_species_by_key(global.using_map.default_species)


### PR DESCRIPTION
the default skin tone was overwriting it even though it shouldn't have