### PR TITLE
Fix emergency equipment being overwritten by loadout

### DIFF
--- a/code/__defines/items_clothing.dm
+++ b/code/__defines/items_clothing.dm
@@ -266,3 +266,10 @@ var/global/list/all_hand_slots = list(
 	BP_R_HAND_UPPER,
 	BP_MOUTH
 )
+
+/// If this item conflicts with a loadout item, simply delete it.
+#define LOADOUT_CONFLICT_DELETE 0
+/// If this item conflicts with a loadout item, place this item in storage.
+#define LOADOUT_CONFLICT_STORAGE 1
+/// If this item conflicts with a loadout item, place THE LOADOUT ITEM in storage.
+#define LOADOUT_CONFLICT_KEEP 2

--- a/code/game/objects/items/__item.dm
+++ b/code/game/objects/items/__item.dm
@@ -89,8 +89,8 @@
 	var/tmp/use_single_icon
 	var/center_of_mass = @'{"x":16,"y":16}' //can be null for no exact placement behaviour
 
-	/// Used when this item is replaced by a loadout item. If TRUE, loadout places src in wearer's storage. If FALSE, src is deleted.
-	var/replaced_in_loadout = TRUE
+	/// Controls what method is used to resolve conflicts between equipped items and mob loadout.
+	var/replaced_in_loadout = LOADOUT_CONFLICT_DELETE
 
 	var/paint_color
 	var/paint_verb
@@ -1120,9 +1120,12 @@ modules/mob/living/human/life.dm if you die, you will be zoomed out.
 /obj/item/proc/handle_loadout_equip_replacement(obj/item/old_item)
 	return
 
-/// Used to handle equipped icons overwritten by custom loadout. If TRUE, loadout places src in wearer's storage. If FALSE, src is deleted by loadout.
+/// Used to handle equipped items overwritten by custom loadout.
+/// Returns one of LOADOUT_CONFLICT_DELETE, LOADOUT_CONFLICT_STORAGE, or LOADOUT_CONFLICT_KEEP.
 /obj/item/proc/loadout_should_keep(obj/item/new_item, mob/wearer)
-	return type != new_item.type && !replaced_in_loadout
+	if(type == new_item.type) // for exact type collisions, just delete by default
+		return LOADOUT_CONFLICT_DELETE
+	return replaced_in_loadout
 
 /obj/item/equipped(mob/user, slot)
 	. = ..()

--- a/code/modules/client/preference_setup/loadout/loadout.dm
+++ b/code/modules/client/preference_setup/loadout/loadout.dm
@@ -553,7 +553,7 @@
 				place_in_storage_or_drop(wearer, old_item)
 			else
 				qdel(old_item)
-		return item
+	return item
 
 /decl/loadout_option/proc/spawn_in_storage_or_drop(mob/living/human/wearer, metadata)
 	var/obj/item/item = spawn_and_validate_item(wearer, metadata)

--- a/code/modules/client/preference_setup/loadout/loadout.dm
+++ b/code/modules/client/preference_setup/loadout/loadout.dm
@@ -537,18 +537,19 @@
 	item.loadout_setup(wearer, metadata)
 
 	var/obj/item/old_item = wearer.get_equipped_item(slot)
-	var/attached_as_accessory = FALSE
 	if(istype(old_item, /obj/item/clothing) && istype(item, /obj/item/clothing))
 		var/obj/item/clothing/worn = old_item
 		if(worn.can_attach_accessory(item, wearer))
 			worn.attach_accessory(wearer, item)
-			attached_as_accessory = TRUE
 			return TRUE
 
-	if(!attached_as_accessory && wearer.equip_to_slot_if_possible(item, slot, del_on_fail = TRUE, force = TRUE, delete_old_item = FALSE, ignore_equipped = replace_equipped))
+	var/resolution_strategy = old_item?.loadout_should_keep(item, wearer)
+	if(resolution_strategy == LOADOUT_CONFLICT_KEEP)
+		place_in_storage_or_drop(wearer, item)
+	else if(wearer.equip_to_slot_if_possible(item, slot, del_on_fail = TRUE, force = TRUE, delete_old_item = FALSE, ignore_equipped = replace_equipped))
 		if(old_item && wearer.get_equipped_item(slot) != old_item)
 			item.handle_loadout_equip_replacement(old_item)
