### PR TITLE
Fix windows being excessively transparent

### DIFF
--- a/code/game/objects/structures/_structure_materials.dm
+++ b/code/game/objects/structures/_structure_materials.dm
@@ -3,6 +3,8 @@
 	var/decl/material/reinf_material
 	var/material_alteration
 	var/dismantled
+	/// The base alpha used to calculate material-based alpha in update_material_color().
+	var/base_alpha = 50
 
 /obj/structure/get_material()
 	RETURN_TYPE(/decl/material)
@@ -52,7 +54,7 @@
 /obj/structure/proc/update_material_color()
 	color = get_color()
 	if(istype(material))
-		alpha = clamp((50 + material.opacity * 255), 0, 255)
+		alpha = clamp((base_alpha + material.opacity * 255), 0, 255)
 	else
 		alpha = initial(alpha)
 

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -10,7 +10,8 @@
 	anchored = FALSE // Base, non-premapped type should start unanchored.
 	atom_flags = ATOM_FLAG_CHECKS_BORDER | ATOM_FLAG_CAN_BE_PAINTED
 	obj_flags = OBJ_FLAG_ROTATABLE | OBJ_FLAG_MOVES_UNSUPPORTED
-	alpha = 180
+	base_alpha = 100 // at 0.3 opacity for glass, this will result in a total alpha of around 176
+	alpha = 180 // preview value
 	material_alteration = MAT_FLAG_ALTERATION_COLOR
 	material = /decl/material/solid/glass
 	rad_resistance_modifier = 0.5


### PR DESCRIPTION
## Description of changes
Since windows were made to use `MAT_FLAG_ALTERATION_COLOR` their alpha was dropped dramatically. I made it so that it still uses that code but has adjustable transparency to avoid, well, *over*transparency.

## Why and what will this PR improve
Windows are actually visible now.