### PR TITLE
Allow /obj/item/var/list/attack_verb to be a string

### DIFF
--- a/code/__defines/lists.dm
+++ b/code/__defines/lists.dm
@@ -4,7 +4,7 @@
 // All of these are null-safe, you can use them without knowing if the list var is initialized yet
 
 //Picks from the list, with some safeties, and returns the "default" arg if it fails
-#define DEFAULTPICK(L, default) ((istype(L, /list) && L:len) ? pick(L) : default)
+#define DEFAULTPICK(L, default) ((islist(L) && length(L)) ? pick(L) : default)
 //Supplies null as the default to DEFAULTPICK
 #define SAFEPICK(L) DEFAULTPICK(L, null)
 // Ensures L is initailized after this point

--- a/code/game/objects/effects/spiders.dm
+++ b/code/game/objects/effects/spiders.dm
@@ -36,10 +36,7 @@
 /obj/effect/spider/attackby(var/obj/item/used_item, var/mob/user)
 	user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
 
-	if(used_item.attack_verb.len)
-		visible_message("<span class='warning'>\The [src] has been [pick(used_item.attack_verb)] with \the [used_item][(user ? " by [user]." : ".")]</span>")
-	else
-		visible_message("<span class='warning'>\The [src] has been attacked with \the [used_item][(user ? " by [user]." : ".")]</span>")
+	visible_message("<span class='warning'>\The [src] has been [used_item.pick_attack_verb()] with \the [used_item][(user ? " by [user]." : ".")]</span>")
 
 	var/damage = used_item.expend_attack_force(user) / 4
 

--- a/code/game/objects/items/__item.dm
+++ b/code/game/objects/items/__item.dm
@@ -23,7 +23,7 @@
 	var/no_attack_log = FALSE
 	var/obj/item/master = null
 	var/origin_tech                    //Used by R&D to determine what research bonuses it grants.
-	var/list/attack_verb = list("hit") //Used in attackby() to say how something was attacked "[x] has been [z.attack_verb] by [y] with [z]"
+	VAR_PROTECTED/list/attack_verb = "hit" //Used in attackby() to say how something was attacked "[x] has been [z.attack_verb] by [y] with [z]"
 	var/lock_picking_level = 0 //used to determine whether something can pick a lock, and how well.
 	var/attack_cooldown = DEFAULT_WEAPON_COOLDOWN
 	var/melee_accuracy_bonus = 0
@@ -1354,3 +1354,6 @@ modules/mob/living/human/life.dm if you die, you will be zoomed out.
 	material = null
 	if(!skip_qdel)
 		qdel(src)
+
+/obj/item/proc/pick_attack_verb()
+	return DEFAULTPICK(attack_verb, attack_verb) || "attacked" // if it's not a list, return itself or just "attacked"

--- a/code/game/objects/items/blades/folding.dm
+++ b/code/game/objects/items/blades/folding.dm
@@ -55,12 +55,10 @@
 	. = ..()
 	set_edge(open)
 	set_sharp(open)
-	if(open)
-		w_class     = open_item_size
-		attack_verb = open_attack_verbs
-	else
-		w_class     = closed_item_size
-		attack_verb = closed_attack_verbs
+	w_class = open ? open_item_size : closed_item_size
+
+/obj/item/bladed/folding/pick_attack_verb()
+	return DEFAULTPICK(open ? open_attack_verbs : closed_attack_verbs, ..())
 
 // Only show the inhand sprite when open.
 /obj/item/bladed/folding/get_mob_overlay(mob/user_mob, slot, bodypart, use_fallback_if_icon_missing = TRUE, skip_adjustment = FALSE)

--- a/code/game/objects/items/fleece.dm
+++ b/code/game/objects/items/fleece.dm
@@ -4,7 +4,7 @@
 	icon        = 'icons/obj/items/fleece.dmi'
 	icon_state  = ICON_STATE_WORLD
 	w_class     = ITEM_SIZE_HUGE // an entire fleece is quite large in terms of volume
-	attack_verb = list("slapped")
+	attack_verb = "slapped"
 	hitsound    = 'sound/weapons/towelwhip.ogg'
 	material    = /decl/material/solid/organic/cloth/wool
 	material_alteration = MAT_FLAG_ALTERATION_COLOR

