### PR TITLE
Remove some entirely-unused defunct variables

### DIFF
--- a/code/game/machinery/_machines_base/stock_parts/cupholder.dm
+++ b/code/game/machinery/_machines_base/stock_parts/cupholder.dm
@@ -7,7 +7,6 @@
 	part_flags = PART_FLAG_HAND_REMOVE
 	place_verb = "place"
 	eject_handler = /decl/interaction_handler/remove_held_item/cup
-	var/image/cupholder_overlay
 	var/obj/item/cup
 
 /obj/item/stock_parts/item_holder/cupholder/Destroy()

--- a/code/game/machinery/_machines_base/stock_parts/network_lock.dm
+++ b/code/game/machinery/_machines_base/stock_parts/network_lock.dm
@@ -21,7 +21,6 @@
 
 	var/interact_sounds = list("keyboard", "keystroke")
 	var/interact_sound_volume = 40
-	var/static/legacy_compatibility_mode = TRUE     // Makes legacy access on ids play well with mapped devices with network locks. Override if your server is fully using network-enabled ids or has no mapped access.
 
 /obj/item/stock_parts/network_receiver/network_lock/modify_mapped_vars(map_hash)
 	..()

--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -845,7 +845,6 @@ FIRE ALARM
 	var/time =         1 SECOND
 	var/timing =       FALSE
 	var/last_process = 0
-	var/static/list/overlays_cache
 
 	var/sound_id
 	var/datum/sound_token/sound_token

--- a/code/game/machinery/embedded_controller/embedded_controller_base.dm
+++ b/code/game/machinery/embedded_controller/embedded_controller_base.dm
@@ -61,8 +61,6 @@
 	var/tmp/screen_state    = "screen_standby"
 	///Bitflag to indicate which indicator lights are on so dummy controllers can match the same state
 	var/tmp/indicator_state = 0
-	///If set, this controller will route its commands to the master controller with the same id_tag.
-	var/obj/machinery/embedded_controller/radio/master
 	///Radio connection to use for emiting commands
 	var/datum/radio_frequency/radio_connection
 

--- a/code/game/machinery/turret_control.dm
+++ b/code/game/machinery/turret_control.dm
@@ -20,7 +20,6 @@
 	var/lethal = 0
 	var/locked = 1
 	var/area/control_area //can be area name, path or nothing.
-	var/mob/living/silicon/ai/master_ai
 
 	var/check_arrest = 1	//checks if the perp is set to arrest
 	var/check_records = 1	//checks if a security record exists at all

--- a/code/game/machinery/turrets/_turrets.dm
+++ b/code/game/machinery/turrets/_turrets.dm
@@ -23,10 +23,6 @@
 	var/image/transverse_left // Images for displaying the range of the turret's transverse
 	var/image/transverse_right
 
-	// Sounds
-	var/turn_on_sound = null // Played when turret goes from off to on.
-	var/turn_off_sound = null // The above, in reverse.
-
 	// Shooting
 	var/obj/item/gun/installed_gun = /obj/item/gun/energy/laser/practice // Instance of the gun inside the turret.
 	var/gun_looting_prob = 25 // If the turret dies and then is disassembled, this is the odds of getting the gun.

--- a/code/game/objects/effects/wet_floor.dm
+++ b/code/game/objects/effects/wet_floor.dm
@@ -5,7 +5,6 @@
 	mouse_opacity = MOUSE_OPACITY_UNCLICKABLE
 	simulated = FALSE
 	var/wetness = 0
-	var/image/wet_overlay = null
 	var/wet_timer_id
 
 /atom/movable/wet_floor/Initialize()

--- a/code/game/objects/items/devices/chameleonproj.dm
+++ b/code/game/objects/items/devices/chameleonproj.dm
@@ -103,7 +103,6 @@
 	anchored = TRUE
 	is_spawnable_type = FALSE
 	movement_handlers = list(/datum/movement_handler/delay/chameleon_projector)
-	var/can_move = TRUE
 	var/obj/item/chameleon/master = null
 
 /obj/effect/dummy/chameleon/Initialize(mapload, var/obj/item/chameleon/projector)

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -56,7 +56,6 @@
 	var/broadcasting = FALSE
 	var/listening = TRUE
 	var/list/channels
-	var/default_color = "#6d3f40"
 	var/decrypt_all_messages = FALSE
 	var/can_use_analog = TRUE
 	var/datum/extension/network_device/radio/radio_device_type = /datum/extension/network_device/radio

--- a/code/game/objects/random/subtypes/misc.dm
+++ b/code/game/objects/random/subtypes/misc.dm
@@ -117,7 +117,6 @@
 	desc = "This is some random junk."
 	icon = 'icons/obj/items/storage/trashbag.dmi'
 	icon_state = "trashbag3"
-	var/spawn_choice
 
 /obj/random/junk/spawn_choices()
 	var/static/list/spawnable_choices

--- a/code/game/objects/structures/fires.dm
+++ b/code/game/objects/structures/fires.dm
@@ -57,7 +57,6 @@
 	var/light_color_low =  "#ff0000"
 
 	var/list/affected_exterior_turfs