-			if(old_item.loadout_should_keep(item, wearer))
+			if(resolution_strategy == LOADOUT_CONFLICT_STORAGE)
 				place_in_storage_or_drop(wearer, old_item)
 			else
 				qdel(old_item)

--- a/code/modules/clothing/_clothing.dm
+++ b/code/modules/clothing/_clothing.dm
@@ -4,7 +4,7 @@
 	origin_tech = @'{"materials":1,"engineering":1}'
 	material = /decl/material/solid/organic/cloth
 	paint_verb = "dyed"
-	replaced_in_loadout = TRUE
+	replaced_in_loadout = LOADOUT_CONFLICT_DELETE
 	w_class = ITEM_SIZE_SMALL
 	icon_state = ICON_STATE_WORLD
 	_base_attack_force = 3

--- a/code/modules/clothing/gloves/latex.dm
+++ b/code/modules/clothing/gloves/latex.dm
@@ -7,7 +7,7 @@
 	icon_state = ICON_STATE_WORLD
 	anomaly_shielding = 0.1
 	material = /decl/material/solid/organic/plastic //todo: latex
-	replaced_in_loadout = FALSE
+	replaced_in_loadout = LOADOUT_CONFLICT_STORAGE
 
 /obj/item/clothing/gloves/latex/nitrile
 	name = "nitrile gloves"

--- a/code/modules/clothing/gloves/miscellaneous.dm
+++ b/code/modules/clothing/gloves/miscellaneous.dm
@@ -12,7 +12,7 @@
 	icon_state = ICON_STATE_WORLD
 	material = /decl/material/solid/organic/plastic //TODO: rubber
 	matter = list(/decl/material/solid/organic/cloth = MATTER_AMOUNT_REINFORCEMENT)
-	replaced_in_loadout = FALSE
+	replaced_in_loadout = LOADOUT_CONFLICT_STORAGE
 
 /obj/item/clothing/gloves/insulated/cheap                             //Cheap Chinese Crap
 	desc = "These gloves are cheap copies of the coveted gloves, no way this can end badly."

--- a/code/modules/clothing/gloves/thick.dm
+++ b/code/modules/clothing/gloves/thick.dm
@@ -19,7 +19,7 @@
 		ARMOR_BOMB = ARMOR_BOMB_RESISTANT,
 		ARMOR_BIO = ARMOR_BIO_MINOR)
 	material = /decl/material/solid/organic/leather
-	replaced_in_loadout = FALSE
+	replaced_in_loadout = LOADOUT_CONFLICT_STORAGE
 
 /obj/item/clothing/gloves/thick/swat
 	desc = "These tactical gloves are somewhat fire and impact-resistant."

--- a/code/modules/clothing/head/hardhat.dm
+++ b/code/modules/clothing/head/hardhat.dm
@@ -22,7 +22,7 @@
 	material = /decl/material/solid/organic/plastic
 	matter = list(/decl/material/solid/metal/steel = MATTER_AMOUNT_REINFORCEMENT)
 	origin_tech = @'{"materials":1,"engineering":1,"combat":1}'
-	replaced_in_loadout = FALSE
+	replaced_in_loadout = LOADOUT_CONFLICT_STORAGE
 	_base_attack_force = 5
 
 /obj/item/clothing/head/hardhat/orange

--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -25,7 +25,7 @@
 	matter = list(/decl/material/solid/metal/plasteel = MATTER_AMOUNT_TRACE)
 	origin_tech = @'{"materials":1,"engineering":1,"combat":1}'
 	protects_against_weather = TRUE
