### PR TITLE
Adds a flash effect on mob damage.

### DIFF
--- a/code/controllers/subsystems/processing/fast_process.dm
+++ b/code/controllers/subsystems/processing/fast_process.dm
@@ -2,4 +2,4 @@
 
 PROCESSING_SUBSYSTEM_DEF(fastprocess)
 	name = "Fast Processing"
-	wait = 2
+	wait = 1

--- a/code/game/objects/items/devices/t_scanner.dm
+++ b/code/game/objects/items/devices/t_scanner.dm
@@ -19,6 +19,10 @@
 
 	var/static/list/overlay_cache = list() //cache recent overlays
 
+/obj/item/t_scanner/Initialize(ml, material_key)
+	. = ..()
+	global.events_repository.register(/decl/observ/moved, src, src, TYPE_PROC_REF(/obj/item/t_scanner, update_tile_overlays))
+
 /obj/item/t_scanner/Destroy()
 	. = ..()
 	if(on)
@@ -44,16 +48,18 @@
 /obj/item/t_scanner/proc/set_active(var/active)
 	on = active
 	if(on)
-		START_PROCESSING(SSfastprocess, src)
+		START_PROCESSING(SSobj, src)
 	else
-		STOP_PROCESSING(SSfastprocess, src)
+		STOP_PROCESSING(SSobj, src)
 		set_user_client(null)
 	update_icon()
 
-//If reset is set, then assume the client has none of our overlays, otherwise we only send new overlays.
 /obj/item/t_scanner/Process()
-	if(!on) return
+	update_tile_overlays()
 
+//If reset is set, then assume the client has none of our overlays, otherwise we only send new overlays.
+/obj/item/t_scanner/proc/update_tile_overlays()
+	if(!on) return
 	//handle clients changing
 	var/client/loc_client = null
 	if(ismob(src.loc))

--- a/code/modules/mob/animations.dm
+++ b/code/modules/mob/animations.dm
@@ -96,6 +96,7 @@
 	// Reset plane and layer so that it doesn't inherit the UI settings from equipped items.
 	var/image/I = new(loc = A)
 	I.appearance = weapon
+	I.appearance_flags |= KEEP_APART
 	I.plane = DEFAULT_PLANE
 	I.layer = A.layer + 0.1
 	I.pixel_x = -(A.pixel_x)

--- a/code/modules/mob/living/human/human_damage.dm
+++ b/code/modules/mob/living/human/human_damage.dm
@@ -89,20 +89,20 @@
 	SHOULD_CALL_PARENT(FALSE) // take/heal overall call update_health regardless of arg
 	if(amount > 0)
 		take_overall_damage(amount, 0)
+		if(istype(ai))
+			ai.retaliate()
 	else
 		heal_overall_damage(-amount, 0)
 	BITSET(hud_updateflag, HEALTH_HUD)
-	if(amount > 0 && istype(ai))
-		ai.retaliate()
 
 /mob/living/human/adjustFireLoss(var/amount, var/do_update_health = TRUE)
 	if(amount > 0)
 		take_overall_damage(0, amount)
+		if(istype(ai))
+			ai.retaliate()
 	else
 		heal_overall_damage(0, -amount)
 	BITSET(hud_updateflag, HEALTH_HUD)
-	if(amount > 0 && istype(ai))
-		ai.retaliate()
 
 /mob/living/human/getCloneLoss()
 	var/amount = 0

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1,5 +1,7 @@
 /mob/living/Initialize()
 
+	render_target = "render_\ref[src]"
+
 	current_health            = get_max_health()
 	original_fingerprint_seed = sequential_id(/mob)
 	fingerprint               = md5(num2text(original_fingerprint_seed))

--- a/code/modules/mob/living/silicon/ai/ai_damage.dm
+++ b/code/modules/mob/living/silicon/ai/ai_damage.dm
@@ -13,7 +13,8 @@
 	return oxyloss
 
 /mob/living/silicon/ai/adjustFireLoss(var/amount, var/do_update_health = TRUE)
-	if(status_flags & GODMODE) return
+	if(status_flags & GODMODE)
+		return
 	fireloss = max(0, fireloss + min(amount, current_health))
 	if(do_update_health)
 		update_health()

--- a/code/modules/mob/living/simple_animal/simple_animal_damage.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal_damage.dm
@@ -37,6 +37,8 @@
 /mob/living/simple_animal/adjustBruteLoss(var/amount, var/do_update_health = TRUE)
 	brute_damage = clamp(brute_damage + amount, 0, get_max_health())
 	. = ..()
