### PR TITLE
Split preferences.copy_to across many, many procs

### DIFF
--- a/code/modules/client/preference_setup/background/01_species.dm
+++ b/code/modules/client/preference_setup/background/01_species.dm
@@ -6,6 +6,9 @@
 	sort_order = 1
 	var/hide_species = TRUE
 
+/datum/category_item/player_setup_item/background/species/populate_mob_snapshot(datum/mob_snapshot/snapshot, is_preview_copy = FALSE)
+	snapshot.root_species = pref.get_species_decl()
+
 // This must always return a decl, NEVER null.
 /datum/preferences/proc/get_species_decl()
 	RETURN_TYPE(/decl/species)

--- a/code/modules/client/preference_setup/background/02_background.dm
+++ b/code/modules/client/preference_setup/background/02_background.dm
@@ -25,6 +25,13 @@
 		hidden[cat_type] = TRUE
 	..()
 
+/datum/category_item/player_setup_item/background/details/copy_to_nonphysical(mob/living/human/character, is_preview_copy = FALSE)
+	if(is_preview_copy)
+		return
+	for(var/token in pref.background_info)
+		character.set_background_value(token, pref.background_info[token], defer_language_update = TRUE)
+	character.update_languages()
+
 /datum/category_item/player_setup_item/background/details/sanitize_character()
 
 	if(!islist(pref.background_info))

--- a/code/modules/client/preference_setup/background/02_background.dm
+++ b/code/modules/client/preference_setup/background/02_background.dm
@@ -25,7 +25,7 @@
 		hidden[cat_type] = TRUE
 	..()
 
-/datum/category_item/player_setup_item/background/details/copy_to_nonphysical(mob/living/human/character, is_preview_copy = FALSE)
+/datum/category_item/player_setup_item/background/details/apply_post_snapshot_preferences(mob/living/human/character, is_preview_copy = FALSE)
 	if(is_preview_copy)
 		return
 	for(var/token in pref.background_info)

--- a/code/modules/client/preference_setup/background/03_language.dm
+++ b/code/modules/client/preference_setup/background/03_language.dm
@@ -7,7 +7,7 @@
 	var/list/allowed_languages
 	var/list/free_languages
 
-/datum/category_item/player_setup_item/background/languages/copy_to_nonphysical(mob/living/human/character, is_preview_copy = FALSE)
+/datum/category_item/player_setup_item/background/languages/apply_post_snapshot_preferences(mob/living/human/character, is_preview_copy = FALSE)
 	if(is_preview_copy)
 		return
 	for(var/lang in pref.alternate_languages)

--- a/code/modules/client/preference_setup/background/03_language.dm
+++ b/code/modules/client/preference_setup/background/03_language.dm
@@ -7,6 +7,12 @@
 	var/list/allowed_languages
 	var/list/free_languages
 
+/datum/category_item/player_setup_item/background/languages/copy_to_nonphysical(mob/living/human/character, is_preview_copy = FALSE)
+	if(is_preview_copy)
+		return
+	for(var/lang in pref.alternate_languages)
+		character.add_language(lang)
+
 /datum/category_item/player_setup_item/background/languages/load_character(datum/pref_record_reader/R)
 	pref.alternate_languages = list()
 	var/list/language_names = R.read("language")

--- a/code/modules/client/preference_setup/general/01_basic.dm
+++ b/code/modules/client/preference_setup/general/01_basic.dm
@@ -18,7 +18,7 @@
 	name = "Basic"
 	sort_order = 1
 
-/datum/category_item/player_setup_item/physical/basic/copy_to_nonphysical(mob/living/human/character, is_preview_copy = FALSE)
+/datum/category_item/player_setup_item/physical/basic/apply_post_snapshot_preferences(mob/living/human/character, is_preview_copy = FALSE)
 	character.set_gender(pref.gender)
 
 /datum/category_item/player_setup_item/physical/basic/preload_character(datum/pref_record_reader/R)

--- a/code/modules/client/preference_setup/general/01_basic.dm
+++ b/code/modules/client/preference_setup/general/01_basic.dm
@@ -18,6 +18,9 @@
 	name = "Basic"
 	sort_order = 1
 
+/datum/category_item/player_setup_item/physical/basic/copy_to_nonphysical(mob/living/human/character, is_preview_copy = FALSE)
+	character.set_gender(pref.gender)
+
 /datum/category_item/player_setup_item/physical/basic/preload_character(datum/pref_record_reader/R)
 	pref.gender =         R.read("gender")
 	pref.bodytype =       R.read("bodytype")
@@ -66,6 +69,22 @@
 	if(!istype(bodytype) || !(bodytype in S.available_bodytypes))
 		bodytype = S.get_bodytype_by_pronouns(pronouns)
 		pref.set_bodytype(bodytype.name)
+
+/datum/category_item/player_setup_item/physical/basic/populate_mob_snapshot(datum/mob_snapshot/snapshot, is_preview_copy = FALSE)
+	snapshot.root_bodytype = pref.get_bodytype_decl()
+	var/new_real_name = pref.real_name
+	if(pref.be_random_name)
+		var/decl/background_detail/background = pref.get_background_datum_by_flag(BACKGROUND_FLAG_NAMING)
+		if(background)
+			new_real_name = background.get_random_name(pref.gender)
+	if(get_config_value(/decl/config/toggle/humans_need_surnames))
+		var/firstspace = findtext(new_real_name, " ")
+		var/name_length = length(new_real_name)
+		if(!firstspace)	//we need a surname
+			new_real_name += " [pick(global.using_map.last_names)]"
+		else if(firstspace == name_length) // someone tried to cheese it by putting a space at the end
+			new_real_name += "[pick(global.using_map.last_names)]"
+	snapshot.real_name = new_real_name
 
 /datum/category_item/player_setup_item/physical/basic/content()
 

