### PR TITLE
Clarifying/standardizing random language getter procs and some associated code.

### DIFF
--- a/code/_helpers/mobs.dm
+++ b/code/_helpers/mobs.dm
@@ -13,7 +13,8 @@
 		if(current_species)
 			var/decl/background_detail/background = current_species.get_default_background_datum_by_flag(BACKGROUND_FLAG_NAMING)
 			if(background)
-				return background.get_random_name(null, gender)
+				return background.get_random_cultural_name(gender = gender, species = species)
+
 	return capitalize(pick(gender == FEMALE ? global.using_map.first_names_female : global.using_map.first_names_male)) + " " + capitalize(pick(global.using_map.last_names))
 
 /proc/random_skin_tone(var/decl/bodytype/current_bodytype)

--- a/code/datums/trading/_trader.dm
+++ b/code/datums/trading/_trader.dm
@@ -41,7 +41,7 @@
 	if(ispath(name_language, /decl/language))
 		var/decl/language/L = GET_DECL(name_language)
 		if(istype(L))
-			name = L.get_random_name(pick(MALE,FEMALE))
+			name = L.get_random_language_name(pick(MALE,FEMALE))
 	if(!name)
 		name = capitalize(pick(global.using_map.first_names_female + global.using_map.first_names_male)) + " " + capitalize(pick(global.using_map.last_names))
 

--- a/code/game/movietitles.dm
+++ b/code/game/movietitles.dm
@@ -80,12 +80,12 @@ var/global/list/end_titles
 			background = GET_DECL(/decl/background_detail/heritage/human)
 		if(!showckey)
 			if(prob(90))
-				chunk += "[background.get_random_name(H, H.gender)]\t \t \t \t[uppertext(used_name)][job]"
+				chunk += "[background.get_random_cultural_name(H, H.gender, H.get_species())]\t \t \t \t[uppertext(used_name)][job]"
 			else
 				var/decl/pronouns/pronouns = H.get_pronouns()
 				chunk += "[used_name]\t \t \t \t[uppertext(pronouns.him)]SELF"
 		else
-			chunk += "[uppertext(background.get_random_name(H, H.gender))] a.k.a. '[uppertext(H.ckey)]'\t \t \t \t[uppertext(used_name)][job]"
+			chunk += "[uppertext(background.get_random_cultural_name(H, H.gender, H.get_species()))] a.k.a. '[uppertext(H.ckey)]'\t \t \t \t[uppertext(used_name)][job]"
 		chunksize++
 		if(chunksize > 2)
 			cast += "<center>[jointext(chunk,"<br>")]</center>"
@@ -119,7 +119,7 @@ var/global/list/end_titles
 		if(C.holder.rights & (R_DEBUG|R_ADMIN))
 			var/list/all_backgrounds = decls_repository.get_decls_of_subtype(/decl/background_detail/heritage)
 			var/decl/background_detail/cult = all_backgrounds[pick(all_backgrounds)]
-			staff += "[uppertext(pick(staffjobs))] - [cult.get_random_name(C.gender)] a.k.a. '[C.key]'"
+			staff += "[uppertext(pick(staffjobs))] - [cult.get_random_cultural_name(C.mob, C.mob.gender, C.mob.get_species())] a.k.a. '[C.key]'"
 		else if(C.holder.rights & R_MOD)
 			goodboys += "[C.key]"
 

--- a/code/game/objects/structures/pit.dm
+++ b/code/game/objects/structures/pit.dm
@@ -200,7 +200,7 @@
 	icon_state = pick("wood","cross")
 
 	var/decl/background_detail/S = GET_DECL(/decl/background_detail/heritage/human)
-	var/nam = S.get_random_name(null, pick(MALE,FEMALE))
+	var/nam = S.get_random_cultural_name(null, pick(MALE,FEMALE))
 	var/cur_year = global.using_map.game_year
 	var/born = cur_year - rand(5,150)
 	var/died = max(cur_year - rand(0,70),born)

