### PR TITLE
Fix solid turfs not blocking spacedrift

### DIFF
--- a/code/__defines/misc.dm
+++ b/code/__defines/misc.dm
@@ -382,6 +382,7 @@
 #define CRAYON_DRAW_ARROW    "arrow"
 
 // Enum for results of is_space_movement_permitted()
-#define SPACE_MOVE_SUPPORTED (-1)
-#define SPACE_MOVE_FORBIDDEN   0
-#define SPACE_MOVE_PERMITTED   1
+// Note that it may also return an instance of /atom/movable, which acts as SPACE_MOVE_SUPPORTED.
+#define SPACE_MOVE_SUPPORTED (-1) //! Mob should run space-slipping checks.
+#define SPACE_MOVE_FORBIDDEN   0  //! Mob should begin spacedrift.
+#define SPACE_MOVE_PERMITTED   1  //! Mob should stop/prevent spacedrift.

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -58,7 +58,8 @@
 	SSspacedrift.processing[src] = src
 	return 1
 
-//return SPACE_MOVE_FORBIDDEN to space drift, SPACE_MOVE_PERMITTED to stop, SPACE_MOVE_SUPPORTED for mobs to handle space slips
+// return SPACE_MOVE_FORBIDDEN to space drift, SPACE_MOVE_PERMITTED to stop, SPACE_MOVE_SUPPORTED for mobs to handle space slips
+// Note that it may also return an instance of /atom/movable, which acts as SPACE_MOVE_SUPPORTED and results in pushing the movable backwards.
 /atom/movable/proc/is_space_movement_permitted(allow_movement = FALSE)
 	if(!simulated)
 		return SPACE_MOVE_PERMITTED

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1429,6 +1429,8 @@
 	for(var/turf/neighbor in RANGE_TURFS(my_turf, 1))
 		if(neighbor == my_turf)
 			continue
+		if(neighbor.is_wall() || neighbor.is_floor())
+			return neighbor
 		var/dense_object = neighbor.get_first_dense_object(exceptions = src)
 		if(dense_object)
 			return dense_object


### PR DESCRIPTION
Fixes #5046. Part of the issue was my fault because `contains_dense_object` checks turf density while `get_first_dense_object` does not. Floors already didn't count though. This fixes it. I didn't include `has_gravity() || has_magnetised_footing()` checks because they're already done at the callsite for this proc in the one place where it matters (`can_slip()`) and in the other spot it shouldn't check that.

Adds some comments too.