### PR TITLE
Replace deprecated bodytype `has_eyes` variable

### DIFF
--- a/code/modules/bodytype/_bodytype.dm
+++ b/code/modules/bodytype/_bodytype.dm
@@ -53,8 +53,6 @@ var/global/list/bodytypes_by_category = list()
 	var/nail_noun
 	/// What tech levels should limbs of this type use/need?
 	var/limb_tech            = @'{"biotech":2}'
-	/// Determines if eyes should render on heads using this bodytype.
-	var/has_eyes             = TRUE
 	/// Prefixed to the initial name of the limb, if non-null.
 	var/modifier_string
 	/// Modifies min and max broken damage for the limb.
@@ -231,7 +229,7 @@ var/global/list/bodytypes_by_category = list()
 	var/eye_contaminant_guard       = 0
 	/// Are the eyes of this bodytype resistant to flashes?
 	var/eye_innate_flash_protection = FLASH_PROTECTION_NONE
-	/// Icon to draw eye overlays from.
+	/// Icon to draw eye overlays from. If null, eyes will not be drawn.
 	var/eye_icon                    = 'icons/mob/human_races/species/default_eyes.dmi'
 	/// Do the eyes of this mob apply a pref colour like hair?
 	var/apply_eye_colour            = TRUE

--- a/mods/content/corporate/datum/robolimbs.dm
+++ b/mods/content/corporate/datum/robolimbs.dm
@@ -13,7 +13,7 @@
 	name = "Bishop Rook"
 	desc = "This limb has a polished metallic casing and a holographic face emitter."
 	icon_base = 'mods/content/corporate/icons/cyberlimbs/bishop/bishop_rook.dmi'
-	has_eyes = FALSE
+	eye_icon = null // Do not draw eyes.
 	bodytype_category = BODYTYPE_HUMANOID
 	organ_material = /decl/material/solid/metal/steel
 	matter = list(
@@ -32,7 +32,7 @@
 	name = "Hephaestus Titan"
 	desc = "This limb has a casing of an olive drab finish, providing a reinforced housing look."
 	icon_base = 'mods/content/corporate/icons/cyberlimbs/hephaestus/hephaestus_titan.dmi'
-	has_eyes = FALSE
+	eye_icon = null // Do not draw eyes.
 	bodytype_category = BODYTYPE_HUMANOID
 	uid = "bodytype_prosthetic_hephaestus_titan"
 
@@ -88,7 +88,7 @@
 	name = "Morpheus Mantis"
 	desc = "This limb has a casing of sleek black metal and repulsive insectile design."
 	icon_base = 'mods/content/corporate/icons/cyberlimbs/morpheus/morpheus_mantis.dmi'
-	has_eyes = FALSE
+	eye_icon = null // Do not draw eyes.
 	uid = "bodytype_prosthetic_morpheus_mantis"
 
 /decl/bodytype/prosthetic/veymed


### PR DESCRIPTION
Replaces `has_eyes = FALSE` with `eye_icon = null`, which actually works. Also adds comments explaining this usage.