### PR TITLE
Simple animal default colours can be retrieved with a helper.

### DIFF
--- a/code/modules/mob/living/simple_animal/_simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/_simple_animal.dm
@@ -114,6 +114,10 @@
 /mob/living/simple_animal/Initialize()
 	. = ..()
 
+	if(isnull(draw_visible_overlays))
+		var/list/defaults = get_default_animal_colours()
+		draw_visible_overlays = defaults?.Copy() // do not mutate static list
+
 	if(length(ability_handlers))
 		for(var/handler in ability_handlers)
 			add_ability_handler(handler)
@@ -127,6 +131,9 @@
 		minbodytemp = 0
 
 	check_mob_icon_states(TRUE)
+	if(length(draw_visible_overlays))
+		update_icon()
+
 	if(isnull(base_animal_type))
 		base_animal_type = type
 	if(LAZYLEN(natural_armor))
@@ -603,3 +610,10 @@ var/global/list/simplemob_icon_bitflag_cache = list()
 
 /mob/living/simple_animal/is_space_movement_permitted(allow_movement = FALSE)
 	return skip_spacemove ? SPACE_MOVE_PERMITTED : ..()
+
+/mob/living/simple_animal/proc/get_default_animal_colour(marking_type)
+	var/list/colors = get_default_animal_colours()
+	return LAZYACCESS(colors, marking_type) // Return null if unset, rather than forcing COLOR_BLACK or such.
+
+/mob/living/simple_animal/proc/get_default_animal_colours()
+	return

--- a/code/modules/mob/living/simple_animal/passive/deer.dm
+++ b/code/modules/mob/living/simple_animal/passive/deer.dm
@@ -23,11 +23,13 @@
 	ai                 = /datum/mob_controller/passive/deer
 	eye_color          = "#1a1a1a"
 