--- a/code/modules/client/preference_setup/general/02_body.dm
+++ b/code/modules/client/preference_setup/general/02_body.dm
@@ -14,6 +14,57 @@
 	name = "Body"
 	sort_order = 2
 
+// apply sprite accessories to an existing mob
+// actually this might not be necessary because we apply the snapshot
+/* /datum/category_item/player_setup_item/physical/body/copy_to_physical(mob/living/human/character, is_preview_copy = FALSE)
+	for(var/obj/item/organ/external/O in character.get_external_organs())
+		for(var/decl/sprite_accessory_category/sprite_category in O.get_sprite_accessory_categories())
+			if(!sprite_category.clear_in_pref_apply)
+				continue
+			O.clear_sprite_accessories_by_category(sprite_category.type, skip_update = TRUE)
+	for(var/accessory_category in pref.sprite_accessories)
+		var/decl/sprite_accessory_category/acc_cat = GET_DECL(accessory_category)
+		var/list/accessories = pref.sprite_accessories[accessory_category]
+		acc_cat.prepare_character(character, accessories)
+		for(var/accessory in accessories)
+			var/decl/sprite_accessory/accessory_decl = GET_DECL(accessory)
+			var/accessory_metadata = accessories[accessory]
+			for(var/bodypart in accessory_decl.body_parts)
+				var/obj/item/organ/external/O = GET_EXTERNAL_ORGAN(character, bodypart)
+				if(O)
+					O.set_sprite_accessory(accessory, accessory_category, accessory_metadata, skip_update = TRUE) */
+
+/datum/category_item/player_setup_item/physical/body/populate_mob_snapshot(datum/mob_snapshot/snapshot, is_preview_copy = FALSE)
+	snapshot.blood_type = pref.blood_type
+	// we don't check appearance_flags here, apply_appearance_to does that
+	snapshot.skin_color = pref.skin_colour
+	snapshot.skin_tone = pref.skin_tone
+	snapshot.eye_color = pref.eye_colour
+	// so this is the hellish part.
+	// pref.sprite_accessories is sprite_accessories[accessory_category.type][loaded_accessory.type] = metadata
+	// snapshot.sprite_accessories is sprite_accessories[organ_tag][accessory_category.type][loaded_accessory.type] = metadata
+	// we have to convert it here
+	var/list/new_sprite_accessories = list()
+	for(var/accessory_category in pref.sprite_accessories)
+		var/decl/sprite_accessory_category/acc_cat = GET_DECL(accessory_category)
+		var/list/accessories = pref.sprite_accessories[accessory_category]
+		acc_cat.prepare_mob_snapshot(snapshot, accessories)
+		// todo: copy this elsewhere
+		// ^ i have no clue if i ever did this or not. presumably bc i don't know what i meant needed copying
+		for(var/accessory in accessories)
+			var/decl/sprite_accessory/accessory_decl = GET_DECL(accessory)
+			var/accessory_metadata = accessories[accessory]
+			for(var/bodypart in accessory_decl.body_parts)
+				LAZYINITLIST(new_sprite_accessories[bodypart])
+				LAZYSET(new_sprite_accessories[bodypart][accessory_category], accessory, accessory_metadata)
+	if(length(new_sprite_accessories))
+		snapshot.sprite_accessories = new_sprite_accessories
+
+// this should probably be named copy_to_after_physical, lol
+/datum/category_item/player_setup_item/physical/body/copy_to_nonphysical(mob/living/human/character, is_preview_copy = FALSE)
+	if(LAZYLEN(pref.appearance_descriptors))
+		character.appearance_descriptors = pref.appearance_descriptors.Copy()
+
 /datum/category_item/player_setup_item/physical/body/load_character(datum/pref_record_reader/R)
 
 	pref.skin_colour =            R.read("skin_colour")

--- a/code/modules/client/preference_setup/general/02_body.dm
+++ b/code/modules/client/preference_setup/general/02_body.dm
@@ -14,26 +14,6 @@
 	name = "Body"
 	sort_order = 2
 
-// apply sprite accessories to an existing mob
-// actually this might not be necessary because we apply the snapshot
-/* /datum/category_item/player_setup_item/physical/body/copy_to_physical(mob/living/human/character, is_preview_copy = FALSE)
-	for(var/obj/item/organ/external/O in character.get_external_organs())
-		for(var/decl/sprite_accessory_category/sprite_category in O.get_sprite_accessory_categories())
-			if(!sprite_category.clear_in_pref_apply)
-				continue
-			O.clear_sprite_accessories_by_category(sprite_category.type, skip_update = TRUE)
-	for(var/accessory_category in pref.sprite_accessories)
-		var/decl/sprite_accessory_category/acc_cat = GET_DECL(accessory_category)
-		var/list/accessories = pref.sprite_accessories[accessory_category]
-		acc_cat.prepare_character(character, accessories)
-		for(var/accessory in accessories)
-			var/decl/sprite_accessory/accessory_decl = GET_DECL(accessory)
-			var/accessory_metadata = accessories[accessory]
-			for(var/bodypart in accessory_decl.body_parts)
-				var/obj/item/organ/external/O = GET_EXTERNAL_ORGAN(character, bodypart)
-				if(O)
-					O.set_sprite_accessory(accessory, accessory_category, accessory_metadata, skip_update = TRUE) */
-
 /datum/category_item/player_setup_item/physical/body/populate_mob_snapshot(datum/mob_snapshot/snapshot, is_preview_copy = FALSE)
 	snapshot.blood_type = pref.blood_type
 	// we don't check appearance_flags here, apply_appearance_to does that
