### PR TITLE
Fix a few staging-branch issues

### DIFF
--- a/code/game/turfs/floors/floor_icon.dm
+++ b/code/game/turfs/floors/floor_icon.dm
@@ -71,15 +71,17 @@
 
 		// Draw a cliff wall if we have a northern neighbor that isn't part of our trench.
 		var/turf/floor/neighbor = get_step_resolving_mimic(src, NORTH)
-		if(isturf(neighbor) && neighbor.is_open())
+		// skip null and unsim edges, because we don't want trench edges along the edges of a map for no reason
+		if(!neighbor?.simulated || (isturf(neighbor) && neighbor.is_open()))
 			return
 
-		if(!istype(neighbor) || (neighbor.get_physical_height() > my_height))
+		if(!istype(neighbor, /turf/floor) || (neighbor.get_physical_height() > my_height))
 
-			var/trench_icon = (istype(neighbor) && neighbor.get_trench_icon()) || get_trench_icon()
+			var/trench_icon = (istype(neighbor, /turf/floor) && neighbor.get_trench_icon()) || get_trench_icon()
 			if(trench_icon)
 				// cache the trench image, keyed by icon and color
-				var/trench_color = isatom(neighbor) ? neighbor.get_color() : get_color()
+				// formerly an isatom check but it should never be a non-atom true value
+				var/trench_color = neighbor ? neighbor.get_color() : get_color()
 				var/trench_icon_key = "[ref(trench_icon)][trench_color]"
 				I = _trench_image_cache[trench_icon_key]
 				if(!I)

--- a/code/modules/butchery/butchery_hook.dm
+++ b/code/modules/butchery/butchery_hook.dm
@@ -176,9 +176,9 @@
 		clear_occupant()
 	else if(occupant_state == CARCASS_EMPTY)
 		for(var/obj/item/embedded in occupant.embedded)
-			occupant.remove_implant(occupant.embedded, TRUE) // surgical removal to prevent pointless damage pre-deletion
-		for(var/obj/item/W in occupant)
-			occupant.drop_from_inventory(W)
+			occupant.remove_implant(embedded, TRUE) // surgical removal to prevent pointless damage pre-deletion
+		for(var/obj/item/thing in occupant)
+			occupant.drop_from_inventory(thing)
 		qdel(occupant)
 		clear_occupant()
 	update_icon()

--- a/code/modules/materials/_materials.dm
+++ b/code/modules/materials/_materials.dm
@@ -1071,7 +1071,7 @@ INITIALIZE_IMMEDIATE(/obj/effect/gas_overlay)
 /decl/material/proc/get_presentation_name(var/obj/item/prop)
 	if(islist(prop?.reagents?.reagent_data))
 		. = LAZYACCESS(prop.reagents.reagent_data[type], DATA_MASK_NAME)
-	. ||= glass_name || liquid_name
+	. ||= glass_name || get_reagent_name(prop?.reagents)
 	if(prop?.reagents?.total_volume)
 		. = build_presentation_name_from_reagents(prop, .)
 


### PR DESCRIPTION
## Description of changes
skips null/unsim (dark filler) edges in trench icon code, so there are no longer weird ghost trench edges on the north side of the forest in shadedhills
replaces a hardcoded use of `liquid_name` with `get_reagent_name` so the reagent presentation name respects phase
replaces incorrect usage of `occupant.embedded` with just `embedded` in butcher hook code

## Why and what will this PR improve
trenches on the map edge looked weird, this fixes that
get_reagent_name is more robust/accurate than liquid_name, which means presentation name should be more accurate
butchering a mob with an arrow in it no longer causes a runtime

## Authorship
Me