### PR TITLE
Fix trash from salads eaten with utensils

### DIFF
--- a/code/game/objects/items/_item_edibility.dm
+++ b/code/game/objects/items/_item_edibility.dm
@@ -4,7 +4,7 @@
 		add_trace_DNA(target)
 
 // Used to get a piece of food from an item.
-/obj/item/proc/seperate_food_chunk(obj/item/utensil/utensil, mob/user)
+/obj/item/proc/separate_food_chunk(obj/item/utensil/utensil, mob/user)
 	var/utensil_food_type = get_utensil_food_type()
 	if(!istype(utensil) || !utensil_food_type)
 		return
@@ -14,8 +14,12 @@
 		// Create a dummy copy of the target food item.
 		// This ensures we keep all food behavior, strings, sounds, etc.
 		utensil.loaded_food = new utensil_food_type(utensil, material?.type, TRUE)
-		QDEL_NULL(utensil.loaded_food.trash)
-		QDEL_NULL(utensil.loaded_food.plate)
+		if(ismovable(utensil.loaded_food.trash))
+			qdel(utensil.loaded_food.trash)
+		utensil.loaded_food.trash = null // Unset it even if it didn't need deleting (e.g. it was a path)
+		if(ismovable(utensil.loaded_food.plate))
+			qdel(utensil.loaded_food.plate)
+		utensil.loaded_food.plate = null
 		utensil.loaded_food.color = color
 		utensil.loaded_food.filling_color = get_food_filling_color()
 		utensil.loaded_food.SetName("\proper some [utensil.loaded_food.name]")
@@ -25,12 +29,12 @@
 		reagents.trans_to(utensil.loaded_food, remove_amt)
 		handle_chunk_separated()
 		if(!reagents.total_volume)
-			handle_consumed()
+			handle_consumed(user) // it's not actually being consumed, so i'm not sure this is correct
 		utensil.update_icon()
 
 	else // This shouldn't happen, but who knows.
 		to_chat(user, SPAN_WARNING("None of \the [src] is left!"))
-		handle_consumed()
+		handle_consumed(user)
 	return TRUE
 
 /obj/item/proc/get_food_filling_color()

--- a/code/modules/food/utensils/_utensil.dm
+++ b/code/modules/food/utensils/_utensil.dm
@@ -61,14 +61,14 @@
 			add_overlay(overlay_image(icon, loaded_state, loaded_food.reagents?.get_color() || loaded_food.filling_color || get_color(), RESET_COLOR))
 
 /obj/item/food/proc/handle_utensil_collection(obj/item/utensil/utensil, mob/user)
-	seperate_food_chunk(utensil, user)
+	separate_food_chunk(utensil, user)
 	if(utensil.loaded_food)
 		to_chat(user, SPAN_NOTICE("You collect [utensil.loaded_food] with \the [utensil]."))
 		return TRUE
 	return FALSE
 
 /obj/item/food/proc/handle_utensil_scooping(obj/item/utensil/utensil, mob/user)
-	seperate_food_chunk(utensil, user)
+	separate_food_chunk(utensil, user)
 	if(utensil.loaded_food)
 		to_chat(user, SPAN_NOTICE("You scoop up [utensil.loaded_food] with \the [utensil]."))
 		return TRUE

--- a/code/modules/reagents/reagent_containers/_glass.dm
+++ b/code/modules/reagents/reagent_containers/_glass.dm
@@ -167,7 +167,7 @@ var/global/list/lid_check_glass_types = list()
 		if(!reagents?.total_volume)
 			to_chat(user, SPAN_WARNING("\The [src] is empty."))
 			return TRUE
-		seperate_food_chunk(utensil, user)
+		separate_food_chunk(utensil, user)
 		if(utensil.loaded_food?.reagents?.total_volume)
 			to_chat(user, SPAN_NOTICE("You scoop up some of \the [utensil.loaded_food.reagents.get_primary_reagent_name()] with \the [utensil]."))
 		return TRUE

--- a/code/modules/reagents/reagent_containers/food_edibility.dm
+++ b/code/modules/reagents/reagent_containers/food_edibility.dm
@@ -35,6 +35,7 @@
 		if(trash_ref)
 			if(ispath(trash_ref, /obj/item))
 				var/obj/item/trash_item = new trash_ref(loc_ref)
+				trash_item.dropInto(loc_ref)
 				if(feeder)
 					feeder.put_in_hands(trash_item)
 			else if(istype(trash_ref, /obj/item))


### PR DESCRIPTION
There was a runtime if `trash` or `plate` were types and not instances. Separately, `handle_consumed()` with no arguments resulted in the salad being placed inside the mob's torso with no attempt to drop it into the loc or etc. This fixes that.