@@ -60,8 +40,7 @@
 	if(length(new_sprite_accessories))
 		snapshot.sprite_accessories = new_sprite_accessories
 
-// this should probably be named copy_to_after_physical, lol
-/datum/category_item/player_setup_item/physical/body/copy_to_nonphysical(mob/living/human/character, is_preview_copy = FALSE)
+/datum/category_item/player_setup_item/physical/body/apply_post_snapshot_preferences(mob/living/human/character, is_preview_copy = FALSE)
 	if(LAZYLEN(pref.appearance_descriptors))
 		character.appearance_descriptors = pref.appearance_descriptors.Copy()
 

--- a/code/modules/client/preference_setup/general/03_traits.dm
+++ b/code/modules/client/preference_setup/general/03_traits.dm
@@ -39,6 +39,11 @@
 	else
 		pref.prune_invalid_traits()
 
+/datum/category_item/player_setup_item/traits/copy_to_nonphysical(mob/living/human/character, is_preview_copy = FALSE)
+	character.clear_extrinsic_traits()
+	for(var/trait_type in pref.traits)
+		character.set_trait(trait_type, (pref.traits[trait_type] || TRAIT_LEVEL_EXISTS))
+
 /datum/category_item/player_setup_item/traits/save_character(datum/pref_record_writer/writer)
 	var/list/trait_ids = list()
 	for(var/trait_type in pref.traits)

--- a/code/modules/client/preference_setup/general/03_traits.dm
+++ b/code/modules/client/preference_setup/general/03_traits.dm
@@ -39,7 +39,7 @@
 	else
 		pref.prune_invalid_traits()
 
-/datum/category_item/player_setup_item/traits/copy_to_nonphysical(mob/living/human/character, is_preview_copy = FALSE)
+/datum/category_item/player_setup_item/traits/apply_post_snapshot_preferences(mob/living/human/character, is_preview_copy = FALSE)
 	character.clear_extrinsic_traits()
 	for(var/trait_type in pref.traits)
 		character.set_trait(trait_type, (pref.traits[trait_type] || TRAIT_LEVEL_EXISTS))

--- a/code/modules/client/preference_setup/general/04_equipment.dm
+++ b/code/modules/client/preference_setup/general/04_equipment.dm
@@ -22,7 +22,7 @@
 			var/decl/backpack_outfit/backpack_outfit = bos[backpack_option]
 			backpacks_by_name[backpack_outfit.name] = backpack_outfit
 
-/datum/category_item/player_setup_item/physical/equipment/copy_to_nonphysical(mob/living/human/character, is_preview_copy = FALSE)
+/datum/category_item/player_setup_item/physical/equipment/apply_post_snapshot_preferences(mob/living/human/character, is_preview_copy = FALSE)
 	QDEL_NULL_LIST(character.worn_underwear)
 	character.worn_underwear = list()
 	for(var/underwear_category_name in pref.all_underwear)

--- a/code/modules/client/preference_setup/general/04_equipment.dm
+++ b/code/modules/client/preference_setup/general/04_equipment.dm
@@ -22,6 +22,22 @@
 			var/decl/backpack_outfit/backpack_outfit = bos[backpack_option]
 			backpacks_by_name[backpack_outfit.name] = backpack_outfit
 
+/datum/category_item/player_setup_item/physical/equipment/copy_to_nonphysical(mob/living/human/character, is_preview_copy = FALSE)
+	QDEL_NULL_LIST(character.worn_underwear)
+	character.worn_underwear = list()
+	for(var/underwear_category_name in pref.all_underwear)
+		var/datum/category_group/underwear/underwear_category = global.underwear.categories_by_name[underwear_category_name]
+		if(underwear_category)
+			var/underwear_item_name = pref.all_underwear[underwear_category_name]
+			var/datum/category_item/underwear/UWD = underwear_category.items_by_name[underwear_item_name]
+			var/metadata = pref.all_underwear_metadata[underwear_category_name]
+			var/obj/item/underwear/UW = UWD.create_underwear(character, metadata)
+			if(UW)
+				UW.ForceEquipUnderwear(character, FALSE)
+		else
+			pref.all_underwear -= underwear_category_name
+	character.backpack_setup = new(pref.backpack, pref.backpack_metadata["[pref.backpack]"])
+
 /datum/category_item/player_setup_item/physical/equipment/load_character(datum/pref_record_reader/R)
 	pref.all_underwear =          R.read("all_underwear")
 	pref.all_underwear_metadata = R.read("all_underwear_metadata")

--- a/code/modules/client/preference_setup/general/05_flavor.dm
+++ b/code/modules/client/preference_setup/general/05_flavor.dm
@@ -6,7 +6,7 @@
 	name = "Flavor"
 	sort_order = 5
 
-/datum/category_item/player_setup_item/physical/flavor/copy_to_nonphysical(mob/living/human/character, is_preview_copy = FALSE)
+/datum/category_item/player_setup_item/physical/flavor/apply_post_snapshot_preferences(mob/living/human/character, is_preview_copy = FALSE)
 	if(is_preview_copy)
 		return
 	character.flavor_texts = pref.flavor_texts.Copy()

