### PR TITLE
Fix wood structure hitsound and boulders in solid objects

### DIFF
--- a/code/modules/materials/definitions/solids/materials_solid_wood.dm
+++ b/code/modules/materials/definitions/solids/materials_solid_wood.dm
@@ -26,7 +26,7 @@
 	dooropen_noise = 'sound/effects/doorcreaky.ogg'
 	door_icon_base = "wood"
 	destruction_desc = "splinters"
-	hitsound = 'sound/effects/woodhit.ogg'
+	hitsound = 'sound/effects/hit_wood.ogg'
 	conductive = 0
 	construction_difficulty = MAT_VALUE_NORMAL_DIY
 	dissolves_into = list(

--- a/code/modules/random_map/noise/forage.dm
+++ b/code/modules/random_map/noise/forage.dm
@@ -92,7 +92,7 @@
 
 	if(T.is_outside())
 		if(istype(T, /turf/exterior/rock))
-			if(prob(15)) // Static as current map has limited amount of rock turfs
+			if(prob(15) && !T.contains_dense_objects()) // Static as current map has limited amount of rock turfs
 				var/rock_type = pick(forage["rocks"])
 				new rock_type(T)
 				return


### PR DESCRIPTION
## Description of changes
Wood structures have had the wrong hitsound for like 7 years. `material.hitsound` is used for something made of that material getting hit, but the sound used is for "hitting a fleshy mob with something wooden". The correct sound already existed but wasn't used.
Also, prevents boulders from spawning in solid objects like the kiln.

## Why and what will this PR improve
Hitting wooden stuff now sounds a lot better. Boulders won't spawn inside pre-existing solid objects (kiln, etc) on Shaded Hills.

## Authorship
Me

## Changelog
:cl:
soundadd: made wood structures have the correct hitsound
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->