--- a/code/game/turfs/floors/subtypes/floor_misc.dm
+++ b/code/game/turfs/floors/subtypes/floor_misc.dm
@@ -54,6 +54,9 @@
 /turf/floor/plating
 	_base_flooring = /decl/flooring/plating // Setting here so overrides on /turf/floor do not impact explicitly typed plating turfs.
 
+/turf/floor/plating/flooded
+	flooded = /decl/material/liquid/water
+
 // Dirt plating for Tradeship farms.
 /turf/floor/plating/dirt
 	name = "dirt"

--- a/code/modules/abstract/corpse_spawner.dm
+++ b/code/modules/abstract/corpse_spawner.dm
@@ -90,7 +90,7 @@
 
 	var/decl/background_detail/background = M.get_background_datum_by_flag(BACKGROUND_FLAG_NAMING)
 	if(background && CORPSE_SPAWNER_RANDOM_NAME & spawn_flags)
-		M.SetName(background.get_random_name(M.gender))
+		M.SetName(background.get_random_cultural_name(M, M.gender, M.get_species()))
 	else
 		M.SetName(name)
 	M.real_name = M.name

--- a/code/modules/backgrounds/_background.dm
+++ b/code/modules/backgrounds/_background.dm
@@ -46,7 +46,7 @@
 			secondary_langs -= additional_langs
 		UNSETEMPTY(secondary_langs)
 
-/decl/background_detail/proc/get_random_name(var/mob/M, var/gender)
+/decl/background_detail/proc/get_random_cultural_name(mob/recipient, gender, species)
 	var/decl/language/_language
 	if(name_language)
 		_language = GET_DECL(name_language)
@@ -55,7 +55,7 @@
 	else if(language)
 		_language = GET_DECL(language)
 	if(_language)
-		return _language.get_random_name(gender)
+		return _language.get_random_language_name(gender)
 	return capitalize(pick(gender==FEMALE ? global.using_map.first_names_female : global.using_map.first_names_male)) + " " + capitalize(pick(global.using_map.last_names))
 
 /decl/background_detail/proc/sanitize_background_name(new_name)

--- a/code/modules/backgrounds/heritage/heritage_hidden.dm
+++ b/code/modules/backgrounds/heritage/heritage_hidden.dm
@@ -15,7 +15,7 @@
 	language = /decl/language/cultcommon
 	uid = "heritage_bloodcult"
 
-/decl/background_detail/heritage/hidden/cultist/get_random_name()
+/decl/background_detail/heritage/hidden/cultist/get_random_cultural_name(mob/recipient, gender, species)
 	return "[pick("Anguished", "Blasphemous", "Corrupt", "Cruel", "Depraved", "Despicable", "Disturbed", "Exacerbated", "Foul", "Hateful", "Inexorable", "Implacable", "Impure", "Malevolent", "Malignant", "Malicious", "Pained", "Profane", "Profligate", "Relentless", "Resentful", "Restless", "Spiteful", "Tormented", "Unclean", "Unforgiving", "Vengeful", "Vindictive", "Wicked", "Wronged")] [pick("Apparition", "Aptrgangr", "Dis", "Draugr", "Dybbuk", "Eidolon", "Fetch", "Fylgja", "Ghast", "Ghost", "Gjenganger", "Haint", "Phantom", "Phantasm", "Poltergeist", "Revenant", "Shade", "Shadow", "Soul", "Spectre", "Spirit", "Spook", "Visitant", "Wraith")]"
 
 /decl/background_detail/heritage/hidden/monkey

--- a/code/modules/client/preference_setup/background/02_background.dm
+++ b/code/modules/client/preference_setup/background/02_background.dm
@@ -67,7 +67,7 @@
 	if(istype(check))
 		pref.real_name = check.sanitize_background_name(pref.real_name, pref.species)
 		if(!pref.real_name)
-			pref.real_name = check.get_random_name(get_mannequin(pref.client?.ckey), pref.gender)
+			pref.real_name = check.get_random_cultural_name(get_mannequin(pref.client?.ckey), pref.gender, pref.species)
 
 // Load an associative list of background category type to a background type.
 /datum/category_item/player_setup_item/background/details/load_character(datum/pref_record_reader/R)

