### PR TITLE
Move some variables onto /mob/living to slightly optimize dview

### DIFF
--- a/code/modules/clothing/spacesuits/rig/modules/computer.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/computer.dm
@@ -56,11 +56,11 @@
 	)
 	origin_tech = @'{"programming":6,"materials":5,"engineering":6}'
 
-	var/mob/integrated_ai // Direct reference to the actual mob held in the suit.
+	var/mob/living/integrated_ai // Direct reference to the actual mob held in the suit.
 	var/obj/item/ai_card  // Reference to the object previously holding the AI.
 	var/obj/item/ai_verbs/verb_holder
 
-/mob
+/mob/living
 	var/get_rig_stats = 0
 
 /obj/item/rig_module/ai_container/Process()

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -7,6 +7,7 @@
 	//Health and life related vars
 	max_health = 100 //Maximum health that should be possible.
 	current_health = INFINITY // A mob's current health. Set by update_health(). Defaults to INFINITY so mobs don't die on init.
+	skillset = /datum/skillset // moved here from /mob to avoid giving dview a skillset
 
 	var/hud_updateflag = 0
 

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -115,7 +115,7 @@
 
 	var/flavor_text = ""
 
-	var/datum/skillset/skillset = /datum/skillset
+	var/datum/skillset/skillset
 
 	var/list/additional_vision_handlers // A lazylist of atoms from which additional vision data is retrieved
 

--- a/code/modules/organs/pain.dm
+++ b/code/modules/organs/pain.dm
@@ -1,15 +1,15 @@
-/mob
+/mob/living
 	var/obj/screen/fullscreen/pain/pain
 
-/mob/Initialize()
+/mob/living/Initialize()
 	pain = new(null, src)
 	. = ..()
 
-/mob/Destroy()
+/mob/living/Destroy()
 	QDEL_NULL(pain)
 	. = ..()
 
-/mob/proc/flash_pain(var/target)
+/mob/living/proc/flash_pain(var/target)
 	if(pain)
 		var/matrix/M
 		if(client && max(client.last_view_x_dim, client.last_view_y_dim) > 7)


### PR DESCRIPTION
`/mob/dview` is an internal mob used for optimizations and does not need a skillset or a pain overlay. The pain overlay is actually somewhat expensive given it uses an icon containing 31 480x480 icon states, and creating one means the icon has to be loaded into memory. Delaying this as long as possible is good, generally. This should also apply to `/mob/observer` and especially `/mob/observer/virtual`.