### PR TITLE
Rewrite CELLRATE macro for cleanliness

### DIFF
--- a/code/__defines/machinery.dm
+++ b/code/__defines/machinery.dm
@@ -4,9 +4,8 @@ var/global/defer_powernet_rebuild = 0      // True if net rebuild will be called
 #define MEGAWATTS *1000000
 #define GIGAWATTS *1000000000
 
-#define MACHINERY_TICKRATE 2		// Tick rate for machinery in seconds. As it affects CELLRATE calculation it is kept as define here
-
-#define CELLRATE (1 / ( 3600 / MACHINERY_TICKRATE )) // Multiplier for charge units. Converts cell charge units(watthours) to joules. Takes into consideration that our machinery ticks once per two seconds.
+/// Multiplier for charge units. Converts cell charge units(watthours) to joules. Takes into consideration that our machinery ticks once per two seconds.
+#define CELLRATE (/datum/controller/subsystem/machines::wait / (1 HOUR))
 
 // Doors!
 #define DOOR_CRUSH_DAMAGE 40


### PR DESCRIPTION
We can access the `wait` var on SSmachines, so we don't need `MACHINERY_TICKRATE` defined anymore, which reduces redundancy. Also, `1/(X/Y)` is just `Y/X`. By using deciseconds for tickrate as well, we can do `(1 HOUR)` instead of `3600`, so we get rid of a magic number too.

They're otherwise the exact same number, I just hated seeing those numbers and having no clue what they meant.