--- a/code/modules/client/preference_setup/general/01_basic.dm
+++ b/code/modules/client/preference_setup/general/01_basic.dm
@@ -76,7 +76,7 @@
 	if(pref.be_random_name)
 		var/decl/background_detail/background = pref.get_background_datum_by_flag(BACKGROUND_FLAG_NAMING)
 		if(background)
-			new_real_name = background.get_random_name(pref.gender)
+			new_real_name = background.get_random_cultural_name(gender = pref.gender, species = pref.species)
 	if(get_config_value(/decl/config/toggle/humans_need_surnames))
 		var/firstspace = findtext(new_real_name, " ")
 		var/name_length = length(new_real_name)

--- a/code/modules/clothing/masks/miscellaneous.dm
+++ b/code/modules/clothing/masks/miscellaneous.dm
@@ -157,7 +157,7 @@
 	if(istype(S))
 		var/decl/background_detail/C = GET_DECL(S.default_background_info[/decl/background_category/heritage])
 		if(istype(C))
-			visible_name = C.get_random_name(pick(MALE,FEMALE))
+			visible_name = C.get_random_cultural_name(gender = pick(MALE,FEMALE), species = species)
 
 /obj/item/clothing/mask/rubber/species/cat
 	name = "cat mask"

--- a/code/modules/games/spaceball_cards.dm
+++ b/code/modules/games/spaceball_cards.dm
@@ -16,7 +16,7 @@
 		else
 			var/decl/language/L = GET_DECL(/decl/language/human/common)
 			var/team = pick("Brickburn Galaxy Trekers","Mars Rovers", "Qerrbalak Saints", "Moghes Rockets", "Ahdomai Lightening")
-			P.name = "[L.get_random_name(pick(MALE,FEMALE))], [global.using_map.game_year - rand(0,50)] [team]"
+			P.name = "[L.get_random_language_name(pick(MALE,FEMALE))], [global.using_map.game_year - rand(0,50)] [team]"
 			P.card_icon = "spaceball_standard"
 			P.desc = "A Spaceball playing card."
 		P.back_icon = "card_back_spaceball"

--- a/code/modules/mob/language/alien/antag.dm
+++ b/code/modules/mob/language/alien/antag.dm
@@ -48,7 +48,7 @@
 	. = ..()
 	speech_verb = pick("hisses","growls","whistles","blubbers","chirps","skreeches","rumbles","clicks")
 
-/decl/language/alium/get_random_name()
+/decl/language/alium/get_random_language_name(gender, name_count=2, syllable_count=4, syllable_divisor=2)
 	var/new_name = ""
 	var/name_length = rand(1,3)
 	for(var/i=0 to name_length)

--- a/code/modules/mob/language/human/human.dm
+++ b/code/modules/mob/language/human/human.dm
@@ -18,14 +18,12 @@
 			return ask_verb
 	return speech_verb
 
-/decl/language/human/get_random_name(var/gender)
+/decl/language/human/get_random_language_name(gender, name_count=2, syllable_count=4, syllable_divisor=2)
 	if (prob(80))
 		if(gender==FEMALE)
 			return capitalize(pick(global.using_map.first_names_female)) + " " + capitalize(pick(global.using_map.last_names))
