### PR TITLE
Prevent suit cyclers from rotating with shuttles

### DIFF
--- a/code/game/machinery/suit_cycler.dm
+++ b/code/game/machinery/suit_cycler.dm
@@ -521,8 +521,5 @@
 		boots.refit_for_bodytype(target_bodytype)
 		boots.SetName("refitted [initial(boots.name)]")
 
-// Update icon on rotate so that overlays rotate as well
-/obj/machinery/suit_cycler/shuttle_rotate(angle)
-	. = ..()
-	if(.)
-		addtimer(CALLBACK(src, TYPE_PROC_REF(/atom, queue_icon_update)), 1)
+/obj/machinery/suit_cycler/shuttle_rotate(angle) // DO NOT CHANGE DIR. Change this when someone adds directional sprites for suit cyclers.
+	return


### PR DESCRIPTION
fixes #4927, I think. the suits were doing the right thing, the issue is just the cyclers were mapped in a weird direction and it wasn't visible because they only have south-facing sprites. this just disables rotation so they stay south-facing.