### PR TITLE
Clean up and consolidate some redundant logic

### DIFF
--- a/code/modules/maps/template_types/random_exoplanet/fauna_generator.dm
+++ b/code/modules/maps/template_types/random_exoplanet/fauna_generator.dm
@@ -150,12 +150,12 @@
 /datum/fauna_generator/proc/try_respawn_from_queue()
 	. = LAZYACCESS(respawn_queue, 1)
 	if(.)
-		respawn_queue = respawn_queue.Copy(2) //Clear first entry
+		respawn_queue.Cut(1,2) //Clear first entry
 
 /datum/fauna_generator/proc/pick_fauna_to_respawn()
 	. = LAZYACCESS(respawn_queue & fauna_types, 1)
 	if(.)
-		respawn_queue = respawn_queue.Copy(2) //Clear first entry
+		respawn_queue.Cut(1,2) //Clear first entry
 	else
 		//Grab from our fauna list if we don't have anything set to respawn
 		. = pickweight(fauna_types)
@@ -163,7 +163,7 @@
 /datum/fauna_generator/proc/pick_megafauna_to_respawn()
 	. = LAZYACCESS(respawn_queue & megafauna_types, 1)
 	if(.)
-		respawn_queue = respawn_queue.Copy(2) //Clear first entry
+		respawn_queue.Cut(1,2) //Clear first entry
 	else
 		//Grab from our fauna list if we don't have anything set to respawn
 		. = pickweight(megafauna_types)

--- a/code/modules/maps/template_types/random_exoplanet/random_planet_landmarks.dm
+++ b/code/modules/maps/template_types/random_exoplanet/random_planet_landmarks.dm
@@ -66,4 +66,4 @@
 /obj/abstract/landmark/exoplanet_spawn/large_plant/do_spawn(var/datum/planetoid_data/planet)
 	if(!istype(planet) || !planet.flora)
 		return
-	planet.flora.spawn_random_big_flora(get_turf(src))
+	planet.spawn_random_big_flora(get_turf(src))

--- a/code/modules/mining/drilling/drill.dm
+++ b/code/modules/mining/drilling/drill.dm
@@ -166,12 +166,11 @@
 			resources.resources -= material_typepath
 
 /obj/machinery/mining_drill/proc/deplete_turf(turf/T)
-	if(!turf_has_ore(T))
-		if(istype(T))
-			turfs_to_mine -= T
-			if(has_extension(T, /datum/extension/buried_resources))
-				remove_extension(T, /datum/extension/buried_resources)
-	// TODO: suppress the message if no screen is installed?
+	if(!turf_has_ore(T) && istype(T))
+		turfs_to_mine -= T
+		if(has_extension(T, /datum/extension/buried_resources))
+			remove_extension(T, /datum/extension/buried_resources)
+
 /obj/machinery/mining_drill/proc/choose_turf_to_mine()
 	current_turf = turfs_to_mine[1]
 

--- a/code/modules/mining/drilling/drill_fsm.dm
+++ b/code/modules/mining/drilling/drill_fsm.dm
@@ -156,13 +156,9 @@
 	)
 
 /decl/state/drill/switching_target/process(obj/machinery/mining_drill/drill)
-	if(!drill.turf_has_ore(drill.current_turf))
-		if(istype(drill.current_turf))
-			drill.turfs_to_mine -= drill.current_turf
-			if(has_extension(drill.current_turf, /datum/extension/buried_resources))
-				remove_extension(drill.current_turf, /datum/extension/buried_resources)
+	drill.deplete_turf(drill.current_turf)
 	if(length(drill.turfs_to_mine))
-		drill.current_turf = drill.turfs_to_mine[1]
+		drill.choose_turf_to_mine()
 	else
 		drill.current_turf = null
 

--- a/code/modules/synthesized_instruments/globals.dm
+++ b/code/modules/synthesized_instruments/globals.dm
@@ -212,20 +212,15 @@ Bit flags that modify the behavior of above properties
 
 
 /datum/musical_config/proc/environment_to_id(environment)
-	if (environment in src.all_environments)
-		return src.all_environments.Find(environment) - 2
-	return -1
-
+	return index_to_id(src.all_environments.Find(environment))
 
 /datum/musical_config/proc/id_to_environment(id)
 	if (id >= -1 && id <= 26)
 		return src.all_environments[id+2]
 	return "None"
 
-
 /datum/musical_config/proc/index_to_id(index)
 	return max(min(index-2, 26), -1)
-
 
 /datum/musical_config/proc/is_custom_env(id)
 	return id_to_environment(id) == src.all_environments[28]


### PR DESCRIPTION
- We now use `planet.spawn_random_big_flora()` instead of directly calling `planet.flora.spawn_random_big_flora()`. This has the same effect but more abstraction/indirection, so we don't interrogate the planet's generators directly.
- We use `respawn_queue.Cut(1,2)` instead of `respawn_queue = respawn_queue.Copy(2)` to avoid copying the entire list and doing an assignment for no reason. This should reduce list churn. (This just got included while I did the prior change.)
- Makes some drill code use `deplete_turf()` instead (which the replaced code just duplicated).
- Makes `choose_turf_to_mine()` (in drill code) actually get used.
- Simplifies `/datum/musical_config/proc/environment_to_id(environment)` and makes the `/datum/musical_config/proc/index_to_id(index)` proc actually get used. Should still do the same thing.