### PR TITLE
Add noise texture overlay to stone walls

### DIFF
--- a/code/modules/materials/definitions/solids/materials_solid_stone.dm
+++ b/code/modules/materials/definitions/solids/materials_solid_stone.dm
@@ -25,6 +25,15 @@
 	ore_result_amount = 4
 	sound_manipulate = 'sound/foley/rockscrape.ogg'
 	sound_dropped    = 'sound/foley/rockscrape.ogg'
+	var/image/texture
+
+/decl/material/solid/stone/Initialize()
+	. = ..()
+	texture = image('icons/turf/wall_texture.dmi', "concrete")
+	texture.blend_mode = BLEND_MULTIPLY
+
+/decl/material/solid/stone/get_wall_texture()
+	return texture
 
 /decl/material/solid/stone/sandstone
 	name = "sandstone"
@@ -114,12 +123,3 @@
 	melting_point  = T0C + 1200
 	exoplanet_rarity_plant = MAT_RARITY_NOWHERE
 	exoplanet_rarity_gas = MAT_RARITY_NOWHERE
-	var/image/texture
-
-/decl/material/solid/stone/concrete/Initialize()
-	. = ..()
-	texture = image('icons/turf/wall_texture.dmi', "concrete")
-	texture.blend_mode = BLEND_MULTIPLY
-
-/decl/material/solid/stone/concrete/get_wall_texture()
-	return texture


### PR DESCRIPTION
## Description of changes
walls made of stone now have a noise texture applied. it just uses the concrete one, so basically i moved the concrete noise texture up to stone-level. this makes the stone walls on pyrelight a little less smooth and uniform-looking which i think improves it a lot.

## Why and what will this PR improve
shaded hills looks way too uniform, which gives a weird impression. this helps with that somewhat

## Authorship
me for code. just moving the existing texture from concrete to stone

## Changelog
:cl:
tweak: stone walls now have a slight noise effect on their sprite
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->