### PR TITLE
ambience: Fix member turfs list corruption

### DIFF
--- a/code/modules/lighting/ambient_group.dm
+++ b/code/modules/lighting/ambient_group.dm
@@ -44,7 +44,7 @@ var/global/ambience_group_map[BITWISE_MAX_BITS]
 	set waitfor = FALSE
 
 	UNTIL(!busy)
-	if (T.z > member_turfs_by_z)
+	if (T.z > member_turfs_by_z.len)
 		member_turfs_by_z.len = T.z
 
 	LAZYADD(member_turfs_by_z[T.z], T)


### PR DESCRIPTION
changes: 
- Adding a turf to an ambience group with a Z less than the local maximum will no longer erase the ambience group.