+	if(amount > 0 && istype(ai))
+		ai.retaliate()
 
 /mob/living/simple_animal/adjustFireLoss(var/amount, var/do_update_health = TRUE)
 	burn_damage = clamp(burn_damage + amount, 0, get_max_health())

--- a/maps/tradeship/tradeship.dm
+++ b/maps/tradeship/tradeship.dm
@@ -4,6 +4,8 @@
 		#include "../../code/unit_tests/offset_tests.dm"
 	#endif
 
+	#include "../../mods/content/silhouette/_silhouette.dme"
+
 	#include "../../mods/content/tabloids/_tabloids.dme"
 
 	#include "../random_ruins/exoplanet_ruins/playablecolony/playablecolony.dm"

--- a/mods/content/integrated_electronics/components/time.dm
+++ b/mods/content/integrated_electronics/components/time.dm
@@ -82,11 +82,6 @@
 	spawn_flags = IC_SPAWN_RESEARCH
 	power_draw_per_use = 4
 
-/obj/item/integrated_circuit/time/ticker/Destroy()
-	if(is_running)
-		STOP_PROCESSING(SSfastprocess, src)
-	return ..()
-
 /obj/item/integrated_circuit/time/ticker/on_data_written()
 	var/do_tick = get_pin_data(IC_INPUT, 1)
 	if(do_tick && !is_running)
@@ -95,14 +90,12 @@
 	else if(!do_tick && is_running)
 		is_running = FALSE
 
-
 /obj/item/integrated_circuit/time/ticker/proc/tick()
 	if(is_running)
 		addtimer(CALLBACK(src, PROC_REF(tick)), delay)
 		if(world.time > next_fire)
 			next_fire = world.time + delay
 			activate_pin(1)
-
 
 /obj/item/integrated_circuit/time/ticker/custom
 	name = "custom ticker"

--- a/mods/content/silhouette/_silhouette.dm
+++ b/mods/content/silhouette/_silhouette.dm
@@ -1,0 +1,2 @@
+/decl/modpack/silhouette
+	name = "Damage Silhouette"

--- a/mods/content/silhouette/_silhouette.dme
+++ b/mods/content/silhouette/_silhouette.dme
@@ -1,0 +1,8 @@
+#ifndef MOD_SILHOUETTE
+#define MOD_SILHOUETTE
+// BEGIN_INCLUDE
+#include "_silhouette.dm"
+#include "effect.dm"
+#include "mob_damage.dm"
+// END_INCLUDE
+#endif

--- a/mods/content/silhouette/effect.dm
+++ b/mods/content/silhouette/effect.dm
@@ -1,0 +1,51 @@
+// A silhouette mask used to cause mobs to flash a solid colour when hit.
+/obj/effect/silhouette
+	icon              = 'icons/effects/32x32.dmi'
+	icon_state        = "FFF"
+	mouse_opacity     = MOUSE_OPACITY_UNCLICKABLE
+	layer             = ABOVE_LIGHTING_LAYER
+	plane             = ABOVE_LIGHTING_PLANE
+	appearance_flags  = RESET_ALPHA|RESET_COLOR|KEEP_APART
+	is_spawnable_type = FALSE
+	alpha             = 0
+	var/mob/living/owner
+
+/obj/effect/silhouette/Initialize(mapload)
+	. = ..()
+	owner = loc
+	if(!istype(owner))
+		return INITIALIZE_HINT_QDEL
+	global.events_repository.register(/decl/observ/moved, owner, src, TYPE_PROC_REF(/obj/effect/silhouette, follow_owner))
+	add_filter("owner_mask", 1, list(type = "alpha", render_source = "render_\ref[owner]"))
+	name = null
+	verbs.Cut()
+	update_transforms_from_mob(owner)
+
+/obj/effect/silhouette/Destroy()
+	if(owner)
+		global.events_repository.unregister(/decl/observ/moved, owner, src)
+		if(owner.silhouette == src)
+			owner.silhouette = null
+		owner = null
+	if(is_processing)
+		STOP_PROCESSING(SSfastprocess, src)
+	return ..()
+
+/obj/effect/silhouette/Process()
+	..()
+	update_transforms_from_mob(owner)
+
+/obj/effect/silhouette/proc/update_transforms_from_mob(mob/donor)
+	if(!QDELETED(donor))
+		alpha = 0
+		return
+	transform = donor.transform
+	pixel_x = donor.pixel_x
+	pixel_y = donor.pixel_y
+	pixel_z = donor.pixel_z
+	pixel_w = donor.pixel_w
+	glide_size = donor.glide_size
+
+/obj/effect/silhouette/proc/follow_owner()
+	glide_size = owner.glide_size
+	forceMove(owner.loc)