-		else
-			return capitalize(pick(global.using_map.first_names_male)) + " " + capitalize(pick(global.using_map.last_names))
-	else
-		return ..()
+		return capitalize(pick(global.using_map.first_names_male)) + " " + capitalize(pick(global.using_map.last_names))
+	return ..()
 
 /*//////////////////////////////////////////////////////////////////////////////////////////////////////
 	Syllable list compiled in this file based on work by Stefan Trost, available at the following URLs

--- a/code/modules/mob/language/language.dm
+++ b/code/modules/mob/language/language.dm
@@ -67,12 +67,11 @@
 /decl/language/proc/muddle(var/message)
 	return message
 
-/decl/language/proc/get_random_name(var/gender, name_count=2, syllable_count=4, syllable_divisor=2)
+/decl/language/proc/get_random_language_name(gender, name_count=2, syllable_count=4, syllable_divisor=2)
 	if(!length(syllables))
 		if(gender==FEMALE)
 			return capitalize(pick(global.using_map.first_names_female)) + " " + capitalize(pick(global.using_map.last_names))
-		else
-			return capitalize(pick(global.using_map.first_names_male)) + " " + capitalize(pick(global.using_map.last_names))
+		return capitalize(pick(global.using_map.first_names_male)) + " " + capitalize(pick(global.using_map.last_names))
 
 	var/possible_syllables = allow_repeated_syllables ? syllables : syllables.Copy()
 	for(var/i in 1 to name_count)

--- a/code/modules/mob/living/human/human_presets.dm
+++ b/code/modules/mob/living/human/human_presets.dm
@@ -35,7 +35,7 @@
 	. = ..(mapload, species_uid, supplied_appearance) // do not pass the corpse landmark
 	var/decl/background_detail/background = get_background_datum_by_flag(BACKGROUND_FLAG_NAMING)
 	if(background)
-		var/newname = background.get_random_name(src, gender, species.uid)
+		var/newname = background.get_random_cultural_name(src, gender, get_species())
 		if(newname && newname != name)
 			real_name = newname
 			SetName(newname)

--- a/code/modules/mob/new_player/preferences_setup.dm
+++ b/code/modules/mob/new_player/preferences_setup.dm
@@ -119,7 +119,7 @@
 /datum/preferences/proc/get_random_name()
 	var/decl/background_detail/background = get_background_datum_by_flag(BACKGROUND_FLAG_NAMING)
 	if(istype(background))
-		return background.get_random_name(client?.mob, gender)
+		return background.get_random_cultural_name(client?.mob, gender, species)
 	return random_name(gender, species)
 
 /datum/preferences/proc/get_background_datum_by_flag(background_flag)

--- a/code/modules/organs/external/_external.dm
+++ b/code/modules/organs/external/_external.dm
@@ -11,7 +11,6 @@
 	scale_max_damage_to_species_health = TRUE
 	abstract_type = /obj/item/organ/external
 
-	var/_slowdown = 0
 	var/tmp/_icon_cache_key
 	// Strings
 	var/broken_description             // fracture string if any.

--- a/mods/content/bigpharma/_bigpharma.dm
+++ b/mods/content/bigpharma/_bigpharma.dm
@@ -6,7 +6,7 @@ var/global/list/reagent_names_to_medication_names
 	. = LAZYACCESS(global.reagent_names_to_medication_names, reagent_name)
 	if(!.)
 		var/decl/language/bigpharma/pharma = GET_DECL(/decl/language/bigpharma)
-		LAZYSET(global.reagent_names_to_medication_names, reagent_name, pharma.get_random_name())
+		LAZYSET(global.reagent_names_to_medication_names, reagent_name, pharma.get_random_language_name())
 		. = global.reagent_names_to_medication_names[reagent_name]
 
 var/global/list/reagent_names_to_colours

--- a/mods/content/bigpharma/language.dm
+++ b/mods/content/bigpharma/language.dm
@@ -21,5 +21,5 @@
 	)
 	var/list/marks = list("™️","©️","®️")
 
-/decl/language/bigpharma/get_random_name()
+/decl/language/bigpharma/get_random_language_name(gender, name_count=2, syllable_count=4, syllable_divisor=2)
 	. = capitalize("[..(FEMALE, 1, rand(2,3), 1)][pick(endings)][pick(marks)]")

--- a/mods/content/fantasy/datum/kobaloi/language.dm
+++ b/mods/content/fantasy/datum/kobaloi/language.dm
@@ -20,7 +20,7 @@
 	var/list/s3c  = list("m", "r", "ng", "b", "rb", "mb", "g", "lg", "l", "lb", "lm", "k", "nk", "ld", "d", "rsn")
 	var/list/s3r  = list("is", "us", "er", "in")
 
-/decl/language/kobaloi/get_random_name(gender, name_count=2, syllable_count=4, syllable_divisor=2)
+/decl/language/kobaloi/get_random_language_name(gender, name_count=2, syllable_count=4, syllable_divisor=2)
 	return capitalize(get_next_scramble_token())
 
 /decl/language/kobaloi/get_next_scramble_token()

--- a/mods/content/fantasy/items/material_overrides.dm
+++ b/mods/content/fantasy/items/material_overrides.dm
@@ -24,7 +24,7 @@
 
 /obj/item/chems/drinks/bottle/premiumwine/make_random_name()
 	var/decl/language/hnoll/hnoll_language = GET_DECL(/decl/language/hnoll)
-	return "bottle of vintage [hnoll_language.get_random_name(FEMALE, name_count = prob(20) ? 2 : 1)]"
+	return "bottle of vintage [hnoll_language.get_random_language_name(FEMALE, name_count = prob(20) ? 2 : 1)]"
 
 /obj/item/chems/drinks/bottle/wine
 	name = "bottle of red wine"
@@ -34,5 +34,5 @@
 /obj/item/chems/drinks/bottle/wine/Initialize()
 	. = ..()
 	var/decl/language/hnoll/hnoll_language = GET_DECL(/decl/language/hnoll)
-	place_of_origin = hnoll_language.get_random_name(FEMALE, name_count = prob(20) ? 2 : 1)
+	place_of_origin = hnoll_language.get_random_language_name(FEMALE, name_count = prob(20) ? 2 : 1)
 	desc += " It has a label that reads '[place_of_origin]'."

--- a/mods/content/government/ruins/ec_old_crash/ec_old_crash.dm
+++ b/mods/content/government/ruins/ec_old_crash/ec_old_crash.dm
@@ -80,12 +80,12 @@
 	I've used this module as a strongbox, because it is only one rated for re-entry. I leave the astrodata I managed to salvage here. It has a few promising scans. I would not want it to be wasted.<br>
 	Some of the crew wrote letters to their kin, in case we are found. They deserve any consolation they get, so I've put the letters here, too.<br>
 	The crew for this mission is:<br>
-	Ensign [S.get_random_name(null, pick(MALE,FEMALE))]<br>
-	Ensign [S.get_random_name(null, pick(MALE,FEMALE))]<br>
-	Chief Explorer [S.get_random_name(null, pick(MALE,FEMALE))]<br>
-	Senior Explorer [S.get_random_name(null, pick(MALE,FEMALE))]<br>
-	Senior Explorer [S.get_random_name(null, pick(MALE,FEMALE))]<br>
-	Explorer [S.get_random_name(null, pick(MALE,FEMALE))]<br>
+	Ensign [S.get_random_cultural_name(gender = pick(MALE,FEMALE))]<br>
+	Ensign [S.get_random_cultural_name(gender = pick(MALE,FEMALE))]<br>
+	Chief Explorer [S.get_random_cultural_name(gender = pick(MALE,FEMALE))]<br>
+	Senior Explorer [S.get_random_cultural_name(gender = pick(MALE,FEMALE))]<br>
+	Senior Explorer [S.get_random_cultural_name(gender = pick(MALE,FEMALE))]<br>
+	Explorer [S.get_random_cultural_name(gender = pick(MALE,FEMALE))]<br>
 	I am Lieutenant Hao Ru, captain of [shipname] of the Terran Commonwealth Expeditionary Corps. I will be joining my crew in cryo now.<br>
 	<i>3rd December [global.using_map.game_year - 142]</i></tt>
 	"}

--- a/mods/mobs/dionaea/datums/language.dm
+++ b/mods/mobs/dionaea/datums/language.dm
@@ -12,5 +12,5 @@
 	machine_understands = FALSE
 	hidden_from_codex = TRUE
 
-/decl/language/diona/get_random_name()
+/decl/language/diona/get_random_language_name(gender, name_count=2, syllable_count=4, syllable_divisor=2)
 	. = "[pick(list("To Sleep Beneath","Wind Over","Embrace of","Dreams of","Witnessing","To Walk Beneath","Approaching the"))] [pick(list("the Void","the Sky","Encroaching Night","Planetsong","Starsong","the Wandering Star","the Empty Day","Daybreak","Nightfall","the Rain"))]"

--- a/mods/species/adherent/datum/culture.dm
+++ b/mods/species/adherent/datum/culture.dm
@@ -12,7 +12,7 @@
 	)
 	uid = "heritage_adherent"
 
-/decl/background_detail/heritage/adherent/get_random_name(gender)
+/decl/background_detail/heritage/adherent/get_random_cultural_name(mob/recipient, gender, species)
 	return "[uppertext("[pick(global.alphabet)][pick(global.alphabet)]-[pick(global.alphabet)] [rand(1000,9999)]")]"
 
 /decl/background_detail/heritage/adherent/sanitize_background_name(name)

--- a/mods/species/ascent/datum/antagonist.dm
+++ b/mods/species/ascent/datum/antagonist.dm
@@ -20,7 +20,7 @@
 	var/lineage = create_gyne_name()
 	if(ishuman(player.current))
 		var/mob/living/human/H = player.current
-		H.set_gyne_lineage(lineage) // This makes all antag ascent have the same lineage on get_random_name.
+		set_gyne_lineage(H, lineage) // This makes all antag ascent have the same lineage on get_random_cultural_name().
 		var/species_uid = H.get_species()?.uid
 		if(!leader && is_species_whitelisted(player.current, /decl/species/mantid/gyne::uid))
 			leader = player
@@ -32,7 +32,7 @@
 				H.set_species(/decl/species/mantid::uid)
 			H.set_gender(MALE)
 		var/decl/background_detail/heritage/ascent/background = GET_DECL(/decl/background_detail/heritage/ascent)
-		H.real_name = background.get_random_name(H, H.gender)
+		H.real_name = background.get_random_cultural_name(H, H.gender, H.get_species())
 		H.name = H.real_name
 
 /decl/special_role/hunter/equip_role(var/mob/living/human/player)

--- a/mods/species/ascent/datum/culture.dm
+++ b/mods/species/ascent/datum/culture.dm
@@ -1,15 +1,15 @@
 var/global/list/gyne_lineage = list()
-/mob/living/proc/get_gyne_name()
-	. = get_gyne_lineage()
+/proc/get_gyne_name(mob/recipient)
+	. = get_gyne_lineage(recipient)
 	if(!.)
 		. = create_gyne_name()
-		set_gyne_lineage(.)
+		set_gyne_lineage(recipient, .)
 
-/mob/living/proc/get_gyne_lineage()
-	return global.gyne_lineage["\ref[src]"]
+/proc/get_gyne_lineage(mob/recipient)
+	return global.gyne_lineage["\ref[recipient]"]
 
-/mob/living/proc/set_gyne_lineage(value)
-	global.gyne_lineage["\ref[src]"] = value
+/proc/set_gyne_lineage(mob/recipient, value)
+	global.gyne_lineage["\ref[recipient]"] = value
 
 /proc/create_gyne_name()
 	. = "[capitalize(pick(global.gyne_architecture))] [capitalize(pick(global.gyne_geoforms))]"
@@ -86,15 +86,11 @@ var/global/list/gyne_architecture = list(
 	queens."
 	uid = "heritage_ascent"
 
-/decl/background_detail/heritage/ascent/get_random_name(var/mob/M, var/gender)
-	var/mob/living/human/H = M
-	var/lineage = create_gyne_name()
-	if(istype(H) && H.get_gyne_lineage())
-		lineage = H.get_gyne_lineage()
+/decl/background_detail/heritage/ascent/get_random_cultural_name(mob/recipient, gender, species)
+	var/lineage = get_gyne_lineage(recipient) || create_gyne_name()
 	if(gender == MALE)
 		return "[random_id(/decl/species/mantid, 10000, 99999)] [lineage]"
-	else
-		return "[random_id(/decl/species/mantid, 1, 99)] [lineage]"
+	return "[random_id(/decl/species/mantid, 1, 99)] [lineage]"
 
 /decl/background_detail/location/kharmaani
 	name = "Ascent Core"

--- a/mods/species/ascent/machines/magnetotron.dm
+++ b/mods/species/ascent/machines/magnetotron.dm
@@ -39,7 +39,7 @@
 	if(do_after(target, 10 SECONDS, src, TRUE))
 		// Convert to gyne successfully.
 		var/lineage = create_gyne_name()
-		target.set_gyne_lineage(lineage)
+		set_gyne_lineage(target, lineage)
 		target.real_name = "[rand(1, 99)] [lineage]"
 		target.SetName(target.real_name)
 

--- a/mods/species/ascent/mobs/bodyparts_insectoid.dm
+++ b/mods/species/ascent/mobs/bodyparts_insectoid.dm
@@ -28,7 +28,7 @@
 			living_user.adjust_nutrition(-1 * egg_metabolic_cost)
 			living_user.visible_message(SPAN_NOTICE("\icon[living_user] [living_user] carelessly deposits an egg on \the [get_turf(src)]."))
 			var/obj/structure/insectoid_egg/egg = new(get_turf(living_user)) // splorp
-			egg.lineage = living_user.get_gyne_lineage()
+			egg.lineage = get_gyne_lineage(living_user)
 
 /obj/item/organ/external/foot/insectoid/mantid
 	name = "left tail tip"

--- a/mods/species/ascent/mobs/nymph/nymph_life.dm
+++ b/mods/species/ascent/mobs/nymph/nymph_life.dm
@@ -42,8 +42,8 @@
 	if(molt == 5)
 		if(do_after(src, 10 SECONDS, src, FALSE))
 			var/mob/living/human/H = new(get_turf(src), /decl/species/mantid::uid)
-			H.set_gyne_lineage(get_gyne_lineage())
-			H.real_name = "[random_id(/decl/species/mantid, 10000, 99999)] [H.get_gyne_name()]"
+			set_gyne_lineage(H, get_gyne_lineage(H))
+			H.real_name = "[random_id(/decl/species/mantid, 10000, 99999)] [get_gyne_name(H)]"
 			H.nutrition = nutrition * 0.25 // Homgry after molt.
 			mind.transfer_to(H)
 			qdel(src)

--- a/mods/species/drakes/language.dm
+++ b/mods/species/drakes/language.dm
@@ -34,7 +34,7 @@
 	syllables = list("hss", "ssh", "khs", "hrr", "rrr", "rrn")
 	drake_compatible = TRUE
 
-/decl/language/grafadreka/get_random_name()
+/decl/language/grafadreka/get_random_language_name(gender, name_count=2, syllable_count=4, syllable_divisor=2)
 	var/static/list/drake_names = list(
 		"Almond",     "Pepper",      "Pear",        "Apple",       "Apricot",
 		"Crabapple",  "Berry",       "Quince",      "Hawthorn",    "Rowan",

--- a/mods/species/neoavians/datum/language.dm
+++ b/mods/species/neoavians/datum/language.dm
@@ -21,7 +21,7 @@
 		'mods/species/neoavians/sound/crow4.ogg'
 	)
 
-/decl/language/corvid/get_random_name(gender)
+/decl/language/corvid/get_random_language_name(gender, name_count=2, syllable_count=4, syllable_divisor=2)
 	. = capitalize((gender == FEMALE) ? pick(global.using_map.first_names_female) : pick(global.using_map.first_names_male))
 	. += " [pick(list("Albus","Corax","Corone","Meeki","Insularis","Orru","Sinaloae", "Enca", "Edithae", "Kubaryi"))]"
 	. += " [pick(list("Hyperion","Earth","Mars","Venus","Neith","Luna","Halo","Pandora","Neptune","Triton", "Haumea", "Eris", "Makemake"))]"
@@ -42,7 +42,7 @@
 			"ci", "ri", "mi", "si", "ni", "ti", "li", "shi", "schi", "i", "i"
 		)
 
-/decl/language/neoavian/get_random_name(gender)
+/decl/language/neoavian/get_random_language_name(gender, name_count=2, syllable_count=4, syllable_divisor=2)
 	return ..(gender, 2, 4, 1.5)
 
 /decl/background_detail/heritage/neoavian

--- a/mods/species/random_species/aliumizer.dm
+++ b/mods/species/random_species/aliumizer.dm
@@ -27,7 +27,7 @@
 	new /obj/item/implanter/translator(get_turf(src))
 	H.change_species(/decl/species/alium::uid)
 	var/decl/background_detail/background = H.get_background_datum_by_flag(BACKGROUND_FLAG_NAMING)
-	H.fully_replace_character_name(background.get_random_name(H, H.gender))
+	H.fully_replace_character_name(background.get_random_cultural_name(H, H.gender, /decl/species/alium::uid))
 	H.rename_self("Humanoid Alien", 1)
 	return TRUE
 

--- a/mods/species/skrell/datum/language.dm
+++ b/mods/species/skrell/datum/language.dm
@@ -31,5 +31,5 @@ var/global/list/last_name_skrell =   file2list("mods/species/skrell/names/last_n
 		/decl/language/skrell = 90
 	)
 
-/decl/language/skrell/get_random_name(var/gender)
+/decl/language/skrell/get_random_language_name(gender, name_count=2, syllable_count=4, syllable_divisor=2)
 	return capitalize(pick(global.first_name_skrell)) + capitalize(pick(global.last_name_skrell))

--- a/mods/species/tajaran/datum/language.dm
+++ b/mods/species/tajaran/datum/language.dm
@@ -13,7 +13,7 @@
 	"ka","aasi","far","wa","baq","ara","qara","zir","sam","mak","hrar","nja","rir","khan","jun","dar","rik","kah",
 	"hal","ket","jurl","mah","tul","cresh","azu","ragh","mro","mra","mrro","mrra")
 
-/decl/language/tajaran/get_random_name(var/gender, name_count=2, syllable_count=4, syllable_divisor=2)
+/decl/language/tajaran/get_random_language_name(gender, name_count=2, syllable_count=4, syllable_divisor=2)
 	var/new_name = ..(gender,1)
 	if(prob(70))
 		new_name += " [pick(list("Hadii","Kaytam","Nazkiin","Zhan-Khazan","Hharar","Njarir'Akhan","Faaira'Nrezi","Rhezar","Mi'dynh","Rrhazkal","Bayan","Al'Manq","Mi'jri","Chur'eech","Sanu'dra","Ii'rka"))]"

--- a/mods/species/vox/datum/language.dm
+++ b/mods/species/vox/datum/language.dm
@@ -22,5 +22,5 @@
 		return FALSE
 	return TRUE
 
-/decl/language/vox/get_random_name()
+/decl/language/vox/get_random_language_name(gender, name_count=2, syllable_count=4, syllable_divisor=2)
 	return ..(FEMALE,1,6)

--- a/mods/~compatibility/patches/heist_vox.dm
+++ b/mods/~compatibility/patches/heist_vox.dm
@@ -35,7 +35,7 @@
 	var/newname = sanitize_safe(input(vox,"Enter a name, or leave blank for the default name.", "Name change","") as text, MAX_NAME_LEN)
 	if(!newname || newname == "")
 		var/decl/background_detail/background = GET_DECL(/decl/background_detail/heritage/vox/raider)
-		newname = background.get_random_name()
+		newname = background.get_random_cultural_name()
 	vox.real_name = newname
 	vox.SetName(vox.real_name)
 	var/decl/special_role/raider/raiders = GET_DECL(/decl/special_role/raider)


### PR DESCRIPTION
## Description of changes
- Renames language `get_random_name()` to `get_random_language_name()`, standardises parameters.
- Renames cultural `get_random_name()` to `get_random_cultural_name()`, standardises parameters, adds a species parameter.
- Moves gyne lineage and name procs off mob onto global scope.

## TODO
- [x] Test.

## Why and what will this PR improve
Cleans up random name generation and supports doing stuff based on recipient species. Originally coded for Newropa.

## Authorship
Myself.

## Changelog
Nothing player-facing.