--- a/code/modules/client/preference_setup/general/05_flavor.dm
+++ b/code/modules/client/preference_setup/general/05_flavor.dm
@@ -6,6 +6,11 @@
 	name = "Flavor"
 	sort_order = 5
 
+/datum/category_item/player_setup_item/physical/flavor/copy_to_nonphysical(mob/living/human/character, is_preview_copy = FALSE)
+	if(is_preview_copy)
+		return
+	character.flavor_texts = pref.flavor_texts.Copy()
+
 /datum/category_item/player_setup_item/physical/flavor/load_character(datum/pref_record_reader/R)
 	pref.flavor_texts["general"] = R.read("flavor_texts_general")
 	pref.flavor_texts["head"] =    R.read("flavor_texts_head")

--- a/code/modules/client/preference_setup/preference_setup.dm
+++ b/code/modules/client/preference_setup/preference_setup.dm
@@ -94,14 +94,14 @@ var/global/const/CHARACTER_PREFERENCE_INPUT_TITLE = "Character Preference"
 	for(var/datum/category_group/player_setup_category/PS in categories)
 		PS.save_preferences(writer)
 
-/datum/category_collection/player_setup_collection/proc/copy_to_physical(mob/living/human/character, is_preview_copy = FALSE)
+/datum/category_collection/player_setup_collection/proc/apply_snapshot_to_mob(mob/living/human/character, is_preview_copy = FALSE)
 	// Assumes a character has already been loaded.
 	for(var/datum/category_group/player_setup_category/PS in categories)
-		PS.copy_to_physical(character, is_preview_copy)
+		PS.apply_snapshot_to_mob(character, is_preview_copy)
 
-/datum/category_collection/player_setup_collection/proc/copy_to_nonphysical(mob/living/human/character, is_preview_copy = FALSE)
+/datum/category_collection/player_setup_collection/proc/apply_post_snapshot_preferences(mob/living/human/character, is_preview_copy = FALSE)
 	for(var/datum/category_group/player_setup_category/PS in categories)
-		PS.copy_to_nonphysical(character, is_preview_copy)
+		PS.apply_post_snapshot_preferences(character, is_preview_copy)
 
 /datum/category_collection/player_setup_collection/proc/populate_mob_snapshot(datum/mob_snapshot/snapshot, is_preview_copy = FALSE)
 	for(var/datum/category_group/player_setup_category/PG in categories)
@@ -178,14 +178,14 @@ var/global/const/CHARACTER_PREFERENCE_INPUT_TITLE = "Character Preference"
 	for(var/datum/category_item/player_setup_item/PI in items)
 		PI.save_preferences(writer)
 
-/datum/category_group/player_setup_category/proc/copy_to_physical(mob/living/human/character, is_preview_copy = FALSE)
+/datum/category_group/player_setup_category/proc/apply_snapshot_to_mob(mob/living/human/character, is_preview_copy = FALSE)
 	// Assumes a character has already been loaded.
 	for(var/datum/category_item/player_setup_item/PI in items)
-		PI.copy_to_physical(character, is_preview_copy)
+		PI.apply_snapshot_to_mob(character, is_preview_copy)
 
-/datum/category_group/player_setup_category/proc/copy_to_nonphysical(mob/living/human/character, is_preview_copy = FALSE)
+/datum/category_group/player_setup_category/proc/apply_post_snapshot_preferences(mob/living/human/character, is_preview_copy = FALSE)
 	for(var/datum/category_item/player_setup_item/PI in items)
-		PI.copy_to_nonphysical(character, is_preview_copy)
+		PI.apply_post_snapshot_preferences(character, is_preview_copy)
 
 /datum/category_group/player_setup_category/proc/populate_mob_snapshot(datum/mob_snapshot/snapshot, is_preview_copy = FALSE)
 	for(var/datum/category_item/player_setup_item/PI in items)
@@ -259,10 +259,10 @@ var/global/const/CHARACTER_PREFERENCE_INPUT_TITLE = "Character Preference"
 /*
 * Called when actually populating a character based on character creation preferences
 */
-/datum/category_item/player_setup_item/proc/copy_to_physical(mob/living/human/character, is_preview_copy = FALSE)
+/datum/category_item/player_setup_item/proc/apply_snapshot_to_mob(mob/living/human/character, is_preview_copy = FALSE)
 	return // Note that the prefs-level call will apply anything already done in populate_mob_snapshot
 
