### PR TITLE
Generalize stat organ code from drakes

### DIFF
--- a/code/modules/mob/living/human/human_organs.dm
+++ b/code/modules/mob/living/human/human_organs.dm
@@ -74,6 +74,10 @@
 		LAZYINITLIST(organs_by_category)
 		LAZYDISTINCTADD(organs_by_category[O.organ_category], O)
 
+	// Update stat organs as well
+	if(O.has_stat_info)
+		LAZYDISTINCTADD(stat_organs, O)
+
 	. = ..()
 	if(!.)
 		return
@@ -112,6 +116,10 @@
 		organs_by_category[O.organ_category] -= O
 		if(LAZYLEN(organs_by_category[O.organ_category]) <= 0)
 			LAZYREMOVE(organs_by_category, O.organ_category)
+
+	// Update stat organs as well
+	if(O.has_stat_info && stat_organs)
+		LAZYREMOVE(stat_organs, O)
 
 	if(!O.is_internal())
 		refresh_modular_limb_verbs()

--- a/code/modules/organs/organ.dm
+++ b/code/modules/organs/organ.dm
@@ -55,8 +55,8 @@
 	/// Whether or not we should scale the damage values of this organ to the owner species.
 	var/scale_max_damage_to_species_health
 
-	/// Set to true if this organ should return info to Stat(). See get_stat_info().
-	var/has_stat_info
+	/// Set to TRUE if this organ should return info to Stat(). See get_stat_info().
+	var/has_stat_info = FALSE
 
 /obj/item/organ/proc/reset_matter()
 	matter = null
@@ -687,7 +687,7 @@ var/global/list/ailment_reference_cache = list()
 		place_butcher_product(GET_DECL(species.butchery_data))
 	return ..()
 
-/// Returns a list with two entries, first being the stat panel title, the second being the value. See has_stat_value bool above.
+/// Returns a list with two entries, first being the stat panel title, the second being the value. See has_stat_info bool above.
 /obj/item/organ/proc/get_stat_info()
 	return null
 

--- a/mods/species/drakes/drake_organs.dm
+++ b/mods/species/drakes/drake_organs.dm
@@ -11,6 +11,7 @@
 	relative_size = 60
 	min_regeneration_cutoff_threshold = 2
 	max_regeneration_cutoff_threshold = 5
+	has_stat_info = TRUE
 	var/datum/reagents/sap_crop
 
 /obj/item/organ/internal/drake_gizzard/Initialize()
@@ -22,14 +23,7 @@
 	if(owner && owner.stat != DEAD && !is_broken() && sap_crop && sap_crop.total_volume < 10)
 		sap_crop.add_reagent(/decl/material/liquid/sifsap, 0.5)
 
-/obj/item/organ/internal/drake_gizzard/do_install(var/mob/living/human/target, var/obj/item/organ/external/affected, var/in_place = FALSE, var/update_icon = TRUE, var/detached = FALSE)
-	. = ..()
-	if(owner)
-		LAZYDISTINCTADD(owner.stat_organs, src)
-
 /obj/item/organ/internal/drake_gizzard/do_uninstall(in_place, detach, ignore_children, update_icon)
-	if(owner)
-		LAZYREMOVE(owner.stat_organs, src)
 	. = ..()
 	if(sap_crop?.total_volume)
 		if(reagents)


### PR DESCRIPTION
Moves `stat_organs` handling off of drake gizzards and onto organ code. handled similarly to `organs_by_category`. Also implements `has_stat_info` in the process.
- [x] Tested