### PR TITLE
Add support for saltwater turfs

### DIFF
--- a/code/controllers/subsystems/fluids.dm
+++ b/code/controllers/subsystems/fluids.dm
@@ -71,7 +71,10 @@ SUBSYSTEM_DEF(fluids)
 				continue
 			checked_targets[neighbor] = TRUE
 			flooded_a_neighbor = TRUE
-			neighbor.add_to_reagents(current_fluid_holder.flooded, FLUID_MAX_DEPTH)
+			if(current_fluid_holder.contaminant_reagent_type && current_fluid_holder.contaminant_proportion)
+				neighbor.add_to_reagents_contaminated(current_fluid_holder.flooded, FLUID_MAX_DEPTH, contaminant_type = current_fluid_holder.contaminant_reagent_type, contaminant_proportion = current_fluid_holder.contaminant_proportion)
+			else
+				neighbor.add_to_reagents(current_fluid_holder.flooded, FLUID_MAX_DEPTH)
 
 		if(!flooded_a_neighbor)
 			REMOVE_ACTIVE_FLUID_SOURCE(current_fluid_holder)

--- a/code/game/turfs/flooring/flooring_path.dm
+++ b/code/game/turfs/flooring/flooring_path.dm
@@ -16,7 +16,7 @@
 	var/paver_noun = "stones"
 
 /decl/flooring/path/update_turf_strings(turf/floor/target)
-	var/decl/material/floor_material = target?.get_material()
+	var/decl/material/floor_material = RESOLVE_TO_DECL(target?.get_material())
 	ASSERT(floor_material?.adjective_name)
 	ASSERT(paver_noun)
 	target.SetName("[floor_material.adjective_name] [name]")

--- a/code/game/turfs/flooring/flooring_rock.dm
+++ b/code/game/turfs/flooring/flooring_rock.dm
@@ -10,7 +10,7 @@
 	uid             = "floor_reinf_shuttle_rock"
 
 /decl/flooring/rock/update_turf_strings(turf/floor/target)
-	var/decl/material/turf_material = target?.get_material()
+	var/decl/material/turf_material = RESOLVE_TO_DECL(target?.get_material())
 	ASSERT(turf_material?.adjective_name)
 	target.SetName("[turf_material.adjective_name] [name]")
 	target.desc = "An expanse of bare [turf_material.solid_name]."

--- a/code/game/turfs/floors/_floor.dm
+++ b/code/game/turfs/floors/_floor.dm
@@ -11,7 +11,7 @@
 	zone_membership_candidate = TRUE
 	open_turf_type = /turf/open/airless
 
-	// Reagent to use to fill the turf.
+	/// Reagent to use to refill trenches to capacity automatically.
 	var/fill_reagent_type
 	var/can_engrave = TRUE
 
@@ -69,7 +69,12 @@
 	var/my_height = get_physical_height()
 	if(fill_reagent_type && my_height < 0 && (!reagents || !QDELING(reagents)) && REAGENT_TOTAL_VOLUME(reagents) < abs(my_height))
 		var/reagents_to_add = abs(my_height) - REAGENT_TOTAL_VOLUME(reagents)
-		add_to_reagents(fill_reagent_type, reagents_to_add, phase = MAT_PHASE_LIQUID)
+		var/contaminant_to_add = 0
+		if(contaminant_reagent_type)
+			contaminant_to_add = CHEMS_QUANTIZE(reagents_to_add * contaminant_proportion)
+		add_to_reagents(fill_reagent_type, reagents_to_add - contaminant_to_add, phase = MAT_PHASE_LIQUID, defer_update = !!contaminant_to_add)
+		if(contaminant_to_add)
+			add_to_reagents(contaminant_reagent_type, contaminant_to_add, phase = MAT_PHASE_LIQUID)
 
 /turf/floor/can_climb_from_below(var/mob/climber)
 	return TRUE

--- a/code/game/turfs/floors/_floor.dm
+++ b/code/game/turfs/floors/_floor.dm
@@ -76,6 +76,11 @@
 		if(contaminant_to_add)
 			add_to_reagents(contaminant_reagent_type, contaminant_to_add, phase = MAT_PHASE_LIQUID)
 
