### PR TITLE
Recursive Ambient Z-Lighting

### DIFF
--- a/code/game/turfs/turf_changing.dm
+++ b/code/game/turfs/turf_changing.dm
@@ -64,6 +64,7 @@
 	var/old_affecting_lights = affecting_lights
 	var/old_lighting_overlay = lighting_overlay
 	var/old_dynamic_lighting = TURF_IS_DYNAMICALLY_LIT_UNSAFE(src)
+	var/old_z_opacity        = z_flags & ZM_ALLOW_LIGHTING
 	var/old_flooded =          flooded
 	var/old_outside =          is_outside
 	var/old_is_open =          is_open()
@@ -144,6 +145,11 @@
 
 	if (old_ambience != ambient_light || old_ambience_mult != ambient_light_multiplier)
 		update_ambient_light(FALSE)
+
+	var/new_z_opacity = z_flags & ZM_ALLOW_LIGHTING
+	if (new_z_opacity != old_z_opacity)
+		for (var/datum/lighting_corner/corn in corners)
+			corn.rebuild_ztraversal(!new_z_opacity)
 
 	var/tidlu = TURF_IS_DYNAMICALLY_LIT_UNSAFE(src)
 	if ((old_opacity != opacity) || (tidlu != old_dynamic_lighting) || force_lighting_update)

--- a/code/game/turfs/walls/wall_attacks.dm
+++ b/code/game/turfs/walls/wall_attacks.dm
@@ -17,7 +17,6 @@
 	for(var/turf/turf in loc)
 		if(turf.simulated)
 			SSair.mark_for_update(turf)
-	set_light(density)
 	update_icon()
 	update_air()
 	refresh_opacity()

--- a/code/modules/lighting/ambient_turf.dm
+++ b/code/modules/lighting/ambient_turf.dm
@@ -69,10 +69,6 @@
 			SSlighting.total_ambient_turfs -= 1
 		return
 
-	if (!ambient_active)
-		SSlighting.total_ambient_turfs += 1
-		ambient_active = TRUE
-
 	// There are four corners per (lit) turf, we don't want to apply our light 4 times -- compensate by dividing by 4.
 	lr /= 4
 	lg /= 4
@@ -86,15 +82,17 @@
 	ambient_light_old_g += lg
 	ambient_light_old_b += lb
 
-	if (!corners || !lighting_corners_initialised)
-		if (TURF_IS_DYNAMICALLY_LIT_UNSAFE(src))
+	if (TURF_IS_DYNAMICALLY_LIT_UNSAFE(src))
+		if (!corners || !lighting_corners_initialised)
 			generate_missing_corners()
-		else
-			return
 
-	// This list can contain nulls on things like space turfs -- they only have their neighbors' corners.
-	for (var/datum/lighting_corner/C in corners)
-		C.update_ambient_lumcount(lr, lg, lb, !update)
+		// This list can contain nulls on things like space turfs -- they only have their neighbors' corners.
+		for (var/datum/lighting_corner/C in corners)
+			C.update_ambient_lumcount(lr, lg, lb, !update)
+
+	if (!ambient_active)
+		SSlighting.total_ambient_turfs += 1
+		ambient_active = TRUE
 
 /// Wipe the entire self-ambience channel. This will preserve ambience from ambience groups.
 /turf/proc/clear_ambient_light()

