### PR TITLE
Add a message implying that skill affects planetoid sensor readings

### DIFF
--- a/code/modules/overmap/planetoids/_planetoids.dm
+++ b/code/modules/overmap/planetoids/_planetoids.dm
@@ -64,7 +64,7 @@
 			var/inaccuracy = rand(8,12)/10
 			. += "Atmosphere pressure [atmosphere.return_pressure()*inaccuracy] kPa, temperature [atmosphere.temperature*inaccuracy] K<br>"
 		else if(user.skill_check(SKILL_SCIENCE, SKILL_BASIC) || user.skill_check(SKILL_ATMOS, SKILL_BASIC))
-				. += "Atmosphere present. Sensor suite calibration required for detailed scan. Contact a qualified technician for calibration assistance.<br>"
+			. += "Atmosphere present. Sensor suite calibration required for detailed scan. Contact a qualified technician for calibration assistance.<br>"
 		. += "<br>"
 
 	var/datum/planetoid_data/E = get_planetoid_data()

--- a/code/modules/overmap/planetoids/_planetoids.dm
+++ b/code/modules/overmap/planetoids/_planetoids.dm
@@ -64,7 +64,7 @@
 			var/inaccuracy = rand(8,12)/10
 			. += "Atmosphere pressure [atmosphere.return_pressure()*inaccuracy] kPa, temperature [atmosphere.temperature*inaccuracy] K<br>"
 		else if(user.skill_check(SKILL_SCIENCE, SKILL_BASIC) || user.skill_check(SKILL_ATMOS, SKILL_BASIC))
-			. += "Atmosphere present<br>"
+				. += "Atmosphere present. Sensor suite calibration required for detailed scan. Contact a qualified technician for calibration assistance.<br>"
 		. += "<br>"
 
 	var/datum/planetoid_data/E = get_planetoid_data()


### PR DESCRIPTION
see title.

i considered adding one for not even meeting the basic skillcheck but honestly, i figure it's something like "your character doesn't even know how to scan the atmosphere," and if you don't turn on the atmospheric sensor suite or whatever it might just flat out not give any diagnostics indicating that. god knows i've run into that sort of thing