### PR TITLE
Fix material color not being applied to items

### DIFF
--- a/code/game/objects/items/_item_materials.dm
+++ b/code/game/objects/items/_item_materials.dm
@@ -91,6 +91,7 @@
 			obj_flags &= (~OBJ_FLAG_CONDUCTIBLE)
 		if(isnull(initial(paint_verb)))
 			paint_verb = material.paint_verb
+		refresh_color() // apply material color
 		update_attack_force()
 		update_name()
 		if(material_armor_multiplier)


### PR DESCRIPTION
Fix color not being refreshed in item `set_material()`, resulting in material color not applying until the next time `refresh_color()` is called.