### PR TITLE
Fix missing allergen_flags on bones

### DIFF
--- a/code/modules/materials/_materials.dm
+++ b/code/modules/materials/_materials.dm
@@ -344,7 +344,6 @@ INITIALIZE_IMMEDIATE(/obj/effect/gas_overlay)
 	var/compost_value = 0
 
 	/// Nutrition values!
-	var/nutriment_animal     = FALSE
 	var/nutriment_factor     = 0 // Per removed amount each tick
 	var/hydration_factor     = 0 // Per removed amount each tick
 	var/injectable_nutrition = FALSE

--- a/code/modules/materials/definitions/solids/materials_solid_butchery.dm
+++ b/code/modules/materials/definitions/solids/materials_solid_butchery.dm
@@ -20,7 +20,6 @@
 	sound_dropped = 'sound/foley/meat2.ogg'
 	hitsound = 'sound/effects/squelch1.ogg'
 	fishing_bait_value = 1
-	nutriment_animal = TRUE
 	reagent_overlay = "soup_chunks"
 	nutriment_factor = 10
 	allergen_flags = ALLERGEN_MEAT
@@ -87,7 +86,6 @@
 	fishing_bait_value = 0.75
 	tans_to = /decl/material/solid/organic/leather
 	compost_value = 0.8
-	nutriment_animal = TRUE
 	allergen_flags = ALLERGEN_MEAT
 
 /decl/material/solid/organic/skin/lizard
@@ -224,7 +222,7 @@
 	sound_manipulate = 'sound/foley/stickspickup1.ogg'
 	sound_dropped = 'sound/foley/sticksdrop1.ogg'
 	compost_value = 0.5
-	nutriment_animal = TRUE
+	allergen_flags = ALLERGEN_MEAT
 	exoplanet_rarity_plant = MAT_RARITY_EXOTIC
 
 // Stub to stop eggs melting while being boiled.


### PR DESCRIPTION
Bones are meat. Yum. Removes an unused/defunct `nutriment_animal` var too.