--- a/code/game/objects/items/passport.dm
+++ b/code/game/objects/items/passport.dm
@@ -5,7 +5,7 @@
 	_base_attack_force = 1
 	gender = PLURAL
 	w_class = ITEM_SIZE_SMALL
-	attack_verb = list("whipped")
+	attack_verb = "whipped"
 	hitsound = 'sound/weapons/towelwhip.ogg'
 	desc = "A set of identifying documents."
 	material = /decl/material/solid/organic/paper

--- a/code/game/objects/items/plunger.dm
+++ b/code/game/objects/items/plunger.dm
@@ -3,7 +3,7 @@
 	desc = "This is possibly the least sanitary object around."
 	icon = 'icons/obj/items/plunger.dmi'
 	icon_state = ICON_STATE_WORLD
-	attack_verb = list("plunged")
+	attack_verb = "plunged"
 	_base_attack_force = 1
 	w_class = ITEM_SIZE_NORMAL
 	slot_flags = SLOT_HEAD | SLOT_FACE

--- a/code/game/objects/items/tools/screwdriver.dm
+++ b/code/game/objects/items/tools/screwdriver.dm
@@ -7,7 +7,7 @@
 	w_class = ITEM_SIZE_TINY
 	material = /decl/material/solid/metal/steel
 	center_of_mass = @'{"x":16,"y":7}'
-	attack_verb = list("stabbed")
+	attack_verb = "stabbed"
 	lock_picking_level = 5
 	sharp = TRUE
 	material_alteration = MAT_FLAG_ALTERATION_COLOR

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -145,11 +145,11 @@
 	desc = "A cheap, plastic replica of an energy sword. Realistic sounds! Ages 8 and up."
 	sharp = FALSE
 	edge = FALSE
-	attack_verb = list("hit")
+	attack_verb = "hit"
 	material = /decl/material/solid/organic/plastic
 	active_hitsound = 'sound/weapons/genhit.ogg'
 	active_descriptor = "extended"
-	active_attack_verb = list("hit")
+	active_attack_verb = "hit"
 	active_edge = FALSE
 	active_sharp = FALSE
 	_active_base_attack_force = 1

--- a/code/game/objects/items/weapons/clown_items.dm
+++ b/code/game/objects/items/weapons/clown_items.dm
@@ -24,7 +24,7 @@
 	w_class = ITEM_SIZE_SMALL
 	throw_speed = 3
 	throw_range = 15