-/datum/category_item/player_setup_item/proc/copy_to_nonphysical(mob/living/human/character, is_preview_copy = FALSE)
+/datum/category_item/player_setup_item/proc/apply_post_snapshot_preferences(mob/living/human/character, is_preview_copy = FALSE)
 	return
 
 /* need overrides for:

--- a/code/modules/client/preference_setup/preference_setup.dm
+++ b/code/modules/client/preference_setup/preference_setup.dm
@@ -94,6 +94,19 @@ var/global/const/CHARACTER_PREFERENCE_INPUT_TITLE = "Character Preference"
 	for(var/datum/category_group/player_setup_category/PS in categories)
 		PS.save_preferences(writer)
 
+/datum/category_collection/player_setup_collection/proc/copy_to_physical(mob/living/human/character, is_preview_copy = FALSE)
+	// Assumes a character has already been loaded.
+	for(var/datum/category_group/player_setup_category/PS in categories)
+		PS.copy_to_physical(character, is_preview_copy)
+
+/datum/category_collection/player_setup_collection/proc/copy_to_nonphysical(mob/living/human/character, is_preview_copy = FALSE)
+	for(var/datum/category_group/player_setup_category/PS in categories)
+		PS.copy_to_nonphysical(character, is_preview_copy)
+
+/datum/category_collection/player_setup_collection/proc/populate_mob_snapshot(datum/mob_snapshot/snapshot, is_preview_copy = FALSE)
+	for(var/datum/category_group/player_setup_category/PG in categories)
+		PG.populate_mob_snapshot(snapshot, is_preview_copy)
+
 /datum/category_collection/player_setup_collection/proc/header()
 	var/dat = ""
 	for(var/datum/category_group/player_setup_category/PS in categories)
@@ -165,6 +178,19 @@ var/global/const/CHARACTER_PREFERENCE_INPUT_TITLE = "Character Preference"
 	for(var/datum/category_item/player_setup_item/PI in items)
 		PI.save_preferences(writer)
 
+/datum/category_group/player_setup_category/proc/copy_to_physical(mob/living/human/character, is_preview_copy = FALSE)
+	// Assumes a character has already been loaded.
+	for(var/datum/category_item/player_setup_item/PI in items)
+		PI.copy_to_physical(character, is_preview_copy)
+
+/datum/category_group/player_setup_category/proc/copy_to_nonphysical(mob/living/human/character, is_preview_copy = FALSE)
+	for(var/datum/category_item/player_setup_item/PI in items)
+		PI.copy_to_nonphysical(character, is_preview_copy)
+
+/datum/category_group/player_setup_category/proc/populate_mob_snapshot(datum/mob_snapshot/snapshot, is_preview_copy = FALSE)
+	for(var/datum/category_item/player_setup_item/PI in items)
+		PI.populate_mob_snapshot(snapshot, is_preview_copy)
+
 /datum/category_group/player_setup_category/proc/content(var/mob/user)
 	. = "<table style='width:100%'><tr style='vertical-align:top'><td style='width:50%'>"
 	var/current = 0
@@ -228,6 +254,28 @@ var/global/const/CHARACTER_PREFERENCE_INPUT_TITLE = "Character Preference"
 * Called when the item is asked to save user/global settings
 */
 /datum/category_item/player_setup_item/proc/save_preferences(datum/pref_record_writer/writer)
+	return
+
+/*
+* Called when actually populating a character based on character creation preferences
+*/
+/datum/category_item/player_setup_item/proc/copy_to_physical(mob/living/human/character, is_preview_copy = FALSE)
+	return // Note that the prefs-level call will apply anything already done in populate_mob_snapshot
+
+/datum/category_item/player_setup_item/proc/copy_to_nonphysical(mob/living/human/character, is_preview_copy = FALSE)
+	return
+
+/* need overrides for:
+- name (done)
+- eye colour (done)
+- blood type (done)
+- skin colour/tone (done)
+- species (done)
+- bodytype (done)
+- sprite accessories (done)
+- maybe genetic conditions from traits?
+*/
+/datum/category_item/player_setup_item/proc/populate_mob_snapshot(datum/mob_snapshot/snapshot, is_preview_copy = FALSE)
 	return
 
 /datum/category_item/player_setup_item/proc/content()

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -346,92 +346,50 @@ var/global/list/time_prefs_fixed = list()
 	update_setup_window(usr)
 	return 1
 
+/datum/category_item/player_setup_item/records/character_info/copy_to_nonphysical(mob/living/human/character, is_preview_copy = FALSE)
+	if(is_preview_copy)
+		return
+	pref.validate_comments_record() // Make sure a record has been generated for this character.
+	character.comments_record_id = pref.comments_record_id
+
+/datum/preferences/proc/create_character(spawn_turf)
+	// Sanitizing rather than saving as someone might still be editing.
+	player_setup.sanitize_setup()
+	// first, handle basic appearance stuff via mob_snapshot
+	var/datum/mob_snapshot/new_character_snapshot = new /datum/mob_snapshot
+	player_setup.populate_mob_snapshot(new_character_snapshot, FALSE)
+	var/mob/living/human/character = new(spawn_turf, null, new_character_snapshot)
+	copy_to_nonphysical(character, FALSE)
+	return character
+
+
 /datum/preferences/proc/copy_to(mob/living/human/character, is_preview_copy = FALSE)
+	copy_to_physical(character, is_preview_copy) // this is effectively what create_character does, but on an existing mob
+	copy_to_nonphysical(character, is_preview_copy) // this is the stuff we need to share
 
-	if(!player_setup)
-		return // WHY IS THIS EVEN HAPPENING.
-
+/datum/preferences/proc/copy_to_physical(mob/living/human/character, is_preview_copy = FALSE)
 	// Sanitizing rather than saving as someone might still be editing when copy_to occurs.
 	player_setup.sanitize_setup()
-	validate_comments_record() // Make sure a record has been generated for this character.
-	character.comments_record_id = comments_record_id
+	// todo: move this part into some sort of pre-copy sanitizing? move it into the trait stuff? check if it's even necessary?
+	// i guess this is for if we're using it to refresh an existing character from prefs via admin tools
 	character.clear_extrinsic_traits()
+	// first, handle basic appearance stuff via mob_snapshot
+	var/datum/mob_snapshot/new_character_snapshot = new /datum/mob_snapshot // we assume we want a full repopulation, so don't persist anything from the donor
+	player_setup.populate_mob_snapshot(new_character_snapshot, is_preview_copy)
+	new_character_snapshot.apply_appearance_to(character, do_update = FALSE)
+	// not sure why we have real_name on snapshot; it's only used in one spot in setup_human
+	character.set_real_name(new_character_snapshot.real_name)
+	// now actually load everything else
+	player_setup.copy_to_physical(character, is_preview_copy)
+	return character
 