-	replaced_in_loadout = FALSE
+	replaced_in_loadout = LOADOUT_CONFLICT_STORAGE
 	_base_attack_force = 8
 
 /obj/item/clothing/head/helmet/tactical

--- a/code/modules/clothing/head/misc_special.dm
+++ b/code/modules/clothing/head/misc_special.dm
@@ -31,7 +31,7 @@
 	w_class = ITEM_SIZE_NORMAL
 	flash_protection = FLASH_PROTECTION_MAJOR
 	tint = TINT_HEAVY
-	replaced_in_loadout = FALSE
+	replaced_in_loadout = LOADOUT_CONFLICT_STORAGE
 	accessory_slot = null // cannot be equipped on top of helmets
 	var/up = 0
 	var/base_state

--- a/code/modules/clothing/spacesuits/spacesuits.dm
+++ b/code/modules/clothing/spacesuits/spacesuits.dm
@@ -26,7 +26,7 @@
 	brightness_on = 4
 	light_wedge = LIGHT_WIDE
 	on = 0
-	replaced_in_loadout = FALSE
+	replaced_in_loadout = LOADOUT_CONFLICT_KEEP
 
 	var/obj/machinery/camera/camera
 	var/tinted = null	//Set to non-null for toggleable tint helmets
@@ -144,7 +144,7 @@
 		/decl/material/solid/organic/plastic = MATTER_AMOUNT_REINFORCEMENT
 	)
 	protects_against_weather = TRUE
-	replaced_in_loadout = FALSE
+	replaced_in_loadout = LOADOUT_CONFLICT_KEEP
 
 /obj/item/clothing/suit/space/Initialize()
 	. = ..()

--- a/code/modules/clothing/suits/armor/_armor.dm
+++ b/code/modules/clothing/suits/armor/_armor.dm
@@ -22,5 +22,5 @@
 	siemens_coefficient = 0.6
 	blood_overlay_type = "armor"
 	origin_tech = @'{"materials":1,"engineering":1,"combat":1}'
-	replaced_in_loadout = FALSE
+	replaced_in_loadout = LOADOUT_CONFLICT_STORAGE
 	_base_attack_force = 5

--- a/code/modules/clothing/suits/bio.dm
+++ b/code/modules/clothing/suits/bio.dm
@@ -17,7 +17,7 @@
 		/decl/material/solid/organic/plastic = MATTER_AMOUNT_REINFORCEMENT,
 		/decl/material/solid/metal/silver = MATTER_AMOUNT_REINFORCEMENT
 	)
-	replaced_in_loadout = FALSE
+	replaced_in_loadout = LOADOUT_CONFLICT_KEEP
 
 /obj/item/clothing/suit/bio_suit
 	name = "bio suit"
@@ -40,7 +40,7 @@
 		/decl/material/solid/organic/plastic = MATTER_AMOUNT_REINFORCEMENT,
 		/decl/material/solid/metal/silver = MATTER_AMOUNT_REINFORCEMENT
 	)
-	replaced_in_loadout = FALSE
+	replaced_in_loadout = LOADOUT_CONFLICT_KEEP
 
 /obj/item/clothing/suit/bio_suit/Initialize()
 	. = ..()

--- a/code/modules/clothing/suits/toggles.dm
+++ b/code/modules/clothing/suits/toggles.dm
@@ -2,7 +2,7 @@
 /obj/item/clothing/suit/toggle
 	abstract_type = /obj/item/clothing/suit/toggle
 	storage = /datum/storage/pockets/suit
-	replaced_in_loadout = FALSE
+	replaced_in_loadout = LOADOUT_CONFLICT_STORAGE
 
 /obj/item/clothing/suit/toggle/get_assumed_clothing_state_modifiers()
 	var/static/list/expected_state_modifiers = list(


### PR DESCRIPTION
I thought I fixed this but I guess not. Some jobs on a downstream (Spacefarers) spawn you in an unsafe environment with EVA gear and active internals, but it kept getting put in your backpack if you had loadout equipment. Yeesh. This fixes that.