### PR TITLE
Implement initial network ID and key on network receivers

### DIFF
--- a/code/game/machinery/_machines_base/stock_parts/network_lock.dm
+++ b/code/game/machinery/_machines_base/stock_parts/network_lock.dm
@@ -8,8 +8,6 @@
 	base_type = /obj/item/stock_parts/network_receiver/network_lock
 
 	var/auto_deny_all								// Set this to TRUE to deny all access attempts if network connection is lost.
-	var/initial_network_id							// The address to the network
-	var/initial_network_key							// network KEY
 	var/selected_parent_group						// Current selected parent_group for access assignment.
 
 	var/list/groups									// List of lists of groups. In order to access the device, users must have membership in at least one
@@ -22,10 +20,6 @@
 	var/interact_sounds = list("keyboard", "keystroke")
 	var/interact_sound_volume = 40
 	var/static/legacy_compatibility_mode = TRUE     // Makes legacy access on ids play well with mapped devices with network locks. Override if your server is fully using network-enabled ids or has no mapped access.
-
-/obj/item/stock_parts/network_receiver/network_lock/modify_mapped_vars(map_hash)
-	..()
-	ADJUST_TAG_VAR(initial_network_id, map_hash)
 
 /obj/item/stock_parts/network_receiver/network_lock/emag_act(remaining_charges, mob/user, emag_source)
 	. = ..()

--- a/code/game/machinery/_machines_base/stock_parts/network_receiver.dm
+++ b/code/game/machinery/_machines_base/stock_parts/network_receiver.dm
@@ -8,7 +8,7 @@
 	var/initial_network_id  // The address to the network
 	var/initial_network_key // network KEY
 
-/obj/item/stock_parts/network_receiver/network_lock/modify_mapped_vars(map_hash)
+/obj/item/stock_parts/network_receiver/modify_mapped_vars(map_hash)
 	..()
 	ADJUST_TAG_VAR(initial_network_id, map_hash)
 	ADJUST_TAG_VAR(initial_network_key, map_hash)

--- a/code/game/machinery/_machines_base/stock_parts/network_receiver.dm
+++ b/code/game/machinery/_machines_base/stock_parts/network_receiver.dm
@@ -5,10 +5,17 @@
 	desc = "A network receiver designed for use with machinery otherwise disconnected from a network."
 	icon_state = "net_lock"
 	part_flags = PART_FLAG_QDEL
+	var/initial_network_id  // The address to the network
+	var/initial_network_key // network KEY
+
+/obj/item/stock_parts/network_receiver/network_lock/modify_mapped_vars(map_hash)
+	..()
+	ADJUST_TAG_VAR(initial_network_id, map_hash)
+	ADJUST_TAG_VAR(initial_network_key, map_hash)
 
 /obj/item/stock_parts/network_receiver/Initialize(ml, material_key)
 	. = ..()
-	set_extension(src, /datum/extension/network_device/stock_part)
+	set_extension(src, /datum/extension/network_device/stock_part, initial_network_id, initial_network_key)
 
 /obj/item/stock_parts/network_receiver/on_install(obj/machinery/machine)
 	. = ..()

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -96,6 +96,11 @@
 	if(analog && frequency)
 		analog_radio_connection = radio_controller.add_object(src, frequency, RADIO_CHAT)
 
+/obj/item/radio/modify_mapped_vars(map_hash)
+	..()
+	ADJUST_TAG_VAR(initial_network_id, map_hash)
+	ADJUST_TAG_VAR(initial_network_key, map_hash)
+
 /obj/item/radio/Initialize()
 	. = ..()
 	wires = new(src)

--- a/code/modules/fabrication/_fabricator.dm
+++ b/code/modules/fabrication/_fabricator.dm
@@ -96,6 +96,7 @@
 /obj/machinery/fabricator/modify_mapped_vars(map_hash)
 	..()
 	ADJUST_TAG_VAR(initial_network_id, map_hash)
+	ADJUST_TAG_VAR(initial_network_key, map_hash)
 
 /obj/machinery/fabricator/handle_post_network_connection()
 	..()

--- a/code/modules/research/design_console.dm
+++ b/code/modules/research/design_console.dm
@@ -26,6 +26,7 @@
 /obj/machinery/computer/design_console/modify_mapped_vars(map_hash)
 	..()
 	ADJUST_TAG_VAR(initial_network_id, map_hash)
+	ADJUST_TAG_VAR(initial_network_key, map_hash)
 
 /obj/machinery/computer/design_console/RefreshParts()
 	. = ..()

--- a/code/modules/research/design_database.dm
+++ b/code/modules/research/design_database.dm
@@ -106,6 +106,7 @@ var/global/list/default_initial_tech_levels
 /obj/machinery/design_database/modify_mapped_vars(map_hash)
 	..()
 	ADJUST_TAG_VAR(initial_network_id, map_hash)
+	ADJUST_TAG_VAR(initial_network_key, map_hash)
 
 /obj/machinery/design_database/handle_post_network_connection()
 	..()

--- a/code/modules/research/design_database_analyzer.dm
+++ b/code/modules/research/design_database_analyzer.dm
@@ -23,6 +23,7 @@
 /obj/machinery/destructive_analyzer/modify_mapped_vars(map_hash)
 	..()
 	ADJUST_TAG_VAR(initial_network_id, map_hash)
+	ADJUST_TAG_VAR(initial_network_key, map_hash)
 
 /obj/machinery/destructive_analyzer/RefreshParts()
 	var/T = 0


### PR DESCRIPTION
Implements `initial_network_id` and `initial_network_key` on network receiver stock parts (moved up from network lock stock parts, since network receivers handle the creation of the extension anyway). Also fixes research machinery not updating their mapped vars based on the map hash, which would make them out of sync with `/obj/machinery/network`.
- [ ] Tested