+/turf/floor/get_examine_strings(mob/user, distance, infix, suffix)
+	. = ..()
+	if(check_fluid_depth(FLUID_SHALLOW))
+		. += SPAN_NOTICE("It has a pool of [get_fluid_name()].")
+
 /turf/floor/can_climb_from_below(var/mob/climber)
 	return TRUE
 

--- a/code/game/turfs/floors/floor_icon.dm
+++ b/code/game/turfs/floors/floor_icon.dm
@@ -128,6 +128,9 @@
 	else
 		SetName(initial(name))
 		desc = initial(desc)
+	// do this once name and desc have been updated
+	if(check_fluid_depth(FLUID_SHALLOW))
+		SetName(get_fluid_name()) // just entirely overwrite name, but keep desc
 
 /turf/floor/proc/update_floor_icon()
 	var/decl/flooring/use_flooring = get_topmost_flooring()

--- a/code/game/turfs/floors/floor_icon.dm
+++ b/code/game/turfs/floors/floor_icon.dm
@@ -123,8 +123,7 @@
 /turf/floor/proc/update_floor_strings()
 	var/decl/flooring/flooring = get_topmost_flooring()
 	if(istype(flooring))
-		SetName(flooring.name)
-		desc = flooring.desc
+		flooring.update_turf_strings(src)
 	else
 		SetName(initial(name))
 		desc = initial(desc)

--- a/code/game/turfs/floors/subtypes/floor_concrete.dm
+++ b/code/game/turfs/floors/subtypes/floor_concrete.dm
@@ -13,6 +13,10 @@
 	flooded        = /decl/material/liquid/water
 	color          = COLOR_LIQUID_WATER
 
+/turf/floor/concrete/flooded/salt
+	contaminant_reagent_type = /decl/material/solid/sodiumchloride
+	contaminant_proportion = 0.10 // 1:10 salt:water, NOT 10% salt
+
 /turf/floor/concrete/reinforced
 	name           = "reinforced concrete"
 	icon_state     = "hexacrete"

--- a/code/game/turfs/floors/subtypes/floor_natural.dm
+++ b/code/game/turfs/floors/subtypes/floor_natural.dm
@@ -85,12 +85,24 @@
 	height            = -(FLUID_SHALLOW)
 	fill_reagent_type = /decl/material/liquid/water
 
+/turf/floor/mud/water/salt
+	contaminant_reagent_type = /decl/material/solid/sodiumchloride
+	contaminant_proportion = 0.10 // 1:10 salt:water, NOT 10% salt
+
 /turf/floor/mud/water/deep
 	color             = COLOR_BLUE
 	height            = -(FLUID_DEEP)
 
+/turf/floor/mud/water/deep/salt
+	contaminant_reagent_type = /decl/material/solid/sodiumchloride
+	contaminant_proportion = 0.10 // 1:10 salt:water
+
 /turf/floor/mud/flooded
 	flooded           = /decl/material/liquid/water
+
+/turf/floor/mud/flooded/salt
+	contaminant_reagent_type = /decl/material/solid/sodiumchloride
+	contaminant_proportion = 0.10 // 1:10 salt:water
 
 /turf/floor/dry
 	name              = "dry mud"
@@ -117,9 +129,17 @@
 	height            = -(FLUID_SHALLOW)
 	fill_reagent_type = /decl/material/liquid/water
 
+/turf/floor/rock/sand/water/salt
+	contaminant_reagent_type = /decl/material/solid/sodiumchloride
+	contaminant_proportion = 0.10 // 1:10 salt:water
+
 /turf/floor/rock/sand/water/deep
 	color             = COLOR_BLUE
 	height            = -(FLUID_DEEP)
+
+/turf/floor/rock/sand/water/deep/salt
+	contaminant_reagent_type = /decl/material/solid/sodiumchloride
+	contaminant_proportion = 0.10 // 1:10 salt:water
 
 /turf/floor/seafloor
 	name              = "sea floor"
@@ -130,6 +150,10 @@
 /turf/floor/seafloor/flooded
 	flooded           = /decl/material/liquid/water
 	color             = COLOR_LIQUID_WATER
