### PR TITLE
Clean up unused antagonist code on special_role and mind

### DIFF
--- a/code/controllers/subsystems/ticker.dm
+++ b/code/controllers/subsystems/ticker.dm
@@ -315,7 +315,7 @@ Helpers
 /datum/controller/subsystem/ticker/proc/attempt_late_antag_spawn(var/list/antag_choices)
 	var/decl/special_role/antag = antag_choices[1]
 	while(antag_choices.len && antag)
-		var/needs_ghost = antag.flags & (ANTAG_OVERRIDE_JOB | ANTAG_OVERRIDE_MOB)
+		var/needs_ghost = antag.is_latejoin_template()
 		if (needs_ghost)
 			looking_for_antags = 1
 			antag_pool.Cut()

--- a/code/datums/mind/mind.dm
+++ b/code/datums/mind/mind.dm
@@ -449,20 +449,6 @@
 	if(H)
 		qdel(H)
 
-
-// check whether this mind's mob has been brigged for the given duration
-// have to call this periodically for the duration to work properly
-/datum/mind/proc/is_brigged(duration)
-	var/area/A = get_area(current)
-	if(!isturf(current.loc) || !istype(A) || !(A.area_flags & AREA_FLAG_PRISON) || current.GetIdCard())
-		brigged_since = -1
-		return 0
-
-	if(brigged_since == -1)
-		brigged_since = world.time
-
-	return (duration <= world.time - brigged_since)
-
 /datum/mind/proc/reset()
 	assigned_role =         null
 	assigned_special_role = null

--- a/code/datums/mind/mind.dm
+++ b/code/datums/mind/mind.dm
@@ -46,12 +46,8 @@
 
 	var/list/datum/objective/objectives = list()
 
-	var/has_been_rev = 0//Tracks if this mind has been a rev or not
-
-	var/rev_cooldown = 0
-
-	// the world.time since the mob has been brigged, or -1 if not at all
-	var/brigged_since = -1
+	/// The world.time value after which another conversion can be attempted.
+	var/conversion_cooldown = 0
 
 	//put this here for easier tracking ingame
 	var/datum/money_account/initial_account
@@ -456,9 +452,7 @@
 	assigned_job =          null
 	initial_account =       null
 	objectives =            list()
-	has_been_rev =          0
-	rev_cooldown =          0
-	brigged_since =         -1
+	conversion_cooldown =   0
 
 //Initialisation procs
 /mob/living/proc/mind_initialize()

--- a/code/game/antagonist/antagonist.dm
+++ b/code/game/antagonist/antagonist.dm
@@ -193,7 +193,7 @@
 
 /decl/special_role/proc/attempt_random_spawn()
 	update_current_antag_max(SSticker.mode)
-	build_candidate_list(SSticker.mode, flags & (ANTAG_OVERRIDE_MOB|ANTAG_OVERRIDE_JOB))
+	build_candidate_list(SSticker.mode, is_latejoin_template())
 	attempt_spawn()
 	finalize_spawn()
 
@@ -209,7 +209,7 @@
 		message_admins("Could not auto-spawn a [name], active antag limit reached.")
 		return 0
 
-	build_candidate_list(SSticker.mode, flags & (ANTAG_OVERRIDE_MOB|ANTAG_OVERRIDE_JOB))
+	build_candidate_list(SSticker.mode, is_latejoin_template())
 	if(!candidates.len)
 		message_admins("Could not auto-spawn a [name], no candidates found.")
 		return 0

--- a/code/game/antagonist/antagonist.dm
+++ b/code/game/antagonist/antagonist.dm
@@ -140,9 +140,6 @@
 /decl/special_role/proc/get_leader_welcome_text(mob/recipient)
 	return leader_welcome_text
 
-/decl/special_role/proc/tick()
-	return 1
-
 // Get the raw list of potential players.
 /decl/special_role/proc/build_candidate_list(decl/game_mode/mode, ghosts_only)
 	candidates = list() // Clear.

--- a/code/game/antagonist/antagonist_factions.dm
+++ b/code/game/antagonist/antagonist_factions.dm
@@ -18,7 +18,7 @@
 		to_chat(src, "<span class='warning'>\The [player.current] cannot be \a [faction.faction_name]!</span>")
 		return
 
-	if(world.time < player.rev_cooldown)
+	if(world.time < player.conversion_cooldown)
 		to_chat(src, "<span class='danger'>You must wait five seconds between attempts.</span>")
 		return
 
@@ -26,7 +26,7 @@
 	log_admin("[src]([src.ckey]) attempted to convert [player.current] to the [faction.faction_name] faction.")
 	message_admins("<span class='danger'>[src]([src.ckey]) attempted to convert [player.current] to the [faction.faction_name] faction.</span>")
 
-	player.rev_cooldown = world.time + 5 SECONDS
+	player.conversion_cooldown = world.time + 5 SECONDS
 	if (!faction.is_antagonist(player))
 		var/choice = alert(player.current,"Asked by [src]: Do you want to join the [faction.faction_descriptor]?","Join the [faction.faction_descriptor]?","No!","Yes!")
 		if(!(player.current in able_mobs_in_oview(src)))

--- a/code/game/world_topic_commands.dm
+++ b/code/game/world_topic_commands.dm
@@ -263,7 +263,6 @@
 		info["turf"] = MT ? "[MT] @ [MT.x], [MT.y], [MT.z]" : "null"
 		info["area"] = MT ? "[MT.loc]" : "null"
 		info["antag"] = M.mind ? (M.mind.get_special_role_name("Not antag")) : "No mind"
-		info["hasbeenrev"] = M.mind ? M.mind.has_been_rev : "No mind"
 		info["stat"] = M.stat
 		info["type"] = M.type
 		if(isliving(M))

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -910,9 +910,9 @@
 
 		//Job + antagonist
 		if(M.mind)
-			special_role_description = "Role: <b>[M.mind.assigned_role]</b>; Antagonist: <font color='red'><b>[M.mind.get_special_role_name("unknown role")]</b></font>; Has been rev: [(M.mind.has_been_rev)?"Yes":"No"]"
+			special_role_description = "Role: <b>[M.mind.assigned_role]</b>; Antagonist: <font color='red'><b>[M.mind.get_special_role_name("unknown role")]</b></font>"
 		else
-			special_role_description = "Role: <i>Mind datum missing</i> Antagonist: <i>Mind datum missing</i>; Has been rev: <i>Mind datum missing</i>;"
+			special_role_description = "Role: <i>Mind datum missing</i> Antagonist: <i>Mind datum missing</i>"
 
 		//Health
 		if(isliving(M))


### PR DESCRIPTION
## Description of changes
Cleans up and/or implements unused code related to antagonists.

## Why and what will this PR improve
`/datum/mind/proc/is_brigged()` is a legacy helper that is now unused and irrelevant to the present state of the game. It should be removed to improve maintainability and avoid confusion.
`/decl/special_role/proc/tick()` is unused and not called anywhere, and ticking special roles are no longer supported. To avoid issues with subtypes overriding this unused method and getting unexpected results, the method should be removed entirely.
`/decl/special_role/proc/is_latejoin_template()` exists but is unused. Several checks that are identical to its definition exist in the code. They have been replaced with `is_latejoin_template()` to reduce redundancy and make future extension easier.