-	draw_visible_overlays = list(
+/mob/living/simple_animal/passive/deer/get_default_animal_colours()
+	var/static/list/default_colors = list(
 		"base"     = "#b39161",
 		"markings" = "#3a3329",
 		"socks"    = "#ddd5c9"
 	)
+	return default_colors
 
 /mob/living/simple_animal/passive/deer/get_bodytype()
 	return GET_DECL(/decl/bodytype/quadruped/animal/deer)

--- a/code/modules/mob/living/simple_animal/passive/fox.dm
+++ b/code/modules/mob/living/simple_animal/passive/fox.dm
@@ -9,12 +9,15 @@
 	pass_flags         = PASS_FLAG_TABLE
 	butchery_data      = /decl/butchery_data/animal/fox
 	eye_color          = "#1d628a"
-	draw_visible_overlays = list(
+	ability_handlers = list(/datum/ability_handler/predator)
+
+/mob/living/simple_animal/passive/fox/get_default_animal_colours()
+	var/static/list/default_colors = list(
 		"base"     = "#ed5a20",
 		"markings" = "#efe9e6",
 		"socks"    = "#36221b"
 	)
-	ability_handlers = list(/datum/ability_handler/predator)
+	return default_colors
 
 /mob/living/simple_animal/passive/fox/get_available_postures()
 	var/static/list/available_postures = list(
@@ -51,31 +54,38 @@
 	name           = "arctic fox"
 	desc           = "A cunning and graceful predatory mammal, known for leaping headfirst into snowbanks while hunting burrowing rodents."
 	eye_color      = "#7a6f3b"
-	draw_visible_overlays = list(
+
+/mob/living/simple_animal/passive/fox/arctic/get_default_animal_colours()
+	var/static/list/default_colors = list(
 		"base"     = "#ccc496",
 		"markings" = "#efe9e6",
 		"socks"    = "#cab9b1"
 	)
+	return default_colors
 
 /mob/living/simple_animal/passive/fox/silver
 	name           = "silver fox"
 	desc           = "A cunning and graceful predatory mammal, known for the rarity and high value of their pelts."
 	eye_color      = "#2db1c9"
-	draw_visible_overlays = list(
+
+/mob/living/simple_animal/passive/fox/silver/get_default_animal_colours()
+	var/static/list/default_colors = list(
 		"base"     = "#2c2c2a",
 		"markings" = "#3d3b39",
 		"socks"    = "#746d66"
 	)
+	return default_colors
 
 /mob/living/simple_animal/passive/fox/sparkle
 	name = "sparklefox"
 	desc = "A cunning and graceful predatory mammal, known for being really into hardstyle."
 
 /mob/living/simple_animal/passive/fox/sparkle/Initialize()
-	eye_color      = get_random_colour(TRUE)
 	draw_visible_overlays = list(
 		"base"     = get_random_colour(),
 		"markings" = get_random_colour(TRUE),
 		"socks"    = get_random_colour()
 	)
+	eye_color      = get_random_colour(TRUE)
 	. = ..()
+

--- a/code/modules/mob/living/simple_animal/passive/horse.dm
+++ b/code/modules/mob/living/simple_animal/passive/horse.dm
@@ -15,7 +15,7 @@
 	max_rider_size        = MOB_SIZE_MEDIUM
 	ai                    = /datum/mob_controller/passive/horse
 	color                 = "#806146" // preview color
-	draw_visible_overlays = null // e.g. list("base" = "#806146")
+	draw_visible_overlays = list() // to avoid applying any defaults
 
 /datum/mob_controller/passive/horse
 	emote_speech = list("Neigh!","NEIGH!","Neigh?")

--- a/code/modules/mob/living/simple_animal/passive/rabbit.dm
+++ b/code/modules/mob/living/simple_animal/passive/rabbit.dm
@@ -11,11 +11,14 @@
 	ai = /datum/mob_controller/passive/rabbit
 	butchery_data      = /decl/butchery_data/animal/rabbit
 	eye_color = COLOR_BLACK
-	draw_visible_overlays = list(
+
+/mob/living/simple_animal/passive/rabbit/get_default_animal_colours()
+	var/static/list/default_colors = list(
 		"base"     = "#e6e5da",
 		"markings" = "#c8b1a5",
 		"socks"    = "#e6e5da"
 	)
+	return default_colors
 
 /datum/mob_controller/passive/rabbit
 	emote_hear = list("chitters")
@@ -31,30 +34,36 @@
 /mob/living/simple_animal/passive/rabbit/brown
 	name = "brown rabbit"
 	butchery_data = /decl/butchery_data/animal/rabbit/brown
-	draw_visible_overlays = list(
+
+/mob/living/simple_animal/passive/rabbit/brown/get_default_animal_colours()
+	var/static/list/default_colors = list(
 		"base"     = "#62472b",
 		"markings" = "#958279",
 		"socks"    = "#62472b"
 	)
+	return default_colors
 
 /mob/living/simple_animal/passive/rabbit/black
 	name = "black rabbit"
 	butchery_data = /decl/butchery_data/animal/rabbit/black
-	draw_visible_overlays = list(
+
+/mob/living/simple_animal/passive/rabbit/black/get_default_animal_colours()
+	var/static/list/default_colors = list(
 		"base"     = "#4f4f4f",
 		"markings" = "#958279",
 		"socks"    = "#4f4f4f"
 	)
+	return default_colors
 
 /mob/living/simple_animal/passive/rabbit/sparkle
 	name = "sparklerabbit"
 	desc = "A hopping mammal with long ears and a love for raves."
 
 /mob/living/simple_animal/passive/rabbit/sparkle/Initialize()
-	eye_color     = get_random_colour(TRUE)
 	draw_visible_overlays = list(
 		"base"     = get_random_colour(),
 		"markings" = get_random_colour(TRUE),
 		"socks"    = get_random_colour()
 	)
+	eye_color     = get_random_colour(TRUE)
 	. = ..()

--- a/code/modules/mob/living/simple_animal/passive/wolf.dm
+++ b/code/modules/mob/living/simple_animal/passive/wolf.dm
@@ -11,11 +11,13 @@
 	eye_color          = "#9b7214"
 	ability_handlers = list(/datum/ability_handler/predator)
 
-	draw_visible_overlays = list(
+/mob/living/simple_animal/passive/wolf/get_default_animal_colours()
+	var/static/list/default_colors = list(
 		"base"     = "#6a6a6d",
 		"markings" = "#574938",
 		"socks"    = "#41414d"
 	)
+	return default_colors
 
 /datum/mob_controller/passive/hunter/wolf
 	emote_speech   = list("Awoo!","Aroo!","Rrr!")


### PR DESCRIPTION
## Description of changes
- Adds `get_default_animal_colours()` and `get_default_animal_colour()` to simple_animal.
- Moves wolf, rabbit, deer and fox initial colouration into the proc.

## Why and what will this PR improve
Not actually sure if we want this one. Opening it just because it's some general code from Pyrelight that might have utility elsewhere.

## Authorship
Myself.

## Changelog
Nothing player-facing.