-	var/decl/bodytype/new_bodytype = get_bodytype_decl()
-	var/decl/species/character_species = character.get_species()
-	if(species == character_species.uid)
-		character.set_bodytype(new_bodytype)
-	else
-		character.change_species(species, new_bodytype)
+// this should honestly maybe be copy_to_after_physical
+/datum/preferences/proc/copy_to_nonphysical(mob/living/human/character, is_preview_copy = FALSE)
+	player_setup.copy_to_nonphysical(character, is_preview_copy)
 
-	if(be_random_name)
-		var/decl/background_detail/background = get_background_datum_by_flag(BACKGROUND_FLAG_NAMING)
-		if(background)
-			real_name = background.get_random_name(gender)
-
-	if(get_config_value(/decl/config/toggle/humans_need_surnames))
-		var/firstspace = findtext(real_name, " ")
-		var/name_length = length(real_name)
-		if(!firstspace)	//we need a surname
-			real_name += " [pick(global.using_map.last_names)]"
-		else if(firstspace == name_length)
-			real_name += "[pick(global.using_map.last_names)]"
-
-	character.fully_replace_character_name(real_name)
-
-	character.set_gender(gender)
-	character.blood_type = blood_type
-
-	character.set_skin_colour(skin_colour, skip_update = TRUE)
-	character.skin_tone = skin_tone
-
-	QDEL_NULL_LIST(character.worn_underwear)
-	character.worn_underwear = list()
-
-	for(var/underwear_category_name in all_underwear)
-		var/datum/category_group/underwear/underwear_category = global.underwear.categories_by_name[underwear_category_name]
-		if(underwear_category)
-			var/underwear_item_name = all_underwear[underwear_category_name]
-			var/datum/category_item/underwear/UWD = underwear_category.items_by_name[underwear_item_name]
-			var/metadata = all_underwear_metadata[underwear_category_name]
-			var/obj/item/underwear/UW = UWD.create_underwear(character, metadata)
-			if(UW)
-				UW.ForceEquipUnderwear(character, FALSE)
-		else
-			all_underwear -= underwear_category_name
-
-	character.backpack_setup = new(backpack, backpack_metadata["[backpack]"])
-
-	if(length(traits))
-		for(var/trait_type in traits)
-			character.set_trait(trait_type, (traits[trait_type] || TRAIT_LEVEL_EXISTS))
-
-	character.set_eye_colour(eye_colour, skip_update = TRUE)
-
-	for(var/obj/item/organ/external/O in character.get_external_organs())
-		for(var/decl/sprite_accessory_category/sprite_category in O.get_sprite_accessory_categories())
-			if(!sprite_category.clear_in_pref_apply)
-				continue
-			O.clear_sprite_accessories_by_category(sprite_category.type, skip_update = TRUE)
-
-	for(var/accessory_category in sprite_accessories)
-		var/decl/sprite_accessory_category/acc_cat = GET_DECL(accessory_category)
-		var/list/accessories = sprite_accessories[accessory_category]
-		acc_cat.prepare_character(character, accessories)
-		for(var/accessory in accessories)
-			var/decl/sprite_accessory/accessory_decl = GET_DECL(accessory)
-			var/accessory_metadata = accessories[accessory]
-			for(var/bodypart in accessory_decl.body_parts)
-				var/obj/item/organ/external/O = GET_EXTERNAL_ORGAN(character, bodypart)
-				if(O)
-					O.set_sprite_accessory(accessory, accessory_category, accessory_metadata, skip_update = TRUE)
-
-	if(LAZYLEN(appearance_descriptors))
-		character.appearance_descriptors = appearance_descriptors.Copy()
-
-	character.force_update_limbs()
+	// this happens here because i didn't want to duplicate it between copy_to_physical and create_character
+	character.force_update_limbs() // contains update_body(0)
 	character.update_genetic_conditions(0)
-	character.update_body(0)
 	character.update_underwear(0)
 	character.update_hair(0)
 	character.update_icon()
@@ -440,22 +398,7 @@ var/global/list/time_prefs_fixed = list()
 	if(is_preview_copy)
 		return
 
-	for(var/token in background_info)
-		character.set_background_value(token, background_info[token], defer_language_update = TRUE)
-	character.update_languages()
-	for(var/lang in alternate_languages)
-		character.add_language(lang)
-
-	character.flavor_texts["general"] = flavor_texts["general"]
-	character.flavor_texts["head"] = flavor_texts["head"]
-	character.flavor_texts["face"] = flavor_texts["face"]
-	character.flavor_texts["eyes"] = flavor_texts["eyes"]
-	character.flavor_texts["torso"] = flavor_texts["torso"]
-	character.flavor_texts["arms"] = flavor_texts["arms"]
-	character.flavor_texts["hands"] = flavor_texts["hands"]
-	character.flavor_texts["legs"] = flavor_texts["legs"]
-	character.flavor_texts["feet"] = flavor_texts["feet"]
-
+	// why is this in copy_to? jfc
 	if(!character.isSynthetic())
 		character.set_nutrition(rand(140,360))
 		character.set_hydration(rand(140,360))

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -346,28 +346,28 @@ var/global/list/time_prefs_fixed = list()
 	update_setup_window(usr)
 	return 1
 
