### PR TITLE
Implement lock_complexity var for lock preset landmarks

### DIFF
--- a/code/modules/locks/lock.dm
+++ b/code/modules/locks/lock.dm
@@ -5,13 +5,14 @@
 	name = "locked door"
 	var/lock_preset_id  = "default"
 	var/lock_material   = /decl/material/solid/metal/iron
+	/// If lock_preset_id is null, a random key with this complexity will be generated instead.
 	var/lock_complexity = 1
 
 /obj/abstract/landmark/lock_preset/Initialize()
 	..()
 	for(var/obj/structure/thing in loc)
 		if(!thing.lock && thing.can_install_lock())
-			thing.lock = new /datum/lock(thing, lock_preset_id, lock_material)
+			thing.lock = new /datum/lock(thing, lock_preset_id || lock_complexity, lock_material)
 			thing.update_icon()
 	return INITIALIZE_HINT_QDEL
 


### PR DESCRIPTION
## Description of changes
If `lock_preset_id` on a lock preset landmark is unset, `lock_complexity` will be passed instead, which causes a random lock with the specified length (complexity) to be used. A doc comment has been added to the `var/lock_complexity` variable on `/obj/abstract/landmark/lock_preset` to explain this functionality.

## Why and what will this PR improve
The `lock_complexity` variable is now used.