### PR TITLE
Make the supermatter crystal not a machine

### DIFF
--- a/maps/away/unishi/unishi-2.dmm
+++ b/maps/away/unishi/unishi-2.dmm
@@ -2727,7 +2727,7 @@
 /area/unishi/smresearch)
 "ho" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging,
-/obj/machinery/power/supermatter/inert{
+/obj/structure/supermatter/inert{
 	color = ""
 	},
 /obj/machinery/mass_driver{

--- a/maps/away/unishi/unishi.dm
+++ b/maps/away/unishi/unishi.dm
@@ -49,12 +49,12 @@
 	landmark_tag = "nav_unishi_3"
 
 
-/obj/machinery/power/supermatter/randomsample
+/obj/structure/supermatter/randomsample
 	name = "experimental supermatter sample"
 	icon = 'icons/obj/supermatter_32.dmi'
 	icon_state = "supermatter_shard"
 
-/obj/machinery/power/supermatter/randomsample/Initialize()
+/obj/structure/supermatter/randomsample/Initialize()
 	. = ..()
 	nitrogen_retardation_factor = rand(0.01, 1)	  //Higher == N2 slows reaction more
 	thermal_release_modifier = rand(100, 1000000) //Higher == more heat released during reaction
@@ -69,7 +69,7 @@
 	charging_factor = rand(0, 1)
 	damage_rate_limit = rand( 1, 10)		//damage rate cap at power = 300, scales linearly with power
 
-/obj/machinery/power/supermatter/inert
+/obj/structure/supermatter/inert
 	name = "experimental supermatter sample"
 	icon = 'icons/obj/supermatter_32.dmi'
 	icon_state = "supermatter_shard"
@@ -87,7 +87,7 @@
 	desc = "Are you sure you want to open this?"
 
 /obj/structure/closet/crate/secure/large/supermatter/experimentalsm/WillContain()
-	return list(/obj/machinery/power/supermatter/randomsample)
+	return list(/obj/structure/supermatter/randomsample)
 /obj/item/paper/prof1
 	name = "error log"
 	info = "<large> COMPUTER ID: 15231 <br> Attempting recovery of document directory. <br> Three files recovered <br> Printing file (1/2) <br> </large> ... about your concerns. I told you that the shielding is strong enough to avoid ANY leaks of radiation or hazardous materials. The entire lab is 100% isolated from the ship in terms of even the air supply. Leave me and my students the fuck alone. Your job is to maintain the fucking reactor an !#@!dqma211.<br> <large> File (2/3) Tested SM </large> This thing has a lot of potential. It doesn't produce any measurable levels of gas, or even significant thermal signature. The potential is nearly limitless. We've had to fine tune our activation procedures as even a short beam of the emitter seems to activate this thing. CTI Engineering dept still won't fucking answer where they got this thing, but it's simply amazing. I've sent an ema #@^%da12k"

--- a/maps/exodus/exodus-2.dmm
+++ b/maps/exodus/exodus-2.dmm
@@ -56232,7 +56232,7 @@
 /turf/floor/plating,
 /area/exodus/maintenance/portsolar)
 "cnh" = (
-/obj/machinery/power/supermatter,
+/obj/structure/supermatter,
 /obj/machinery/mass_driver{
 	id_tag = "enginecore"
 	},

--- a/maps/ministation/ministation-0.dmm
+++ b/maps/ministation/ministation-0.dmm
@@ -11507,7 +11507,7 @@
 /turf/floor/tiled,
 /area/ministation/hall/n)
 "Qv" = (
-/obj/machinery/power/supermatter,
+/obj/structure/supermatter,
 /obj/machinery/mass_driver{
 	id_tag = "eject"
 	},

--- a/mods/content/supermatter/_supermatter.dme
+++ b/mods/content/supermatter/_supermatter.dme
@@ -7,6 +7,7 @@
 #include "datums\sm_follow.dm"
 #include "datums\sm_grief_fix.dm"
 #include "datums\sm_looping_sound.dm"
+#include "datums\sm_material.dm"
 #include "datums\sm_subsystem.dm"
 #include "datums\sm_supply_drop.dm"
 #include "datums\sm_supply_pack.dm"

--- a/mods/content/supermatter/_supermatter.dme
+++ b/mods/content/supermatter/_supermatter.dme
@@ -7,6 +7,7 @@
 #include "datums\sm_follow.dm"
 #include "datums\sm_grief_fix.dm"
 #include "datums\sm_looping_sound.dm"
+#include "datums\sm_subsystem.dm"
 #include "datums\sm_supply_drop.dm"
 #include "datums\sm_supply_pack.dm"
 #include "datums\supermatter_monitor.dm"
@@ -16,7 +17,6 @@
 #include "items\sm_book.dm"
 #include "items\sm_grenade.dm"
 #include "machinery\sm_supply_beacon.dm"
-#include "machinery\supermatter.dm"
 #include "machinery\supermatter_core_console.dm"
 #include "overrides\sm_fuel_compressor.dm"
 #include "overrides\sm_meteor.dm"
@@ -26,5 +26,6 @@
 #include "overrides\sm_unit_tests.dm"
 #include "overrides\sm_xenoarchaeology.dm"
 #include "structures\sm_closets.dm"
+#include "structures\supermatter_crystal.dm"
 // END_INCLUDE
 #endif

--- a/mods/content/supermatter/admin_setup_supermatter.dm
+++ b/mods/content/supermatter/admin_setup_supermatter.dm
@@ -101,7 +101,7 @@
 	if(!last)
 		return ENGINE_SETUP_DELAYED
 	..()
-	var/obj/machinery/power/supermatter/SM = locate() in get_turf(src)
+	var/obj/structure/supermatter/SM = locate() in get_turf(src)
 	if(!SM)
 		log_and_message_admins("## ERROR: Unable to locate supermatter core at [x] [y] [z]!")
 		return ENGINE_SETUP_ERROR

--- a/mods/content/supermatter/datums/sm_codex.dm
+++ b/mods/content/supermatter/datums/sm_codex.dm
@@ -4,7 +4,7 @@
 	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
 
 /datum/codex_entry/supermatter
-	associated_paths = list(/obj/machinery/power/supermatter)
+	associated_paths = list(/obj/structure/supermatter)
 	mechanics_text = "When energized by a laser (or something hitting it), it emits radiation and heat.  If the heat reaches above 7000 kelvin, it will send an alert and start taking damage. \
 	After integrity falls to zero percent, it will delaminate, causing a massive explosion, station-wide radiation spikes, and hallucinations. \
 	Supermatter reacts badly to oxygen in the atmosphere.  It'll also heat up really quick if it is in vacuum.<br>\

--- a/mods/content/supermatter/datums/sm_follow.dm
+++ b/mods/content/supermatter/datums/sm_follow.dm
@@ -1,3 +1,3 @@
 /datum/follow_holder/supermatter
 	sort_order = 10
-	followed_type = /obj/machinery/power/supermatter
+	followed_type = /obj/structure/supermatter

--- a/mods/content/supermatter/datums/sm_grief_fix.dm
+++ b/mods/content/supermatter/datums/sm_grief_fix.dm
@@ -4,5 +4,5 @@
 
 /decl/atmos_grief_fix_step/supermatter/act()
 	// Depower the supermatter, as it would quickly blow up once we remove all gases from the pipes.
-	for(var/obj/machinery/power/supermatter/S in SSmachines.machinery)
+	for(var/obj/structure/supermatter/S in SSsupermatter.processing)
 		S.power = 0

--- a/mods/content/supermatter/datums/sm_material.dm
+++ b/mods/content/supermatter/datums/sm_material.dm
@@ -1,0 +1,12 @@
+/decl/material/solid/exotic_matter/supermatter
+	name = "supermatter"
+	uid = "solid_supermatter"
+	lore_text = "Hypercrystalline supermatter is a subset of non-baryonic 'exotic' matter with unusual properties that make it desirable for energy generation, and also very dangerous."
+	accelerant_value = FUEL_VALUE_NONE
+	vapor_products = null
+	melting_point = null
+	gas_flags = null
+	ignition_point = null
+	gas_symbol_html = "Sp<sub>*</sub>"
+	gas_symbol = "Sp*"
+	default_solid_form = /obj/item/stack/material/gemstone

--- a/mods/content/supermatter/datums/sm_subsystem.dm
+++ b/mods/content/supermatter/datums/sm_subsystem.dm
@@ -1,0 +1,7 @@
+// A replacement for having the supermatter tick on SSmachinery, since it's no longer a machine.
+PROCESSING_SUBSYSTEM_DEF(supermatter)
+	name = "Supermatter"
+	priority = SS_PRIORITY_MACHINERY
+	flags = SS_KEEP_TIMING|SS_NO_INIT
+	runlevels = RUNLEVEL_GAME|RUNLEVEL_POSTGAME
+	wait = 2 SECONDS

--- a/mods/content/supermatter/datums/sm_supply_drop.dm
+++ b/mods/content/supermatter/datums/sm_supply_drop.dm
@@ -2,4 +2,4 @@
 	name = "Supermatter"
 /datum/supply_drop_loot/supermatter/New()
 	..()
-	contents = list(/obj/machinery/power/supermatter)
+	contents = list(/obj/structure/supermatter)

--- a/mods/content/supermatter/datums/sm_supply_pack.dm
+++ b/mods/content/supermatter/datums/sm_supply_pack.dm
@@ -1,6 +1,6 @@
 /decl/hierarchy/supply_pack/engineering/smbig
 	name = "Power - Supermatter core"
-	contains = list(/obj/machinery/power/supermatter)
+	contains = list(/obj/structure/supermatter)
 	containertype = /obj/structure/closet/crate/secure/large/supermatter
 	containername = "\improper Supermatter crate (CAUTION)"
 	access = access_ce

--- a/mods/content/supermatter/datums/supermatter_monitor.dm
+++ b/mods/content/supermatter/datums/supermatter_monitor.dm
@@ -32,7 +32,7 @@
 /datum/nano_module/program/supermatter_monitor
 	name = "Supermatter monitor"
 	var/list/supermatters
-	var/obj/machinery/power/supermatter/active = null		// Currently selected supermatter crystal.
+	var/obj/structure/supermatter/active = null		// Currently selected supermatter crystal.
 	var/screen = SM_MONITOR_SCREEN_MAIN // Which screen the monitor is currently on
 
 /datum/nano_module/program/supermatter_monitor/Destroy()
@@ -44,7 +44,7 @@
 	..()
 	refresh()
 
-/datum/nano_module/program/supermatter_monitor/proc/can_read(obj/machinery/power/supermatter/S)
+/datum/nano_module/program/supermatter_monitor/proc/can_read(obj/structure/supermatter/S)
 	if(!istype(S.loc, /turf/))
 		return FALSE
 	if(S.exploded || S.grav_pulling)
@@ -57,7 +57,7 @@
 // Refreshes list of active supermatter crystals
 /datum/nano_module/program/supermatter_monitor/proc/refresh()
 	supermatters = list()
-	for(var/obj/machinery/power/supermatter/S in SSmachines.machinery)
+	for(var/obj/structure/supermatter/S in SSsupermatter.processing)
 		// Delaminating, not within coverage, not on a tile.
 		if(!can_read(S))
 			continue
@@ -70,7 +70,7 @@
 /datum/nano_module/program/supermatter_monitor/proc/get_status()
 	. = SUPERMATTER_INACTIVE
 	var/needs_refresh
-	for(var/obj/machinery/power/supermatter/S in supermatters)
+	for(var/obj/structure/supermatter/S in supermatters)
 		if(!can_read(S))
 			needs_refresh = TRUE
 			continue
@@ -161,7 +161,7 @@
 	else
 		var/list/SMS = list()
 		var/needs_refresh //need to refresh because some of crystals are not readable. For finding new crystals user can just refresh manually like a scrub
-		for(var/obj/machinery/power/supermatter/S in supermatters)
+		for(var/obj/structure/supermatter/S in supermatters)
 			var/area/A = get_area(S)
 			if(!A)
 				continue
@@ -211,7 +211,7 @@
 		return 1
 	if( href_list["set"] )
 		var/newuid = text2num(href_list["set"])
-		for(var/obj/machinery/power/supermatter/S in supermatters)
+		for(var/obj/structure/supermatter/S in supermatters)
 			if(S.uid == newuid)
 				active = S
 		return 1

--- a/mods/content/supermatter/overrides/sm_fuel_compressor.dm
+++ b/mods/content/supermatter/overrides/sm_fuel_compressor.dm
@@ -2,7 +2,7 @@
 	. = ..()
 	if(.)
 		return TRUE
-	if(istype(thing, /obj/machinery/power/supermatter/shard))
+	if(istype(thing, /obj/structure/supermatter/shard))
 		var/exotic_matter_amount = thing?.matter?[/decl/material/solid/exotic_matter]
 		if(exotic_matter_amount <= 0)
 			return FALSE

--- a/mods/content/supermatter/overrides/sm_strings.dm
+++ b/mods/content/supermatter/overrides/sm_strings.dm
@@ -14,6 +14,3 @@
 	. = ..()
 	. += "a supermatter engine"
 	return .
-
-/decl/material/solid/exotic_matter
-	lore_text = "Hypercrystalline supermatter is a subset of non-baryonic 'exotic' matter. It is found mostly in the heart of large stars, and features heavily in all kinds of fringe physics-defying technology."

--- a/mods/content/supermatter/overrides/sm_trader.dm
+++ b/mods/content/supermatter/overrides/sm_trader.dm
@@ -1,3 +1,3 @@
 /datum/trader/ship/unique/rock/New()
 	..()
-	possible_trading_items[/obj/machinery/power/supermatter] = TRADER_ALL
+	possible_trading_items[/obj/structure/supermatter] = TRADER_ALL

--- a/mods/content/supermatter/overrides/sm_xenoarchaeology.dm
+++ b/mods/content/supermatter/overrides/sm_xenoarchaeology.dm
@@ -1,7 +1,7 @@
 /datum/artifact_find/New()
 	var/static/supermatter_injected = FALSE
 	if(!supermatter_injected)
-		potential_finds[/obj/machinery/power/supermatter] = 5
-		potential_finds[/obj/machinery/power/supermatter/shard] = 25
+		potential_finds[/obj/structure/supermatter] = 5
+		potential_finds[/obj/structure/supermatter/shard] = 25
 		supermatter_injected = TRUE
 	..()

--- a/mods/content/supermatter/structures/supermatter_crystal.dm
+++ b/mods/content/supermatter/structures/supermatter_crystal.dm
@@ -103,7 +103,7 @@ var/global/list/supermatter_delam_accent_sounds = list(
 	var/rads = 500
 	SSradiation.radiate(source, rads)
 
-/obj/machinery/power/supermatter
+/obj/structure/supermatter
 	name = "supermatter crystal"
 	desc = "A strangely translucent and iridescent crystal. <span class='danger'>You get headaches just from looking at it.</span>"
 	icon = 'icons/obj/supermatter_48.dmi'
@@ -189,6 +189,9 @@ var/global/list/supermatter_delam_accent_sounds = list(
 
 	var/datum/composite_sound/supermatter/soundloop
 
+	// A uniquely-identifying number assigned to this supermatter crystal. Mostly used by the supermatter monitoring console.
+	var/uid = 0
+
 	var/damage_animation = FALSE //are we doing our damage animation?
 
 	var/list/threshholds = list( // List of lists defining the amber/red labeling threshholds in readouts. Numbers are minminum red and amber and maximum amber and red, in that order
@@ -198,26 +201,28 @@ var/global/list/supermatter_delam_accent_sounds = list(
 		list("name" = SUPERMATTER_DATA_EPR,         "min_h" = -1, "min_l" = 1.0, "max_l" = 2.5,  "max_h" = 4.0)
 	)
 
-/obj/machinery/power/supermatter/Initialize()
+/obj/structure/supermatter/Initialize()
 	. = ..()
-	uid = gl_uid++
+	uid = sequential_id(/obj/structure/supermatter)
 	soundloop = new(list(src), TRUE)
 	update_icon()
 	add_filter("outline", 1, list(type = "drop_shadow", size = 0, color = COLOR_WHITE, x = 0, y = 0))
+	START_PROCESSING(SSsupermatter, src)
 
-/obj/machinery/power/supermatter/Destroy()
-	. = ..()
+/obj/structure/supermatter/Destroy()
 	QDEL_NULL(soundloop)
+	STOP_PROCESSING(SSsupermatter, src)
+	. = ..()
 
-/obj/machinery/power/supermatter/on_update_icon()
+/obj/structure/supermatter/on_update_icon()
 	. = ..()
 	underlays.Cut()
 	underlays += mutable_appearance(icon, "[icon_state]_underplate", flags = RESET_COLOR, plane = plane, layer = OBJ_LAYER)
 
-/obj/machinery/power/supermatter/get_matter_amount_modifier()
+/obj/structure/supermatter/get_matter_amount_modifier()
 	. = ..() * (1/HOLLOW_OBJECT_MATTER_MULTIPLIER) * 10 // Big solid chunk of matter.
 
-/obj/machinery/power/supermatter/proc/handle_admin_warnings()
+/obj/structure/supermatter/proc/handle_admin_warnings()
 	if(disable_adminwarn)
 		return
 
@@ -238,7 +243,7 @@ var/global/list/supermatter_delam_accent_sounds = list(
 	else
 		aw_EPR = FALSE
 
-/obj/machinery/power/supermatter/proc/status_adminwarn_check(var/min_status, var/current_state, var/message, var/send_webhook = FALSE)
+/obj/structure/supermatter/proc/status_adminwarn_check(var/min_status, var/current_state, var/message, var/send_webhook = FALSE)
 	var/status = get_status()
 	if(status >= min_status)
 		if(!current_state)
@@ -249,7 +254,7 @@ var/global/list/supermatter_delam_accent_sounds = list(
 	else
 		return FALSE
 
-/obj/machinery/power/supermatter/proc/get_epr()
+/obj/structure/supermatter/proc/get_epr()
 	var/turf/T = get_turf(src)
 	if(!istype(T))
 		return
@@ -258,7 +263,7 @@ var/global/list/supermatter_delam_accent_sounds = list(
 		return 0
 	return round((air.total_moles / air.group_multiplier) / 23.1, 0.01)
 
-/obj/machinery/power/supermatter/proc/get_status()
+/obj/structure/supermatter/proc/get_status()
 	var/turf/T = get_turf(src)
 	if(!T)
 		return SUPERMATTER_ERROR
@@ -286,7 +291,7 @@ var/global/list/supermatter_delam_accent_sounds = list(
 	return SUPERMATTER_INACTIVE
 
 
-/obj/machinery/power/supermatter/proc/explode()
+/obj/structure/supermatter/proc/explode()
 	set waitfor = 0
 
 	if(exploded)
@@ -354,7 +359,7 @@ var/global/list/supermatter_delam_accent_sounds = list(
 		explosion(TS, explosion_power/2, explosion_power, explosion_power * 2, explosion_power * 4, 1)
 		qdel(src)
 
-/obj/machinery/power/supermatter/get_examine_strings(mob/user, distance, infix, suffix)
+/obj/structure/supermatter/get_examine_strings(mob/user, distance, infix, suffix)
 	. = ..()
 	if(user.skill_check(SKILL_ENGINES, SKILL_EXPERT))
 		var/integrity_message
@@ -373,19 +378,19 @@ var/global/list/supermatter_delam_accent_sounds = list(
 			. += "Eyeballing it, you place the relative EER at around [display_power] MeV/cm3."
 
 //Changes color and luminosity of the light to these values if they were not already set
-/obj/machinery/power/supermatter/proc/shift_light(var/lum, var/clr)
+/obj/structure/supermatter/proc/shift_light(var/lum, var/clr)
 	if(lum != light_range || abs(power - last_power) > 10 || clr != light_color)
 		set_light(lum, LIGHT_POWER_CALC, clr)
 		last_power = power
 
-/obj/machinery/power/supermatter/proc/get_integrity()
+/obj/structure/supermatter/proc/get_integrity()
 	var/integrity = damage / explosion_point
 	integrity = round(100 - integrity * 100)
 	integrity = integrity < 0 ? 0 : integrity
 	return integrity
 
 
-/obj/machinery/power/supermatter/proc/announce_warning()
+/obj/structure/supermatter/proc/announce_warning()
 	var/integrity = get_integrity()
 	var/alert_msg = " Integrity at [integrity]%"
 
@@ -418,7 +423,7 @@ var/global/list/supermatter_delam_accent_sounds = list(
 			public_alert = 0
 
 
-/obj/machinery/power/supermatter/Process()
+/obj/structure/supermatter/Process()
 	var/turf/L = loc
 
 	if(isnull(L))		// We have a null turf...something is wrong, stop processing this entity.
@@ -553,7 +558,7 @@ var/global/list/supermatter_delam_accent_sounds = list(
 
 	return 1
 
-/obj/machinery/power/supermatter/proc/start_damage_animation()
+/obj/structure/supermatter/proc/start_damage_animation()
 	if(damage_animation)
 		return
 	if(!get_filter("rays"))
@@ -565,10 +570,10 @@ var/global/list/supermatter_delam_accent_sounds = list(
 	animate(time = 2 SECONDS, size = 10, loop=-1, flags = ANIMATION_PARALLEL)
 	addtimer(CALLBACK(src, PROC_REF(finish_damage_animation)), 12 SECONDS)
 
-/obj/machinery/power/supermatter/proc/finish_damage_animation()
+/obj/structure/supermatter/proc/finish_damage_animation()
 	damage_animation = FALSE
 
-/obj/machinery/power/supermatter/bullet_act(var/obj/item/projectile/Proj)
+/obj/structure/supermatter/bullet_act(var/obj/item/projectile/Proj)
 	var/turf/L = loc
 	if(!istype(L))		// We don't run process() when we are in space
 		return 0	// This stops people from being able to really power up the supermatter
@@ -582,23 +587,23 @@ var/global/list/supermatter_delam_accent_sounds = list(
 		damage += proj_damage * config_bullet_energy
 	return 0
 
-/obj/machinery/power/supermatter/attack_robot(mob/user)
+/obj/structure/supermatter/attack_robot(mob/user)
 	ui_interact(user)
 	return TRUE
 
-/obj/machinery/power/supermatter/attack_ai(mob/living/silicon/ai/user)
+/obj/structure/supermatter/attack_ai(mob/living/silicon/ai/user)
 	ui_interact(user)
 	return TRUE
 
-/obj/machinery/power/supermatter/attack_ghost(mob/user)
+/obj/structure/supermatter/attack_ghost(mob/user)
 	ui_interact(user)
 	return TRUE
 
-/obj/machinery/power/supermatter/attack_hand(mob/user)
+/obj/structure/supermatter/attack_hand(mob/user)
 	return Consume(null, user, TRUE) || ..()
 
 // This is purely informational UI that may be accessed by AIs or robots
-/obj/machinery/power/supermatter/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null, var/force_open = 1)
+/obj/structure/supermatter/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null, var/force_open = 1)
 	var/data[0]
 
 	data["integrity_percentage"] = round(get_integrity())
@@ -624,7 +629,7 @@ var/global/list/supermatter_delam_accent_sounds = list(
 		ui.open()
 		ui.set_auto_update(1)
 
-/obj/machinery/power/supermatter/attackby(obj/item/used_item, mob/user)
+/obj/structure/supermatter/attackby(obj/item/used_item, mob/user)
 
 	if(istype(used_item, /obj/item/stack/tape_roll/duct_tape))
 		var/obj/item/stack/tape_roll/duct_tape/T = used_item
@@ -648,11 +653,11 @@ var/global/list/supermatter_delam_accent_sounds = list(
 	user.apply_damage(150, IRRADIATE, damage_flags = DAM_DISPERSED)
 	return TRUE
 
-/obj/machinery/power/supermatter/Bumped(atom/AM)
+/obj/structure/supermatter/Bumped(atom/AM)
 	if(!Consume(null, AM))
 		return ..()
 
-/obj/machinery/power/supermatter/proc/Consume(var/mob/living/user, var/obj/item/thing, var/touched)
+/obj/structure/supermatter/proc/Consume(var/mob/living/user, var/obj/item/thing, var/touched)
 	. = try_supermatter_consume(user, thing, src, touched)
 	if(. <= 0)
 		return
@@ -663,19 +668,19 @@ var/global/list/supermatter_delam_accent_sounds = list(
 	for(var/atom/A in range(pull_range, target))
 		A.singularity_pull(target, pull_power)
 
-/obj/machinery/power/supermatter/GotoAirflowDest(n) //Supermatter not pushed around by airflow
+/obj/structure/supermatter/GotoAirflowDest(n) //Supermatter not pushed around by airflow
 	return
 
-/obj/machinery/power/supermatter/RepelAirflowDest(n)
+/obj/structure/supermatter/RepelAirflowDest(n)
 	return
 
-/obj/machinery/power/supermatter/explosion_act(var/severity)
+/obj/structure/supermatter/explosion_act(var/severity)
 	. = ..()
 	if(.)
 		power *= max(1, 5 - severity)
 		log_and_message_admins("WARN: Explosion near the Supermatter! New EER: [power].")
 
-/obj/machinery/power/supermatter/singularity_act()
+/obj/structure/supermatter/singularity_act()
 	if(!src.loc)
 		return
 
@@ -689,10 +694,10 @@ var/global/list/supermatter_delam_accent_sounds = list(
 	qdel(src)
 	return 50000
 
-/obj/machinery/power/supermatter/get_artifact_scan_data()
+/obj/structure/supermatter/get_artifact_scan_data()
 	return "Superdense crystalline structure - appears to have been shaped or hewn, lattice is approximately 20 times denser than should be possible."
 
-/obj/machinery/power/supermatter/shard //Small subtype, less efficient and more sensitive, but less boom.
+/obj/structure/supermatter/shard //Small subtype, less efficient and more sensitive, but less boom.
 	name = "supermatter shard"
 	desc = "A strangely translucent and iridescent crystal that looks like it used to be part of a larger structure. <span class='danger'>You get headaches just from looking at it.</span>"
 	icon = 'icons/obj/supermatter_32.dmi'
@@ -708,14 +713,14 @@ var/global/list/supermatter_delam_accent_sounds = list(
 	pull_time = 150
 	explosion_power = 3
 
-/obj/machinery/power/supermatter/medium
+/obj/structure/supermatter/medium
 	icon = 'icons/obj/supermatter_32.dmi'
 	w_class = (ITEM_SIZE_STRUCTURE + ITEM_SIZE_LARGE_STRUCTURE) / 2 // halfway between a shard and a normal SM
 
-/obj/machinery/power/supermatter/shard/announce_warning() //Shards don't get announcements
+/obj/structure/supermatter/shard/announce_warning() //Shards don't get announcements
 	return
 
-/obj/machinery/power/supermatter/shard/singularity_act()
+/obj/structure/supermatter/shard/singularity_act()
 	src.forceMove(null)
 	qdel(src)
 	return 5000

--- a/mods/content/supermatter/structures/supermatter_crystal.dm
+++ b/mods/content/supermatter/structures/supermatter_crystal.dm
@@ -112,8 +112,8 @@ var/global/list/supermatter_delam_accent_sounds = list(
 	anchored = FALSE
 	light_range = 4
 	layer = ABOVE_HUMAN_LAYER
+	material = /decl/material/solid/exotic_matter/supermatter
 	matter = list(
-		/decl/material/solid/exotic_matter = MATTER_AMOUNT_PRIMARY,
 		/decl/material/solid/metal/steel =   MATTER_AMOUNT_REINFORCEMENT
 	)
 	w_class = ITEM_SIZE_LARGE_STRUCTURE


### PR DESCRIPTION
## Description of changes
The supermatter crystal is now a structure and not a machine. It processes on its own subsystem `SSsupermatter`.
- [x] Tested (also make sure material alteration and stuff doesn't cause visual issues)

## Why and what will this PR improve
It didn't use any machinery features except for `uid` and `Process()`, and having it be a machine made a lot of stuff... weird. Now it's just a big crystal that acts funny when you shoot it. Woo.

## Authorship
Me