### PR TITLE
Rename a var from `usr` to `user`

### DIFF
--- a/code/modules/character_info/_comment.dm
+++ b/code/modules/character_info/_comment.dm
@@ -25,7 +25,7 @@
 /datum/character_comment/proc/is_stale()
 	return !get_config_value(/decl/config/num/hide_comments_older_than) || (REALTIMEOFDAY - last_updated) > (get_config_value(/decl/config/num/hide_comments_older_than))
 
-/datum/character_comment/proc/get_comment_html(var/datum/character_information/presenting, var/mob/usr, var/row_bkg_color)
+/datum/character_comment/proc/get_comment_html(var/datum/character_information/presenting, var/mob/user, var/row_bkg_color)
 
 	if(!istype(main_mood))
 		main_mood = GET_DECL(/decl/comment_mood/unknown)
@@ -39,14 +39,14 @@
 		"<td title = '[mood_title]' style=\"border: 1px solid [border_mood ? border_mood.bg_color : main_mood.fg_color];\" width = 360px bgcolor = '[main_mood.bg_color]'><center><font color = '[main_mood.fg_color]'>[body]</font></center></td>",
 		"<td width = 170px>"
 	)
-	if(usr)
+	if(user)
 		. += "<center>"
-		if(author_ckey == usr.ckey || check_rights(R_MOD))
+		if(author_ckey == user.ckey || check_rights(R_MOD))
 			. += "<a href='byond://?src=\ref[presenting];comment_ref=\ref[src];edit_comment=1'>Edit</a><br/>"
 			. += "<a href='byond://?src=\ref[presenting];comment_ref=\ref[src];delete_comment=1'>Delete</a><br/>"
 			. += "<a href='byond://?src=\ref[presenting];comment_ref=\ref[src];change_comment_mood=primary'>Change primary mood</a><br/>"
 			. += "<a href='byond://?src=\ref[presenting];comment_ref=\ref[src];change_comment_mood=border'>Change border mood</a>"
-		else if(usr.ckey == presenting.ckey)
+		else if(user.ckey == presenting.ckey)
 			. += "<a href='byond://?src=\ref[presenting];comment_ref=\ref[src];delete_comment=1'>Delete</a>"
 		else
 			. += "<small><i>Not editable.</i></small>"


### PR DESCRIPTION
<!-- !! PLEASE, READ THIS !! -->
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/NebulaSS13/Nebula/blob/dev/CONTRIBUTING.md -->
<!-- If you're opening a pull request which changes A LOT of icon/map files: -->
<!-- Add [IDB IGNORE] (to ignore icon file changes) or [MDB IGNORE] (to ignore map file changes) in the PR title. -->
<!-- These tags prevent huge diffs from overloading IconDiffBot and MapDiffBot. -->

## Description of changes
<!-- Describe the pull request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

OpenDream is adding `usr` to the `SoftReservedKeyword` pragma: https://github.com/OpenDreamProject/OpenDream/pull/2307

This PR renames a `var/mob/usr` to `var/mob/user`.

## Why and what will this PR improve
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

This pragma is currently an error on Nebula, because using internal var names for declared var names is cringe.

## Authorship
<!-- Describe original authors of changes to credit them. -->
I wrote the DM changes. See https://github.com/OpenDreamProject/OpenDream/pull/2307 for the OpenDream side of things.

## Changelog

it's a var rename

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->