+
+/turf/floor/seafloor/flooded/salt
+	contaminant_reagent_type = /decl/material/solid/sodiumchloride
+	contaminant_proportion = 0.10 // 1:10 salt:water
 
 /turf/floor/shrouded
 	name              = "packed sand"

--- a/code/game/turfs/floors/subtypes/floor_path.dm
+++ b/code/game/turfs/floors/subtypes/floor_path.dm
@@ -11,8 +11,10 @@
 	_base_flooring = /decl/flooring/dirt
 
 /turf/floor/path/Initialize(mapload, no_update_icon)
+	// Take advantage of the set_turf_materials call in ..()
+	// to avoid doing pointless work
+	material ||= get_strata_material_type() || /decl/material/solid/stone/sandstone
 	. = ..()
-	set_turf_materials(material || get_strata_material_type() || /decl/material/solid/stone/sandstone, skip_update = no_update_icon)
 	if(mapload && is_outside() && prob(20))
 		var/image/moss = image('icons/effects/decals/plant_remains.dmi', "leafy_bits", DECAL_LAYER)
 		moss.pixel_x = rand(-6, 6)

--- a/code/game/turfs/floors/subtypes/floor_rock.dm
+++ b/code/game/turfs/floors/subtypes/floor_rock.dm
@@ -5,8 +5,9 @@
 	_base_flooring = /decl/flooring/rock
 
 /turf/floor/rock/Initialize(mapload, no_update_icon)
+	// Take advantage of the set_turf_materials call in ..()
+	material ||= get_strata_material_type() || /decl/material/solid/stone/sandstone
 	. = ..()
-	set_turf_materials(material || get_strata_material_type() || /decl/material/solid/stone/sandstone, skip_update = no_update_icon)
 
 /turf/floor/rock/volcanic
 	name     = "volcanic floor"

--- a/code/game/turfs/open/_open.dm
+++ b/code/game/turfs/open/_open.dm
@@ -27,6 +27,11 @@
 	name = "open water"
 	flooded = /decl/material/liquid/water
 
+/turf/open/flooded/salt
+	name = "open saltwater" // alt. ver: open ocean?
+	contaminant_reagent_type = /decl/material/solid/sodiumchloride
+	contaminant_proportion = 0.10 // 1:10 salt:water, NOT 10% salt
+
 /turf/open/Entered(var/atom/movable/mover, var/atom/oldloc)
 	..()
 	mover.fall(oldloc)

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -38,6 +38,14 @@
 	var/footstep_type
 	var/open_turf_type = /turf/open // Which open turf type to use by default above this turf in a multiz context. Overridden by area.
 
+	// If you ever need to refill or flood a turf with more than two reagents, this should be rewritten entirely.
+	// The reason it's written like this is to avoid creating a new list for every turf with contaminants
+	// and that should still hold up even if you have turfs with three or more liquids in the mixture.
+	/// Reagent to contaminate refilled or flooded reagents.
+	var/contaminant_reagent_type
+	/// What fraction of the refilled/flooded liquid should be the contaminant? If zero, no contaminant is added.
+	var/contaminant_proportion
+
 	var/tmp/changing_turf
 	var/tmp/prev_type // Previous type of the turf, prior to turf translation.
 

--- a/code/game/turfs/turf_fluids.dm
+++ b/code/game/turfs/turf_fluids.dm
@@ -75,8 +75,8 @@
 	. = (get_fluid_depth() >= min)
 
 /turf/proc/get_fluid_name()
-	var/decl/material/mat = reagents?.get_primary_reagent_decl()
-	return mat.get_reagent_name(reagents, MAT_PHASE_LIQUID) || "liquid"
+	var/decl/material/mat = reagents?.get_primary_reagent_decl() || RESOLVE_TO_DECL(flooded)
+	return mat?.get_reagent_name(reagents, MAT_PHASE_LIQUID) || "liquid"
 
 /turf/get_fluid_depth()
 	if(is_flooded(absolute=1))

--- a/code/game/turfs/unsimulated/mask.dm
+++ b/code/game/turfs/unsimulated/mask.dm
@@ -9,6 +9,11 @@
 	icon_state = "rockvault"
 	color = COLOR_SILVER
 