--- a/code/modules/lighting/lighting_corner.dm
+++ b/code/modules/lighting/lighting_corner.dm
@@ -34,7 +34,7 @@ var/global/list/REVERSE_LIGHTING_CORNER_DIAGONAL = list(0, 0, 0, 0, 3, 4, 0, 0, 
 	var/self_g = 0
 	var/self_b = 0
 
-	// The intensity we're inheriting from the turf below us, if we're a Z-turf.
+	// The intensity we're inheriting from the turf below us, if we're a Z-turf. This is a sum of all below turfs in the Z-stack.
 	var/below_r = 0
 	var/below_g = 0
 	var/below_b = 0
@@ -201,10 +201,13 @@ var/global/list/REVERSE_LIGHTING_CORNER_DIAGONAL = list(0, 0, 0, 0, 3, 4, 0, 0, 
 		T = null
 
 	if (TURF_IS_DYNAMICALLY_LIT(T))
-		if (!T.corners || !T.corners[Ti])
-			T.generate_missing_corners()
-		var/datum/lighting_corner/above = T.corners[Ti]
-		above.update_below_lumcount(delta_r, delta_g, delta_b, now)
+		do
+			if (!T.corners || !T.corners[Ti])
+				T.generate_missing_corners()
+
+			// Above corners never get instant updates; they're less important, so better to avoid risk of lag.
+			T.corners[Ti].update_below_lumcount(delta_r, delta_g, delta_b)
+		while ((T = T.above) && (T.z_flags & ZM_ALLOW_LIGHTING))
 
 	// This needs to be down here instead of the above if so the lum values are properly updated.
 	if (needs_update)
@@ -216,7 +219,7 @@ var/global/list/REVERSE_LIGHTING_CORNER_DIAGONAL = list(0, 0, 0, 0, 3, 4, 0, 0, 
 		needs_update = TRUE
 		SSlighting.corner_queue += src
 
-/datum/lighting_corner/proc/update_below_lumcount(delta_r, delta_g, delta_b, now = FALSE)
+/datum/lighting_corner/proc/update_below_lumcount(delta_r, delta_g, delta_b)
 	if (!(delta_r + delta_g + delta_b))
 		return
 
@@ -232,11 +235,8 @@ var/global/list/REVERSE_LIGHTING_CORNER_DIAGONAL = list(0, 0, 0, 0, 3, 4, 0, 0, 
 	if (needs_update)
 		return
 
-	if (!now)
-		needs_update = TRUE
-		SSlighting.corner_queue += src
-	else
-		update_overlays(TRUE)
+	needs_update = TRUE
+	SSlighting.corner_queue += src
 
 /datum/lighting_corner/proc/update_ambient_lumcount(delta_r, delta_g, delta_b, skip_update = FALSE)
 
@@ -303,8 +303,6 @@ var/global/list/REVERSE_LIGHTING_CORNER_DIAGONAL = list(0, 0, 0, 0, 3, 4, 0, 0, 
 	needs_update = TRUE
 	SSlighting.corner_queue += src
 
-#undef UPDATE_APPARENT
-
 /datum/lighting_corner/proc/update_overlays(now = FALSE)
 	var/lr = apparent_r
 	var/lg = apparent_g
@@ -339,6 +337,75 @@ var/global/list/REVERSE_LIGHTING_CORNER_DIAGONAL = list(0, 0, 0, 0, 3, 4, 0, 0, 
 				Ov.needs_update = TRUE
 				SSlighting.overlay_queue += Ov
 
+// This is called when our turf's downward Z-opacity changes.
+/datum/lighting_corner/proc/rebuild_ztraversal(new_opacity)
+	/*
+		If opacity transitions to off:
+		- Look down stack, removing below lights contributing to us
+		- Look up stack, updating turfs with our new below lighting value
+		If opacity transitions to on:
+		- Look down stack, add below contributors
+		- Look up stack, updating turfs with our new below lighting value
+	*/
+	below_r = below_g = below_b = 0
+	var/turf/T = null
+	var/datum/lighting_corner/Tcorn = src
+	var/Ti
+
+	if (!new_opacity)
+		for (;;)
+			if (Tcorn.t1 && (T = Tcorn.t1.below || GET_BELOW(Tcorn.t1)) && (T.above?.z_flags & ZM_ALLOW_LIGHTING))
+				Ti = Tcorn.t1i
+			else if (Tcorn.t2 && (T = Tcorn.t2.below || GET_BELOW(Tcorn.t2)) && (T.above?.z_flags & ZM_ALLOW_LIGHTING))
+				Ti = Tcorn.t2i
+			else if (Tcorn.t3 && (T = Tcorn.t3.below || GET_BELOW(Tcorn.t3)) && (T.above?.z_flags & ZM_ALLOW_LIGHTING))
+				Ti = Tcorn.t3i
+			else if (Tcorn.t4 && (T = Tcorn.t4.below || GET_BELOW(Tcorn.t4)) && (T.above?.z_flags & ZM_ALLOW_LIGHTING))
+				Ti = Tcorn.t4i
+			else	// Nothing above us that cares about below light.
+				break
+
+			Tcorn = T.corners[Ti]
+			below_r += Tcorn.apparent_r
+			below_g += Tcorn.apparent_g
+			below_b += Tcorn.apparent_b
+
+	UPDATE_APPARENT(src, r)
+	UPDATE_APPARENT(src, g)
+	UPDATE_APPARENT(src, b)
+
+	if (!needs_update)
+		needs_update = TRUE
+		SSlighting.corner_queue += src
+
+	T = null
+	Tcorn = src
+
+	for (;;)
+		if (Tcorn.t1 && (T = Tcorn.t1.above || GET_ABOVE(Tcorn.t1)) && (T.z_flags & ZM_ALLOW_LIGHTING))
+			Ti = Tcorn.t1i
+		else if (Tcorn.t2 && (T = Tcorn.t2.above || GET_ABOVE(Tcorn.t2)) && (T.z_flags & ZM_ALLOW_LIGHTING))
+			Ti = Tcorn.t2i
+		else if (Tcorn.t3 && (T = Tcorn.t3.above || GET_ABOVE(Tcorn.t3)) && (T.z_flags & ZM_ALLOW_LIGHTING))
+			Ti = Tcorn.t3i
+		else if (Tcorn.t4 && (T = Tcorn.t4.above || GET_ABOVE(Tcorn.t4)) && (T.z_flags & ZM_ALLOW_LIGHTING))
+			Ti = Tcorn.t4i
+		else	// Nothing above us that cares about below light.
+			break
+
+		Tcorn = T.corners[Ti]
+		Tcorn.below_r += apparent_r
+		Tcorn.below_g += apparent_g
+		Tcorn.below_b += apparent_b
+
+		UPDATE_APPARENT(Tcorn, r)
+		UPDATE_APPARENT(Tcorn, g)
+		UPDATE_APPARENT(Tcorn, b)
+
+		if (!Tcorn.needs_update)
+			Tcorn.needs_update = TRUE
+			SSlighting.corner_queue += Tcorn
+
 /datum/lighting_corner/Destroy(force = FALSE)
 	PRINT_STACK_TRACE("Someone [force ? "force-" : ""]deleted a lighting corner.")
 	if (!force)
@@ -349,3 +416,5 @@ var/global/list/REVERSE_LIGHTING_CORNER_DIAGONAL = list(0, 0, 0, 0, 3, 4, 0, 0, 
 
 /datum/lighting_corner/dummy/New()
 	return
+
+#undef UPDATE_APPARENT

--- a/code/modules/lighting/lighting_corner.dm
+++ b/code/modules/lighting/lighting_corner.dm
@@ -189,13 +189,14 @@ var/global/list/REVERSE_LIGHTING_CORNER_DIAGONAL = list(0, 0, 0, 0, 3, 4, 0, 0, 
 	var/turf/T
 	var/Ti
 	// Grab the first master that's a Z-turf, if one exists.
-	if (t1 && (T = GET_ABOVE(t1)) && (T.z_flags & ZM_ALLOW_LIGHTING))
+	// The above var cannot be relied on due to init ordering, but we can use it if it is set.
+	if (t1 && (T = t1.above || GET_ABOVE(t1)) && (T.z_flags & ZM_ALLOW_LIGHTING))
 		Ti = t1i
-	else if (t2 && (T = GET_ABOVE(t2)) && (T.z_flags & ZM_ALLOW_LIGHTING))
+	else if (t2 && (T = t2.above || GET_ABOVE(t2)) && (T.z_flags & ZM_ALLOW_LIGHTING))
 		Ti = t2i
-	else if (t3 && (T = GET_ABOVE(t3)) && (T.z_flags & ZM_ALLOW_LIGHTING))
+	else if (t3 && (T = t3.above || GET_ABOVE(t3)) && (T.z_flags & ZM_ALLOW_LIGHTING))
 		Ti = t3i
-	else if (t4 && (T = GET_ABOVE(t4)) && (T.z_flags & ZM_ALLOW_LIGHTING))
+	else if (t4 && (T = t4.above || GET_ABOVE(t4)) && (T.z_flags & ZM_ALLOW_LIGHTING))
 		Ti = t4i
 	else	// Nothing above us that cares about below light.
 		T = null
@@ -251,26 +252,21 @@ var/global/list/REVERSE_LIGHTING_CORNER_DIAGONAL = list(0, 0, 0, 0, 3, 4, 0, 0, 
 	var/turf/T
 	var/Ti
 
-	if (t1 && (t1.below || HasBelow(t1.z)) && (t1.z_flags & ZM_ALLOW_LIGHTING) && TURF_IS_DYNAMICALLY_LIT_UNSAFE(t1))
+	if (t1)
 		T = t1
 		Ti = t1i
-	else if (t2 && (t2.below || HasBelow(t2.z)) && (t2.z_flags & ZM_ALLOW_LIGHTING) && TURF_IS_DYNAMICALLY_LIT_UNSAFE(t2))
+	else if (t2)
 		T = t2
 		Ti = t2i
-	else if (t3 && (t3.below || HasBelow(t3.z)) && (t3.z_flags & ZM_ALLOW_LIGHTING) && TURF_IS_DYNAMICALLY_LIT_UNSAFE(t3))
+	else if (t3)
 		T = t3
 		Ti = t3i
-	else if (t4 && (t4.below || HasBelow(t4.z)) && (t4.z_flags & ZM_ALLOW_LIGHTING) && TURF_IS_DYNAMICALLY_LIT_UNSAFE(t4))
+	else if (t4)
 		T = t4
 		Ti = t4i
-	// No MZ candidates below, just update.
-	else if (needs_update || skip_update)
-		return
 	else
-		// Always queue for this, not important enough to hit the synchronous path.
-		needs_update = TRUE
-		SSlighting.corner_queue += src
-		return
+		// This should be impossible to reach -- how do we exist without at least one master turf?
+		CRASH("Corner has no masters!")
 
 	var/datum/lighting_corner/below = src
 

--- a/code/modules/lighting/lighting_turf.dm
+++ b/code/modules/lighting/lighting_turf.dm
@@ -126,6 +126,11 @@
 		recalc_atom_opacity() // Make sure to do this before reconsider_lights(), incase we're on instant updates.
 		reconsider_lights()
 
+// The normal opacity logic doesn't work for entities not located inside turfs, such as turfs.
+/turf/set_opacity(new_opacity)
+	. = ..()
+	reconsider_lights()
+
 // This block isn't needed now, but it's here if supporting area dyn lighting changes is needed later.
 
 // /turf/change_area(area/old_area, area/new_area)


### PR DESCRIPTION
changes:
- Ambient lights now propagate upwards recursively instead of a single level.
- Ambient light z-propagation updates are now always queued.
- Fixes an issue where ambient light delta updates would break (burn) for turfs that had a light initialize before ambience.
- Turf opacity changes now trigger lighting vis updates as you'd expect them to.

~~Briefly tested as working on O7, but completely untested here.~~ Ambient light burn has been tested fixed, propagation is not tested here but works elsewhere.