### PR TITLE
Implement sprite accessory metadata sanitize_data proc

### DIFF
--- a/code/modules/client/preference_setup/general/02_body.dm
+++ b/code/modules/client/preference_setup/general/02_body.dm
@@ -196,9 +196,7 @@
 				for(var/metadata_type in acc_data)
 					var/decl/sprite_accessory_metadata/metadata = GET_DECL(metadata_type)
 					if(istype(metadata))
-						var/value = acc_data[metadata_type]
-						if(!metadata.validate_data(value))
-							acc_data[metadata_type] = metadata.default_value
+						acc_data[metadata_type] = metadata.sanitize_data(acc_data[metadata_type])
 					else
 						acc_data -= metadata_type
 

--- a/code/modules/sprite_accessories/_accessory.dm
+++ b/code/modules/sprite_accessories/_accessory.dm
@@ -166,8 +166,7 @@
 	LAZYINITLIST(metadata)
 	for(var/metadata_type in accessory_metadata_types)
 		var/decl/sprite_accessory_metadata/metadata_decl = GET_DECL(metadata_type)
-		if(!(metadata_type in metadata) || !metadata_decl.validate_data(metadata[metadata_type]))
-			metadata[metadata_type] = metadata_decl.default_value
+		metadata[metadata_type] = metadata_decl.sanitize_data(metadata[metadata_type])
 	return metadata
 
 /decl/sprite_accessory/proc/get_cached_accessory_icon_key(var/obj/item/organ/external/organ, var/list/metadata)

--- a/code/modules/sprite_accessories/metadata/_accessory_metadata.dm
+++ b/code/modules/sprite_accessories/metadata/_accessory_metadata.dm
@@ -11,7 +11,9 @@
 	return FALSE
 
 /decl/sprite_accessory_metadata/proc/sanitize_data(value)
-	return value || default_value
+	if(validate_data(value))
+		return value
+	return default_value
 
 /decl/sprite_accessory_metadata/proc/get_metadata_options_string(datum/preferences/pref, decl/sprite_accessory_category/accessory_category_decl, decl/sprite_accessory/accessory_decl, value)
 	return

--- a/code/modules/sprite_accessories/metadata/accessory_metadata_color.dm
+++ b/code/modules/sprite_accessories/metadata/accessory_metadata_color.dm
@@ -7,8 +7,7 @@
 	return istext(value) && (length(value) == 7 || length(value) == 9)
 
 /decl/sprite_accessory_metadata/color/get_metadata_options_string(datum/preferences/pref, decl/sprite_accessory_category/accessory_category_decl, decl/sprite_accessory/accessory_decl, value)
-	if(!value || !validate_data(value))
-		value = default_value
+	value = sanitize_data(value)
 	return "[COLORED_SQUARE(value)] <a href='byond://?src=\ref[pref];acc_cat_decl=\ref[accessory_category_decl];acc_decl=\ref[accessory_decl];acc_metadata=\ref[src]'>Change</a>"
 
 /decl/sprite_accessory_metadata/color/get_new_value_for(mob/user, decl/sprite_accessory/accessory_decl, current_value)

--- a/code/modules/sprite_accessories/metadata/accessory_metadata_gradient.dm
+++ b/code/modules/sprite_accessories/metadata/accessory_metadata_gradient.dm
@@ -41,8 +41,7 @@
 	return istext(value) && (value in selectable_states_to_labels)
 
 /decl/sprite_accessory_metadata/gradient/get_metadata_options_string(datum/preferences/pref, decl/sprite_accessory_category/accessory_category_decl, decl/sprite_accessory/accessory_decl, value)
-	if(!value || !validate_data(value))
-		value = default_value
+	value = sanitize_data(value)
 	return "<a href='byond://?src=\ref[pref];acc_cat_decl=\ref[accessory_category_decl];acc_decl=\ref[accessory_decl];acc_metadata=\ref[src]'>[selectable_states_to_labels[value]]</a>"
 
 /decl/sprite_accessory_metadata/gradient/get_new_value_for(mob/user, decl/sprite_accessory/accessory_decl, current_value)


### PR DESCRIPTION
Split out of #4969.
`metadata.sanitize_data` should now handle default values for sprite accessory metadata, as well as validation failures. This is basically just what some other code does but in its own helper.
This was tested when it was done in #4969 but it hasn't been tested over several months' worth of rebases, so I'll declare this one untested.