-/datum/category_item/player_setup_item/records/character_info/copy_to_nonphysical(mob/living/human/character, is_preview_copy = FALSE)
+/datum/category_item/player_setup_item/records/character_info/apply_post_snapshot_preferences(mob/living/human/character, is_preview_copy = FALSE)
 	if(is_preview_copy)
 		return
 	pref.validate_comments_record() // Make sure a record has been generated for this character.
 	character.comments_record_id = pref.comments_record_id
 
-/datum/preferences/proc/create_character(spawn_turf)
+/datum/preferences/proc/create_character_from_snapshot(spawn_turf)
 	// Sanitizing rather than saving as someone might still be editing.
 	player_setup.sanitize_setup()
 	// first, handle basic appearance stuff via mob_snapshot
 	var/datum/mob_snapshot/new_character_snapshot = new /datum/mob_snapshot
 	player_setup.populate_mob_snapshot(new_character_snapshot, FALSE)
 	var/mob/living/human/character = new(spawn_turf, null, new_character_snapshot)
-	copy_to_nonphysical(character, FALSE)
+	apply_post_snapshot_preferences(character, FALSE)
 	return character
 
 
 /datum/preferences/proc/copy_to(mob/living/human/character, is_preview_copy = FALSE)
-	copy_to_physical(character, is_preview_copy) // this is effectively what create_character does, but on an existing mob
-	copy_to_nonphysical(character, is_preview_copy) // this is the stuff we need to share
+	apply_snapshot_to_mob(character, is_preview_copy) // this is effectively what create_character_from_snapshot does, but on an existing mob
+	apply_post_snapshot_preferences(character, is_preview_copy) // this is the stuff we need to share
 
-/datum/preferences/proc/copy_to_physical(mob/living/human/character, is_preview_copy = FALSE)
+/datum/preferences/proc/apply_snapshot_to_mob(mob/living/human/character, is_preview_copy = FALSE)
 	// Sanitizing rather than saving as someone might still be editing when copy_to occurs.
 	player_setup.sanitize_setup()
 	// todo: move this part into some sort of pre-copy sanitizing? move it into the trait stuff? check if it's even necessary?
@@ -380,14 +380,13 @@ var/global/list/time_prefs_fixed = list()
 	// not sure why we have real_name on snapshot; it's only used in one spot in setup_human
 	character.set_real_name(new_character_snapshot.real_name)
 	// now actually load everything else
-	player_setup.copy_to_physical(character, is_preview_copy)
+	player_setup.apply_snapshot_to_mob(character, is_preview_copy)
 	return character
 
-// this should honestly maybe be copy_to_after_physical
-/datum/preferences/proc/copy_to_nonphysical(mob/living/human/character, is_preview_copy = FALSE)
-	player_setup.copy_to_nonphysical(character, is_preview_copy)
+/datum/preferences/proc/apply_post_snapshot_preferences(mob/living/human/character, is_preview_copy = FALSE)
+	player_setup.apply_post_snapshot_preferences(character, is_preview_copy)
 
-	// this happens here because i didn't want to duplicate it between copy_to_physical and create_character
+	// this happens here because i didn't want to duplicate it between apply_snapshot_to_mob and create_character_from_snapshot
 	character.force_update_limbs() // contains update_body(0)
 	character.update_genetic_conditions(0)
 	character.update_underwear(0)

--- a/code/modules/mob/mob_snapshot.dm
+++ b/code/modules/mob/mob_snapshot.dm
@@ -14,6 +14,8 @@
 
 	var/list/sprite_accessories
 	var/list/genetic_conditions
+	/// Please find a better way to do this. This is done to add tails if we have the tail accessory selected...
+	var/list/extra_limbs
 
 /datum/mob_snapshot/New(mob/living/donor, genetic_info_only = FALSE)
 
@@ -59,7 +61,7 @@
 	return clone
 
 // Replaces UpdateAppearance().
-/datum/mob_snapshot/proc/apply_appearance_to(mob/living/target)
+/datum/mob_snapshot/proc/apply_appearance_to(mob/living/target, do_update = TRUE)
 
 	if(istype(root_species) && root_species != target.get_species())
 		if(istype(root_bodytype))
@@ -75,15 +77,22 @@
 	target.set_eye_colour(eye_color)
 	target.set_skin_tone(skin_tone)
 
+	for(var/limb_data in extra_limbs)
+		var/limb_path = extra_limbs[limb_data]["path"]
+		var/obj/item/organ/external/new_limb = new limb_path(null, null, src)
+		target.add_organ(new_limb, null, TRUE, FALSE, FALSE, TRUE)
+	extra_limbs = null // can't reuse it!
+
 	for(var/obj/item/organ/organ in target.get_organs())
 		organ.copy_from_mob_snapshot(src)
 
 	for(var/decl/genetic_condition/condition as anything in genetic_conditions)
 		target.add_genetic_condition(condition.type)
 
-	target.force_update_limbs()
-	target.update_hair(update_icons = FALSE)
-	target.update_eyes()
+	if(do_update)
+		target.force_update_limbs()
+		target.update_hair(update_icons = FALSE)
+		target.update_eyes()
 	return TRUE
 
 /mob/proc/get_mob_snapshot(check_dna = FALSE)

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -374,20 +374,16 @@ INITIALIZE_IMMEDIATE(/mob/new_player)
 		if(!check_species_allowed(chosen_species))
 			spawning = 0 //abort
 			return null
