### PR TITLE
Fix issues with ZM discovery and updates

### DIFF
--- a/code/controllers/subsystems/zcopy.dm
+++ b/code/controllers/subsystems/zcopy.dm
@@ -502,12 +502,13 @@ SUBSYSTEM_DEF(zcopy)
 
 	ZM_RECORD_START
 
+	var/above_needs_discovery = FALSE
 	if (!object.bound_overlay)
 		var/atom/movable/openspace/mimic/M = new(T)
 		object.bound_overlay = M
+		M.z_flags = object.z_flags // Necessary to ensure MOVABLE_IS_ON_ZTURF works
 		M.associated_atom = object
-		if (TURF_IS_MIMICKING(M.loc))
-			.(M)
+		above_needs_discovery = TRUE
 
 	var/override_depth
 	var/original_type = object.type
@@ -557,6 +558,9 @@ SUBSYSTEM_DEF(zcopy)
 
 	ZM_RECORD_STOP
 	ZM_RECORD_WRITE(discovery_stats, "Depth [OO.depth] on [OO.z]")
+
+	if (above_needs_discovery && MOVABLE_IS_ON_ZTURF(OO))
+		discover_movable(OO) // recursion!
 
 	return FALSE
 

--- a/code/controllers/subsystems/zcopy.dm
+++ b/code/controllers/subsystems/zcopy.dm
@@ -493,6 +493,8 @@ SUBSYSTEM_DEF(zcopy)
 // return: is-invalid
 /datum/controller/subsystem/zcopy/proc/discover_movable(atom/movable/object)
 	ASSERT(!QDELETED(object))
+	if(init_state < SS_INITSTATE_STARTED)
+		return FALSE // no-op, discover_movable is only valid during or after zcopy init
 
 	var/turf/Tloc = object.loc
 	if (!isturf(Tloc) || !Tloc.above)

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -614,7 +614,7 @@
 	- Return: The result of the forceMove() at the end.
 */
 /atom/movable/proc/dropInto(var/atom/destination)
-	while(istype(destination))
+	while(!QDELETED(src) && istype(destination))
 		var/atom/drop_destination = destination.onDropInto(src)
 		if(!istype(drop_destination) || drop_destination == destination)
 			return forceMove(destination)

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -165,6 +165,7 @@
 	//  Both the origin and destination are turfs with different areas.
 	//  When either origin or destination is a turf and the other is not.
 	var/is_new_area = (is_origin_turf ^ is_destination_turf) || (is_origin_turf && is_destination_turf && loc.loc != destination.loc)
+	var/was_below_z_turf = MOVABLE_IS_BELOW_ZTURF(src)
 
 	var/atom/origin = loc
 	loc = destination
@@ -206,6 +207,18 @@
 			L = thing
 			L.source_atom.update_light()
 
+	// Z-Mimic.
+	if (bound_overlay)
+		// The overlay will handle cleaning itself up on non-openspace turfs.
+		if (isturf(destination))
+			bound_overlay.forceMove(get_step(src, UP))
+			if (dir != bound_overlay.dir)
+				bound_overlay.set_dir(dir)
+		else	// Not a turf, so we need to destroy immediately instead of waiting for the destruction timer to proc.
+			qdel(bound_overlay)
+	else if (isturf(loc) && (!origin || !was_below_z_turf) && MOVABLE_SHALL_MIMIC(src))
+		SSzcopy.discover_movable(src)
+
 	if(buckled_mob)
 		if(isturf(loc))
 			buckled_mob.glide_size = glide_size // Setting loc apparently does animate with glide size.
@@ -228,7 +241,7 @@
 /atom/movable/Move(...)
 
 	var/old_loc = loc
-
+	var/was_below_z_turf = MOVABLE_IS_BELOW_ZTURF(src)
 	. = ..()
 
 	if(.)
@@ -264,7 +277,7 @@
 			bound_overlay.forceMove(get_step(src, UP))
 			if (bound_overlay.dir != dir)
 				bound_overlay.set_dir(dir)
-		else if (isturf(loc) && (!old_loc || !TURF_IS_MIMICKING(old_loc)) && MOVABLE_SHALL_MIMIC(src))
+		else if (isturf(loc) && (!old_loc || !was_below_z_turf) && MOVABLE_SHALL_MIMIC(src))
 			SSzcopy.discover_movable(src)
 
 //called when src is thrown into hit_atom

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -153,7 +153,7 @@
 
 /atom/movable/proc/forceMove(atom/destination)
 
-	if(QDELETED(src) && !QDESTROYING(src) && !isnull(destination))
+	if(QDELETED(src) && !isnull(destination))
 		CRASH("Attempted to forceMove a QDELETED [src] out of nullspace!!!")
 
 	if(loc == destination)

--- a/code/modules/clothing/under/accessories/accessory.dm
+++ b/code/modules/clothing/under/accessories/accessory.dm
@@ -32,7 +32,7 @@
 	var/obj/item/clothing/suit = loc
 	if(istype(suit))
 		if(user)
-			usr.put_in_hands(src)
+			user.put_in_hands(src)
 			src.add_fingerprint(user)
 		else
 			dropInto(loc)

--- a/code/modules/lighting/lighting_atom.dm
+++ b/code/modules/lighting/lighting_atom.dm
@@ -83,15 +83,3 @@
 		T.recalc_atom_opacity()
 		if (old_has_opaque_atom != T.has_opaque_atom)
 			T.reconsider_lights()
-
-/atom/movable/forceMove()
-	. = ..()
-
-	if (light_source_solo)
-		light_source_solo.source_atom.update_light()
-	else if (light_source_multi)
-		var/datum/light_source/L
-		var/thing
-		for (thing in light_source_multi)
-			L = thing
-			L.source_atom.update_light()

--- a/code/modules/multiz/zmimic/mimic_movable.dm
+++ b/code/modules/multiz/zmimic/mimic_movable.dm
@@ -4,17 +4,6 @@
 	/// Movable-level Z-Mimic flags. This uses ZMM_* flags, not ZM_* flags.
 	var/z_flags = 0
 
-/atom/movable/forceMove(atom/dest)
-	. = ..(dest)
-	if (. && bound_overlay)
-		// The overlay will handle cleaning itself up on non-openspace turfs.
-		if (isturf(dest))
-			bound_overlay.forceMove(get_step(src, UP))
-			if (dir != bound_overlay.dir)
-				bound_overlay.set_dir(dir)
-		else	// Not a turf, so we need to destroy immediately instead of waiting for the destruction timer to proc.
-			qdel(bound_overlay)
-
 /atom/movable/set_dir(ndir)
 	. = ..()
 	if (. && bound_overlay)
@@ -24,9 +13,7 @@
 	if (!bound_overlay || !isturf(loc))
 		return
 
-	var/turf/T = loc
-
-	if (TURF_IS_MIMICKING(T.above))
+	if (MOVABLE_IS_BELOW_ZTURF(src))
 		SSzcopy.queued_overlays += bound_overlay
 		bound_overlay.queued += 1
 	else
@@ -161,7 +148,7 @@
 /atom/movable/openspace/mimic/forceMove(turf/dest)
 	var/atom/old_loc = loc
 	. = ..()
-	if (TURF_IS_MIMICKING(dest))
+	if (MOVABLE_IS_ON_ZTURF(src))
 		if (destruction_timer)
 			deltimer(destruction_timer)
 			destruction_timer = null


### PR DESCRIPTION
Fixes #4998. Generally just does a correctness pass on movable discovery in ZM, with lots and lots of guidance from Lohikar. Also collapses some duplicate movable-level definitions of forceMove, one of which was already redundant.