### PR TITLE
Replace defunct show_reagent_name variable

### DIFF
--- a/code/game/objects/items/welding/weldingtool_tank.dm
+++ b/code/game/objects/items/welding/weldingtool_tank.dm
@@ -11,7 +11,7 @@
 	atom_flags         = ATOM_FLAG_OPEN_CONTAINER
 	obj_flags          = OBJ_FLAG_HOLLOW
 	volume             = 20
-	show_reagent_name  = TRUE
+	presentation_flags = PRESENTATION_FLAG_NAME
 	current_health     = 40
 	max_health         = 40
 	material           = /decl/material/solid/metal/steel
@@ -123,7 +123,7 @@
 	size_in_use        = ITEM_SIZE_LARGE
 	unlit_force        = 9
 	lit_force          = 15
-	show_reagent_name  = FALSE
+	presentation_flags = 0
 	_base_attack_force = 8
 	var/tmp/last_gen   = 0
 

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -14,7 +14,6 @@
 	var/volume = 30
 	var/label_text
 	var/presentation_flags = 0
-	var/show_reagent_name = FALSE
 	var/detail_color
 	var/detail_state
 


### PR DESCRIPTION
This was replaced with presentation_flags, but I think merge skew meant it wasn't ever fully removed?