### PR TITLE
Use mend_fracture helper proc where possible

### DIFF
--- a/code/modules/surgery/bones.dm
+++ b/code/modules/surgery/bones.dm
@@ -138,10 +138,14 @@
 /decl/surgery_step/bone/finish/end_step(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = GET_EXTERNAL_ORGAN(target, target_zone)
 	var/bone = affected.encased ? "\the [target]'s damaged [affected.encased]" : "damaged bones in [target]'s [affected.name]"
-	user.visible_message("<span class='notice'>[user] has mended [bone] with \the [tool].</span>"  , \
-		"<span class='notice'>You have mended [bone] with \the [tool].</span>" )
-	affected.mend_fracture()
-	affected.stage = 0
+	// if it's too damaged to mend/will just re-break, warn them and don't lower our stage
+	if(affected.mend_fracture())
+		user.visible_message(SPAN_NOTICE("[user] has mended [bone] with \the [tool].")  , \
+			SPAN_NOTICE("You have mended [bone] with \the [tool]."))
+		affected.stage = 0
+	else
+		user.visible_message(SPAN_WARNING("[user] attempted to mend [bone] with \the [tool], but it was too damaged!"),
+			SPAN_WARNING("You failed to mend [bone] with \the [tool], as it is too damaged."))
 	affected.update_wounds()
 	..()
 

--- a/code/modules/surgery/bones.dm
+++ b/code/modules/surgery/bones.dm
@@ -140,7 +140,7 @@
 	var/bone = affected.encased ? "\the [target]'s damaged [affected.encased]" : "damaged bones in [target]'s [affected.name]"
 	user.visible_message("<span class='notice'>[user] has mended [bone] with \the [tool].</span>"  , \
 		"<span class='notice'>You have mended [bone] with \the [tool].</span>" )
-	affected.status &= ~ORGAN_BROKEN
+	affected.mend_fracture()
 	affected.stage = 0
 	affected.update_wounds()
 	..()

--- a/mods/content/psionics/system/psionics/faculties/redaction.dm
+++ b/mods/content/psionics/system/psionics/faculties/redaction.dm
@@ -91,7 +91,7 @@
 				return TRUE
 			if(E.status & ORGAN_BROKEN)
 				to_chat(user, SPAN_NOTICE("You coax shattered bones to come together and fuse, mending the break."))
-				E.status &= ~ORGAN_BROKEN
+				E.mend_fracture()
 				E.stage = 0
 				return TRUE
 			if(E.is_dislocated() && !E.is_parent_dislocated())

--- a/mods/gamemodes/cult/runes.dm
+++ b/mods/gamemodes/cult/runes.dm
@@ -568,7 +568,7 @@
 	if(charges >= 15)
 		for(var/obj/item/organ/external/e in user.get_external_organs())
 			if(e && e.status & ORGAN_BROKEN)
-				e.status &= ~ORGAN_BROKEN
+				e.mend_fracture()
 				statuses += "bones in your [e.name] snap into place"
 				charges -= 15
 				if(charges < 15)


### PR DESCRIPTION
Separated out of #4969. Code that sets `status &= ~BROKEN` on external organs will now attempt to use the previously-unused `mend_fracture()` helper where possible. Also includes some UX improvements for bones too damaged to repair.