### PR TITLE
Various supporting changes for modular map generator.

### DIFF
--- a/code/_helpers/logging.dm
+++ b/code/_helpers/logging.dm
@@ -212,6 +212,8 @@ var/global/log_end= world.system_type == UNIX ? ascii2text(13) : ""
 		return json_encode(d)
 	return d.get_log_info_line()
 
+var/global/_gag_report_progress = 0
 /proc/report_progress(var/progress_message)
-	admin_notice("<span class='boldannounce'>[progress_message]</span>", R_DEBUG)
-	log_world(progress_message)
+	if(global._gag_report_progress <= 0)
+		admin_notice("<span class='boldannounce'>[progress_message]</span>", R_DEBUG)
+		to_world_log(progress_message)

--- a/code/controllers/subsystems/mapping.dm
+++ b/code/controllers/subsystems/mapping.dm
@@ -10,6 +10,7 @@ SUBSYSTEM_DEF(mapping)
 	var/list/submaps =                   list()
 	var/list/map_templates_by_category = list()
 	var/list/map_templates_by_type =     list()
+	var/list/spawnable_map_templates =   list()
 	var/list/banned_maps =               list()
 	var/list/banned_template_names =     list()
 
@@ -169,11 +170,15 @@ SUBSYSTEM_DEF(mapping)
 	map_templates =             SSmapping.map_templates
 	map_templates_by_category = SSmapping.map_templates_by_category
 	map_templates_by_type =     SSmapping.map_templates_by_type
+	spawnable_map_templates =   SSmapping.spawnable_map_templates
 
 /datum/controller/subsystem/mapping/proc/register_map_template(var/datum/map_template/map_template)
 	if(!validate_map_template(map_template) || !map_template.preload())
 		return FALSE
-	map_templates[map_template.name] = map_template
+	map_templates[map_template.name]         = map_template
+	map_templates_by_type[map_template.type] = map_template
+	if(map_template.is_spawnable)
+		spawnable_map_templates += map_template
 	for(var/temple_cat in map_template.template_categories) // :3
 		LAZYINITLIST(map_templates_by_category[temple_cat])
 		LAZYSET(map_templates_by_category[temple_cat], map_template.name, map_template)

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -644,7 +644,7 @@
 		return zone.air?.graphic
 	if(external_atmosphere_participation && is_outside())
 		var/datum/level_data/level = SSmapping.levels_by_z[z]
-		return level.exterior_atmosphere.graphic
+		return level.exterior_atmosphere?.graphic
 	var/datum/gas_mixture/environment = return_air()
 	return environment?.graphic
 

--- a/code/modules/admin/verbs/map_template_loadverb.dm
+++ b/code/modules/admin/verbs/map_template_loadverb.dm
@@ -5,7 +5,7 @@
 
 	if (!check_rights(R_FUN)) return
 
-	var/map = input(usr, "Choose a Map Template to place at your CURRENT LOCATION","Place Map Template") as null|anything in SSmapping.map_templates
+	var/map = input(usr, "Choose a Map Template to place at your CURRENT LOCATION","Place Map Template") as null|anything in SSmapping.spawnable_map_templates
 	if(!map)
 		return
 
@@ -37,7 +37,7 @@
 		to_chat(usr, "Please wait for the master controller to initialize before loading maps!")
 		return
 
-	var/map = input(usr, "Choose a Map Template to place on a new zlevel","Place Map Template") as null|anything in SSmapping.map_templates
+	var/map = input(usr, "Choose a Map Template to place on a new zlevel","Place Map Template") as null|anything in SSmapping.spawnable_map_templates
 	if(!map)
 		return
 

--- a/code/modules/maps/_map_template.dm
+++ b/code/modules/maps/_map_template.dm
@@ -26,6 +26,8 @@
 	var/list/template_categories
 	///The initial type of level_data to instantiate new z-level with initially. (Is replaced by whatever is in the map file.) If null, will use default.
 	var/level_data_type
+	/// Whether or not this should show up for admin map spawning.
+	var/is_spawnable = TRUE
 	/// Various tags used for selecting templates for placement on a map.
 	var/template_tags = 0
 


### PR DESCRIPTION
- Allows map templates to be non-spawnable via the admin tool.
- Allows map templates to gag progress reporting.
- Fixes a null runtime in level graphic code.