--- a/mods/content/silhouette/effect.dm
+++ b/mods/content/silhouette/effect.dm
@@ -36,7 +36,7 @@
 	update_transforms_from_mob(owner)
 
 /obj/effect/silhouette/proc/update_transforms_from_mob(mob/donor)
-	if(!QDELETED(donor))
+	if(QDELETED(donor))
 		alpha = 0
 		return
 	transform = donor.transform

--- a/mods/content/silhouette/mob_damage.dm
+++ b/mods/content/silhouette/mob_damage.dm
@@ -1,0 +1,78 @@
+/mob/living
+	var/obj/effect/silhouette/silhouette
+
+/mob/living/Initialize()
+	silhouette = new(src)
+	return ..()
+
+/mob/living/Destroy()
+	QDEL_NULL(silhouette)
+	return ..()
+
+/mob/living/proc/flash_silhouette(flash_time = 2, flash_color = COLOR_WHITE)
+	update_appearance_flags(add_flags = KEEP_TOGETHER)
+	if(QDELETED(silhouette))
+		return
+	silhouette.alpha = 255
+	silhouette.color = flash_color
+	if(!silhouette.is_processing)
+		START_PROCESSING(SSfastprocess, silhouette)
+	addtimer(CALLBACK(src, PROC_REF(hide_silhouette)), flash_time, (TIMER_OVERRIDE | TIMER_UNIQUE | TIMER_NO_HASH_WAIT))
+
+/mob/living/proc/hide_silhouette()
+	update_appearance_flags(remove_flags = KEEP_TOGETHER)
+	if(QDELETED(silhouette))
+		return
+	silhouette.alpha = 0
+	if(silhouette.is_processing)
+		STOP_PROCESSING(SSfastprocess, silhouette)
+
+/mob/living/proc/flash_damage(damage_type)
+	var/flash_color
+	switch(damage_type)
+		if(BRUTE)
+			flash_color = COLOR_RED
+		if(BURN)
+			flash_color = COLOR_ORANGE
+		if(TOX)
+			flash_color = COLOR_LIME
+		if(CLONE)
+			flash_color = COLOR_PURPLE
+		if(OXY)
+			flash_color = COLOR_BLUE
+	if(flash_color)
+		flash_silhouette(flash_color = flash_color)
+
+/mob/living/take_damage(damage, damage_type = BRUTE, damage_flags, inflicter, armor_pen = 0, silent, do_update_health)
+	. = ..()
+	if(damage >= 3)
+		flash_damage(damage_type)
+
+// These do not use the standard take_damage() proc so need to be overridden specifically.
+/mob/living/human/take_overall_damage(var/brute, var/burn, var/sharp = 0, var/edge = 0, var/used_weapon = null)
+	. = ..()
+	if(brute >= 3)
+		flash_damage(BRUTE)
+	else if(burn >= 3)
+		flash_damage(BURN)
+
+/mob/living/human/take_organ_damage(var/brute = 0, var/burn = 0, var/bypass_armour = FALSE, var/override_droplimb)
+	. = ..()
+	if(brute >= 3)
+		flash_damage(BRUTE)
+	else if(burn >= 3)
+		flash_damage(BURN)
+
+/mob/living/silicon/robot/take_overall_damage(var/brute = 0, var/burn = 0, var/sharp = 0, var/used_weapon = null)
+	. = ..()
+	if(brute >= 3)
+		flash_damage(BRUTE)
+	else if(burn >= 3)
+		flash_damage(BURN)
+
+/mob/living/silicon/robot/take_organ_damage(var/brute = 0, var/burn = 0, var/bypass_armour = FALSE, var/override_droplimb)
+	. = ..()
+	if(brute >= 3)
+		flash_damage(BRUTE)
+	else if(burn >= 3)
+		flash_damage(BURN)


### PR DESCRIPTION
## Description of changes
- Adds a modpacked feature that causes mobs to briefly flash a solid colour when hit.
- Speeds SSfastprocessing up to 1ds.
- Moves T-ray scanners off SSfastprocessing.
- Removes outdated IC removal from SSfastprocessing.

Opening as a draft because I'm really not sure if it should go in - it can look quite weird and choppy due to the silhouette not lerping when the donor mob is moving between animation states. Would appreciate some feedback on this one.

## TODO
- [ ] Test T-ray scanners.

## Why and what will this PR improve
Immediate damage feedback is nice.

## Authorship
Myself.

## Changelog
:cl:
add: Added a modpack for mobs flashing a solid colour when damaged.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->