### PR TITLE
Fix several psi-related issues

### DIFF
--- a/code/datums/extensions/abilities/ability_handler.dm
+++ b/code/datums/extensions/abilities/ability_handler.dm
@@ -21,7 +21,7 @@
 	if(!istype(owner))
 		CRASH("Ability handler received invalid owner!")
 	..()
-	refresh_login()
+	refresh_login(being_created = TRUE)
 
 /datum/ability_handler/Process()
 
@@ -211,7 +211,7 @@
 			stat(stat_strings[1], stat_strings[2])
 
 /// Individual ability methods/disciplines (psioncs, etc.) so that mobs can have multiple.
-/datum/ability_handler/proc/refresh_login()
+/datum/ability_handler/proc/refresh_login(being_created = FALSE)
 	SHOULD_CALL_PARENT(TRUE)
 	if(LAZYLEN(screen_elements))
 		var/list/add_elements = list()

--- a/mods/content/psionics/system/psionics/complexus/complexus.dm
+++ b/mods/content/psionics/system/psionics/complexus/complexus.dm
@@ -1,4 +1,6 @@
 /datum/ability_handler/psionics
+	category_toggle_type = null       // we don't use this at the moment, but maybe should eventually.
+
 	var/announced = FALSE             // Whether or not we have been announced to our holder yet.
 	var/suppressed = TRUE             // Whether or not we are suppressing our psi powers.
 	var/use_psi_armour = TRUE         // Whether or not we should automatically deflect/block incoming damage.

--- a/mods/content/psionics/system/psionics/complexus/complexus_process.dm
+++ b/mods/content/psionics/system/psionics/complexus/complexus_process.dm
@@ -1,4 +1,4 @@
-/datum/ability_handler/psionics/proc/update(var/force)
+/datum/ability_handler/psionics/proc/update(var/force, can_delete = TRUE)
 
 	set waitfor = FALSE
 
@@ -23,7 +23,7 @@
 	var/rank_count = max(1, LAZYLEN(ranks))
 	if(force || last_rating != ceil(combined_rank/rank_count))
 		if(highest_rank <= 1)
-			if(highest_rank == 0)
+			if(highest_rank == 0 && can_delete) // hack to prevent deletion on update(TRUE) in New
 				qdel(src)
 			return
 		else

--- a/mods/content/psionics/system/psionics/faculties/coercion.dm
+++ b/mods/content/psionics/system/psionics/faculties/coercion.dm
@@ -67,7 +67,7 @@
 		return
 
 	if(target.stat == DEAD || (target.status_flags & FAKEDEATH) || !target.client)
-		to_chat(user, SPAN_WARNING("\The [target] is in no state for a mind-ream."))
+		to_chat(user, SPAN_WARNING("\The [target] is in no state for a mind-read."))
 		return TRUE
 
 	user.visible_message(SPAN_WARNING("\The [user] touches \the [target]'s temple..."))

--- a/mods/content/psionics/system/psionics/mob/mob.dm
+++ b/mods/content/psionics/system/psionics/mob/mob.dm
@@ -1,6 +1,7 @@
-/datum/ability_handler/psionics/refresh_login()
+/datum/ability_handler/psionics/refresh_login(being_created)
 	. = ..()
-	update(TRUE)
+	// stopgap to prevent us from deleting ourselves during init
+	update(TRUE, can_delete = !being_created)
 	if(!suppressed)
 		show_auras()
 


### PR DESCRIPTION
Fixes a typo and the currently-unused ability toggle button.
Applies a hacky fix for psi handler self-deletion since I had no clue how to fix it properly.