-		new_character = new(spawn_turf, chosen_species.uid)
-
-	if(!new_character)
-		new_character = new(spawn_turf)
-
-	new_character.lastarea = get_area(spawn_turf)
-
-	if(global.random_players)
+	if(global.random_players) // apply randomness prior to creating the character
 		var/decl/species/current_species = client.prefs.get_species_decl()
 		var/decl/pronouns/pronouns = pick(current_species.available_pronouns)
 		client.prefs.gender = pronouns.name
 		client.prefs.real_name = client.prefs.get_random_name()
 		client.prefs.randomize_appearance_and_body_for(new_character)
-	client.prefs.copy_to(new_character)
+	new_character = client.prefs.create_character(spawn_turf)
+	new_character.lastarea = get_area(spawn_turf)
+
+	// client.prefs.copy_to(new_character) // not anymore lol
 
 	sound_to(src, sound(null, repeat = 0, wait = 0, volume = 85, channel = sound_channels.lobby_channel))// MAD JAMS cant last forever yo
 

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -380,7 +380,7 @@ INITIALIZE_IMMEDIATE(/mob/new_player)
 		client.prefs.gender = pronouns.name
 		client.prefs.real_name = client.prefs.get_random_name()
 		client.prefs.randomize_appearance_and_body_for(new_character)
-	new_character = client.prefs.create_character(spawn_turf)
+	new_character = client.prefs.create_character_from_snapshot(spawn_turf)
 	new_character.lastarea = get_area(spawn_turf)
 
 	// client.prefs.copy_to(new_character) // not anymore lol

--- a/code/modules/sprite_accessories/_accessory.dm
+++ b/code/modules/sprite_accessories/_accessory.dm
@@ -263,3 +263,6 @@
 /decl/sprite_accessory_category/proc/prepare_character(mob/living/character, list/accessories)
 	return
 
+/decl/sprite_accessory_category/proc/prepare_mob_snapshot(datum/mob_snapshot/snapshot, list/accessories)
+	return
+

--- a/code/modules/sprite_accessories/tails/_accessory_tail.dm
+++ b/code/modules/sprite_accessories/tails/_accessory_tail.dm
@@ -13,6 +13,14 @@
 		var/obj/item/organ/external/tail/new_tail = new(null, null, character.get_mob_snapshot())
 		character.add_organ(new_tail, null, TRUE, FALSE, FALSE, TRUE)
 
+/decl/sprite_accessory_category/tail/prepare_mob_snapshot(datum/mob_snapshot/snapshot, list/accessories)
+	if(!length(accessories))
+		return
+	// Give us a tail if we need one.
+	var/decl/sprite_accessory/tail_data = GET_DECL(accessories[1])
+	if(tail_data?.draw_accessory && !snapshot.root_bodytype.has_limbs[BP_TAIL])
+		LAZYSET(snapshot.extra_limbs, BP_TAIL, list("path" = /obj/item/organ/external/tail))
+
 /decl/sprite_accessory/tail
 	abstract_type = /decl/sprite_accessory/tail
 	hidden_by_gear_slot  = list(slot_w_uniform_str, slot_wear_suit_str)

--- a/mods/content/psionics/_psionics.dm
+++ b/mods/content/psionics/_psionics.dm
@@ -25,13 +25,6 @@
 		. += "Only available for living mobs, sorry."
 	. = jointext(., null)
 
-// this probably shouldn't be necessary anymore now that we have refresh_login()?
-/* /datum/preferences/copy_to_nonphysical(mob/living/human/character, is_preview_copy = FALSE)
-	character = ..()
-	var/datum/ability_handler/psionics/psi = !is_preview_copy && istype(character) && character.get_ability_handler(/datum/ability_handler/psionics)
-	if(psi)
-		psi.update() */
-
 /decl/ability/can_use_ability(mob/user, list/metadata, silent = FALSE)
 	. = ..()
 	if(. && is_supernatural)

--- a/mods/content/psionics/_psionics.dm
+++ b/mods/content/psionics/_psionics.dm
@@ -25,11 +25,12 @@
 		. += "Only available for living mobs, sorry."
 	. = jointext(., null)
 
-/datum/preferences/copy_to(mob/living/human/character, is_preview_copy = FALSE)
+// this probably shouldn't be necessary anymore now that we have refresh_login()?
+/* /datum/preferences/copy_to_nonphysical(mob/living/human/character, is_preview_copy = FALSE)
 	character = ..()
 	var/datum/ability_handler/psionics/psi = !is_preview_copy && istype(character) && character.get_ability_handler(/datum/ability_handler/psionics)
 	if(psi)
-		psi.update()
+		psi.update() */
 
 /decl/ability/can_use_ability(mob/user, list/metadata, silent = FALSE)
 	. = ..()


### PR DESCRIPTION
## Description of changes
Splits up `/datum/preferences/proc/copy_to()` into `copy_to_physical()` and `copy_to_nonphysical()`. Those have also been split across the various `player_setup_item`s. At some point I think the prefs vars those access should even be moved onto it, but that'd cause a lot of headaches I think because there's a ton of cross-dependencies.

I did some testing but it's very likely this is fundamentally broken in some non-obvious way I haven't been able to identify.

Oh and there's some commented-out code. I kept it in for review to make sure I didn't miss/overlook anything 🥲 

## Why and what will this PR improve
I wanted to be able to remove/replace the way characters are created and/or populated from prefs on a downstream.
Also, spawning in creates a character directly rather than populating a blank one, which lets us save some wasted time in init.

## Authorship
Me