-	attack_verb = list("HONKED")
+	attack_verb = "HONKED"
 	material = /decl/material/solid/metal/steel
 	matter = list(
 		/decl/material/solid/organic/plastic = MATTER_AMOUNT_SECONDARY

--- a/code/game/objects/items/weapons/dice.dm
+++ b/code/game/objects/items/weapons/dice.dm
@@ -5,7 +5,7 @@
 	icon_state = "d66"
 	w_class = ITEM_SIZE_TINY
 	var/sides = 6
-	attack_verb = list("diced")
+	attack_verb = "diced"
 	material = /decl/material/solid/organic/plastic
 
 /obj/item/dice/Initialize()

--- a/code/game/objects/items/weapons/melee/energy.dm
+++ b/code/game/objects/items/weapons/melee/energy.dm
@@ -39,9 +39,9 @@
 
 	var/inactive_sound =      'sound/weapons/saberoff.ogg'
 
-	attack_verb =                   list("hit")
+	attack_verb =                   "hit"
 	var/list/active_attack_verb	=   list("attacked", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
-	var/list/inactive_attack_verb = list("hit")
+	var/list/inactive_attack_verb = "hit"
 
 /obj/item/energy_blade/get_max_weapon_force()
 	return _active_base_attack_force
@@ -82,6 +82,9 @@
 		return _active_base_attack_force
 	return _base_attack_force
 
+/obj/item/energy_blade/pick_attack_verb()
+	return DEFAULTPICK(active ? active_attack_verb : inactive_attack_verb, ..())
+
 /obj/item/energy_blade/proc/toggle_active(var/mob/user)
 
 	active = !active
@@ -93,7 +96,6 @@
 		base_parry_chance = active_parry_chance
 		armor_penetration = active_armour_pen
 		hitsound =          active_hitsound
-		attack_verb =       active_attack_verb
 
 		w_class = max(w_class, ITEM_SIZE_NORMAL)
 		slot_flags &= ~SLOT_POCKET
@@ -108,7 +110,6 @@
 		base_parry_chance = initial(base_parry_chance)
 		armor_penetration = initial(armor_penetration)
 		hitsound =          initial(hitsound)
-		attack_verb =       inactive_attack_verb
 
 		w_class = initial(w_class)
 		slot_flags = initial(slot_flags)

--- a/code/game/objects/items/weapons/storage/lunchbox.dm
+++ b/code/game/objects/items/weapons/storage/lunchbox.dm
@@ -4,7 +4,7 @@
 	icon = 'icons/obj/items/storage/lunchboxes/lunchbox_rainbow.dmi'
 	icon_state = ICON_STATE_WORLD
 	w_class = ITEM_SIZE_NORMAL
-	attack_verb = list("lunched")
+	attack_verb = "lunched"
 	material = /decl/material/solid/organic/plastic
 	storage = /datum/storage/lunchbox
 	var/tmp/filled = FALSE

--- a/code/game/objects/items/weapons/storage/picnic_basket.dm
+++ b/code/game/objects/items/weapons/storage/picnic_basket.dm
@@ -6,7 +6,7 @@
 	icon_state = ICON_STATE_WORLD
 	w_class = ITEM_SIZE_NORMAL
 	storage = /datum/storage/picnic_basket
-	attack_verb = list("picnics")
+	attack_verb = "picnics"
 	material = /decl/material/solid/organic/plastic
 	var/tmp/filled = FALSE
 

--- a/code/game/objects/items/weapons/storage/toolbox.dm
+++ b/code/game/objects/items/weapons/storage/toolbox.dm
@@ -11,7 +11,7 @@
 	w_class = ITEM_SIZE_LARGE
 	storage = /datum/storage/toolbox
 	origin_tech = @'{"combat":1}'
-	attack_verb = list("robusted")
+	attack_verb = "robusted"
 	material = /decl/material/solid/metal/aluminium
 	_base_attack_force = 20
 

--- a/code/game/objects/items/weapons/stunbaton.dm
+++ b/code/game/objects/items/weapons/stunbaton.dm
@@ -7,7 +7,7 @@
 	slot_flags = SLOT_LOWER_BODY
 	w_class = ITEM_SIZE_NORMAL
 	origin_tech = @'{"combat":2}'
-	attack_verb = list("beaten")
+	attack_verb = "beaten"
 	base_parry_chance = 30
 	material = /decl/material/solid/metal/aluminium
 	matter = list(
@@ -207,7 +207,7 @@
 	stunforce = 0
 	agonyforce = 60	//same force as a stunbaton, but uses way more charge.
 	hitcost = 25
-	attack_verb = list("poked")
+	attack_verb = "poked"
 	slot_flags = null
 	matter = list(
 		/decl/material/solid/organic/plastic = MATTER_AMOUNT_TRACE,

--- a/code/game/objects/items/weapons/surgery_tools.dm
+++ b/code/game/objects/items/weapons/surgery_tools.dm
@@ -63,7 +63,7 @@
 	obj_flags = OBJ_FLAG_CONDUCTIBLE
 	w_class = ITEM_SIZE_SMALL
 	origin_tech = @'{"materials":1,"biotech":1}'
-	attack_verb = list("burnt")
+	attack_verb = "burnt"
 
 /obj/item/cautery/Initialize()
 	. = ..()
@@ -84,7 +84,7 @@
 	_base_attack_force = 15
 	w_class = ITEM_SIZE_NORMAL
 	origin_tech = @'{"materials":1,"biotech":1}'
-	attack_verb = list("drilled")
+	attack_verb = "drilled"
 
 /obj/item/surgicaldrill/Initialize()
 	. = ..()

--- a/code/game/objects/items/weapons/towels.dm
+++ b/code/game/objects/items/weapons/towels.dm
@@ -7,7 +7,7 @@
 	slot_flags = SLOT_HEAD | SLOT_LOWER_BODY | SLOT_OVER_BODY
 	_base_attack_force = 1
 	w_class = ITEM_SIZE_NORMAL
-	attack_verb = list("whipped")
+	attack_verb = "whipped"
 	hitsound = 'sound/weapons/towelwhip.ogg'
 	material = /decl/material/solid/organic/cloth
 	material_alteration = MAT_FLAG_ALTERATION_ALL
@@ -188,7 +188,7 @@
 	name = "fleece" // sets its name to 'golden fleece' due to material
 	desc = "The legendary Golden Fleece of Jason made real."
 	_base_attack_force = 1
-	attack_verb = list("smote")
+	attack_verb = "smote"
 	material = /decl/material/solid/metal/gold
 
 /obj/item/towel/fleece/update_material_description()

--- a/code/game/objects/structures/_structure_construction.dm
+++ b/code/game/objects/structures/_structure_construction.dm
@@ -65,7 +65,7 @@
 		var/force = used_item.expend_attack_force(user)
 		if(force && user.check_intent(I_FLAG_HARM))
 			attack_animation(user)
-			visible_message(SPAN_DANGER("\The [src] has been [pick(used_item.attack_verb)] with \the [used_item] by \the [user]!"))
+			visible_message(SPAN_DANGER("\The [src] has been [used_item.pick_attack_verb()] with \the [used_item] by \the [user]!"))
 			take_damage(force, used_item.atom_damage_type)
 			user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
 			add_fingerprint(user)

--- a/code/game/objects/structures/fireaxe_cabinet.dm
+++ b/code/game/objects/structures/fireaxe_cabinet.dm
@@ -86,7 +86,7 @@
 		user.setClickCooldown(10)
 		attack_animation(user)
 		playsound(user, 'sound/effects/Glasshit.ogg', 50, 1)
-		visible_message("<span class='danger'>[user] [pick(used_item.attack_verb)] \the [src]!</span>")
+		visible_message("<span class='danger'>[user] [used_item.pick_attack_verb()] \the [src]!</span>")
 		if(damage_threshold > force)
 			to_chat(user, "<span class='danger'>Your strike is deflected by the reinforced glass!</span>")
 			return TRUE

--- a/code/game/objects/structures/railing.dm
+++ b/code/game/objects/structures/railing.dm
@@ -304,7 +304,7 @@ WOOD_RAILING_SUBTYPE(yew)
 	var/force = used_item.expend_attack_force(user)
 	if(force && (used_item.atom_damage_type == BURN || used_item.atom_damage_type == BRUTE))
 		user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
-		visible_message("<span class='danger'>\The [src] has been [LAZYLEN(used_item.attack_verb) ? pick(used_item.attack_verb) : "attacked"] with \the [used_item] by \the [user]!</span>")
+		visible_message("<span class='danger'>\The [src] has been [used_item.pick_attack_verb()] with \the [used_item] by \the [user]!</span>")
 		take_damage(force, used_item.atom_damage_type)
 		return TRUE
 	. = ..()

--- a/code/game/turfs/walls/wall_attacks.dm
+++ b/code/game/turfs/walls/wall_attacks.dm
@@ -308,13 +308,13 @@
 		material_divisor = max(material.burn_armor, reinf_material?.burn_armor)
 	var/effective_force = round(force / material_divisor)
 	if(effective_force < 2)
-		visible_message(SPAN_DANGER("\The [user] [pick(used_item.attack_verb)] \the [src] with \the [used_item], but it had no effect!"))
+		visible_message(SPAN_DANGER("\The [user] [used_item.pick_attack_verb()] \the [src] with \the [used_item], but it had no effect!"))
 		playsound(src, hitsound, 25, 1)
 		return TRUE
 	// Check for a glancing blow.
 	var/dam_prob = max(0, 100 - material.hardness + effective_force + used_item.armor_penetration)
 	if(!prob(dam_prob))
-		visible_message(SPAN_DANGER("\The [user] [pick(used_item.attack_verb)] \the [src] with \the [used_item], but it bounced off!"))
+		visible_message(SPAN_DANGER("\The [user] [used_item.pick_attack_verb()] \the [src] with \the [used_item], but it bounced off!"))
 		playsound(src, hitsound, 25, 1)
 		if(user.skill_fail_prob(SKILL_HAULING, 40, SKILL_ADEPT))
 			SET_STATUS_MAX(user, STAT_WEAK, 2)
@@ -322,6 +322,6 @@
 		return TRUE
 
 	playsound(src, get_hit_sound(), 50, 1)
-	visible_message(SPAN_DANGER("\The [user] [pick(used_item.attack_verb)] \the [src] with \the [used_item]!"))
+	visible_message(SPAN_DANGER("\The [user] [used_item.pick_attack_verb()] \the [src] with \the [used_item]!"))
 	take_damage(effective_force)
 	return TRUE

--- a/code/modules/clothing/gloves/_gloves.dm
+++ b/code/modules/clothing/gloves/_gloves.dm
@@ -11,7 +11,7 @@
 	siemens_coefficient = 0.75
 	body_parts_covered = SLOT_HANDS
 	slot_flags = SLOT_HANDS
-	attack_verb = list("challenged")
+	attack_verb = "challenged"
 	blood_overlay_type = "bloodyhands"
 	bodytype_equip_flags = BODY_EQUIP_FLAG_HUMANOID
 	fallback_slot = slot_gloves_str

--- a/code/modules/materials/material_stack_misc.dm
+++ b/code/modules/materials/material_stack_misc.dm
@@ -113,7 +113,7 @@
 	plural_icon_state = "cube-mult"
 	max_icon_state = "cube-max"
 	max_amount = 100
-	attack_verb = list("cubed")
+	attack_verb = "cubed"
 	stack_merge_type = /obj/item/stack/material/cubes
 	crafting_stack_type = /obj/item/stack/material // cubes can be used for any crafting
 	can_be_pulverized = TRUE

--- a/code/modules/mob/living/human/human_defense.dm
+++ b/code/modules/mob/living/human/human_defense.dm
@@ -124,9 +124,9 @@ meteor_act
 	if(I.attack_message_name())
 		weapon_mention = " with [I.attack_message_name()]"
 	if(effective_force)
-		visible_message("<span class='danger'>[src] has been [I.attack_verb.len? pick(I.attack_verb) : "attacked"] in the [affecting.name][weapon_mention] by [user]!</span>")
+		visible_message("<span class='danger'>[src] has been [I.pick_attack_verb()] in the [affecting.name][weapon_mention] by [user]!</span>")
 	else
-		visible_message("<span class='warning'>[src] has been [I.attack_verb.len? pick(I.attack_verb) : "attacked"] in the [affecting.name][weapon_mention] by [user]!</span>")
+		visible_message("<span class='warning'>[src] has been [I.pick_attack_verb()] in the [affecting.name][weapon_mention] by [user]!</span>")
 		return // If it has no force then no need to do anything else.
 
 	. = standard_weapon_hit_effects(I, user, effective_force, hit_zone)

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -137,9 +137,9 @@
 	if(I.attack_message_name())
 		weapon_mention = " with [I.attack_message_name()]"
 	if(effective_force)
-		visible_message(SPAN_DANGER("\The [src] has been [DEFAULTPICK(I.attack_verb, "attacked")][weapon_mention] by \the [user]!"))
+		visible_message(SPAN_DANGER("\The [src] has been [I.pick_attack_verb()][weapon_mention] by \the [user]!"))
 	else
-		visible_message(SPAN_WARNING("\The [src] has been [DEFAULTPICK(I.attack_verb, "attacked")][weapon_mention] by \the [user]!"))
+		visible_message(SPAN_WARNING("\The [src] has been [I.pick_attack_verb()][weapon_mention] by \the [user]!"))
 	. = standard_weapon_hit_effects(I, user, effective_force, hit_zone)
 	if(I.atom_damage_type == BRUTE && prob(33))
 		blood_splatter(get_turf(loc), src)

--- a/code/modules/mob/living/simple_animal/crow/crow.dm
+++ b/code/modules/mob/living/simple_animal/crow/crow.dm
@@ -37,7 +37,7 @@
 /obj/item/natural_weapon/crow_claws
 	name = "claws"
 	gender = PLURAL
-	attack_verb = list("clawed")
+	attack_verb = "clawed"
 	sharp = TRUE
 	_base_attack_force = 7
 

--- a/code/modules/mob/living/simple_animal/hostile/commanded/nanomachines.dm
+++ b/code/modules/mob/living/simple_animal/hostile/commanded/nanomachines.dm
@@ -20,7 +20,7 @@
 
 /obj/item/natural_weapon/nanomachine
 	name = "decompilers"
-	attack_verb = list("swarmed")
+	attack_verb = "swarmed"
 	_base_attack_force = 2
 	sharp = TRUE
 

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/exoplanet.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/exoplanet.dm
@@ -178,7 +178,7 @@
 /obj/item/natural_weapon/charbaby
 	name = "scalding hide"
 	atom_damage_type =  BURN
-	attack_verb = list("singed")
+	attack_verb = "singed"
 
 /mob/living/simple_animal/hostile/beast/charbaby/default_hurt_interaction(mob/user)
 	. = ..()

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/king_of_goats.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/king_of_goats.dm
@@ -80,7 +80,7 @@
 
 /obj/item/natural_weapon/goatking
 	name = "giant horns"
-	attack_verb = list("brutalized")
+	attack_verb = "brutalized"
 	_base_attack_force = 40
 	sharp = TRUE
 

--- a/code/modules/mob/living/simple_animal/hostile/revenant.dm
+++ b/code/modules/mob/living/simple_animal/hostile/revenant.dm
@@ -27,7 +27,7 @@
 
 /obj/item/natural_weapon/revenant
 	name = "shadow tendril"
-	attack_verb = list("gripped")
+	attack_verb = "gripped"
 	hitsound = 'sound/hallucinations/growl1.ogg'
 	atom_damage_type =  BURN
 	_base_attack_force = 15

--- a/code/modules/mob/living/simple_animal/natural_weapons.dm
+++ b/code/modules/mob/living/simple_animal/natural_weapons.dm
@@ -1,7 +1,7 @@
 /obj/item/natural_weapon
 	name = "natural weapons"
 	gender = PLURAL
-	attack_verb = list("attacked")
+	attack_verb = "attacked"
 	atom_damage_type =  BRUTE
 	canremove = FALSE
 	obj_flags = OBJ_FLAG_CONDUCTIBLE //for intent of shocking checks, they're right inside the animal
@@ -28,7 +28,7 @@
 
 /obj/item/natural_weapon/bite
 	name = "teeth"
-	attack_verb = list("bitten")
+	attack_verb = "bitten"
 	hitsound = 'sound/weapons/bite.ogg'
 	_base_attack_force = 10
 	sharp = TRUE
@@ -39,7 +39,7 @@
 
 /obj/item/natural_weapon/bite/mouse
 	_base_attack_force = 1
-	attack_verb = list("nibbled")
+	attack_verb = "nibbled"
 	hitsound = null
 
 /obj/item/natural_weapon/bite/strong
@@ -61,11 +61,11 @@
 
 /obj/item/natural_weapon/hooves
 	name = "hooves"
-	attack_verb = list("kicked")
+	attack_verb = "kicked"
 
 /obj/item/natural_weapon/punch
 	name = "fists"
-	attack_verb = list("punched")
+	attack_verb = "punched"
 	_base_attack_force = 10
 
 /obj/item/natural_weapon/pincers
@@ -75,7 +75,7 @@
 /obj/item/natural_weapon/drone_slicer
 	name = "sharpened leg"
 	gender = NEUTER
-	attack_verb = list("sliced")
+	attack_verb = "sliced"
 	atom_damage_type =  BRUTE
 	edge = TRUE
 	show_in_message = TRUE

--- a/code/modules/mob/living/simple_animal/simple_animal_damage.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal_damage.dm
@@ -49,9 +49,9 @@
 
 	var/attack_name = O?.attack_message_name()
 	if(attack_name)
-		visible_message(SPAN_DANGER("\The [src] has been [DEFAULTPICK(O.attack_verb, "attacked")] with [attack_name] by \the [user]!"))
+		visible_message(SPAN_DANGER("\The [src] has been [O.pick_attack_verb()] with [attack_name] by \the [user]!"))
 	else
-		visible_message(SPAN_DANGER("\The [src] has been [DEFAULTPICK(O.attack_verb, "attacked")] by \the [user]!"))
+		visible_message(SPAN_DANGER("\The [src] has been [O.pick_attack_verb()] by \the [user]!"))
 
 	if(istype(ai))
 		ai.retaliate(user)

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -16,7 +16,7 @@
 	throw_range            = 1
 	throw_speed            = 1
 	w_class                = ITEM_SIZE_TINY
-	attack_verb            = list("bapped")
+	attack_verb            = "bapped"
 	material               = /decl/material/solid/organic/paper
 	drop_sound             = 'sound/foley/paperpickup1.ogg'
 	pickup_sound           = 'sound/foley/paperpickup2.ogg'

--- a/code/modules/paperwork/paper_bundle.dm
+++ b/code/modules/paperwork/paper_bundle.dm
@@ -14,7 +14,7 @@
 	throw_range       = 2
 	throw_speed       = 1
 	w_class           = ITEM_SIZE_SMALL
-	attack_verb       = list("bapped")
+	attack_verb       = "bapped"
 	drop_sound        = 'sound/foley/paperpickup1.ogg'
 	pickup_sound      = 'sound/foley/paperpickup2.ogg'
 	item_flags        = ITEM_FLAG_CAN_TAPE

--- a/code/modules/paperwork/stamps.dm
+++ b/code/modules/paperwork/stamps.dm
@@ -10,7 +10,7 @@
 	matter      = list(
 		/decl/material/solid/organic/plastic = MATTER_AMOUNT_REINFORCEMENT,
 	)
-	attack_verb = list("stamped")
+	attack_verb = "stamped"
 
 /obj/item/stamp/Initialize()
 	. = ..()

--- a/code/modules/shield_generators/shield.dm
+++ b/code/modules/shield_generators/shield.dm
@@ -226,7 +226,7 @@
 		user.visible_message("<span class='danger'>\The [user] tries to attack \the [src] with \the [weapon], but it passes through!</span>")
 		return TRUE
 	var/force = weapon.expend_attack_force(user)
-	user.visible_message("<span class='danger'>\The [user] [pick(weapon.attack_verb)] \the [src] with \the [weapon]!</span>")
+	user.visible_message("<span class='danger'>\The [user] [weapon.pick_attack_verb()] \the [src] with \the [weapon]!</span>")
 	switch(weapon.atom_damage_type)
 		if(BURN)
 			take_damage(force, SHIELD_DAMTYPE_HEAT)

--- a/mods/content/government/items/clutter.dm
+++ b/mods/content/government/items/clutter.dm
@@ -4,7 +4,7 @@
 	icon_state = "tableflag"
 	_base_attack_force = 1
 	w_class = ITEM_SIZE_SMALL
-	attack_verb = list("whipped")
+	attack_verb = "whipped"
 	hitsound = 'sound/weapons/towelwhip.ogg'
 	desc = "The iconic flag of the Sol Central Government, a symbol with many different meanings."
 	material = /decl/material/solid/organic/plastic

--- a/mods/gamemodes/cult/mobs/constructs/constructs.dm
+++ b/mods/gamemodes/cult/mobs/constructs/constructs.dm
@@ -208,7 +208,7 @@
 
 /obj/item/natural_weapon/cult_builder
 	name = "heavy arms"
-	attack_verb = list("rammed")
+	attack_verb = "rammed"
 
 
 /mob/living/simple_animal/construct/builder/mind_initialize()

--- a/mods/gamemodes/cult/mobs/shade.dm
+++ b/mods/gamemodes/cult/mobs/shade.dm
@@ -33,7 +33,7 @@
 
 /obj/item/natural_weapon/shade
 	name = "foul touch"
-	attack_verb = list("drained")
+	attack_verb = "drained"
 	atom_damage_type =  BURN
 	_base_attack_force = 10
 


### PR DESCRIPTION
## Description of changes
`attack_verb` references have been replaced with a `pick_attack_verb()` method, which handles defaults when null, as well as handling both a list and a string.
If `attack_verb` is a list, it will return a random value from the list. If `attack_verb` is a string, it will return `attack_verb`. If `attack_verb` is null, it will return `"attacked"`.

## Why and what will this PR improve
Saves memory and init time, mostly. This can be a pretty big issue on very large maps. No user-facing changes.