### PR TITLE
Implement unused proc in inertial damper modpack

### DIFF
--- a/mods/content/inertia/inertia_controller.dm
+++ b/mods/content/inertia/inertia_controller.dm
@@ -3,12 +3,12 @@ var/global/list/ship_inertial_dampers = list()
 
 /datum/ship_inertial_damper
 	var/name = "ship inertial damper"
-	var/obj/machinery/holder
+	var/obj/machinery/inertial_damper/holder
 
 /datum/ship_inertial_damper/proc/get_damping_strength(var/reliable)
-	return 0
+	return holder.get_damping_strength(reliable)
 
-/datum/ship_inertial_damper/New(var/obj/machinery/_holder)
+/datum/ship_inertial_damper/New(var/obj/machinery/inertial_damper/_holder)
 	..()
 	holder = _holder
 	global.ship_inertial_dampers += src

--- a/mods/content/inertia/inertia_failure.dm
+++ b/mods/content/inertia/inertia_failure.dm
@@ -17,8 +17,8 @@
 	endWhen = rand(45, 120)
 
 /proc/inertial_dampener_event_can_fire() // Check if we have any ships that require dampers for this event to affect
-	for(var/obj/effect/overmap/visitable/ship/S in SSshuttle.ships)
-		if(S.needs_dampers)
+	for(var/obj/effect/overmap/visitable/ship/ship in SSshuttle.ships)
+		if(ship.needs_dampers)
 			return TRUE
 	return FALSE
 
@@ -26,15 +26,15 @@
 	command_announcement.Announce("Inertial damper calibration error. Please restrict thruster use. Recalibration cycle initiated...", "[location_name()] Inertial Damper Subsystem", zlevels = affecting_z)
 
 /datum/event/inertial_damper/start()
-	for(var/obj/machinery/inertial_damper/I in SSmachines.machinery)
-		I.damping_modifier += -5 //Gm/h
-		I.was_reset = FALSE
+	for(var/obj/machinery/inertial_damper/damper_machine in SSmachines.machinery)
+		damper_machine.damping_modifier += -5 //Gm/h
+		damper_machine.was_reset = FALSE
 
 /datum/event/inertial_damper/end()
 	var/display_announcement = FALSE
-	for(var/obj/machinery/inertial_damper/I in SSmachines.machinery)
-		I.damping_modifier = initial(I.damping_modifier)
-		if(!I.was_reset)
+	for(var/obj/machinery/inertial_damper/damper_machine in SSmachines.machinery)
+		damper_machine.damping_modifier = initial(damper_machine.damping_modifier)
+		if(!damper_machine.was_reset)
 			display_announcement = TRUE
 			break
 

--- a/mods/content/inertia/inertial_damper.dm
+++ b/mods/content/inertia/inertial_damper.dm
@@ -54,9 +54,9 @@
 	update_nearby_tiles(locs)
 	controller = new(src)
 
-	var/obj/effect/overmap/visitable/ship/S = get_owning_overmap_object()
-	if(istype(S))
-		S.inertial_dampers |= controller
+	var/obj/effect/overmap/visitable/ship/ship = get_owning_overmap_object()
+	if(istype(ship))
+		ship.inertial_dampers |= controller
 
 	src.overlays += "activated"
 

--- a/mods/content/inertia/ship_inertia.dm
+++ b/mods/content/inertia/ship_inertia.dm
@@ -8,9 +8,9 @@
 
 /obj/effect/overmap/visitable/ship/populate_sector_objects()
 	..()
-	for(var/datum/ship_inertial_damper/I in global.ship_inertial_dampers)
-		if(check_ownership(I.holder))
-			inertial_dampers |= I
+	for(var/datum/ship_inertial_damper/damper_datum in global.ship_inertial_dampers)
+		if(check_ownership(damper_datum.holder))
+			inertial_dampers |= damper_datum
 
 // Theoretically there's no need to recalculate this every tick,
 // instead it should be recalculated any time damping strength changes
@@ -18,9 +18,8 @@
 /obj/effect/overmap/visitable/ship/Process(wait, tick)
 	. = ..()
 	damping_strength = 0
-	for(var/datum/ship_inertial_damper/I in inertial_dampers)
-		var/obj/machinery/inertial_damper/ID = I.holder
-		damping_strength += ID.get_damping_strength(TRUE)
+	for(var/datum/ship_inertial_damper/damper_datum in inertial_dampers)
+		damping_strength += damper_datum.get_damping_strength(TRUE)
 
 /obj/effect/overmap/visitable/ship/adjust_speed(n_x, n_y)
 	. = ..()
