### PR TITLE
Remove unnecessary powernet == 0 checks

### DIFF
--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -440,7 +440,6 @@ var/global/list/obj/structure/cable/all_cables = list()
 	. = list()	// this will be a list of all connected power objects
 	if(d1 == 0)
 		for(var/obj/machinery/power/P in loc)
-			if(P.powernet == 0) continue // exclude APCs with powernet=0
 			if(!skip_assigned_powernets || !P.powernet)
 				. += P
 

--- a/code/modules/power/power.dm
+++ b/code/modules/power/power.dm
@@ -112,8 +112,6 @@
 
 		if(!cable_only && istype(AM,/obj/machinery/power))
 			var/obj/machinery/power/P = AM
-			if(P.powernet == 0)	continue		// exclude APCs which have powernet=0
-
 			if(!unmarked || !P.powernet)		//if unmarked=1 we only return things with no powernet
 				if(d == 0)
 					. += P


### PR DESCRIPTION
These checks are no longer necessary after #5151, since that hacky `powernet = 0` workaround was removed.