### PR TITLE
Replace two spawn sources in init with timers

### DIFF
--- a/code/game/objects/effects/effect_system.dm
+++ b/code/game/objects/effects/effect_system.dm
@@ -385,31 +385,30 @@ steam.start() -- spawns the effect
 
 
 /datum/effect/effect/system/trail/start()
-	if(!src.on)
-		src.on = 1
-		src.processing = 1
-	if(src.processing)
-		src.processing = 0
-		spawn(0)
-			var/turf/T = get_turf(src.holder)
-			if(T != src.oldposition)
-				if(is_type_in_list(T, specific_turfs) && (!max_number || number < max_number))
-					var/obj/effect/effect/trail = new trail_type(oldposition)
-					src.oldposition = T
-					effect(trail)
-					number++
-					spawn( duration_of_effect )
-						number--
-						qdel(trail)
-				spawn(2)
-					if(src.on)
-						src.processing = 1
-						src.start()
-			else
-				spawn(2)
-					if(src.on)
-						src.processing = 1
-						src.start()
+	set waitfor = FALSE
+	if(!on)
+		on = TRUE
+		processing = TRUE
+	if(processing)
+		processing = FALSE
+		var/turf/our_turf = get_turf(holder)
+		if(our_turf != oldposition)
+			if(is_type_in_list(our_turf, specific_turfs) && (!max_number || number < max_number))
+				var/obj/effect/effect/trail = new trail_type(oldposition)
+				oldposition = our_turf
+				effect(trail)
+				number++
+				addtimer(CALLBACK(src, PROC_REF(end_trail_effect), trail), duration_of_effect)
+		addtimer(CALLBACK(src, PROC_REF(try_start)), 0.2 SECONDS)
+
+/datum/effect/effect/system/trail/proc/try_start()
+	if(on)
+		processing = TRUE
+		start()
+
+/datum/effect/effect/system/trail/proc/end_trail_effect(obj/effect/effect/trail)
+	number--
+	qdel(trail)
 
 /datum/effect/effect/system/trail/proc/stop()
 	src.processing = 0

--- a/code/modules/mob/living/simple_animal/hostile/giant_spiders/ai_nurse.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spiders/ai_nurse.dm
@@ -83,35 +83,40 @@
 		body.visible_message(SPAN_NOTICE("\The [body] begins to secrete a sticky substance around \the [cocoon_target]."))
 		stop_wandering()
 		body.stop_automove()
-		spawn(5 SECONDS)
-			if(get_activity() == AI_ACTIVITY_BUILDING)
-				if(cocoon_target && isturf(cocoon_target.loc) && get_dist(body, cocoon_target) <= 1)
-					var/obj/effect/spider/cocoon/C = new(cocoon_target.loc)
-					var/large_cocoon = 0
-					C.pixel_x = cocoon_target.pixel_x
-					C.pixel_y = cocoon_target.pixel_y
-					for(var/mob/living/M in C.loc)
-						large_cocoon = 1
-						spooder.fed++
-						spooder.max_eggs++
-						body.visible_message(SPAN_WARNING("\The [body] sticks a proboscis into \the [cocoon_target] and sucks a viscous substance out."))
-						M.forceMove(C)
-						C.pixel_x = M.pixel_x
-						C.pixel_y = M.pixel_y
-						break
-					for(var/obj/item/I in C.loc)
-						I.forceMove(C)
-					for(var/obj/structure/S in C.loc)
-						if(!S.anchored)
-							S.forceMove(C)
-					for(var/obj/machinery/M in C.loc)
-						if(!M.anchored)
-							M.forceMove(C)
-					if(large_cocoon)
-						C.icon_state = pick("cocoon_large1","cocoon_large2","cocoon_large3")
-					cocoon_target = null
-				set_activity(AI_ACTIVITY_IDLE)
-				resume_wandering()
+		addtimer(CALLBACK(src, PROC_REF(build_cocoon)), 5 SECONDS)
+
+/datum/mob_controller/aggressive/giant_spider/nurse/proc/build_cocoon()
+	if(get_activity() != AI_ACTIVITY_BUILDING)
+		return FALSE
+	var/mob/living/simple_animal/hostile/giant_spider/nurse/spooder = body
+	if(cocoon_target && isturf(cocoon_target.loc) && get_dist(body, cocoon_target) <= 1)
+		var/obj/effect/spider/cocoon/C = new(cocoon_target.loc)
+		var/large_cocoon = 0
+		C.pixel_x = cocoon_target.pixel_x
+		C.pixel_y = cocoon_target.pixel_y
+		for(var/mob/living/M in C.loc)
+			large_cocoon = 1
+			spooder.fed++
+			spooder.max_eggs++
+			body.visible_message(SPAN_WARNING("\The [body] sticks a proboscis into \the [cocoon_target] and sucks a viscous substance out."))
+			M.forceMove(C)
+			C.pixel_x = M.pixel_x
+			C.pixel_y = M.pixel_y
+			break
+		for(var/obj/item/I in C.loc)
+			I.forceMove(C)
+		for(var/obj/structure/S in C.loc)
+			if(!S.anchored)
+				S.forceMove(C)
+		for(var/obj/machinery/M in C.loc)
+			if(!M.anchored)
+				M.forceMove(C)
+		if(large_cocoon)
+			C.icon_state = pick("cocoon_large1","cocoon_large2","cocoon_large3")
+		cocoon_target = null
+	set_activity(AI_ACTIVITY_IDLE)
+	resume_wandering()
+	return TRUE
 
 /datum/mob_controller/aggressive/giant_spider/nurse/handle_death(gibbed)
 	. = ..()


### PR DESCRIPTION
## Description of changes
Replaces spawn()s in nurse spider AI and trail effects with timers.

## Why and what will this PR improve
Spawning procs are unreliable and can lead to untracked hanging references, and also abusing them so much (like with the effect trail) leads to slowdowns/lag.