-	var/next_fuel_consumption = 0
 	var/last_fuel_burn_temperature = T20C
 	// TODO: Replace this and the fuel var with just tracking currently-burning matter?
 	// Or use atom fires when those are implemented?

--- a/code/game/objects/structures/tables.dm
+++ b/code/game/objects/structures/tables.dm
@@ -26,7 +26,6 @@
 	var/can_flip = TRUE
 	var/is_flipped = FALSE
 	var/decl/material/additional_reinf_material
-	var/base_type = /obj/structure/table
 
 	var/top_surface_noun = "tabletop"
 

--- a/code/modules/backgrounds/citizenship/_citizenship.dm
+++ b/code/modules/backgrounds/citizenship/_citizenship.dm
@@ -1,7 +1,6 @@
 /decl/background_detail/citizenship
 	abstract_type = /decl/background_detail/citizenship
 	category = /decl/background_category/citizenship
-	var/ruling_body = "Other Faction"
 	var/capital
 	var/size_heading = "Systems"
 	var/size_value

--- a/code/modules/client/client_defines.dm
+++ b/code/modules/client/client_defines.dm
@@ -34,7 +34,6 @@
 
 	//IRC admin that spoke with them last.
 	var/irc_admin
-	var/mute_irc = 0
 
 	// Prevents people from being spammed about multikeying every time their mob changes.
 	var/warned_about_multikeying = 0

--- a/code/modules/clothing/spacesuits/rig/modules/infiltration.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/infiltration.dm
@@ -185,7 +185,6 @@
 	interface_name = "dead man's switch"
 	interface_desc = "An integrated automatic self-destruct module. When the wearer dies, so does the surrounding area. Can be triggered manually."
 	var/list/explosion_values = list(1,2,4,5)
-	var/blinking = 0
 	var/blink_mode = 0
 	var/blink_delay = 10
 	var/blink_time = 40

--- a/code/modules/clothing/suits/_suit.dm
+++ b/code/modules/clothing/suits/_suit.dm
@@ -11,7 +11,6 @@
 	valid_accessory_slots = list(ACCESSORY_SLOT_ARMBAND, ACCESSORY_SLOT_OVER)
 	fallback_slot = slot_wear_suit_str
 	var/protects_against_weather = FALSE
-	var/fire_resist = T0C+100
 
 /obj/item/clothing/suit/gives_weather_protection()
 	return protects_against_weather

--- a/code/modules/codex/codex_cataloguer.dm
+++ b/code/modules/codex/codex_cataloguer.dm
@@ -22,8 +22,6 @@
 	var/scan_speed_modifier = 1
 	/// How many tiles away it can scan. Changing this also changes the box size.
 	var/scan_range = 3
-	/// If another person is within this radius, they will also be credited with a successful scan.
-	var/credit_sharing_range = 14
 	/// How much to make the next scan shorter.
 	var/tmp/partial_scan_time = 0
 	/// Weakref of the thing that was last scanned if inturrupted. Used to allow for partial scans to be resumed.

--- a/code/modules/lighting/lighting_corner.dm
+++ b/code/modules/lighting/lighting_corner.dm
@@ -61,9 +61,6 @@ var/global/list/REVERSE_LIGHTING_CORNER_DIAGONAL = list(0, 0, 0, 0, 3, 4, 0, 0, 
 	var/cache_b  = 0
 	var/cache_mx = 0
 
-	/// Used for planet lighting. Probably needs a better system to prevent over-updating when not needed at some point.
-	var/update_gen = 0
-
 /datum/lighting_corner/New(turf/new_turf, diagonal, oi)
 	SSlighting.total_lighting_corners += 1
 

--- a/code/modules/mob/living/simple_animal/_simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/_simple_animal.dm
@@ -81,7 +81,6 @@
 	var/return_damage_min
 	var/return_damage_max
 
-	var/performing_delayed_life_action = FALSE
 	var/glowing_eyes = FALSE
 	var/mob_icon_state_flags = 0
 


### PR DESCRIPTION
All of these variables are entirely-unused and implementing them was undesirable for whatever reason.
- `cupholder_overlay` needs sprites and lots of supporting code to be implemented
- `legacy_compatibility_mode` is just unexplained and unused (maybe an Outreach thing?)
- `overlays_cache` is probably unnecessary now that we have managed overlays
- `master_ai` is unused since malf got removed
- `turn_on_sound` and `turn_off_sound` are defunct because individual turret state machine states have their own transition noises
- `master` is entirely unused (not to be confused with the `master` variable on embedded programs)
- `wet_overlay` is entirely unused
- `can_move` was used to implement a move delay that's now implemented using an actual move delay handler
- radio `default_color` is unused because analog comms all have one color
- `spawn_choice` is just entirely unused
- `next_fuel_consumption` is entirely unused
- `base_type` on tables is unused (and while I see where it could've been used, it doesn't actually seem necessary)
- citizenship `ruling_body` was just copied from location and is unused
- `mute_irc` is defunct and unused
- `blinking` is unused and unnecessary
- `fire_resist` has been unused **_SINCE LITERALLY R4407 APPARENTLY_**
- `credit_sharing_range` doesn't work with our cataloguer data disk point format I'm pretty sure
- `update_gen` is very unused and was accidentally taken from CitRP in a lighting update
- `performing_delayed_life_action` is entirely unused