### PR TITLE
Remove hardcoded /area/space checks

### DIFF
--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -45,6 +45,8 @@ var/global/list/areas = list()
 	var/oneoff_light   =      0
 	var/oneoff_environ =      0
 	var/has_gravity =         TRUE
+	/// If FALSE, this area is unable to have its gravity overridden by a gravity generator. Used on /area/space.
+	var/can_have_gravity =    TRUE
 	var/air_doors_activated = FALSE
 
 	var/obj/machinery/apc/apc

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -31,7 +31,8 @@ var/global/list/areas = list()
 
 	var/lightswitch =         TRUE
 	var/requires_power =      TRUE
-	var/always_unpowered =    FALSE //this gets overriden to 1 for space in area/New()
+	/// Disables constructing or using APCs in this area.
+	var/always_unpowered =    FALSE
 
 	var/atmosalm =            0
 	var/power_equip =         1 // Status
@@ -307,7 +308,7 @@ var/global/list/areas = list()
 #define DO_PARTY(COLOR) animate(color = COLOR, time = 0.5 SECONDS, easing = QUAD_EASING)
 
 /area/on_update_icon()
-	if((atmosalm || fire || eject || party) && (!requires_power||power_environ) && !istype(src, /area/space))//If it doesn't require power, can still activate this proc.
+	if((atmosalm || fire || eject || party) && (!requires_power||power_environ) && !always_unpowered)//If it doesn't require power, can still activate this proc.
 		if(fire && !atmosalm && !eject && !party) // FIRE
 			color = "#ff9292"
 			animate(src)	// stop any current animations.

--- a/code/modules/admin/buildmode/mode_areas.dm
+++ b/code/modules/admin/buildmode/mode_areas.dm
@@ -39,7 +39,7 @@
 /datum/build_mode/areas/Configurate()
 	var/mode = alert("Pick or Create an area.", "Build Mode: Areas", "Pick", "Create", "Cancel")
 	if (mode == "Pick")
-		var/area/path = select_subpath((selected_area?.type || /area/space), /area)
+		var/area/path = select_subpath((selected_area?.type || world.area), /area)
 		if (path)
 			for (var/area/build_area in global.areas)
 				if (build_area.type == path)
@@ -55,7 +55,7 @@
 		new_area.power_equip = 0
 		new_area.power_light = 0
 		new_area.power_environ = 0
-		new_area.always_unpowered = 0
+		new_area.always_unpowered = FALSE
 		SelectArea(new_area)
 		user.client.debug_variables(selected_area)
 		to_chat(user, "Created area [new_area.proper_name]")

--- a/code/modules/maps/template_types/random_exoplanet/random_planet_level_data.dm
+++ b/code/modules/maps/template_types/random_exoplanet/random_planet_level_data.dm
@@ -80,7 +80,7 @@
 	//Try to adopt our parent planet's ambient lighting preferences
 	apply_planet_ambient_lighting(parent_planetoid)
 	//Rename the surface area if we have one yet
-	adapt_location_name(parent_planetoid.name)
+	adapt_to_location_name(parent_planetoid.name)
 
 ///If we're getting atmos from our parent planet, apply it.
 /datum/level_data/planetoid/proc/apply_planet_atmosphere(var/datum/planetoid_data/P)
@@ -96,13 +96,12 @@
 	if(!ambient_light_color)
 		ambient_light_level = P.surface_light_color
 
-/datum/level_data/planetoid/adapt_location_name(location_name)
-	if(!(. = ..()))
-		return
+/datum/level_data/planetoid/adapt_to_location_name(location_name)
 	if(!ispath(base_area) || ispath(base_area, world.area))
 		return
 	var/area/A = get_base_area_instance()
 	//Make sure we're not going to rename the world's base area
 	if(!istype(A, world.area))
+		// vvvv This feels bad, should we be doing this? vvvv
 		global.using_map.area_purity_test_exempt_areas |= A.type //Make sure we add any of those, so unit tests calm down when we rename
 		A.SetName("[location_name]")

--- a/code/modules/multiz/level_data.dm
+++ b/code/modules/multiz/level_data.dm
@@ -504,12 +504,9 @@
 					mob_count--
 					CHECK_TICK
 
-///Changes anything named we may need to rename accordingly to the parent location name. For instance, exoplanets levels.
-/datum/level_data/proc/adapt_location_name(var/location_name)
-	SHOULD_CALL_PARENT(TRUE)
-	if(!base_area || ispath(base_area, /area/space))
-		return FALSE
-	return TRUE
+///Changes anything named we may need to rename based on the parent location name. For instance, exoplanet surface areas.
+/datum/level_data/proc/adapt_to_location_name(var/location_name)
+	return
 
 //#TODO: this could probably be done in a more elegant way. Since most map templates will never call this.
 ///Called before a runtime generated template is generated on our z-level. Only applies to templates generated onto new z-levels.

--- a/code/modules/power/apc/apc_frame.dm
+++ b/code/modules/power/apc/apc_frame.dm
@@ -11,7 +11,7 @@
 
 /obj/item/frame/apc/try_build(turf/on_wall)
 	var/area/A = get_area(src)
-	if (A.requires_power == 0 || istype(A, /area/space))
+	if (A.requires_power == 0 || A.always_unpowered)
 		to_chat(usr, SPAN_WARNING("An APC cannot be placed in this area."))
 		return
 	if (A.get_apc())

--- a/code/modules/power/gravitygenerator.dm
+++ b/code/modules/power/gravitygenerator.dm
@@ -39,7 +39,7 @@
 
 /obj/machinery/gravity_generator/proc/locatelocalareas()
 	for(var/area/A in range(src,effectiverange))
-		if(istype(A,/area/space))
+		if(!A.can_have_gravity)
 			continue // No (de)gravitizing space.
 		localareas |= A
 

--- a/maps/exodus/exodus_areas.dm
+++ b/maps/exodus/exodus_areas.dm
@@ -86,8 +86,8 @@
 	req_access = list(access_engine)
 
 /area/exodus/solar
-	requires_power = 1
-	always_unpowered = 1
+	requires_power = TRUE
+	always_unpowered = TRUE
 	has_gravity = FALSE
 	base_turf = /turf/space
 


### PR DESCRIPTION
## Description of changes
~~Renames `AREA_FLAG_EXTERNAL` to `AREA_FLAG_SPACE_EXPOSED` to make it clearer what it actually does. Removes it from areas where it makes no sense (exoplanet, fantasy, etc.).~~ This change was removed.
Replaces hardcoded `/area/space` checks in APC and area alarm code with an `always_unpowered` check.
Replaces a hardcoded (and redundant) `/area/space` check in level data code with a `world.area` check instead. Also shuffles that proc around a bit and renames it for better clarity, IMO.
Removes a hardcoded space check in gravity generator code by just using a variable for it.
Removes a hardcoded space check in buildmode area mode by using world.area instead.

## Why and what will this PR improve
Steps towards making it easier for downstreams to de-space the codebase, and maybe even a space modpack.

## Authorship
Me