### PR TITLE
Fix issues with grabs

### DIFF
--- a/code/_helpers/game.dm
+++ b/code/_helpers/game.dm
@@ -104,6 +104,11 @@
 	//turfs += centerturf
 	return atoms
 
+/// Despite what the ref says, get_dist does not factor in the Z axis.
+/// This is just get_dist() but Z-aware.
+/proc/get_dist_3d(atom/Loc1, atom/Loc2)
+	return max(abs(Loc1.x-Loc2.x), abs(Loc1.y-Loc2.y), abs(Loc1.z-Loc2.z))
+
 /proc/get_dist_euclidian(atom/Loc1, atom/Loc2)
 	var/dx = Loc1.x - Loc2.x
 	var/dy = Loc1.y - Loc2.y

--- a/code/datums/movement/movement.dm
+++ b/code/datums/movement/movement.dm
@@ -90,10 +90,7 @@ if(LAZYLEN(movement_handlers) && ispath(movement_handlers[1])) { \
 		var/oldloc = loc
 		var/turf/T = get_step(loc, direction)
 		if(istype(T))
-			if(direction in global.cornerdirs) // Diagonal movement with step() currently breaks
-				forceMove(T)                 // grabs, remove these lines when that is fixed.
-			else
-				step(src, direction)
+			step(src, direction)
 		return loc != oldloc
 
 	for(var/datum/movement_handler/movement_handler as anything in movement_handlers)

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -22,7 +22,9 @@
 	// var/elevation = 2    - not used anywhere
 	var/move_speed = 10
 	var/l_move_time = 1
-	var/m_flag = 1
+	var/const/FIRST_DIAGONAL_STEP = 1
+	var/const/SECOND_DIAGONAL_STEP = 2
+	var/moving_diagonally = FALSE // Used so we don't break grabs mid-diagonal-move.
 	var/datum/thrownthing/throwing
 	var/throw_speed = 2
 	var/throw_range = 7

--- a/code/modules/mob/grab/grab_object.dm
+++ b/code/modules/mob/grab/grab_object.dm
@@ -175,7 +175,7 @@
 	current_grab.let_go(src)
 
 /obj/item/grab/proc/on_affecting_move()
-	if(!affecting || !isturf(affecting.loc) || get_dist(affecting, assailant) > 1)
+	if(!affecting || !isturf(affecting.loc) || (get_dist(affecting, assailant) > 1 && affecting.moving_diagonally != /atom/movable::FIRST_DIAGONAL_STEP))
 		force_drop()
 
 /obj/item/grab/proc/force_drop()

--- a/code/modules/mob/grab/grab_object.dm
+++ b/code/modules/mob/grab/grab_object.dm
@@ -175,7 +175,7 @@
 	current_grab.let_go(src)
 
 /obj/item/grab/proc/on_affecting_move()
-	if(!affecting || !isturf(affecting.loc) || (get_dist(affecting, assailant) > 1 && affecting.moving_diagonally != /atom/movable::FIRST_DIAGONAL_STEP))
+	if(!affecting || !isturf(affecting.loc) || (get_dist_3d(affecting, assailant) > 1 && affecting.moving_diagonally != /atom/movable::FIRST_DIAGONAL_STEP))
 		force_drop()
 
 /obj/item/grab/proc/force_drop()

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -87,37 +87,7 @@
 
 //This proc should never be overridden elsewhere at /atom/movable to keep directions sane.
 /atom/movable/Move(newloc, direct)
-	if (direct & (direct - 1))
-		if (direct & 1)
-			if (direct & 4)
-				if (step(src, NORTH))
-					step(src, EAST)
-				else
-					if (step(src, EAST))
-						step(src, NORTH)
-			else
-				if (direct & 8)
-					if (step(src, NORTH))
-						step(src, WEST)
-					else
-						if (step(src, WEST))
-							step(src, NORTH)
-		else
-			if (direct & 2)
-				if (direct & 4)
-					if (step(src, SOUTH))
-						step(src, EAST)
-					else
-						if (step(src, EAST))
-							step(src, SOUTH)
-				else
-					if (direct & 8)
-						if (step(src, SOUTH))
-							step(src, WEST)
-						else
-							if (step(src, WEST))
-								step(src, SOUTH)
-	else
+	if (IS_POWER_OF_TWO(direct))
 		var/atom/A = src.loc
 
 		var/olddir = dir //we can't override this without sacrificing the rest of movable/New()
@@ -128,9 +98,21 @@
 
 		src.move_speed = world.time - src.l_move_time
 		src.l_move_time = world.time
-		src.m_flag = 1
 		if ((A != src.loc && A && A.z == src.z))
 			src.last_move = get_dir(A, src.loc)
+	else // This doesn't handle 3D moves properly, but the old code didn't either.
+		moving_diagonally = /atom/movable::FIRST_DIAGONAL_STEP
+		var/first_dir = FIRST_DIR(direct)
+		var/second_dir = direct & ~first_dir
+		if(step(src, first_dir))
+			if(moving_diagonally) // check if unset by falling
+				moving_diagonally = /atom/movable::SECOND_DIAGONAL_STEP
+				step(src, second_dir)
+		else if(step(src, second_dir))
+			if(moving_diagonally)
+				moving_diagonally = /atom/movable::SECOND_DIAGONAL_STEP
+				step(src, first_dir)
+		moving_diagonally = FALSE
 
 	if(!inertia_moving)
 		inertia_next_move = world.time + inertia_move_delay

--- a/code/modules/multiz/movement.dm
+++ b/code/modules/multiz/movement.dm
@@ -121,6 +121,7 @@
 // Entered() which is part of Move(), by spawn()ing we let that complete.  But we want to preserve if we were in client movement
 // or normal movement so other move behavior can continue.
 /atom/movable/proc/begin_falling(var/lastloc, var/below)
+	moving_diagonally = FALSE // cancel diagonal movement immediately
 	addtimer(CALLBACK(src, TYPE_PROC_REF(/atom/movable, fall_callback), below), 0)
 
 /atom/movable/proc/fall_callback(var/turf/below)

--- a/code/modules/multiz/zmimic/mimic_movable.dm
+++ b/code/modules/multiz/zmimic/mimic_movable.dm
@@ -145,6 +145,10 @@
 	SHOULD_CALL_PARENT(FALSE)
 	. = associated_atom.examine(arglist(args))	// just pass all the args to the copied atom
 
+// Trying to grab a mimic tries to grab the copied atom instead.
+/atom/movable/openspace/mimic/try_make_grab(mob/living/user, defer_hand)
+	return associated_atom.try_make_grab(user, defer_hand)
+
 /atom/movable/openspace/mimic/forceMove(turf/dest)
 	var/atom/old_loc = loc
 	. = ..()


### PR DESCRIPTION
Fixes grabs not factoring distance on the Z-axis.
**_Fixes being able to teleport objects via diagonal grabs._**
Fixes diagonal movements breaking grabs in certain cases.
Cleans up atom diagonal movement code.