### PR TITLE
Adding byond executable mirror to build scripts.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ on:
 
 env:
   BYOND_MAJOR: "515"
-  BYOND_MINOR: "1633"
+  BYOND_MINOR: "1647"
   SPACEMAN_DMM_VERSION: suite-1.8
 
 jobs:

--- a/install-byond.sh
+++ b/install-byond.sh
@@ -8,7 +8,8 @@ else
   mkdir -p "$HOME/BYOND-${BYOND_MAJOR}.${BYOND_MINOR}"
   cd "$HOME/BYOND-${BYOND_MAJOR}.${BYOND_MINOR}"
   echo "Installing DreamMaker to $PWD"
-  curl "http://www.byond.com/download/build/${BYOND_MAJOR}/${BYOND_MAJOR}.${BYOND_MINOR}_byond_linux.zip" -H "User-Agent: NebulaSS13/1.0 Continuous Integration" -o byond.zip
+  #curl "http://www.byond.com/download/build/${BYOND_MAJOR}/${BYOND_MAJOR}.${BYOND_MINOR}_byond_linux.zip" -H "User-Agent: NebulaSS13/1.0 Continuous Integration" -o byond.zip
+  curl "https://spacestation13.github.io/byond-builds/${BYOND_MAJOR}/${BYOND_MAJOR}.${BYOND_MINOR}_byond_linux.zip" -H "User-Agent: NebulaSS13/1.0 Continuous Integration" -o byond.zip
   unzip -o byond.zip
   cd byond
   make here


### PR DESCRIPTION
Adding an alternative source for the CI build scripts due to the DDOS-related failures, with many thanks to @ZeWaka et al for https://github.com/spacestation13/byond-builds

Hopefully this will be a temporary inclusion but god only knows at this point.