+// Why do these exist? Are they just for typechecks when generating random maps? Does the flooding code even run for unsim turfs?
 /turf/unsimulated/mask/flooded
 	flooded = /decl/material/liquid/water
 	color = COLOR_LIQUID_WATER
+
+/turf/unsimulated/mask/flooded/salt
+	contaminant_reagent_type = /decl/material/solid/sodiumchloride
+	contaminant_proportion = 0.10 // 1:10 salt:water, NOT 10% salt

--- a/code/game/turfs/walls/wall_natural.dm
+++ b/code/game/turfs/walls/wall_natural.dm
@@ -20,6 +20,10 @@ var/global/_wall_chisel_skill = SKILL_CONSTRUCTION
 	flooded = /decl/material/liquid/water
 	color = COLOR_LIQUID_WATER
 
+/turf/wall/natural/flooded/salt
+	contaminant_reagent_type = /decl/material/solid/sodiumchloride
+	contaminant_proportion = 0.10 // 1:10 salt:water, NOT 10% salt
+
 /turf/wall/natural/get_paint_examine_message()
 	return SPAN_NOTICE("It has been <font color = '[paint_color]'>noticeably discoloured</font> by the elements.")
 

--- a/code/modules/fluids/fluid_flood.dm
+++ b/code/modules/fluids/fluid_flood.dm
@@ -1,5 +1,7 @@
 // Permaflood overlay.
 var/global/list/flood_type_overlay_cache = list()
+// TODO: does this need to also take contaminant type as an argument? flooding contaminants are totally untested
+// also, do flooded turfs even apply fluid_act and touch effects?
 /proc/get_flood_overlay(fluid_type)
 	if(!ispath(fluid_type, /decl/material))
 		return null

--- a/code/modules/multiz/turf_mimic_edge.dm
+++ b/code/modules/multiz/turf_mimic_edge.dm
@@ -208,6 +208,10 @@
 /turf/mimic_edge/transition/flooded
 	flooded = /decl/material/liquid/water
 
+/turf/mimic_edge/transition/flooded/salt
+	contaminant_reagent_type = /decl/material/solid/sodiumchloride
+	contaminant_proportion = 0.10 // 1:10 salt:water, NOT 10% salt
+
 ////////////////////////////////
 // Loop Edges
 ////////////////////////////////

--- a/code/modules/reagents/Chemistry-Holder.dm
+++ b/code/modules/reagents/Chemistry-Holder.dm
@@ -10,6 +10,16 @@ var/global/datum/reagents/sink/infinite_reagent_sink = new
 /atom/proc/remove_any_reagents(amount = 1, defer_update = FALSE, removed_phases = (MAT_PHASE_LIQUID | MAT_PHASE_SOLID), skip_reagents = null)
 	return reagents?.remove_any(amount, defer_update, removed_phases, skip_reagents)
 
+/// Adds reagents, but contaminated. A fraction of `amount` is replaced with `contaminant_type` according to `contaminant_proportion`.
+/// Handles null contaminant_type and zero contaminant_proportion, but it's probably faster to check before you call this.
+/atom/proc/add_to_reagents_contaminated(reagent_type, amount, data, contaminant_type = null, contaminant_proportion = 0, safety = FALSE, defer_update = FALSE, phase = null)
+	var/contaminant_to_add = 0
+	if(contaminant_type)
+		contaminant_to_add = CHEMS_QUANTIZE(amount * contaminant_proportion)
+	add_to_reagents(reagent_type, amount - contaminant_to_add, data, safety = safety, defer_update = !!contaminant_to_add, phase = MAT_PHASE_LIQUID)
+	if(contaminant_to_add)
+		add_to_reagents(contaminant_type, contaminant_to_add, phase = MAT_PHASE_LIQUID)
+
 /atom/proc/get_reagent_space()
 	if(!REAGENT_MAXIMUM_VOLUME(reagents))
 		return 0


### PR DESCRIPTION
## Description of changes
Salvages an old, forgotten commit that adds support for contaminants to fluid-filled turfs, and uses that system to add saltwater turfs.

## Why and what will this PR improve
Proof-of-concept for contaminated fluid sources.

## Authorship
Me