### PR TITLE
Fix missing 'view/set skills' button in occupations tab when in lobby

### DIFF
--- a/code/modules/client/preference_setup/occupation/occupation.dm
+++ b/code/modules/client/preference_setup/occupation/occupation.dm
@@ -185,9 +185,6 @@
 					skill_link = "<a href='byond://?src=\ref[src];set_skills=[title]'>View Skills</a>"
 				skill_link = "<td>[skill_link]</td>"
 
-				if(!user.skillset?.skills_transferable)
-					skill_link = ""
-
 				// Begin assembling the actual HTML.
 				index += 1
 				if((index >= limit) || (job.title in splitJobs))

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -10,6 +10,7 @@
 	anchored = TRUE	//  don't get pushed around
 	virtual_mob = null // Hear no evil, speak no evil
 	is_spawnable_type = FALSE
+	skillset = /datum/skillset // moved here from /mob to avoid giving dview a skillset
 
 	var/ready = 0
 	/// Referenced when you want to delete the new_player later on in the code.

--- a/code/modules/mob/observer/observer.dm
+++ b/code/modules/mob/observer/observer.dm
@@ -15,6 +15,7 @@ var/global/const/GHOST_IMAGE_ALL = ~GHOST_IMAGE_NONE
 	stat = DEAD
 	status_flags = GODMODE
 	shift_to_open_context_menu = FALSE
+	skillset = /datum/skillset // moved here from /mob to avoid giving dview a skillset
 	var/ghost_image_flag = GHOST_IMAGE_DARKNESS
 	var/image/ghost_image = null //this mobs ghost image, for deleting and stuff
 


### PR DESCRIPTION
1. readds the skillset definition to observer and new_player, because the idea was to just make it so dview didn't instantiate one
2. removes the code that nulled the button anyway. from what i can glean this was meant to hide the skills button for AI/cyborg roles? but it wouldn't work as-written and, yeah.