@@ -30,15 +29,14 @@
 	if(needs_dampers && damping_strength < inertia_strength)
 		var/list/areas_by_name = area_repository.get_areas_by_z_level()
 		for(var/area_name in areas_by_name)
-			var/area/A = areas_by_name[area_name]
-			if(area_belongs_to_zlevels(A, map_z))
-				A.throw_unbuckled_occupants(inertia_strength+2, inertia_strength, inertia_dir)
+			var/area/the_area = areas_by_name[area_name]
+			if(area_belongs_to_zlevels(the_area, map_z))
+				the_area.throw_unbuckled_occupants(inertia_strength+2, inertia_strength, inertia_dir)
 
 // Add additional data to the engine console.
 /obj/machinery/computer/ship/engines/modify_ship_ui_data(list/ui_data)
 	var/damping_strength = 0
 	for(var/datum/ship_inertial_damper/inertia_controller in linked.inertial_dampers)
-		var/obj/machinery/inertial_damper/damper = inertia_controller.holder
-		damping_strength += damper.get_damping_strength(FALSE) // get only the level it's set to, not the actual level
+		damping_strength += inertia_controller.holder.get_damping_strength(FALSE) // get only the level it's set to, not the actual level
 	ui_data["damping_strength"] = damping_strength
 	ui_data["needs_dampers"] = linked.needs_dampers

--- a/mods/content/inertia/wires.dm
+++ b/mods/content/inertia/wires.dm
@@ -13,26 +13,26 @@
 	var/const/DAMPER_WIRE_AICONTROL = 8 // Cut to disable AI control. Mend to restore.
 
 /datum/wires/inertial_damper/CanUse()
-	var/obj/machinery/inertial_damper/I = holder
-	if(I.panel_open)
+	var/obj/machinery/inertial_damper/damper_machine = holder
+	if(damper_machine.panel_open)
 		return TRUE
 	return FALSE
 
 /datum/wires/inertial_damper/UpdateCut(index, mended)
-	var/obj/machinery/inertial_damper/I = holder
+	var/obj/machinery/inertial_damper/damper_machine = holder
 	switch(index)
 		if(DAMPER_WIRE_POWER)
-			I.input_cut = !mended
+			damper_machine.input_cut = !mended
 		if(DAMPER_WIRE_HACK)
 			if(!mended)
-				I.hacked = FALSE
+				damper_machine.hacked = FALSE
 		if(DAMPER_WIRE_CONTROL)
-			I.locked = !mended
+			damper_machine.locked = !mended
 		if(DAMPER_WIRE_AICONTROL)
-			I.ai_control_disabled = !mended
+			damper_machine.ai_control_disabled = !mended
 
 /datum/wires/inertial_damper/UpdatePulsed(var/index)
-	var/obj/machinery/inertial_damper/I = holder
+	var/obj/machinery/inertial_damper/damper_machine = holder
 	switch(index)
 		if(DAMPER_WIRE_HACK)
-			I.hacked = TRUE
+			damper_machine.hacked = TRUE


### PR DESCRIPTION
## Description of changes
Separated out of https://github.com/NebulaSS13/Nebula/pull/4969.
`var/obj/machinery/holder` on `/datum/ship_inertial_damper` has been repathed to `var/obj/machinery/inertial_damper/holder` to make the implicit dependency on the inertial damper type explicit.
Variable names in the inertial damper modpack have also been changed to avoid one- and two-letter variable names.
`/datum/ship_inertial_damper/proc/get_damping_strength(var/reliable)` now calls `/obj/machinery/inertial_damper/proc/get_damping_strength(var/include_modifiers)`. As such, the usage of the `/datum/ship_inertial_damper`-level proc is now preferred over the `/obj/machinery/inertial_damper`-level proc.


## Why and what will this PR improve
The proc `get_damping_strength()` on `/datum/ship_inertial_damper` is unused, and code that should consume it instead uses the `holder` variable. As `/datum/ship_inertial_damper` is intended to be a generic type implementing shared behavior, the unused helper is preferred, but it must first be implemented.

However, currently `/datum/ship_inertial_damper` is too tightly coupled with `/obj/machinery/inertial_damper` for it to be reusable as-intended. To improve this, it has been made _more_ application-specific by specifying the type of the `holder` variable as `/obj/machinery/inertial_damper`. This makes future extension easier by making the dependency explicit, while avoiding the introduction of premature complexity.

One- and two-letter variable names in the inertial damper modpack have also been renamed for clarity and maintainability.