### PR TITLE
Disambiguates and unifies volume vars.

### DIFF
--- a/code/datums/composite_sounds/_composite_sound.dm
+++ b/code/datums/composite_sounds/_composite_sound.dm
@@ -19,7 +19,7 @@
 	var/start_length
 	var/end_sound
 	var/chance
-	var/volume = 100
+	var/play_volume = 100
 	var/max_loops
 	var/direct
 	var/timerid
@@ -71,7 +71,7 @@
 /datum/composite_sound/proc/play(soundfile)
 	var/sound/S = sound(soundfile)
 	for(var/atom/thing as anything in output_atoms)
-		playsound(thing, S, volume)
+		playsound(thing, S, play_volume)
 
 /datum/composite_sound/proc/get_sound(starttime, _mid_sounds)
 	. = _mid_sounds || mid_sounds

--- a/code/datums/composite_sounds/_composite_sound.dm
+++ b/code/datums/composite_sounds/_composite_sound.dm
@@ -6,7 +6,7 @@
 	start_length	(num)					How long to wait before starting the main loop after playing start_sound
 	end_sound		(soundfile)				The sound played after the main loop has concluded
 	chance			(num)					Chance per loop to play a mid_sound
-	volume			(num)					Sound output volume
+	play_volume		(num)					Sound output volume
 	max_loops		(num)					The max amount of loops to run for.
 	direct			(bool)					If true plays directly to provided atoms instead of from them
 */

--- a/code/datums/composite_sounds/fire_sounds.dm
+++ b/code/datums/composite_sounds/fire_sounds.dm
@@ -11,7 +11,7 @@
 	)
 	mid_length = 10
 	end_sound = 'sound/ambience/firecrackle06.ogg'
-	volume = 10
+	play_volume = 10
 
 /datum/composite_sound/grill
 	start_sound = 'sound/machines/kitchen/grill/grill-start.ogg'
@@ -19,4 +19,4 @@
 	mid_sounds = list('sound/machines/kitchen/grill/grill-mid1.ogg'=10)
 	mid_length = 40
 	end_sound = 'sound/machines/kitchen/grill/grill-stop.ogg'
-	volume = 50
+	play_volume = 50

--- a/code/datums/composite_sounds/loom.dm
+++ b/code/datums/composite_sounds/loom.dm
@@ -9,7 +9,7 @@
 		'sound/items/loom3.ogg'
 	)
 	end_sound    = 'sound/items/loomstop.ogg'
-	volume       = 40
+	play_volume  = 40
 
 // Spinning wheel sampled from 'Wooden Spinning Wheel' by Kessir on freesound.org: https://freesound.org/people/kessir/sounds/414554/
 /datum/composite_sound/spinning_wheel_working
@@ -22,4 +22,4 @@
 		'sound/items/spinningwheel3.ogg'
 	)
 	end_sound    = 'sound/items/spinningwheelstop.ogg'
-	volume       = 60
+	play_volume  = 60

--- a/code/datums/composite_sounds/machinery_sounds.dm
+++ b/code/datums/composite_sounds/machinery_sounds.dm
@@ -4,4 +4,4 @@
 	mid_sounds = list('sound/machines/microwave/microwave-mid1.ogg'=10, 'sound/machines/microwave/microwave-mid2.ogg'=1)
 	mid_length = 10
 	end_sound = 'sound/machines/microwave/microwave-end.ogg'
-	volume = 1
+	play_volume = 1

--- a/code/datums/extensions/milkable/milkable.dm
+++ b/code/datums/extensions/milkable/milkable.dm
@@ -85,7 +85,7 @@
 			to_chat(user, SPAN_WARNING("Wait for \the [critter] to stop moving before you try milking it."))
 			return TRUE
 
-	if(container.reagents.total_volume >= container.reagents.maximum_volume)
+	if(REAGENTS_FREE_SPACE(container.reagents) <= 0)
 		to_chat(user, SPAN_WARNING("\The [container] is full."))
 		return TRUE
 
@@ -112,7 +112,7 @@
 		to_chat(user, SPAN_WARNING("\The [critter]'s udder is dry. Wait a little longer."))
 		return TRUE
 
-	if(container.reagents.total_volume >= container.reagents.maximum_volume)
+	if(REAGENTS_FREE_SPACE(container.reagents) <= 0)
 		to_chat(user, SPAN_NOTICE("\The [container] is full."))
 		return TRUE
 

--- a/code/datums/extensions/milkable/milkable.dm
+++ b/code/datums/extensions/milkable/milkable.dm
@@ -85,7 +85,7 @@
 			to_chat(user, SPAN_WARNING("Wait for \the [critter] to stop moving before you try milking it."))
 			return TRUE
 
-	if(container.reagents.total_volume >= container.volume)
+	if(container.reagents.total_volume >= container.reagents.maximum_volume)
 		to_chat(user, SPAN_WARNING("\The [container] is full."))
 		return TRUE
 
@@ -112,7 +112,7 @@
 		to_chat(user, SPAN_WARNING("\The [critter]'s udder is dry. Wait a little longer."))
 		return TRUE
 
-	if(container.reagents.total_volume >= container.volume)
+	if(container.reagents.total_volume >= container.reagents.maximum_volume)
 		to_chat(user, SPAN_NOTICE("\The [container] is full."))
 		return TRUE
 

--- a/code/datums/music_tracks/_music_track.dm
+++ b/code/datums/music_tracks/_music_track.dm
@@ -5,7 +5,7 @@
 	var/decl/license/license
 	var/song
 	var/url // Remember to include http:// or https:// or BYOND will be sad
-	var/volume = 70
+	var/music_volume = 70
 	abstract_type = /decl/music_track
 
 /decl/music_track/Initialize()
@@ -34,7 +34,7 @@
 		to_chat(listener, url)
 
 	to_chat(listener, "<span class='good'>License: <a href='[license.url]'>[license.name]</a></span>")
-	sound_to(listener, sound(song, repeat = 1, wait = 0, volume = volume, channel = sound_channels.lobby_channel))
+	sound_to(listener, sound(song, repeat = 1, wait = 0, volume = music_volume, channel = sound_channels.lobby_channel))
 
 // No VV editing anything about music tracks
 /decl/music_track/VV_static()

--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -272,7 +272,7 @@
 			environment.merge(gas)
 
 /obj/machinery/alarm/proc/overall_danger_level(var/datum/gas_mixture/environment)
-	var/partial_pressure = R_IDEAL_GAS_EQUATION*environment.temperature/environment.air_volume
+	var/partial_pressure = R_IDEAL_GAS_EQUATION*environment.temperature/environment.total_volume
 	var/environment_pressure = environment.return_pressure()
 
 	var/other_moles = 0

--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -272,7 +272,7 @@
 			environment.merge(gas)
 
 /obj/machinery/alarm/proc/overall_danger_level(var/datum/gas_mixture/environment)
-	var/partial_pressure = R_IDEAL_GAS_EQUATION*environment.temperature/environment.volume
+	var/partial_pressure = R_IDEAL_GAS_EQUATION*environment.temperature/environment.air_volume
 	var/environment_pressure = environment.return_pressure()
 
 	var/other_moles = 0

--- a/code/game/machinery/atmoalter/canister.dm
+++ b/code/game/machinery/atmoalter/canister.dm
@@ -9,7 +9,7 @@
 	construct_state  = /decl/machine_construction/pipe/welder
 	stat_immune      = NOSCREEN | NOINPUT | NOPOWER
 	start_pressure   = 45 ATM
-	air_volume       = 1000
+	gas_volume       = 1000
 	interact_offline = TRUE
 	matter           = list(
 		/decl/material/solid/metal/steel = 10 * SHEET_MATERIAL_AMOUNT
@@ -195,7 +195,7 @@ EMPTY_CANISTER(hydrogen, /obj/machinery/portable_atmospherics/canister/hydrogen)
 
 		if((air_contents.temperature > 0) && (pressure_delta > 0))
 			var/transfer_moles = calculate_transfer_moles(air_contents, environment, pressure_delta)
-			transfer_moles = min(transfer_moles, (release_flow_rate/air_contents.air_volume)*air_contents.total_moles) //flow rate limit
+			transfer_moles = min(transfer_moles, (release_flow_rate/air_contents.total_volume)*air_contents.total_moles) //flow rate limit
 			pump_gas_passive(src, air_contents, environment, transfer_moles)
 
 	can_label = (air_contents?.return_pressure() < 1)
@@ -207,13 +207,13 @@ EMPTY_CANISTER(hydrogen, /obj/machinery/portable_atmospherics/canister/hydrogen)
 
 /obj/machinery/portable_atmospherics/canister/proc/return_temperature()
 	var/datum/gas_mixture/GM = return_air()
-	if(GM && GM.air_volume>0)
+	if(GM?.total_volume>0)
 		return GM.temperature
 	return 0
 
 /obj/machinery/portable_atmospherics/canister/proc/return_pressure()
 	var/datum/gas_mixture/GM = return_air()
-	if(GM && GM.air_volume>0)
+	if(GM?.total_volume>0)
 		return GM.return_pressure()
 	return 0
 
@@ -241,7 +241,7 @@ EMPTY_CANISTER(hydrogen, /obj/machinery/portable_atmospherics/canister/hydrogen)
 			//Can not have a pressure delta that would cause environment pressure > tank pressure
 			var/transfer_moles = 0
 			if((air_contents.temperature > 0) && (pressure_delta > 0))
-				transfer_moles = pressure_delta*thejetpack.air_volume/(air_contents.temperature * R_IDEAL_GAS_EQUATION)//Actually transfer the gas
+				transfer_moles = pressure_delta*thejetpack.total_volume/(air_contents.temperature * R_IDEAL_GAS_EQUATION)//Actually transfer the gas
 				var/datum/gas_mixture/removed = air_contents.remove(transfer_moles)
 				thejetpack.merge(removed)
 				to_chat(user, "You pulse-pressurize your jetpack from the tank.")

--- a/code/game/machinery/atmoalter/canister.dm
+++ b/code/game/machinery/atmoalter/canister.dm
@@ -9,7 +9,7 @@
 	construct_state  = /decl/machine_construction/pipe/welder
 	stat_immune      = NOSCREEN | NOINPUT | NOPOWER
 	start_pressure   = 45 ATM
-	volume           = 1000
+	air_volume       = 1000
 	interact_offline = TRUE
 	matter           = list(
 		/decl/material/solid/metal/steel = 10 * SHEET_MATERIAL_AMOUNT
@@ -195,7 +195,7 @@ EMPTY_CANISTER(hydrogen, /obj/machinery/portable_atmospherics/canister/hydrogen)
 
 		if((air_contents.temperature > 0) && (pressure_delta > 0))
 			var/transfer_moles = calculate_transfer_moles(air_contents, environment, pressure_delta)
-			transfer_moles = min(transfer_moles, (release_flow_rate/air_contents.volume)*air_contents.total_moles) //flow rate limit
+			transfer_moles = min(transfer_moles, (release_flow_rate/air_contents.air_volume)*air_contents.total_moles) //flow rate limit
 			pump_gas_passive(src, air_contents, environment, transfer_moles)
 
 	can_label = (air_contents?.return_pressure() < 1)
@@ -207,13 +207,13 @@ EMPTY_CANISTER(hydrogen, /obj/machinery/portable_atmospherics/canister/hydrogen)
 
 /obj/machinery/portable_atmospherics/canister/proc/return_temperature()
 	var/datum/gas_mixture/GM = return_air()
-	if(GM && GM.volume>0)
+	if(GM && GM.air_volume>0)
 		return GM.temperature
 	return 0
 
 /obj/machinery/portable_atmospherics/canister/proc/return_pressure()
 	var/datum/gas_mixture/GM = return_air()
-	if(GM && GM.volume>0)
+	if(GM && GM.air_volume>0)
 		return GM.return_pressure()
 	return 0
 
@@ -241,7 +241,7 @@ EMPTY_CANISTER(hydrogen, /obj/machinery/portable_atmospherics/canister/hydrogen)
 			//Can not have a pressure delta that would cause environment pressure > tank pressure
 			var/transfer_moles = 0
 			if((air_contents.temperature > 0) && (pressure_delta > 0))
-				transfer_moles = pressure_delta*thejetpack.volume/(air_contents.temperature * R_IDEAL_GAS_EQUATION)//Actually transfer the gas
+				transfer_moles = pressure_delta*thejetpack.air_volume/(air_contents.temperature * R_IDEAL_GAS_EQUATION)//Actually transfer the gas
 				var/datum/gas_mixture/removed = air_contents.remove(transfer_moles)
 				thejetpack.merge(removed)
 				to_chat(user, "You pulse-pressurize your jetpack from the tank.")

--- a/code/game/machinery/atmoalter/portable_atmospherics.dm
+++ b/code/game/machinery/atmoalter/portable_atmospherics.dm
@@ -6,7 +6,7 @@
 
 	var/datum/gas_mixture/air_contents = new
 	var/obj/item/tank/holding
-	var/volume = 0
+	var/air_volume = 0
 	var/destroyed = 0
 	var/start_pressure = ONE_ATMOSPHERE
 
@@ -19,7 +19,7 @@
 
 /obj/machinery/portable_atmospherics/Initialize()
 	..()
-	air_contents.volume = volume
+	air_contents.air_volume = air_volume
 	air_contents.temperature = T20C
 
 
@@ -52,7 +52,7 @@
 		/decl/material/gas/nitrogen = N2STANDARD *  MolesForPressure())
 
 /obj/machinery/portable_atmospherics/proc/MolesForPressure(var/target_pressure = start_pressure)
-	return (target_pressure * air_contents.volume) / (R_IDEAL_GAS_EQUATION * air_contents.temperature)
+	return (target_pressure * air_contents.air_volume) / (R_IDEAL_GAS_EQUATION * air_contents.temperature)
 
 /obj/machinery/portable_atmospherics/on_update_icon()
 	return null

--- a/code/game/machinery/atmoalter/portable_atmospherics.dm
+++ b/code/game/machinery/atmoalter/portable_atmospherics.dm
@@ -6,7 +6,7 @@
 
 	var/datum/gas_mixture/air_contents = new
 	var/obj/item/tank/holding
-	var/air_volume = 0
+	var/gas_volume = 0
 	var/destroyed = 0
 	var/start_pressure = ONE_ATMOSPHERE
 
@@ -19,7 +19,7 @@
 
 /obj/machinery/portable_atmospherics/Initialize()
 	..()
-	air_contents.air_volume = air_volume
+	air_contents.total_volume = gas_volume
 	air_contents.temperature = T20C
 
 
@@ -52,7 +52,7 @@
 		/decl/material/gas/nitrogen = N2STANDARD *  MolesForPressure())
 
 /obj/machinery/portable_atmospherics/proc/MolesForPressure(var/target_pressure = start_pressure)
-	return (target_pressure * air_contents.air_volume) / (R_IDEAL_GAS_EQUATION * air_contents.temperature)
+	return (target_pressure * air_contents.total_volume) / (R_IDEAL_GAS_EQUATION * air_contents.temperature)
 
 /obj/machinery/portable_atmospherics/on_update_icon()
 	return null

--- a/code/game/machinery/atmoalter/pump.dm
+++ b/code/game/machinery/atmoalter/pump.dm
@@ -15,7 +15,7 @@
 	var/pressuremin = 0
 	var/pressuremax = 10 ATM
 
-	volume = 1000
+	air_volume = 1000
 
 	power_rating = 7500 //7500 W ~ 10 HP
 	power_losses = 150
@@ -76,11 +76,11 @@
 		var/air_temperature
 		if(direction_out)
 			pressure_delta = target_pressure - environment.return_pressure()
-			output_volume = environment.volume * environment.group_multiplier
+			output_volume = environment.air_volume * environment.group_multiplier
 			air_temperature = environment.temperature? environment.temperature : air_contents.temperature
 		else
 			pressure_delta = environment.return_pressure() - target_pressure
-			output_volume = air_contents.volume * air_contents.group_multiplier
+			output_volume = air_contents.air_volume * air_contents.group_multiplier
 			air_temperature = air_contents.temperature? air_contents.temperature : environment.temperature
 
 		var/transfer_moles = pressure_delta*output_volume/(air_temperature * R_IDEAL_GAS_EQUATION)

--- a/code/game/machinery/atmoalter/pump.dm
+++ b/code/game/machinery/atmoalter/pump.dm
@@ -15,7 +15,7 @@
 	var/pressuremin = 0
 	var/pressuremax = 10 ATM
 
-	air_volume = 1000
+	gas_volume = 1000
 
 	power_rating = 7500 //7500 W ~ 10 HP
 	power_losses = 150
@@ -76,11 +76,11 @@
 		var/air_temperature
 		if(direction_out)
 			pressure_delta = target_pressure - environment.return_pressure()
-			output_volume = environment.air_volume * environment.group_multiplier
+			output_volume = environment.total_volume * environment.group_multiplier
 			air_temperature = environment.temperature? environment.temperature : air_contents.temperature
 		else
 			pressure_delta = environment.return_pressure() - target_pressure
-			output_volume = air_contents.air_volume * air_contents.group_multiplier
+			output_volume = air_contents.total_volume * air_contents.group_multiplier
 			air_temperature = air_contents.temperature? air_contents.temperature : environment.temperature
 
 		var/transfer_moles = pressure_delta*output_volume/(air_temperature * R_IDEAL_GAS_EQUATION)

--- a/code/game/machinery/atmoalter/scrubber.dm
+++ b/code/game/machinery/atmoalter/scrubber.dm
@@ -10,7 +10,7 @@
 	movable_flags = MOVABLE_FLAG_WHEELED
 	var/volume_rate = 800
 
-	volume = 750
+	air_volume = 750
 
 	power_rating = 7500 //7500 W ~ 10 HP
 	power_losses = 150
@@ -67,7 +67,7 @@
 		else
 			environment = loc.return_air()
 
-		var/transfer_moles = min(1, volume_rate/environment.volume)*environment.total_moles
+		var/transfer_moles = min(1, volume_rate/environment.air_volume)*environment.total_moles
 
 		power_draw = scrub_gas(src, scrubbing_gas, environment, air_contents, transfer_moles, power_rating)
 
@@ -151,7 +151,7 @@
 	name = "huge air scrubber"
 	icon_state = "scrubber:0"
 	anchored = TRUE
-	volume = 50000
+	air_volume = 50000
 	volume_rate = 5000
 	base_type = /obj/machinery/portable_atmospherics/powered/scrubber/huge
 

--- a/code/game/machinery/atmoalter/scrubber.dm
+++ b/code/game/machinery/atmoalter/scrubber.dm
@@ -10,7 +10,7 @@
 	movable_flags = MOVABLE_FLAG_WHEELED
 	var/volume_rate = 800
 
-	air_volume = 750
+	gas_volume = 750
 
 	power_rating = 7500 //7500 W ~ 10 HP
 	power_losses = 150
@@ -67,7 +67,7 @@
 		else
 			environment = loc.return_air()
 
-		var/transfer_moles = min(1, volume_rate/environment.air_volume)*environment.total_moles
+		var/transfer_moles = min(1, volume_rate/environment.total_volume)*environment.total_moles
 
 		power_draw = scrub_gas(src, scrubbing_gas, environment, air_contents, transfer_moles, power_rating)
 
@@ -151,7 +151,7 @@
 	name = "huge air scrubber"
 	icon_state = "scrubber:0"
 	anchored = TRUE
-	air_volume = 50000
+	gas_volume = 50000
 	volume_rate = 5000
 	base_type = /obj/machinery/portable_atmospherics/powered/scrubber/huge
 

--- a/code/game/machinery/biogenerator.dm
+++ b/code/game/machinery/biogenerator.dm
@@ -16,6 +16,8 @@
 	construct_state = /decl/machine_construction/default/panel_closed
 	uncreated_component_parts = null
 	stat_immune = 0
+	chem_volume = 1000
+
 	var/processing = 0
 	var/obj/item/chems/glass/beaker = null
 	var/points = 0
@@ -54,7 +56,6 @@
 			/obj/item/stack/material/skin/mapped/synthleather =30))
 
 /obj/machinery/biogenerator/Initialize()
-	create_reagents(1000)
 	beaker = new /obj/item/chems/glass/bottle(src)
 	. = ..()
 

--- a/code/game/machinery/cracker.dm
+++ b/code/game/machinery/cracker.dm
@@ -6,7 +6,7 @@
 	density = TRUE
 	anchored = TRUE
 	waterproof = TRUE
-	air_volume = 5000
+	gas_volume = 5000
 	use_power = POWER_USE_IDLE
 	idle_power_usage = 100
 	active_power_usage = 10000

--- a/code/game/machinery/cracker.dm
+++ b/code/game/machinery/cracker.dm
@@ -6,7 +6,7 @@
 	density = TRUE
 	anchored = TRUE
 	waterproof = TRUE
-	volume = 5000
+	air_volume = 5000
 	use_power = POWER_USE_IDLE
 	idle_power_usage = 100
 	active_power_usage = 10000

--- a/code/game/machinery/jukebox.dm
+++ b/code/game/machinery/jukebox.dm
@@ -17,7 +17,7 @@
 	construct_state = /decl/machine_construction/default/panel_closed
 
 	var/playing = 0
-	var/volume = 20
+	var/music_volume = 20
 
 	var/sound_id
 	var/datum/sound_token/sound_token
@@ -84,7 +84,7 @@
 		"current_track" = current_track != null ? current_track.title : "No track selected",
 		"playing" = playing,
 		"tracks" = juke_tracks,
-		"volume" = volume
+		"volume" = music_volume
 	)
 
 	ui = SSnano.try_update_ui(user, src, ui_key, ui, data, force_open)
@@ -180,12 +180,12 @@
 		return
 
 	// Jukeboxes cheat massively and actually don't share id. This is only done because it's music rather than ambient noise.
-	sound_token = play_looping_sound(src, sound_id, current_track.GetTrack(), volume = volume, range = 7, falloff = 3, prefer_mute = TRUE, preference = /datum/client_preference/play_game_music, streaming = TRUE)
+	sound_token = play_looping_sound(src, sound_id, current_track.GetTrack(), volume = music_volume, range = 7, falloff = 3, prefer_mute = TRUE, preference = /datum/client_preference/play_game_music, streaming = TRUE)
 
 	playing = 1
 	update_use_power(POWER_USE_ACTIVE)
 
 /obj/machinery/media/jukebox/proc/AdjustVolume(var/new_volume)
-	volume = clamp(new_volume, 0, 50)
+	music_volume = clamp(new_volume, 0, 50)
 	if(sound_token)
-		sound_token.SetVolume(volume)
+		sound_token.SetVolume(music_volume)

--- a/code/game/machinery/kitchen/icecream.dm
+++ b/code/game/machinery/kitchen/icecream.dm
@@ -18,6 +18,7 @@
 	anchored = FALSE
 	atom_flags = ATOM_FLAG_NO_CHEM_CHANGE | ATOM_FLAG_OPEN_CONTAINER
 	idle_power_usage = 100
+	chem_volume = 100
 
 	var/list/product_types = list()
 	var/dispense_flavour = ICECREAM_VANILLA
@@ -66,13 +67,8 @@
 
 /obj/machinery/icecream_vat/Initialize(mapload, d, populate_parts)
 	. = ..()
-	initialize_reagents()
 	while(product_types.len < 8)
 		product_types.Add(5)
-
-/obj/machinery/icecream_vat/initialize_reagents(populate = TRUE)
-	create_reagents(100)
-	. = ..()
 
 /obj/machinery/icecream_vat/populate_reagents()
 	add_to_reagents(/decl/material/liquid/drink/milk, 5)
@@ -201,7 +197,7 @@
 	icon_state = "icecream_cone_waffle" //default for admin-spawned cones, href_list["cone"] should overwrite this all the time
 	layer = ABOVE_OBJ_LAYER
 	bitesize = 3
-	volume = 20
+	chem_volume = 20
 	nutriment_amt = 5
 	nutriment_type = /decl/material/liquid/nutriment
 	nutriment_desc = list("crunchy waffle cone" = 1)

--- a/code/game/machinery/kitchen/microwave.dm
+++ b/code/game/machinery/kitchen/microwave.dm
@@ -11,6 +11,8 @@
 	construct_state = /decl/machine_construction/default/panel_closed
 	uncreated_component_parts = null
 	stat_immune = 0
+	chem_volume = 100
+
 	var/operating = FALSE // Is it on?
 	var/dirty = 0 // = {0..100} Does it need cleaning?
 	var/broken = 0 // ={0,1,2} How broken is it???
@@ -37,7 +39,6 @@
 
 /obj/machinery/microwave/Initialize()
 	. = ..()
-	create_reagents(100)
 	soundloop = new(list(src), FALSE)
 
 /obj/machinery/microwave/Destroy()

--- a/code/game/machinery/washing_machine.dm
+++ b/code/game/machinery/washing_machine.dm
@@ -19,6 +19,7 @@
 	obj_flags = OBJ_FLAG_ANCHORABLE
 	clicksound = "button"
 	clickvol = 40
+	chem_volume = 100
 
 	// Power
 	idle_power_usage = 10
@@ -56,10 +57,6 @@
 		/obj/item/clothing/head/helmet
 	)
 	return wash_blacklist
-
-/obj/machinery/washing_machine/Initialize(mapload, d, populate_parts)
-	create_reagents(100)
-	. = ..()
 
 /obj/machinery/washing_machine/get_examine_strings(mob/user, distance, infix, suffix)
 	. = ..()

--- a/code/game/objects/__objs.dm
+++ b/code/game/objects/__objs.dm
@@ -9,8 +9,8 @@
 	///The current health of the obj. Leave to null, unless you want the object to start at a different health than max_health.
 	current_health = null
 
-	// If >0 will create a reagent holder on Initialize()
-	var/chem_volume = 0
+	// If non-null and positive, will create a reagent holder on Initialize()
+	var/chem_volume
 
 	var/obj_flags
 	var/datum/talking_atom/talking_atom
@@ -37,7 +37,7 @@
 		current_health = get_max_health()
 	else
 		current_health = min(current_health, get_max_health())
-	if(chem_volume > 0)
+	if(!isnull(chem_volume) && chem_volume >= 0) // 0-volume holders perserved for legacy code reasons. Ideally shouldn't exist if <= 0
 		initialize_reagents()
 
 /obj/object_shaken()
@@ -271,8 +271,7 @@
 	SHOULD_CALL_PARENT(TRUE)
 	if(reagents?.total_volume > 0)
 		log_warning("\The [src] possibly is initializing its reagents more than once!")
-	if(chem_volume > 0)
-		create_reagents(chem_volume)
+	create_or_update_reagents(chem_volume)
 	if(populate)
 		populate_reagents()
 

--- a/code/game/objects/__objs.dm
+++ b/code/game/objects/__objs.dm
@@ -9,6 +9,9 @@
 	///The current health of the obj. Leave to null, unless you want the object to start at a different health than max_health.
 	current_health = null
 
+	// If >0 will create a reagent holder on Initialize()
+	var/chem_volume = 0
+
 	var/obj_flags
 	var/datum/talking_atom/talking_atom
 	var/list/req_access
@@ -34,6 +37,8 @@
 		current_health = get_max_health()
 	else
 		current_health = min(current_health, get_max_health())
+	if(chem_volume > 0)
+		initialize_reagents()
 
 /obj/object_shaken()
 	shake_animation()
@@ -259,13 +264,15 @@
 	return TRUE
 
 /**
- * Init starting reagents and/or reagent var. Not called at the /obj level.
+ * Init starting reagents and/or reagent var. Called if chem_volume > 0 in /obj/Initialize()
  * populate: If set to true, we expect map load/admin spawned reagents to be set.
  */
 /obj/proc/initialize_reagents(var/populate = TRUE)
 	SHOULD_CALL_PARENT(TRUE)
 	if(reagents?.total_volume > 0)
 		log_warning("\The [src] possibly is initializing its reagents more than once!")
+	if(chem_volume > 0)
+		create_reagents(chem_volume)
 	if(populate)
 		populate_reagents()
 

--- a/code/game/objects/effects/chem/chemsmoke.dm
+++ b/code/game/objects/effects/chem/chemsmoke.dm
@@ -7,13 +7,14 @@
 	layer = ABOVE_PROJECTILE_LAYER
 	time_to_live = 300
 	pass_flags = PASS_FLAG_TABLE | PASS_FLAG_GRILLE | PASS_FLAG_GLASS //PASS_FLAG_GLASS is fine here, it's just so the visual effect can "flow" around glass
+	chem_volume = 500
+
 	var/splash_amount = 10 //atoms moving through a smoke cloud get splashed with up to 10 units of reagent
 	var/turf/destination
 
 /obj/effect/effect/smoke/chem/Initialize(mapload, smoke_duration, turf/dest_turf = null, icon/cached_icon = null)
 	. = ..()
 
-	create_reagents(500)
 
 	if(cached_icon)
 		icon = cached_icon
@@ -76,7 +77,7 @@
 /////////////////////////////////////////////
 /datum/effect/effect/system/smoke_spread/chem
 	smoke_type = /obj/effect/effect/smoke/chem
-	var/obj/chemholder
+	var/obj/effect/chem_holder/chemholder
 	var/range
 	var/list/targetTurfs
 	var/list/wallList
@@ -96,8 +97,7 @@
 
 /datum/effect/effect/system/smoke_spread/chem/New()
 	..()
-	chemholder = new/obj()
-	chemholder.create_reagents(500)
+	chemholder = new(null, 500)
 
 //Sets up the chem smoke effect
 // Calculates the max range smoke can travel, then gets all turfs in that view range.

--- a/code/game/objects/effects/chem/foam.dm
+++ b/code/game/objects/effects/chem/foam.dm
@@ -11,6 +11,7 @@
 	layer = ABOVE_OBJ_LAYER
 	mouse_opacity = MOUSE_OPACITY_UNCLICKABLE
 	animate_movement = 0
+	chem_volume = 10
 	var/amount = 3
 	var/metal = 0
 
@@ -56,11 +57,9 @@
 
 		F = new(T, metal)
 		F.amount = amount
-		if(!metal)
-			F.create_reagents(10)
-			if(reagents)
-				for(var/decl/material/reagent as anything in reagents.reagent_volumes)
-					F.add_to_reagents(reagent, 1, safety = 1) //added safety check since reagents in the foam have already had a chance to react
+		if(!metal && reagents?.total_volume)
+			for(var/decl/material/reagent as anything in reagents.reagent_volumes)
+				F.add_to_reagents(reagent, 1, safety = 1) //added safety check since reagents in the foam have already had a chance to react
 
 /obj/effect/effect/foam/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume) // foam disolves when heated, except metal foams
 	if(!metal && prob(max(0, exposed_temperature - 475)))
@@ -107,8 +106,6 @@
 		F.amount = amount
 
 		if(!metal) // don't carry other chemicals if a metal foam
-			F.create_reagents(10)
-
 			if(carried_reagents)
 				for(var/id in carried_reagents)
 					F.add_to_reagents(id, 1, safety = 1) //makes a safety call because all reagents should have already reacted anyway

--- a/code/game/objects/effects/chem/water.dm
+++ b/code/game/objects/effects/chem/water.dm
@@ -4,6 +4,7 @@
 	icon_state = "extinguish"
 	mouse_opacity = MOUSE_OPACITY_UNCLICKABLE
 	pass_flags = PASS_FLAG_TABLE | PASS_FLAG_GRILLE
+	chem_volume = 10
 
 /obj/effect/effect/water/Initialize()
 	. = ..()
@@ -62,3 +63,4 @@
 	name = "chemicals"
 	icon = 'icons/obj/chempuff.dmi'
 	icon_state = ""
+	chem_volume = 10

--- a/code/game/objects/effects/chem_holder.dm
+++ b/code/game/objects/effects/chem_holder.dm
@@ -1,0 +1,6 @@
+/obj/effect/chem_holder
+	atom_flags = ATOM_FLAG_OPEN_CONTAINER
+
+/obj/effect/chem_holder/Initialize(mapload, _vol)
+	chem_volume = _vol
+	. = ..()

--- a/code/game/objects/effects/decals/Cleanable/misc.dm
+++ b/code/game/objects/effects/decals/Cleanable/misc.dm
@@ -81,12 +81,12 @@
 	icon_state         = "vomit_1"
 	persistent         = TRUE
 	generic_filth      = TRUE
+	chem_volume        = 30
 
 /obj/effect/decal/cleanable/vomit/Initialize(ml, _age)
 	random_icon_states = icon_states(icon)
-	. = ..()
 	atom_flags |= ATOM_FLAG_OPEN_CONTAINER
-	create_reagents(30, src)
+	. = ..()
 	if(prob(75))
 		set_rotation(pick(90, 180, 270))
 

--- a/code/game/objects/explosion.dm
+++ b/code/game/objects/explosion.dm
@@ -182,7 +182,7 @@
 	log_debug("iexpl: Beginning SFX phase.")
 	time = REALTIMEOFDAY
 
-	var/volume = 10 + (power * 20)
+	var/explosion_volume = 10 + (power * 20)
 
 	var/frequency = get_rand_frequency()
 	var/close_dist = round(power + world.view - 2, 1)
@@ -217,12 +217,12 @@
 		var/dist = get_dist(M, epicenter) || 1
 		if ((reception & EXPLFX_SOUND) && !HAS_STATUS(M, STAT_DEAF))
 			if (dist <= close_dist)
-				M.playsound_local(epicenter, explosion_sound, min(100, volume), 1, frequency, falloff = 5)
+				M.playsound_local(epicenter, explosion_sound, min(100, explosion_volume), 1, frequency, falloff = 5)
 				//You hear a far explosion if you're outside the blast radius. Small bombs shouldn't be heard all over the station.
 			else
-				volume = M.playsound_local(epicenter, 'sound/effects/explosionfar.ogg', volume, 1, frequency, falloff = 1000)
+				explosion_volume = M.playsound_local(epicenter, 'sound/effects/explosionfar.ogg', explosion_volume, 1, frequency, falloff = 1000)
 
-		if ((reception & EXPLFX_SHAKE) && volume > 0)
+		if ((reception & EXPLFX_SHAKE) && explosion_volume > 0)
 			shake_camera(M, min(30, max(2,(power*2) / dist)), min(3.5, ((power/3) / dist)),0.05)
 			//Maximum duration is 3 seconds, and max strength is 3.5
 			//Becuse values higher than those just get really silly

--- a/code/game/objects/items/_item_damage.dm
+++ b/code/game/objects/items/_item_damage.dm
@@ -77,14 +77,14 @@
 /obj/item/throw_impact(atom/hit_atom, datum/thrownthing/TT)
 	. = ..()
 	if(isliving(hit_atom)) //Living mobs handle hit sounds differently.
-		var/volume = get_volume_by_throwforce_and_or_w_class()
+		var/impact_volume = get_volume_by_throwforce_and_or_w_class()
 		if (get_thrown_attack_force() > 0)
 			if(hitsound)
-				playsound(hit_atom, hitsound, volume, TRUE, -1)
+				playsound(hit_atom, hitsound, impact_volume, TRUE, -1)
 			else
-				playsound(hit_atom, 'sound/weapons/genhit.ogg', volume, TRUE, -1)
+				playsound(hit_atom, 'sound/weapons/genhit.ogg', impact_volume, TRUE, -1)
 		else
-			playsound(hit_atom, 'sound/weapons/throwtap.ogg', volume, TRUE, -1)
+			playsound(hit_atom, 'sound/weapons/throwtap.ogg', impact_volume, TRUE, -1)
 
 /obj/item/proc/eyestab(mob/living/M, mob/living/user)
 	var/mob/living/human/H = M

--- a/code/game/objects/items/devices/boombox.dm
+++ b/code/game/objects/items/devices/boombox.dm
@@ -14,7 +14,7 @@
 	)
 	var/playing = 0
 	var/track_num = 1
-	var/volume = 20
+	var/music_volume = 20
 	var/max_volume = 40
 	var/frequency = 1
 	var/datum/sound_token/sound_token
@@ -84,10 +84,10 @@
 		start()
 		return TOPIC_HANDLED
 	if(href_list["volup"])
-		change_volume(volume + 10)
+		change_volume(music_volume + 10)
 		return TOPIC_HANDLED
 	if(href_list["voldown"])
-		change_volume(volume - 10)
+		change_volume(music_volume - 10)
 		return TOPIC_HANDLED
 
 /obj/item/boombox/attackby(var/obj/item/used_item, var/mob/user)
@@ -180,7 +180,7 @@
 /obj/item/boombox/proc/start()
 	QDEL_NULL(sound_token)
 	var/datum/track/T = tracks[track_num]
-	sound_token = play_looping_sound(src, sound_id, T.GetTrack(), volume = volume, frequency = frequency, range = 7, falloff = 4, prefer_mute = TRUE, preference = /datum/client_preference/play_game_music, streaming = TRUE)
+	sound_token = play_looping_sound(src, sound_id, T.GetTrack(), volume = music_volume, frequency = frequency, range = 7, falloff = 4, prefer_mute = TRUE, preference = /datum/client_preference/play_game_music, streaming = TRUE)
 	playing = 1
 	update_icon()
 	if(prob(break_chance))
@@ -193,9 +193,9 @@
 	stop()
 
 /obj/item/boombox/proc/change_volume(var/new_volume)
-	volume = clamp(new_volume, 0, max_volume)
+	music_volume = clamp(new_volume, 0, max_volume)
 	if(sound_token)
-		sound_token.SetVolume(volume)
+		sound_token.SetVolume(music_volume)
 
 /obj/random_multi/single_item/boombox
 	name = "boombox spawnpoint"

--- a/code/game/objects/items/devices/oxycandle.dm
+++ b/code/game/objects/items/devices/oxycandle.dm
@@ -14,7 +14,7 @@
 
 	var/target_pressure = ONE_ATMOSPHERE
 	var/datum/gas_mixture/air_contents = null
-	var/volume = 4600
+	var/candle_volume = 4600
 	var/on = 0
 	var/activation_sound = 'sound/effects/flare.ogg'
 	var/brightness_on = 1 // Moderate-low bright.
@@ -33,10 +33,10 @@
 		update_icon()
 		playsound(src.loc, activation_sound, 75, 1)
 		air_contents = new /datum/gas_mixture()
-		air_contents.volume = 200 //liters
+		air_contents.air_volume = 200 //liters
 		air_contents.temperature = T20C
 		var/const/OXYGEN_FRACTION = 1 // separating out the constant so it's clearer why it exists and how to modify it later
-		air_contents.adjust_gas(/decl/material/gas/oxygen, OXYGEN_FRACTION * (target_pressure * air_contents.volume) / (R_IDEAL_GAS_EQUATION * air_contents.temperature))
+		air_contents.adjust_gas(/decl/material/gas/oxygen, OXYGEN_FRACTION * (target_pressure * air_contents.air_volume) / (R_IDEAL_GAS_EQUATION * air_contents.temperature))
 		START_PROCESSING(SSprocessing, src)
 
 // Process of Oxygen candles releasing air. Makes 200 volume of oxygen
@@ -44,7 +44,7 @@
 	if(!loc)
 		return
 	var/turf/pos = get_turf(src)
-	if(volume <= 0 || !pos || (pos.turf_flags & TURF_IS_WET)) //Now uses turf flags instead of whatever aurora did
+	if(candle_volume <= 0 || !pos || (pos.turf_flags & TURF_IS_WET)) //Now uses turf flags instead of whatever aurora did
 		STOP_PROCESSING(SSprocessing, src)
 		on = 2
 		update_icon()
@@ -56,16 +56,16 @@
 		pos.hotspot_expose(1500, 5)
 	var/datum/gas_mixture/environment = loc.return_air()
 	var/pressure_delta = target_pressure - environment.return_pressure()
-	var/output_volume = environment.volume * environment.group_multiplier
+	var/output_volume = environment.air_volume * environment.group_multiplier
 	var/air_temperature = air_contents.temperature? air_contents.temperature : environment.temperature
 	var/transfer_moles = pressure_delta*output_volume/(air_temperature * R_IDEAL_GAS_EQUATION)
 	var/datum/gas_mixture/removed = air_contents.remove(transfer_moles)
 	if (!removed) //Just in case
 		return
 	environment.merge(removed)
-	volume -= 200
+	candle_volume -= 200
 	var/const/OXYGEN_FRACTION = 1 // separating out the constant so it's clearer why it exists and how to modify it later
-	air_contents.adjust_gas(/decl/material/gas/oxygen, OXYGEN_FRACTION * (target_pressure * air_contents.volume) / (R_IDEAL_GAS_EQUATION * air_contents.temperature))
+	air_contents.adjust_gas(/decl/material/gas/oxygen, OXYGEN_FRACTION * (target_pressure * air_contents.air_volume) / (R_IDEAL_GAS_EQUATION * air_contents.temperature))
 
 /obj/item/oxycandle/on_update_icon()
 	. = ..()

--- a/code/game/objects/items/devices/oxycandle.dm
+++ b/code/game/objects/items/devices/oxycandle.dm
@@ -33,10 +33,10 @@
 		update_icon()
 		playsound(src.loc, activation_sound, 75, 1)
 		air_contents = new /datum/gas_mixture()
-		air_contents.air_volume = 200 //liters
+		air_contents.total_volume = 200 //liters
 		air_contents.temperature = T20C
 		var/const/OXYGEN_FRACTION = 1 // separating out the constant so it's clearer why it exists and how to modify it later
-		air_contents.adjust_gas(/decl/material/gas/oxygen, OXYGEN_FRACTION * (target_pressure * air_contents.air_volume) / (R_IDEAL_GAS_EQUATION * air_contents.temperature))
+		air_contents.adjust_gas(/decl/material/gas/oxygen, OXYGEN_FRACTION * (target_pressure * air_contents.total_volume) / (R_IDEAL_GAS_EQUATION * air_contents.temperature))
 		START_PROCESSING(SSprocessing, src)
 
 // Process of Oxygen candles releasing air. Makes 200 volume of oxygen
@@ -56,7 +56,7 @@
 		pos.hotspot_expose(1500, 5)
 	var/datum/gas_mixture/environment = loc.return_air()
 	var/pressure_delta = target_pressure - environment.return_pressure()
-	var/output_volume = environment.air_volume * environment.group_multiplier
+	var/output_volume = environment.total_volume * environment.group_multiplier
 	var/air_temperature = air_contents.temperature? air_contents.temperature : environment.temperature
 	var/transfer_moles = pressure_delta*output_volume/(air_temperature * R_IDEAL_GAS_EQUATION)
 	var/datum/gas_mixture/removed = air_contents.remove(transfer_moles)
@@ -65,7 +65,7 @@
 	environment.merge(removed)
 	candle_volume -= 200
 	var/const/OXYGEN_FRACTION = 1 // separating out the constant so it's clearer why it exists and how to modify it later
-	air_contents.adjust_gas(/decl/material/gas/oxygen, OXYGEN_FRACTION * (target_pressure * air_contents.air_volume) / (R_IDEAL_GAS_EQUATION * air_contents.temperature))
+	air_contents.adjust_gas(/decl/material/gas/oxygen, OXYGEN_FRACTION * (target_pressure * air_contents.total_volume) / (R_IDEAL_GAS_EQUATION * air_contents.temperature))
 
 /obj/item/oxycandle/on_update_icon()
 	. = ..()

--- a/code/game/objects/items/devices/transfer_valve.dm
+++ b/code/game/objects/items/devices/transfer_valve.dm
@@ -175,7 +175,7 @@
 /obj/item/transfer_valve/proc/merge_gases()
 	if(valve_open)
 		return
-	tank_two.air_contents.air_volume += tank_one.air_contents.air_volume
+	tank_two.air_contents.total_volume += tank_one.air_contents.total_volume
 	var/datum/gas_mixture/temp = tank_one.remove_air_ratio(1)
 	tank_two.assume_air(temp)
 	valve_open = 1
@@ -189,9 +189,9 @@
 	if(QDELETED(tank_one) || QDELETED(tank_two))
 		return
 
-	var/ratio1 = tank_one.air_contents.air_volume/tank_two.air_contents.air_volume
+	var/ratio1 = tank_one.air_contents.total_volume/tank_two.air_contents.total_volume
 	var/datum/gas_mixture/temp = tank_two.remove_air_ratio(ratio1)
-	tank_two.air_contents.air_volume -=  tank_one.air_contents.air_volume
+	tank_two.air_contents.total_volume -=  tank_one.air_contents.total_volume
 	tank_one.assume_air(temp)
 
 	/*

--- a/code/game/objects/items/devices/transfer_valve.dm
+++ b/code/game/objects/items/devices/transfer_valve.dm
@@ -175,7 +175,7 @@
 /obj/item/transfer_valve/proc/merge_gases()
 	if(valve_open)
 		return
-	tank_two.air_contents.volume += tank_one.air_contents.volume
+	tank_two.air_contents.air_volume += tank_one.air_contents.air_volume
 	var/datum/gas_mixture/temp = tank_one.remove_air_ratio(1)
 	tank_two.assume_air(temp)
 	valve_open = 1
@@ -189,9 +189,9 @@
 	if(QDELETED(tank_one) || QDELETED(tank_two))
 		return
 
-	var/ratio1 = tank_one.air_contents.volume/tank_two.air_contents.volume
+	var/ratio1 = tank_one.air_contents.air_volume/tank_two.air_contents.air_volume
 	var/datum/gas_mixture/temp = tank_two.remove_air_ratio(ratio1)
-	tank_two.air_contents.volume -=  tank_one.air_contents.volume
+	tank_two.air_contents.air_volume -=  tank_one.air_contents.air_volume
 	tank_one.assume_air(temp)
 
 	/*

--- a/code/game/objects/items/flame/flame_fuelled.dm
+++ b/code/game/objects/items/flame/flame_fuelled.dm
@@ -5,8 +5,8 @@
 	can_manually_light    = TRUE
 	extinguish_on_dropped = FALSE
 	watertight            = TRUE
+	chem_volume           = 5
 
-	var/tmp/max_fuel      = 5
 	var/tmp/start_fuelled = FALSE
 
 	/// TODO: make this calculate a fuel amount via accelerant value or some other check.
@@ -14,10 +14,9 @@
 	var/fuel_type
 
 /obj/item/flame/fuelled/Initialize()
-	. = ..()
 	if(isnull(fuel_type))
 		fuel_type = global.using_map.default_liquid_fuel_type
-	initialize_reagents()
+	. = ..()
 
 // Boilerplate from /obj/item/chems/glass. TODO generalize to a lower level.
 /obj/item/flame/fuelled/use_on_mob(mob/living/target, mob/living/user, animate = TRUE)
@@ -84,14 +83,9 @@
 		return TRUE
 	return FALSE
 
-/obj/item/flame/fuelled/initialize_reagents(populate = TRUE)
-	if(!reagents)
-		create_reagents(max_fuel)
-	. = ..()
-
 /obj/item/flame/fuelled/populate_reagents()
-	if(start_fuelled && fuel_type && max_fuel)
-		add_to_reagents(fuel_type, max_fuel)
+	if(start_fuelled && fuel_type && reagents?.maximum_volume)
+		add_to_reagents(fuel_type, reagents.maximum_volume)
 
 /obj/item/flame/fuelled/Process()
 	. = ..()

--- a/code/game/objects/items/flame/flame_fuelled_lantern.dm
+++ b/code/game/objects/items/flame/flame_fuelled_lantern.dm
@@ -10,7 +10,7 @@
 	slot_flags          = SLOT_LOWER_BODY
 	lit_light_power     = 0.7
 	lit_light_range     = 6
-	max_fuel            = 60
+	chem_volume         = 60
 	_fuel_spend_amt     = (1 / 60) // a full lantern should last an hour
 	material_alteration = MAT_FLAG_ALTERATION_COLOR | MAT_FLAG_ALTERATION_NAME | MAT_FLAG_ALTERATION_DESC
 	material            = /decl/material/solid/metal/copper

--- a/code/game/objects/items/flame/flame_fuelled_lighter_zippo.dm
+++ b/code/game/objects/items/flame/flame_fuelled_lighter_zippo.dm
@@ -1,9 +1,9 @@
 /obj/item/flame/fuelled/lighter/zippo
-	name     = "zippo lighter"
-	desc     = "It's a zippo-styled lighter, using a replaceable flint in a fetching steel case. It makes a clicking sound that everyone loves."
-	icon     = 'icons/obj/items/flame/zippo.dmi'
-	max_fuel = 10
-	material = /decl/material/solid/metal/stainlesssteel
+	name        = "zippo lighter"
+	desc        = "It's a zippo-styled lighter, using a replaceable flint in a fetching steel case. It makes a clicking sound that everyone loves."
+	icon        = 'icons/obj/items/flame/zippo.dmi'
+	chem_volume = 10
+	material    = /decl/material/solid/metal/stainlesssteel
 
 /obj/item/flame/fuelled/lighter/zippo/adjust_mob_overlay(mob/living/user_mob, bodytype, image/overlay, slot, bodypart, use_fallback_if_icon_missing = TRUE, skip_offset = FALSE)
 	if(overlay && lit && (slot in global.all_hand_slots))

--- a/code/game/objects/items/rescuebag.dm
+++ b/code/game/objects/items/rescuebag.dm
@@ -70,7 +70,7 @@
 /obj/structure/closet/body_bag/rescue/Initialize()
 	. = ..()
 	atmo = new()
-	atmo.volume = 0.1*CELL_VOLUME
+	atmo.air_volume = 0.1*CELL_VOLUME
 	START_PROCESSING(SSobj, src)
 
 /obj/structure/closet/body_bag/rescue/Destroy()

--- a/code/game/objects/items/rescuebag.dm
+++ b/code/game/objects/items/rescuebag.dm
@@ -70,7 +70,7 @@
 /obj/structure/closet/body_bag/rescue/Initialize()
 	. = ..()
 	atmo = new()
-	atmo.air_volume = 0.1*CELL_VOLUME
+	atmo.total_volume = 0.1*CELL_VOLUME
 	START_PROCESSING(SSobj, src)
 
 /obj/structure/closet/body_bag/rescue/Destroy()

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -47,7 +47,7 @@
 	throw_range                   = 20
 	possible_transfer_amounts     = null
 	amount_per_transfer_from_this = 10
-	volume                        = 10
+	chem_volume                   = 10
 	material                      = /decl/material/solid/organic/plastic
 	_base_attack_force            = 0
 

--- a/code/game/objects/items/waterskin.dm
+++ b/code/game/objects/items/waterskin.dm
@@ -6,7 +6,7 @@
 	material = /decl/material/solid/organic/leather/gut
 	color = /decl/material/solid/organic/leather/gut::color
 	atom_flags = ATOM_FLAG_OPEN_CONTAINER
-	volume = 120
+	chem_volume = 120
 	material_alteration = MAT_FLAG_ALTERATION_COLOR | MAT_FLAG_ALTERATION_NAME
 	var/decl/material/stopper_material = /decl/material/solid/organic/cloth/hemp
 

--- a/code/game/objects/items/weapons/ecigs.dm
+++ b/code/game/objects/items/weapons/ecigs.dm
@@ -184,7 +184,7 @@
 	icon_state = "ecartridge"
 	material = /decl/material/solid/metal/aluminium
 	matter = list(/decl/material/solid/glass = MATTER_AMOUNT_REINFORCEMENT)
-	volume = 20
+	chem_volume = 20
 	atom_flags = ATOM_FLAG_OPEN_CONTAINER
 
 /obj/item/chems/ecig_cartridge/get_examine_strings(mob/user, distance, infix, suffix)

--- a/code/game/objects/items/weapons/extinguisher.dm
+++ b/code/game/objects/items/weapons/extinguisher.dm
@@ -16,7 +16,7 @@
 	possible_transfer_amounts     = @"[30,60,120]" //units of liquid per spray - 120 -> same as splashing them with a bucket per spray
 	possible_particle_amounts     = @"[1,2,3]"     //Amount of chempuff particles to spawn on spray
 	amount_per_transfer_from_this = 120
-	volume                        = 2000
+	chem_volume                   = 2000
 	spray_particles               = 3                    //Amount of liquid particles to spawn on spray
 	particle_move_delay           = 5                    //Spray effect move delay
 	safety                        = TRUE
@@ -36,7 +36,7 @@
 	possible_particle_amounts     = @"[1,2]"
 	amount_per_transfer_from_this = 80
 	spray_particles               = 2
-	volume                        = 1000
+	chem_volume                   = 1000
 	material                      = /decl/material/solid/organic/plastic
 	matter                        = list(
 		/decl/material/solid/metal/steel = MATTER_AMOUNT_TRACE,

--- a/code/game/objects/items/weapons/grenades/chem_grenade.dm
+++ b/code/game/objects/items/weapons/grenades/chem_grenade.dm
@@ -5,15 +5,13 @@
 	w_class = ITEM_SIZE_SMALL
 	_base_attack_force = 2.0
 	det_time = null
+	chem_volume = 1000
+
 	var/stage = 0
 	var/path = 0
 	var/obj/item/assembly_holder/detonator = null
 	var/list/beakers = new/list()
 	var/list/allowed_containers = list(/obj/item/chems/glass/beaker, /obj/item/chems/glass/bottle)
-
-/obj/item/grenade/chem_grenade/Initialize()
-	. = ..()
-	create_reagents(1000)
 
 /obj/item/grenade/chem_grenade/Destroy()
 	QDEL_NULL(detonator)

--- a/code/game/objects/items/weapons/mop.dm
+++ b/code/game/objects/items/weapons/mop.dm
@@ -11,6 +11,8 @@
 	matter = list(
 		/decl/material/solid/organic/cloth = MATTER_AMOUNT_SECONDARY,
 	)
+	chem_volume = 30
+
 	var/mopspeed = 40
 	var/static/list/moppable_types
 
@@ -23,13 +25,8 @@
 
 /obj/item/mop/Initialize()
 	. = ..()
-	initialize_reagents()
 	if(!moppable_types)
 		populate_moppable_types()
-
-/obj/item/mop/initialize_reagents(populate = TRUE)
-	create_reagents(30)
-	. = ..()
 
 /obj/item/mop/afterattack(atom/A, mob/user, proximity)
 	if(!proximity)

--- a/code/game/objects/items/weapons/paint.dm
+++ b/code/game/objects/items/weapons/paint.dm
@@ -6,7 +6,7 @@
 	w_class = ITEM_SIZE_NORMAL
 	amount_per_transfer_from_this = 10
 	possible_transfer_amounts = @"[10,20,30,60]"
-	volume = 60
+	chem_volume = 60
 	var/pigment
 
 /obj/item/chems/glass/bucket/paint/populate_reagents()

--- a/code/game/objects/items/weapons/soap.dm
+++ b/code/game/objects/items/weapons/soap.dm
@@ -14,8 +14,9 @@
 	material = /decl/material/liquid/cleaner/soap
 	max_health = 5
 	_base_attack_force = 0
-	var/key_data
+	chem_volume = SOAP_MAX_VOLUME
 
+	var/key_data
 	var/list/valid_colors = list(COLOR_GREEN_GRAY, COLOR_RED_GRAY, COLOR_BLUE_GRAY, COLOR_BROWN, COLOR_PALE_PINK, COLOR_PALE_BTL_GREEN, COLOR_OFF_WHITE, COLOR_GRAY40, COLOR_GOLD)
 	var/list/valid_scents = list("fresh air", "cinnamon", "mint", "cocoa", "lavender", "an ocean breeze", "a summer garden", "vanilla", "cheap perfume")
 	var/list/scent_intensity = list("faintly", "strongly", "overbearingly")
@@ -31,16 +32,11 @@
 /obj/item/soap/crafted/generate_icon()
 	return
 
-/obj/item/soap/initialize_reagents(populate = TRUE)
-	create_reagents(SOAP_MAX_VOLUME)
-	. = ..()
-
 /obj/item/soap/populate_reagents()
 	wet()
 
 /obj/item/soap/Initialize()
 	. = ..()
-	initialize_reagents()
 	generate_icon()
 
 /obj/item/soap/proc/generate_icon()

--- a/code/game/objects/items/weapons/storage/fancy/cigar.dm
+++ b/code/game/objects/items/weapons/storage/fancy/cigar.dm
@@ -15,11 +15,7 @@
 	storage = /datum/storage/box/cigar
 
 /obj/item/box/fancy/cigar/Initialize(ml, material_key)
-	. = ..()
-	initialize_reagents()
-
-/obj/item/box/fancy/cigar/initialize_reagents(populate)
-	create_reagents(10 * max(1, storage?.storage_slots))
+	chem_volume = 10 * max(1, /datum/storage/box/cigar::storage_slots)
 	. = ..()
 
 /obj/item/box/fancy/cigar/WillContain()

--- a/code/game/objects/items/weapons/storage/fancy/cigar.dm
+++ b/code/game/objects/items/weapons/storage/fancy/cigar.dm
@@ -15,7 +15,8 @@
 	storage = /datum/storage/box/cigar
 
 /obj/item/box/fancy/cigar/Initialize(ml, material_key)
-	chem_volume = 10 * max(1, /datum/storage/box/cigar::storage_slots)
+	if(istype(storage))
+		chem_volume = 10 * max(1, storage.storage_slots)
 	. = ..()
 
 /obj/item/box/fancy/cigar/WillContain()

--- a/code/game/objects/items/weapons/storage/fancy/cigarettes.dm
+++ b/code/game/objects/items/weapons/storage/fancy/cigarettes.dm
@@ -17,11 +17,7 @@
 	return list(/obj/item/clothing/mask/smokable/cigarette = 6)
 
 /obj/item/box/fancy/cigarettes/Initialize(ml, material_key)
-	. = ..()
-	initialize_reagents()
-
-/obj/item/box/fancy/cigarettes/initialize_reagents(populate)
-	create_reagents(5 * max(storage?.max_storage_space, 1)) //so people can inject cigarettes without opening a packet, now with being able to inject the whole one
+	chem_volume = 5 * max(/datum/storage/box/cigarettes::max_storage_space, 1) //so people can inject cigarettes without opening a packet, now with being able to inject the whole one
 	. = ..()
 
 /obj/item/box/fancy/cigarettes/use_on_mob(mob/living/target, mob/living/user, animate = TRUE)

--- a/code/game/objects/items/weapons/storage/med_pouch.dm
+++ b/code/game/objects/items/weapons/storage/med_pouch.dm
@@ -189,22 +189,22 @@ Single Use Emergency Pouches
 // Pills
 
 /obj/item/chems/pill/pouch_pill
-	name       = "emergency pill"
-	desc       = "An emergency pill from an emergency medical pouch."
-	icon_state = "pill2"
-	volume     = 15
+	name          = "emergency pill"
+	desc          = "An emergency pill from an emergency medical pouch."
+	icon_state    = "pill2"
+	chem_volume   = 15
 	abstract_type = /obj/item/chems/pill/pouch_pill
+	var/_reagent_name
 
 /obj/item/chems/pill/pouch_pill/Initialize(ml, material_key)
 	. = ..()
 	if(!reagents?.total_volume)
 		log_warning("[log_info_line(src)] was deleted for containing no reagents during init!")
 		return INITIALIZE_HINT_QDEL
-
-/obj/item/chems/pill/pouch_pill/initialize_reagents(populate = TRUE)
-	. = ..()
-	if(populate && reagents?.get_primary_reagent_name())
-		SetName("emergency [reagents.get_primary_reagent_name()] pill ([reagents.total_volume]u)")
+	if(reagents?.get_primary_reagent_name() && !_reagent_name)
+		_reagent_name = "emergency [reagents.get_primary_reagent_name()] pill ([reagents.total_volume]u)"
+	if(_reagent_name)
+		SetName(_reagent_name)
 
 /obj/item/chems/pill/pouch_pill/stabilizer/populate_reagents()
 	add_to_reagents(/decl/material/liquid/stabilizer, reagents.maximum_volume)

--- a/code/game/objects/items/weapons/tanks/tank_types.dm
+++ b/code/game/objects/items/weapons/tanks/tank_types.dm
@@ -16,7 +16,7 @@
 	icon = 'icons/obj/items/tanks/tank_blue.dmi'
 	distribute_pressure = ONE_ATMOSPHERE*O2STANDARD
 	starting_pressure = list(/decl/material/gas/oxygen = 6 ATM)
-	volume = 180
+	air_volume = 180
 
 /obj/item/tank/oxygen/yellow
 	desc = "A tank of oxygen. This one is yellow."
@@ -37,7 +37,7 @@
 	desc = "Mixed anyone?"
 	icon = 'icons/obj/items/tanks/tank_blue.dmi'
 	starting_pressure = list(/decl/material/gas/oxygen = (6 ATM) * O2STANDARD, /decl/material/gas/nitrogen = (6 ATM) * N2STANDARD)
-	volume = 180
+	air_volume = 180
 
 /*
  * Hydrogen
@@ -69,7 +69,7 @@
 	attack_cooldown = DEFAULT_WEAPON_COOLDOWN
 	melee_accuracy_bonus = -10
 	distribute_pressure = ONE_ATMOSPHERE*O2STANDARD
-	volume = 40 //Tiny. Real life equivalents only have 21 breaths of oxygen in them. They're EMERGENCY tanks anyway -errorage (dangercon 2011)
+	air_volume = 40 //Tiny. Real life equivalents only have 21 breaths of oxygen in them. They're EMERGENCY tanks anyway -errorage (dangercon 2011)
 
 /obj/item/tank/emergency/oxygen
 	name = "emergency oxygen tank"
@@ -81,13 +81,13 @@
 /obj/item/tank/emergency/oxygen/engi
 	name = "extended-capacity emergency oxygen tank"
 	icon = 'icons/obj/items/tanks/tank_emergency_engineer.dmi'
-	volume = 60
+	air_volume = 60
 
 /obj/item/tank/emergency/oxygen/double
 	name = "double emergency oxygen tank"
 	icon = 'icons/obj/items/tanks/tank_emergency_double.dmi'
 	gauge_icon = "indicator_emergency_double"
-	volume = 90
+	air_volume = 90
 	w_class = ITEM_SIZE_NORMAL
 
 /obj/item/tank/emergency/oxygen/double/red	//firefighting tank, fits on belt, back or suitslot
@@ -105,4 +105,4 @@
 	icon = 'icons/obj/items/tanks/tank_red.dmi'
 	distribute_pressure = ONE_ATMOSPHERE*O2STANDARD
 	starting_pressure = list(/decl/material/gas/nitrogen = 10 ATM)
-	volume = 180
+	air_volume = 180

--- a/code/game/objects/items/weapons/tanks/tank_types.dm
+++ b/code/game/objects/items/weapons/tanks/tank_types.dm
@@ -16,7 +16,7 @@
 	icon = 'icons/obj/items/tanks/tank_blue.dmi'
 	distribute_pressure = ONE_ATMOSPHERE*O2STANDARD
 	starting_pressure = list(/decl/material/gas/oxygen = 6 ATM)
-	air_volume = 180
+	gas_volume = 180
 
 /obj/item/tank/oxygen/yellow
 	desc = "A tank of oxygen. This one is yellow."
@@ -37,7 +37,7 @@
 	desc = "Mixed anyone?"
 	icon = 'icons/obj/items/tanks/tank_blue.dmi'
 	starting_pressure = list(/decl/material/gas/oxygen = (6 ATM) * O2STANDARD, /decl/material/gas/nitrogen = (6 ATM) * N2STANDARD)
-	air_volume = 180
+	gas_volume = 180
 
 /*
  * Hydrogen
@@ -69,7 +69,7 @@
 	attack_cooldown = DEFAULT_WEAPON_COOLDOWN
 	melee_accuracy_bonus = -10
 	distribute_pressure = ONE_ATMOSPHERE*O2STANDARD
-	air_volume = 40 //Tiny. Real life equivalents only have 21 breaths of oxygen in them. They're EMERGENCY tanks anyway -errorage (dangercon 2011)
+	gas_volume = 40 //Tiny. Real life equivalents only have 21 breaths of oxygen in them. They're EMERGENCY tanks anyway -errorage (dangercon 2011)
 
 /obj/item/tank/emergency/oxygen
 	name = "emergency oxygen tank"
@@ -81,13 +81,13 @@
 /obj/item/tank/emergency/oxygen/engi
 	name = "extended-capacity emergency oxygen tank"
 	icon = 'icons/obj/items/tanks/tank_emergency_engineer.dmi'
-	air_volume = 60
+	gas_volume = 60
 
 /obj/item/tank/emergency/oxygen/double
 	name = "double emergency oxygen tank"
 	icon = 'icons/obj/items/tanks/tank_emergency_double.dmi'
 	gauge_icon = "indicator_emergency_double"
-	air_volume = 90
+	gas_volume = 90
 	w_class = ITEM_SIZE_NORMAL
 
 /obj/item/tank/emergency/oxygen/double/red	//firefighting tank, fits on belt, back or suitslot
@@ -105,4 +105,4 @@
 	icon = 'icons/obj/items/tanks/tank_red.dmi'
 	distribute_pressure = ONE_ATMOSPHERE*O2STANDARD
 	starting_pressure = list(/decl/material/gas/nitrogen = 10 ATM)
-	air_volume = 180
+	gas_volume = 180

--- a/code/game/objects/items/weapons/tanks/tanks.dm
+++ b/code/game/objects/items/weapons/tanks/tanks.dm
@@ -42,7 +42,7 @@ var/global/list/global/tank_gauge_cache = list()
 	var/maxintegrity = 20
 	var/valve_welded = 0
 	var/obj/item/tankassemblyproxy/proxyassembly
-	var/air_volume = 70
+	var/gas_volume = 70
 	//Used by _onclick/hud/screen_objects.dm internals to determine if someone has messed with our tank or not.
 	//If they have and we haven't scanned it with the PDA or gas analyzer then we might just breath whatever they put in it.
 	var/manipulated_by = null
@@ -56,9 +56,9 @@ var/global/list/global/tank_gauge_cache = list()
 	proxyassembly = new /obj/item/tankassemblyproxy(src)
 	proxyassembly.tank = src
 
-	air_contents = new /datum/gas_mixture(air_volume, T20C)
+	air_contents = new /datum/gas_mixture(gas_volume, T20C)
 	for(var/gas in starting_pressure)
-		air_contents.adjust_gas(gas, starting_pressure[gas]*air_volume/(R_IDEAL_GAS_EQUATION*T20C), 0)
+		air_contents.adjust_gas(gas, starting_pressure[gas]*gas_volume/(R_IDEAL_GAS_EQUATION*T20C), 0)
 	air_contents.update_values()
 
 	START_PROCESSING(SSobj, src)
@@ -366,7 +366,7 @@ var/global/list/global/tank_gauge_cache = list()
 
 	var/datum/gas_mixture/removed = remove_air(distribute_pressure*volume_to_return/(R_IDEAL_GAS_EQUATION*air_contents.temperature))
 	if(removed)
-		removed.air_volume = volume_to_return
+		removed.total_volume = volume_to_return
 	return removed
 
 /obj/item/tank/Process()
@@ -418,7 +418,7 @@ var/global/list/global/tank_gauge_cache = list()
 			pressure = air_contents.return_pressure()
 			var/strength = ((pressure-TANK_FRAGMENT_PRESSURE)/TANK_FRAGMENT_SCALE)
 
-			var/mult = ((air_contents.air_volume/140)**(1/2)) * (air_contents.total_moles**2/3)/((29*0.64) **2/3) //tanks appear to be experiencing a reduction on scale of about 0.64 total moles
+			var/mult = ((air_contents.total_volume/140)**(1/2)) * (air_contents.total_moles**2/3)/((29*0.64) **2/3) //tanks appear to be experiencing a reduction on scale of about 0.64 total moles
 			//tanks appear to be experiencing a reduction on scale of about 0.64 total moles
 
 			var/turf/T = get_turf(src)
@@ -514,7 +514,7 @@ var/global/list/global/tank_gauge_cache = list()
 	desc = initial(tank_copy.desc)
 	icon = initial(tank_copy.icon)
 	icon_state = initial(tank_copy.icon_state)
-	air_volume = initial(tank_copy.air_volume)
+	gas_volume = initial(tank_copy.gas_volume)
 
 	// Set up explosive mix.
 	air_contents.gas[DEFAULT_GAS_ACCELERANT] = 4 + rand(4)

--- a/code/game/objects/items/weapons/tanks/tanks.dm
+++ b/code/game/objects/items/weapons/tanks/tanks.dm
@@ -42,7 +42,7 @@ var/global/list/global/tank_gauge_cache = list()
 	var/maxintegrity = 20
 	var/valve_welded = 0
 	var/obj/item/tankassemblyproxy/proxyassembly
-	var/volume = 70
+	var/air_volume = 70
 	//Used by _onclick/hud/screen_objects.dm internals to determine if someone has messed with our tank or not.
 	//If they have and we haven't scanned it with the PDA or gas analyzer then we might just breath whatever they put in it.
 	var/manipulated_by = null
@@ -56,9 +56,9 @@ var/global/list/global/tank_gauge_cache = list()
 	proxyassembly = new /obj/item/tankassemblyproxy(src)
 	proxyassembly.tank = src
 
-	air_contents = new /datum/gas_mixture(volume, T20C)
+	air_contents = new /datum/gas_mixture(air_volume, T20C)
 	for(var/gas in starting_pressure)
-		air_contents.adjust_gas(gas, starting_pressure[gas]*volume/(R_IDEAL_GAS_EQUATION*T20C), 0)
+		air_contents.adjust_gas(gas, starting_pressure[gas]*air_volume/(R_IDEAL_GAS_EQUATION*T20C), 0)
 	air_contents.update_values()
 
 	START_PROCESSING(SSobj, src)
@@ -366,7 +366,7 @@ var/global/list/global/tank_gauge_cache = list()
 
 	var/datum/gas_mixture/removed = remove_air(distribute_pressure*volume_to_return/(R_IDEAL_GAS_EQUATION*air_contents.temperature))
 	if(removed)
-		removed.volume = volume_to_return
+		removed.air_volume = volume_to_return
 	return removed
 
 /obj/item/tank/Process()
@@ -418,7 +418,7 @@ var/global/list/global/tank_gauge_cache = list()
 			pressure = air_contents.return_pressure()
 			var/strength = ((pressure-TANK_FRAGMENT_PRESSURE)/TANK_FRAGMENT_SCALE)
 
-			var/mult = ((air_contents.volume/140)**(1/2)) * (air_contents.total_moles**2/3)/((29*0.64) **2/3) //tanks appear to be experiencing a reduction on scale of about 0.64 total moles
+			var/mult = ((air_contents.air_volume/140)**(1/2)) * (air_contents.total_moles**2/3)/((29*0.64) **2/3) //tanks appear to be experiencing a reduction on scale of about 0.64 total moles
 			//tanks appear to be experiencing a reduction on scale of about 0.64 total moles
 
 			var/turf/T = get_turf(src)
@@ -514,7 +514,7 @@ var/global/list/global/tank_gauge_cache = list()
 	desc = initial(tank_copy.desc)
 	icon = initial(tank_copy.icon)
 	icon_state = initial(tank_copy.icon_state)
-	volume = initial(tank_copy.volume)
+	air_volume = initial(tank_copy.air_volume)
 
 	// Set up explosive mix.
 	air_contents.gas[DEFAULT_GAS_ACCELERANT] = 4 + rand(4)

--- a/code/game/objects/items/weapons/towels.dm
+++ b/code/game/objects/items/weapons/towels.dm
@@ -17,8 +17,8 @@
 	var/additional_description
 
 /obj/item/towel/Initialize()
+	chem_volume = round(50 * (w_class / ITEM_SIZE_NORMAL)) // larger towels have more room, smaller ones have less
 	. = ..()
-	initialize_reagents()
 
 /obj/item/towel/Destroy()
 	if(is_processing)
@@ -65,10 +65,6 @@
 		reagents.remove_any(max(MINIMUM_CHEMICAL_VOLUME, CHEMS_QUANTIZE(reagents.total_volume * 0.05)))
 	if(!reagents?.total_volume)
 		return PROCESS_KILL
-
-/obj/item/towel/initialize_reagents()
-	create_reagents(round(50 * (w_class / ITEM_SIZE_NORMAL))) // larger towels have more room, smaller ones have less
-	. = ..()
 
 /obj/item/towel/update_name()
 	if(reagents?.total_volume)

--- a/code/game/objects/items/welding/weldbackpack.dm
+++ b/code/game/objects/items/welding/weldbackpack.dm
@@ -62,14 +62,14 @@
 //Welder Pack
 ////////////////////////////////////////////////////////////
 /obj/item/chems/weldpack
-	name       = "welding kit"
-	desc       = "An unwieldy, heavy backpack with two massive fuel tanks. Comes with an attached welder gun."
-	icon       = 'icons/obj/items/welderpack.dmi'
-	icon_state = ICON_STATE_WORLD
-	slot_flags = SLOT_BACK
-	w_class    = ITEM_SIZE_HUGE
-	atom_flags = ATOM_FLAG_OPEN_CONTAINER
-	volume     = 350
+	name        = "welding kit"
+	desc        = "An unwieldy, heavy backpack with two massive fuel tanks. Comes with an attached welder gun."
+	icon        = 'icons/obj/items/welderpack.dmi'
+	icon_state  = ICON_STATE_WORLD
+	slot_flags  = SLOT_BACK
+	w_class     = ITEM_SIZE_HUGE
+	atom_flags  = ATOM_FLAG_OPEN_CONTAINER
+	chem_volume = 350
 	var/obj/item/weldingtool/weldpack/welder = /obj/item/weldingtool/weldpack
 
 // Duplicated from welder tanks.

--- a/code/game/objects/items/welding/weldingtool_tank.dm
+++ b/code/game/objects/items/welding/weldingtool_tank.dm
@@ -10,7 +10,7 @@
 	w_class            = ITEM_SIZE_SMALL
 	atom_flags         = ATOM_FLAG_OPEN_CONTAINER
 	obj_flags          = OBJ_FLAG_HOLLOW
-	volume             = 20
+	chem_volume        = 20
 	presentation_flags = PRESENTATION_FLAG_NAME
 	max_health         = 40
 	material           = /decl/material/solid/metal/steel
@@ -86,7 +86,7 @@
 	base_name          = "small welding tank"
 	icon_state         = "tank_small"
 	w_class            = ITEM_SIZE_TINY
-	volume             = 5
+	chem_volume        = 5
 	size_in_use        = ITEM_SIZE_SMALL
 	unlit_force        = 5
 	lit_force          = 7
@@ -97,7 +97,7 @@
 	base_name          = "large welding tank"
 	icon_state         = "tank_large"
 	w_class            = ITEM_SIZE_SMALL
-	volume             = 40
+	chem_volume        = 40
 	size_in_use        = ITEM_SIZE_NORMAL
 	_base_attack_force = 6
 
@@ -106,7 +106,7 @@
 	base_name          = "huge welding tank"
 	icon_state         = "tank_huge"
 	w_class            = ITEM_SIZE_NORMAL
-	volume             = 80
+	chem_volume        = 80
 	size_in_use        = ITEM_SIZE_LARGE
 	unlit_force        = 9
 	lit_force          = 15
@@ -117,7 +117,7 @@
 	base_name          = "experimental welding tank"
 	icon_state         = "tank_experimental"
 	w_class            = ITEM_SIZE_NORMAL
-	volume             = 40
+	chem_volume        = 40
 	can_refuel         = FALSE
 	size_in_use        = ITEM_SIZE_LARGE
 	unlit_force        = 9

--- a/code/game/objects/structures/barrels/barrel.dm
+++ b/code/game/objects/structures/barrels/barrel.dm
@@ -12,7 +12,7 @@
 	wrenchable                = FALSE
 	storage                   = /datum/storage/barrel
 	amount_dispensed          = 10
-	volume                    = 7500
+	chem_volume               = 7500
 	movable_flags             = MOVABLE_FLAG_WHEELED
 	throwpass                 = TRUE
 	tool_interaction_flags    = TOOL_INTERACTION_ANCHOR | TOOL_INTERACTION_DECONSTRUCT

--- a/code/game/objects/structures/beds/rollerbed.dm
+++ b/code/game/objects/structures/beds/rollerbed.dm
@@ -22,9 +22,9 @@
 		icon_state = "up"
 	else
 		icon_state = "down"
-	if(beaker)
+	if(beaker?.reagents)
 		var/image/iv = image(icon, "iv[iv_attached]")
-		var/percentage = round((beaker.reagents.total_volume / beaker.volume) * 100, 25)
+		var/percentage = round((beaker.reagents.total_volume / max(beaker.reagents.maximum_volume, 1)) * 100, 25)
 		var/image/filling = image(icon, "iv_filling[percentage]")
 		filling.color = beaker.reagents.get_color()
 		iv.overlays += filling
@@ -74,7 +74,7 @@
 	if(SSobj.times_fired % 2)
 		return
 
-	if(beaker.volume > 0)
+	if(beaker.reagents?.total_volume > 0)
 		beaker.reagents.trans_to_mob(buckled_mob, beaker.amount_per_transfer_from_this, CHEM_INJECT)
 		queue_icon_update()
 

--- a/code/game/objects/structures/chemistry/filter_stand.dm
+++ b/code/game/objects/structures/chemistry/filter_stand.dm
@@ -8,17 +8,10 @@
 	material = /decl/material/solid/organic/wood/oak
 	material_alteration = MAT_FLAG_ALTERATION_ALL
 	atom_flags = ATOM_FLAG_OPEN_CONTAINER
+	chem_volume = 200
 
 	var/obj/item/chems/filter/filter
 	var/obj/item/chems/glass/loaded
-
-/obj/structure/filter_stand/Initialize(ml, _mat, _reinf_mat)
-	. = ..()
-	initialize_reagents()
-
-/obj/structure/filter_stand/initialize_reagents(populate)
-	create_reagents(200)
-	. = ..()
 
 /obj/structure/filter_stand/mapped/Initialize(ml, _mat, _reinf_mat)
 	filter = new(src)
@@ -111,7 +104,7 @@
 	w_class = ITEM_SIZE_TINY
 	material_alteration = MAT_FLAG_ALTERATION_ALL
 	material = /decl/material/solid/organic/cloth
-	volume = 100
+	chem_volume = 100
 	atom_flags = ATOM_FLAG_OPEN_CONTAINER
 
 /obj/item/chems/filter/on_reagent_change()

--- a/code/game/objects/structures/compost.dm
+++ b/code/game/objects/structures/compost.dm
@@ -16,7 +16,7 @@ var/global/const/COMPOST_WORM_HUNGER_FACTOR = MINIMUM_CHEMICAL_VOLUME
 	material_alteration       = MAT_FLAG_ALTERATION_COLOR | MAT_FLAG_ALTERATION_NAME | MAT_FLAG_ALTERATION_DESC
 	wrenchable                = FALSE
 	possible_transfer_amounts = @"[10,25,50,100]"
-	volume                    = 2000
+	chem_volume               = 2000
 	storage                   = /datum/storage/hopper/industrial/compost
 
 /obj/structure/reagent_dispensers/compost_bin/Initialize()

--- a/code/game/objects/structures/fires.dm
+++ b/code/game/objects/structures/fires.dm
@@ -374,12 +374,12 @@
 			if(reagent.accelerant_value <= FUEL_VALUE_SUPPRESSANT && reagent.phase_at_temperature(get_effective_burn_temperature(), ambient_pressure) == MAT_PHASE_GAS)
 				do_steam = TRUE
 
-			var/volume = NONUNIT_CEILING(REAGENT_VOLUME(reagents, reagent) / REAGENT_UNITS_PER_GAS_MOLE, 0.1)
-			var/list/waste_products = burn_material(reagent, volume)
+			var/result_volume = NONUNIT_CEILING(REAGENT_VOLUME(reagents, reagent) / REAGENT_UNITS_PER_GAS_MOLE, 0.1)
+			var/list/waste_products = burn_material(reagent, result_volume)
 			if(!isnull(waste_products))
 				for(var/product in waste_products)
 					waste[product] += waste_products[product]
-				reagents.remove_reagent(reagent.type, volume)
+				reagents.remove_reagent(reagent.type, result_volume)
 
 		dump_waste_products(loc, waste)
 

--- a/code/game/objects/structures/fires.dm
+++ b/code/game/objects/structures/fires.dm
@@ -27,6 +27,7 @@
 	material_alteration = MAT_FLAG_ALTERATION_COLOR | MAT_FLAG_ALTERATION_NAME | MAT_FLAG_ALTERATION_DESC
 	abstract_type = /obj/structure/fire_source
 	throwpass = TRUE
+	chem_volume = 100
 
 	// Counter for world.time, used to reduce lighting spam.
 	var/next_light_spam_guard = 0
@@ -75,7 +76,6 @@
 /obj/structure/fire_source/Initialize()
 	. = ..()
 	update_icon()
-	create_reagents(100)
 	steam = new(name)
 	steam.attach(get_turf(src))
 	steam.set_up(3, 0, get_turf(src))

--- a/code/game/objects/structures/fires.dm
+++ b/code/game/objects/structures/fires.dm
@@ -374,12 +374,12 @@
 			if(reagent.accelerant_value <= FUEL_VALUE_SUPPRESSANT && reagent.phase_at_temperature(get_effective_burn_temperature(), ambient_pressure) == MAT_PHASE_GAS)
 				do_steam = TRUE
 
-			var/result_volume = NONUNIT_CEILING(REAGENT_VOLUME(reagents, reagent) / REAGENT_UNITS_PER_GAS_MOLE, 0.1)
-			var/list/waste_products = burn_material(reagent, result_volume)
+			var/result_amount = NONUNIT_CEILING(REAGENT_VOLUME(reagents, reagent) / REAGENT_UNITS_PER_GAS_MOLE, 0.1)
+			var/list/waste_products = burn_material(reagent, result_amount)
 			if(!isnull(waste_products))
 				for(var/product in waste_products)
 					waste[product] += waste_products[product]
-				reagents.remove_reagent(reagent.type, result_volume)
+				reagents.remove_reagent(reagent.type, result_amount)
 
 		dump_waste_products(loc, waste)
 

--- a/code/game/objects/structures/fishtanks.dm
+++ b/code/game/objects/structures/fishtanks.dm
@@ -25,21 +25,19 @@ var/global/list/fishtank_cache = list()
 	atom_flags = ATOM_FLAG_CHECKS_BORDER | ATOM_FLAG_CLIMBABLE
 	mob_offset = TRUE
 	max_health = 50
+	chem_volume = 300
 
 	var/deleting
 	var/fill_type
-	var/fill_amt
 	var/obj/effect/glass_tank_overlay/tank_overlay // I don't like this, but there's no other way to get a mouse-transparent overlay :(
 
 /obj/structure/glass_tank/aquarium
 	name = "aquarium"
 	desc = "A clear glass box for keeping specimens in. This one is full of water."
 	fill_type = /decl/material/liquid/water
-	fill_amt = 300
 
 /obj/structure/glass_tank/Initialize(mapload)
 	tank_overlay = new(loc, src)
-	initialize_reagents()
 	. = ..()
 	update_icon()
 	if(!mapload)
@@ -53,16 +51,9 @@ var/global/list/fishtank_cache = list()
 	for(var/obj/structure/glass_tank/A in orange(1, oldloc))
 		A.update_icon()
 
-/obj/structure/glass_tank/initialize_reagents(populate = TRUE)
-	if(!fill_amt)
-		return
-	create_reagents(fill_amt)
-	if(!fill_type)
-		return
-	. = ..()
-
 /obj/structure/glass_tank/populate_reagents()
-	add_to_reagents(fill_type, reagents.maximum_volume)
+	if(fill_type)
+		add_to_reagents(fill_type, reagents.maximum_volume)
 
 /obj/structure/glass_tank/attack_hand(var/mob/user)
 	if(user.check_intent(I_FLAG_HARM))

--- a/code/game/objects/structures/fountain.dm
+++ b/code/game/objects/structures/fountain.dm
@@ -10,6 +10,8 @@
 	pixel_x     = -16
 	light_range = 5
 	light_power = 0.5
+	chem_volume = 500
+
 	var/used    = FALSE
 	var/increase_age_prob = (100 / 6)
 
@@ -113,14 +115,6 @@
 	atom_flags             = ATOM_FLAG_OPEN_CONTAINER | ATOM_FLAG_CLIMBABLE
 	light_range            = null
 	light_power            = null
-
-/obj/structure/fountain/mundane/Initialize(ml, _mat, _reinf_mat)
-	. = ..()
-	initialize_reagents(ml)
-
-/obj/structure/fountain/mundane/initialize_reagents(populate = TRUE)
-	create_reagents(500)
-	. = ..()
 
 /obj/structure/fountain/mundane/populate_reagents()
 	add_to_reagents(/decl/material/liquid/water, reagents.maximum_volume) //Don't give free water when building one

--- a/code/game/objects/structures/iv_drip.dm
+++ b/code/game/objects/structures/iv_drip.dm
@@ -192,7 +192,7 @@
 	. += "The IV drip is [mode ? "injecting" : "taking blood"]."
 	. += "It is set to transfer [transfer_amount]u of chemicals per cycle."
 	if(beaker)
-		if(beaker.reagents && beaker.reagents.total_volume)
+		if(beaker.reagents?.total_volume)
 			. += SPAN_NOTICE("Attached is \a [beaker] with [beaker.reagents.total_volume] units of liquid.")
 		else
 			. += SPAN_NOTICE("Attached is an empty [beaker].")

--- a/code/game/objects/structures/iv_drip.dm
+++ b/code/game/objects/structures/iv_drip.dm
@@ -37,10 +37,9 @@
 	base.icon_state = "[beaker ? "beaker" : "nothing"][attached ? "_hooked" : ""]"
 	add_overlay(base)
 
-	if(beaker)
-		var/datum/reagents/reagents = beaker.reagents
-		var/percent = round((reagents.total_volume / beaker.volume) * 100)
-		if(reagents.total_volume)
+	if(beaker?.reagents)
+		var/percent = round((beaker.reagents.total_volume / beaker.reagents.maximum_volume) * 100)
+		if(beaker.reagents.total_volume)
 			var/mutable_appearance/filling = mutable_appearance(icon, "reagent")
 			switch(percent)
 				if(0)
@@ -59,7 +58,7 @@
 					filling.icon_state = "reagent80"
 				if(91 to INFINITY)
 					filling.icon_state = "reagent100"
-			filling.color = reagents.get_color()
+			filling.color = beaker.reagents.get_color()
 			add_overlay(filling)
 
 		if(istype(beaker, /obj/item/chems/ivbag))
@@ -120,7 +119,7 @@
 		return
 
 	if(mode) // Give blood
-		if(beaker.volume > 0)
+		if(beaker.reagents?.total_volume > 0)
 			beaker.reagents.trans_to_mob(attached, transfer_amount, CHEM_INJECT)
 			queue_icon_update()
 	else // Take blood

--- a/code/game/objects/structures/janicart.dm
+++ b/code/game/objects/structures/janicart.dm
@@ -7,22 +7,18 @@
 	density = TRUE
 	atom_flags = ATOM_FLAG_OPEN_CONTAINER | ATOM_FLAG_CLIMBABLE
 	movable_flags = MOVABLE_FLAG_WHEELED
+	chem_volume = 180
+
 	var/obj/item/bag/trash/mybag	= null
 	var/obj/item/mop/mymop = null
 	var/obj/item/chems/spray/myspray = null
 	var/obj/item/lightreplacer/myreplacer = null
 	var/signs = 0	//maximum capacity hardcoded below
 
-
-/obj/structure/janitorialcart/Initialize()
-	. = ..()
-	create_reagents(180)
-
 /obj/structure/janitorialcart/get_examine_strings(mob/user, distance, infix, suffix)
 	. = ..()
 	if(distance <= 1)
 		. += "\The [src] [html_icon(src)] contains [reagents.total_volume] unit\s of liquid!"
-
 
 /obj/structure/janitorialcart/attackby(obj/item/used_item, mob/user)
 	if(istype(used_item, /obj/item/bag/trash) && !mybag)
@@ -191,6 +187,7 @@
 	density =  TRUE
 	material_alteration = MAT_FLAG_ALTERATION_NONE
 	atom_flags = ATOM_FLAG_OPEN_CONTAINER
+	chem_volume = 100
 	movement_handlers = list(
 		/datum/movement_handler/deny_multiz,
 		/datum/movement_handler/delay = list(1),
@@ -208,7 +205,6 @@
 		"[WEST]"  = list("x" =  13, "y" = 7, "z" = 0)
 	)
 	. = ..()
-	create_reagents(100)
 
 /obj/structure/janicart/get_examine_strings(mob/user, distance, infix, suffix)
 	. = ..()

--- a/code/game/objects/structures/mop_bucket.dm
+++ b/code/game/objects/structures/mop_bucket.dm
@@ -6,11 +6,7 @@
 	density = TRUE
 	w_class = ITEM_SIZE_NORMAL
 	atom_flags = ATOM_FLAG_CLIMBABLE | ATOM_FLAG_OPEN_CONTAINER
-
-
-/obj/structure/mopbucket/Initialize()
-	. = ..()
-	create_reagents(180)
+	chem_volume = 180
 
 /obj/structure/mopbucket/get_examine_strings(mob/user, distance, infix, suffix)
 	. = ..()

--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -248,6 +248,7 @@ var/global/list/hygiene_props = list()
 	clogged = -1
 	can_drain = 1
 	drainage = 0.2 			//showers are tiny, drain a little slower
+	chem_volume = 5
 
 	var/on = 0
 	var/next_mist = 0
@@ -259,11 +260,6 @@ var/global/list/hygiene_props = list()
 	var/datum/sound_token/sound_token
 
 //add heat controls? when emagged, you can freeze to death in it?
-
-/obj/structure/hygiene/shower/Initialize()
-	. = ..()
-	create_reagents(5)
-
 /obj/structure/hygiene/shower/Destroy()
 	QDEL_NULL(sound_token)
 	. = ..()

--- a/code/game/objects/structures/well.dm
+++ b/code/game/objects/structures/well.dm
@@ -14,7 +14,7 @@
 	wrenchable                = FALSE
 	amount_dispensed          = 10
 	possible_transfer_amounts = @"[10,25,50,100]"
-	volume                    = 10000
+	chem_volume               = 10000
 	can_toggle_open           = FALSE
 	var/auto_refill
 

--- a/code/game/turfs/turf_fluids.dm
+++ b/code/game/turfs/turf_fluids.dm
@@ -106,18 +106,15 @@
 		ADD_ACTIVE_FLUID(src)
 
 /turf/get_reagents()
-	if(!reagents)
-		create_reagents(FLUID_MAX_DEPTH)
+	create_or_update_reagents(FLUID_MAX_DEPTH)
 	return ..()
 
 /turf/add_to_reagents(reagent_type, amount, data, safety = FALSE, defer_update = FALSE, phase = null)
-	if(!reagents)
-		create_reagents(FLUID_MAX_DEPTH)
+	create_or_update_reagents(FLUID_MAX_DEPTH)
 	return ..()
 
 /turf/get_reagent_space()
-	if(!reagents)
-		create_reagents(FLUID_MAX_DEPTH)
+	create_or_update_reagents(FLUID_MAX_DEPTH)
 	return ..()
 
 /turf/fluid_act(var/datum/reagents/fluids)
@@ -146,8 +143,7 @@
 	// No flowing of reagents without liquids, but this proc should not be called if liquids are not present regardless.
 	if(!reagents?.total_liquid_volume)
 		return
-	if(!target.reagents)
-		target.create_reagents(FLUID_MAX_DEPTH)
+	target.create_or_update_reagents(FLUID_MAX_DEPTH)
 
 	// We reference total_volume instead of total_liquid_volume here because the maximum volume limits of the turfs still respect solid volumes, and depth is still determined by total volume.
 	reagents.trans_to_turf(target, min(reagents.total_volume, min(target.reagents.maximum_volume - target.reagents.total_volume, amount)), defer_update = defer_update)

--- a/code/modules/ZAS/Fire.dm
+++ b/code/modules/ZAS/Fire.dm
@@ -112,15 +112,15 @@ If it gains pressure too slowly, it may leak or just rupture instead of explodin
 	for(var/mob/living/L in loc)
 		L.FireBurn(firelevel, air_contents.temperature, air_contents.return_pressure())  //Burn the mobs!
 
-	loc.fire_act(air_contents, air_contents.temperature, air_contents.volume)
+	loc.fire_act(air_contents, air_contents.temperature, air_contents.air_volume)
 	for(var/atom/A in loc)
-		A.fire_act(air_contents, air_contents.temperature, air_contents.volume)
+		A.fire_act(air_contents, air_contents.temperature, air_contents.air_volume)
 
 	// prioritize nearby fuel overlays first
 	for(var/direction in global.cardinal)
 		var/turf/enemy_tile = get_step(my_tile, direction)
 		if(istype(enemy_tile) && enemy_tile.reagents)
-			enemy_tile.hotspot_expose(air_contents.temperature, air_contents.volume)
+			enemy_tile.hotspot_expose(air_contents.temperature, air_contents.air_volume)
 
 	//spread
 	for(var/direction in global.cardinal)
@@ -141,7 +141,7 @@ If it gains pressure too slowly, it may leak or just rupture instead of explodin
 					enemy_tile.create_fire(firelevel)
 
 			else
-				enemy_tile.adjacent_fire_act(loc, air_contents, air_contents.temperature, air_contents.volume)
+				enemy_tile.adjacent_fire_act(loc, air_contents, air_contents.temperature, air_contents.air_volume)
 
 	animate(src, color = fire_color(air_contents.temperature), 5)
 	set_light(l_color = color)
@@ -209,8 +209,8 @@ If it gains pressure too slowly, it may leak or just rupture instead of explodin
 		var/reaction_limit = min(total_oxidizers*(FIRE_REACTION_FUEL_AMOUNT/FIRE_REACTION_OXIDIZER_AMOUNT), total_fuel) //stoichiometric limit
 
 		//vapour fuels are extremely volatile! The reaction progress is a percentage of the total fuel (similar to old zburn).)
-		var/firelevel = calculate_firelevel(total_fuel, total_oxidizers, reaction_limit, volume*group_multiplier) / vsc.fire_firelevel_multiplier
-		var/min_burn = 0.30*volume*group_multiplier/CELL_VOLUME //in moles - so that fires with very small gas concentrations burn out fast
+		var/firelevel = calculate_firelevel(total_fuel, total_oxidizers, reaction_limit, air_volume*group_multiplier) / vsc.fire_firelevel_multiplier
+		var/min_burn = 0.30*air_volume*group_multiplier/CELL_VOLUME //in moles - so that fires with very small gas concentrations burn out fast
 		var/total_reaction_progress = min(max(min_burn, firelevel*total_fuel)*FIRE_GAS_BURNRATE_MULT, total_fuel)
 		var/used_fuel = min(total_reaction_progress, reaction_limit)
 		var/used_oxidizers = used_fuel*(FIRE_REACTION_OXIDIZER_AMOUNT/FIRE_REACTION_FUEL_AMOUNT)

--- a/code/modules/ZAS/Fire.dm
+++ b/code/modules/ZAS/Fire.dm
@@ -112,15 +112,15 @@ If it gains pressure too slowly, it may leak or just rupture instead of explodin
 	for(var/mob/living/L in loc)
 		L.FireBurn(firelevel, air_contents.temperature, air_contents.return_pressure())  //Burn the mobs!
 
-	loc.fire_act(air_contents, air_contents.temperature, air_contents.air_volume)
+	loc.fire_act(air_contents, air_contents.temperature, air_contents.total_volume)
 	for(var/atom/A in loc)
-		A.fire_act(air_contents, air_contents.temperature, air_contents.air_volume)
+		A.fire_act(air_contents, air_contents.temperature, air_contents.total_volume)
 
 	// prioritize nearby fuel overlays first
 	for(var/direction in global.cardinal)
 		var/turf/enemy_tile = get_step(my_tile, direction)
 		if(istype(enemy_tile) && enemy_tile.reagents)
-			enemy_tile.hotspot_expose(air_contents.temperature, air_contents.air_volume)
+			enemy_tile.hotspot_expose(air_contents.temperature, air_contents.total_volume)
 
 	//spread
 	for(var/direction in global.cardinal)
@@ -141,7 +141,7 @@ If it gains pressure too slowly, it may leak or just rupture instead of explodin
 					enemy_tile.create_fire(firelevel)
 
 			else
-				enemy_tile.adjacent_fire_act(loc, air_contents, air_contents.temperature, air_contents.air_volume)
+				enemy_tile.adjacent_fire_act(loc, air_contents, air_contents.temperature, air_contents.total_volume)
 
 	animate(src, color = fire_color(air_contents.temperature), 5)
 	set_light(l_color = color)
@@ -209,8 +209,8 @@ If it gains pressure too slowly, it may leak or just rupture instead of explodin
 		var/reaction_limit = min(total_oxidizers*(FIRE_REACTION_FUEL_AMOUNT/FIRE_REACTION_OXIDIZER_AMOUNT), total_fuel) //stoichiometric limit
 
 		//vapour fuels are extremely volatile! The reaction progress is a percentage of the total fuel (similar to old zburn).)
-		var/firelevel = calculate_firelevel(total_fuel, total_oxidizers, reaction_limit, air_volume*group_multiplier) / vsc.fire_firelevel_multiplier
-		var/min_burn = 0.30*air_volume*group_multiplier/CELL_VOLUME //in moles - so that fires with very small gas concentrations burn out fast
+		var/firelevel = calculate_firelevel(total_fuel, total_oxidizers, reaction_limit, total_volume*group_multiplier) / vsc.fire_firelevel_multiplier
+		var/min_burn = 0.30*total_volume*group_multiplier/CELL_VOLUME //in moles - so that fires with very small gas concentrations burn out fast
 		var/total_reaction_progress = min(max(min_burn, firelevel*total_fuel)*FIRE_GAS_BURNRATE_MULT, total_fuel)
 		var/used_fuel = min(total_reaction_progress, reaction_limit)
 		var/used_oxidizers = used_fuel*(FIRE_REACTION_OXIDIZER_AMOUNT/FIRE_REACTION_FUEL_AMOUNT)

--- a/code/modules/ZAS/Zone.dm
+++ b/code/modules/ZAS/Zone.dm
@@ -57,7 +57,7 @@ Class Procs:
 	SSair.add_zone(src)
 	air.temperature = TCMB
 	air.group_multiplier = 1
-	air.volume = CELL_VOLUME
+	air.air_volume = CELL_VOLUME
 
 /zone/proc/add(turf/T)
 #ifdef ZASDBG
@@ -136,7 +136,7 @@ Class Procs:
 		CHECK_TICK
 
 /zone/proc/add_tile_air(datum/gas_mixture/tile_air)
-	//air.volume += CELL_VOLUME
+	//air.air_volume += CELL_VOLUME
 	air.group_multiplier = 1
 	air.multiply(contents.len)
 	air.merge(tile_air)
@@ -200,7 +200,7 @@ Class Procs:
 	for(var/g in air.gas)
 		var/decl/material/mat = GET_DECL(g)
 		to_chat(M, "[capitalize(mat.gas_name)]: [air.gas[g]]")
-	to_chat(M, "P: [air.return_pressure()] kPa V: [air.volume]L T: [air.temperature]°K ([air.temperature - T0C]°C)")
+	to_chat(M, "P: [air.return_pressure()] kPa V: [air.air_volume]L T: [air.temperature]°K ([air.temperature - T0C]°C)")
 	to_chat(M, "O2 per N2: [(air.gas[/decl/material/gas/nitrogen] ? air.gas[/decl/material/gas/oxygen]/air.gas[/decl/material/gas/nitrogen] : "N/A")] Moles: [air.total_moles]")
 	to_chat(M, "Simulated: [contents.len] ([air.group_multiplier])")
 	to_chat(M, "Edges: [length(edges)]")

--- a/code/modules/ZAS/Zone.dm
+++ b/code/modules/ZAS/Zone.dm
@@ -57,7 +57,7 @@ Class Procs:
 	SSair.add_zone(src)
 	air.temperature = TCMB
 	air.group_multiplier = 1
-	air.air_volume = CELL_VOLUME
+	air.total_volume = CELL_VOLUME
 
 /zone/proc/add(turf/T)
 #ifdef ZASDBG
@@ -136,7 +136,7 @@ Class Procs:
 		CHECK_TICK
 
 /zone/proc/add_tile_air(datum/gas_mixture/tile_air)
-	//air.air_volume += CELL_VOLUME
+	//air.total_volume += CELL_VOLUME
 	air.group_multiplier = 1
 	air.multiply(contents.len)
 	air.merge(tile_air)
@@ -200,7 +200,7 @@ Class Procs:
 	for(var/g in air.gas)
 		var/decl/material/mat = GET_DECL(g)
 		to_chat(M, "[capitalize(mat.gas_name)]: [air.gas[g]]")
-	to_chat(M, "P: [air.return_pressure()] kPa V: [air.air_volume]L T: [air.temperature]°K ([air.temperature - T0C]°C)")
+	to_chat(M, "P: [air.return_pressure()] kPa V: [air.total_volume]L T: [air.temperature]°K ([air.temperature - T0C]°C)")
 	to_chat(M, "O2 per N2: [(air.gas[/decl/material/gas/nitrogen] ? air.gas[/decl/material/gas/oxygen]/air.gas[/decl/material/gas/nitrogen] : "N/A")] Moles: [air.total_moles]")
 	to_chat(M, "Simulated: [contents.len] ([air.group_multiplier])")
 	to_chat(M, "Edges: [length(edges)]")

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -17,7 +17,7 @@
 	t += "<span class='warning'>Temperature: [env.temperature]</span>\n"
 	t += "<span class='warning'>Pressure: [env.return_pressure()]kPa</span>\n"
 	for(var/g in env.gas)
-		t += "<span class='notice'>[g]: [env.gas[g]] / [env.gas[g] * R_IDEAL_GAS_EQUATION * env.temperature / env.air_volume]kPa</span>\n"
+		t += "<span class='notice'>[g]: [env.gas[g]] / [env.gas[g] * R_IDEAL_GAS_EQUATION * env.temperature / env.total_volume]kPa</span>\n"
 
 	usr.show_message(t, 1)
 	SSstatistics.add_field_details("admin_verb","ASL") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -17,7 +17,7 @@
 	t += "<span class='warning'>Temperature: [env.temperature]</span>\n"
 	t += "<span class='warning'>Pressure: [env.return_pressure()]kPa</span>\n"
 	for(var/g in env.gas)
-		t += "<span class='notice'>[g]: [env.gas[g]] / [env.gas[g] * R_IDEAL_GAS_EQUATION * env.temperature / env.volume]kPa</span>\n"
+		t += "<span class='notice'>[g]: [env.gas[g]] / [env.gas[g] * R_IDEAL_GAS_EQUATION * env.temperature / env.air_volume]kPa</span>\n"
 
 	usr.show_message(t, 1)
 	SSstatistics.add_field_details("admin_verb","ASL") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!

--- a/code/modules/atmospherics/atmos_primitives.dm
+++ b/code/modules/atmospherics/atmos_primitives.dm
@@ -45,7 +45,7 @@
 	//Update flow rate meter
 	if (istype(M, /obj/machinery/atmospherics))
 		var/obj/machinery/atmospherics/A = M
-		A.last_flow_rate = (transfer_moles/source.total_moles)*source.volume //group_multiplier gets divided out here
+		A.last_flow_rate = (transfer_moles/source.total_moles)*source.air_volume //group_multiplier gets divided out here
 
 		if (A.debug)
 			A.visible_message("[A]: source entropy: [round(source.specific_entropy(), 0.01)] J/Kmol --> sink entropy: [round(sink.specific_entropy(), 0.01)] J/Kmol")
@@ -55,7 +55,7 @@
 
 	if (istype(M, /obj/machinery/portable_atmospherics))
 		var/obj/machinery/portable_atmospherics/P = M
-		P.last_flow_rate = (transfer_moles/source.total_moles)*source.volume //group_multiplier gets divided out here
+		P.last_flow_rate = (transfer_moles/source.total_moles)*source.air_volume //group_multiplier gets divided out here
 
 	var/datum/gas_mixture/removed = source.remove(transfer_moles)
 	if (!removed) //Just in case
@@ -86,13 +86,13 @@
 	//Update flow rate meter
 	if (istype(M, /obj/machinery/atmospherics))
 		var/obj/machinery/atmospherics/A = M
-		A.last_flow_rate = (transfer_moles/source.total_moles)*source.volume //group_multiplier gets divided out here
+		A.last_flow_rate = (transfer_moles/source.total_moles)*source.air_volume //group_multiplier gets divided out here
 		if (A.debug)
 			A.visible_message("[A]: moles transferred = [transfer_moles] mol")
 
 	if (istype(M, /obj/machinery/portable_atmospherics))
 		var/obj/machinery/portable_atmospherics/P = M
-		P.last_flow_rate = (transfer_moles/source.total_moles)*source.volume //group_multiplier gets divided out here
+		P.last_flow_rate = (transfer_moles/source.total_moles)*source.air_volume //group_multiplier gets divided out here
 
 	var/datum/gas_mixture/removed = source.remove(transfer_moles)
 	if(!removed) //Just in case
@@ -148,10 +148,10 @@
 	//Update flow rate var
 	if (istype(M, /obj/machinery/atmospherics))
 		var/obj/machinery/atmospherics/A = M
-		A.last_flow_rate = (total_transfer_moles/source.total_moles)*source.volume //group_multiplier gets divided out here
+		A.last_flow_rate = (total_transfer_moles/source.total_moles)*source.air_volume //group_multiplier gets divided out here
 	if (istype(M, /obj/machinery/portable_atmospherics))
 		var/obj/machinery/portable_atmospherics/P = M
-		P.last_flow_rate = (total_transfer_moles/source.total_moles)*source.volume //group_multiplier gets divided out here
+		P.last_flow_rate = (total_transfer_moles/source.total_moles)*source.air_volume //group_multiplier gets divided out here
 
 	var/power_draw = 0
 	for (var/g in filtering)
@@ -217,10 +217,10 @@
 	//Update flow rate var
 	if (istype(M, /obj/machinery/atmospherics))
 		var/obj/machinery/atmospherics/A = M
-		A.last_flow_rate = (total_transfer_moles/source.total_moles)*source.volume //group_multiplier gets divided out here
+		A.last_flow_rate = (total_transfer_moles/source.total_moles)*source.air_volume //group_multiplier gets divided out here
 	if (istype(M, /obj/machinery/portable_atmospherics))
 		var/obj/machinery/portable_atmospherics/P = M
-		P.last_flow_rate = (total_transfer_moles/source.total_moles)*source.volume //group_multiplier gets divided out here
+		P.last_flow_rate = (total_transfer_moles/source.total_moles)*source.air_volume //group_multiplier gets divided out here
 
 	var/datum/gas_mixture/removed = source.remove(total_transfer_moles)
 	if (!removed) //Just in case
@@ -290,10 +290,10 @@
 	//Update Flow Rate var
 	if (istype(M, /obj/machinery/atmospherics))
 		var/obj/machinery/atmospherics/A = M
-		A.last_flow_rate = (total_transfer_moles/source.total_moles)*source.volume //group_multiplier gets divided out here
+		A.last_flow_rate = (total_transfer_moles/source.total_moles)*source.air_volume //group_multiplier gets divided out here
 	if (istype(M, /obj/machinery/portable_atmospherics))
 		var/obj/machinery/portable_atmospherics/P = M
-		P.last_flow_rate = (total_transfer_moles/source.total_moles)*source.volume //group_multiplier gets divided out here
+		P.last_flow_rate = (total_transfer_moles/source.total_moles)*source.air_volume //group_multiplier gets divided out here
 
 	var/datum/gas_mixture/removed = source.remove(total_transfer_moles)
 	if (!removed) //Just in case
@@ -350,7 +350,7 @@
 
 		source_specific_power[source] = calculate_specific_power(source, sink)*mix_ratio/ATMOS_FILTER_EFFICIENCY
 		total_specific_power += source_specific_power[source]
-		total_input_volume += source.volume
+		total_input_volume += source.air_volume
 		total_input_moles += source.total_moles
 
 	if (total_mixing_moles < MINIMUM_MOLES_TO_FILTER) //if we cant transfer enough gas just stop to avoid further processing
@@ -429,7 +429,7 @@
 /proc/calculate_transfer_moles(datum/gas_mixture/source, datum/gas_mixture/sink, var/pressure_delta, var/sink_volume_mod=0)
 	if(source.temperature == 0 || source.total_moles == 0) return 0
 
-	var/output_volume = (sink.volume * sink.group_multiplier) + sink_volume_mod
+	var/output_volume = (sink.air_volume * sink.group_multiplier) + sink_volume_mod
 	var/source_total_moles = source.total_moles * source.group_multiplier
 
 	var/air_temperature = source.temperature
@@ -448,8 +448,8 @@
 	if(source.temperature == 0) return 0
 
 	//Make the approximation that the sink temperature is unchanged after transferring gas
-	var/source_volume = source.volume * source.group_multiplier
-	var/sink_volume = sink.volume * sink.group_multiplier
+	var/source_volume = source.air_volume * source.group_multiplier
+	var/sink_volume = sink.air_volume * sink.group_multiplier
 
 	var/source_pressure = source.return_pressure()
 	var/sink_pressure = sink.return_pressure()

--- a/code/modules/atmospherics/atmos_primitives.dm
+++ b/code/modules/atmospherics/atmos_primitives.dm
@@ -45,7 +45,7 @@
 	//Update flow rate meter
 	if (istype(M, /obj/machinery/atmospherics))
 		var/obj/machinery/atmospherics/A = M
-		A.last_flow_rate = (transfer_moles/source.total_moles)*source.air_volume //group_multiplier gets divided out here
+		A.last_flow_rate = (transfer_moles/source.total_moles)*source.total_volume //group_multiplier gets divided out here
 
 		if (A.debug)
 			A.visible_message("[A]: source entropy: [round(source.specific_entropy(), 0.01)] J/Kmol --> sink entropy: [round(sink.specific_entropy(), 0.01)] J/Kmol")
@@ -55,7 +55,7 @@
 
 	if (istype(M, /obj/machinery/portable_atmospherics))
 		var/obj/machinery/portable_atmospherics/P = M
-		P.last_flow_rate = (transfer_moles/source.total_moles)*source.air_volume //group_multiplier gets divided out here
+		P.last_flow_rate = (transfer_moles/source.total_moles)*source.total_volume //group_multiplier gets divided out here
 
 	var/datum/gas_mixture/removed = source.remove(transfer_moles)
 	if (!removed) //Just in case
@@ -86,13 +86,13 @@
 	//Update flow rate meter
 	if (istype(M, /obj/machinery/atmospherics))
 		var/obj/machinery/atmospherics/A = M
-		A.last_flow_rate = (transfer_moles/source.total_moles)*source.air_volume //group_multiplier gets divided out here
+		A.last_flow_rate = (transfer_moles/source.total_moles)*source.total_volume //group_multiplier gets divided out here
 		if (A.debug)
 			A.visible_message("[A]: moles transferred = [transfer_moles] mol")
 
 	if (istype(M, /obj/machinery/portable_atmospherics))
 		var/obj/machinery/portable_atmospherics/P = M
-		P.last_flow_rate = (transfer_moles/source.total_moles)*source.air_volume //group_multiplier gets divided out here
+		P.last_flow_rate = (transfer_moles/source.total_moles)*source.total_volume //group_multiplier gets divided out here
 
 	var/datum/gas_mixture/removed = source.remove(transfer_moles)
 	if(!removed) //Just in case
@@ -148,10 +148,10 @@
 	//Update flow rate var
 	if (istype(M, /obj/machinery/atmospherics))
 		var/obj/machinery/atmospherics/A = M
-		A.last_flow_rate = (total_transfer_moles/source.total_moles)*source.air_volume //group_multiplier gets divided out here
+		A.last_flow_rate = (total_transfer_moles/source.total_moles)*source.total_volume //group_multiplier gets divided out here
 	if (istype(M, /obj/machinery/portable_atmospherics))
 		var/obj/machinery/portable_atmospherics/P = M
-		P.last_flow_rate = (total_transfer_moles/source.total_moles)*source.air_volume //group_multiplier gets divided out here
+		P.last_flow_rate = (total_transfer_moles/source.total_moles)*source.total_volume //group_multiplier gets divided out here
 
 	var/power_draw = 0
 	for (var/g in filtering)
@@ -217,10 +217,10 @@
 	//Update flow rate var
 	if (istype(M, /obj/machinery/atmospherics))
 		var/obj/machinery/atmospherics/A = M
-		A.last_flow_rate = (total_transfer_moles/source.total_moles)*source.air_volume //group_multiplier gets divided out here
+		A.last_flow_rate = (total_transfer_moles/source.total_moles)*source.total_volume //group_multiplier gets divided out here
 	if (istype(M, /obj/machinery/portable_atmospherics))
 		var/obj/machinery/portable_atmospherics/P = M
-		P.last_flow_rate = (total_transfer_moles/source.total_moles)*source.air_volume //group_multiplier gets divided out here
+		P.last_flow_rate = (total_transfer_moles/source.total_moles)*source.total_volume //group_multiplier gets divided out here
 
 	var/datum/gas_mixture/removed = source.remove(total_transfer_moles)
 	if (!removed) //Just in case
@@ -290,10 +290,10 @@
 	//Update Flow Rate var
 	if (istype(M, /obj/machinery/atmospherics))
 		var/obj/machinery/atmospherics/A = M
-		A.last_flow_rate = (total_transfer_moles/source.total_moles)*source.air_volume //group_multiplier gets divided out here
+		A.last_flow_rate = (total_transfer_moles/source.total_moles)*source.total_volume //group_multiplier gets divided out here
 	if (istype(M, /obj/machinery/portable_atmospherics))
 		var/obj/machinery/portable_atmospherics/P = M
-		P.last_flow_rate = (total_transfer_moles/source.total_moles)*source.air_volume //group_multiplier gets divided out here
+		P.last_flow_rate = (total_transfer_moles/source.total_moles)*source.total_volume //group_multiplier gets divided out here
 
 	var/datum/gas_mixture/removed = source.remove(total_transfer_moles)
 	if (!removed) //Just in case
@@ -350,7 +350,7 @@
 
 		source_specific_power[source] = calculate_specific_power(source, sink)*mix_ratio/ATMOS_FILTER_EFFICIENCY
 		total_specific_power += source_specific_power[source]
-		total_input_volume += source.air_volume
+		total_input_volume += source.total_volume
 		total_input_moles += source.total_moles
 
 	if (total_mixing_moles < MINIMUM_MOLES_TO_FILTER) //if we cant transfer enough gas just stop to avoid further processing
@@ -429,7 +429,7 @@
 /proc/calculate_transfer_moles(datum/gas_mixture/source, datum/gas_mixture/sink, var/pressure_delta, var/sink_volume_mod=0)
 	if(source.temperature == 0 || source.total_moles == 0) return 0
 
-	var/output_volume = (sink.air_volume * sink.group_multiplier) + sink_volume_mod
+	var/output_volume = (sink.total_volume * sink.group_multiplier) + sink_volume_mod
 	var/source_total_moles = source.total_moles * source.group_multiplier
 
 	var/air_temperature = source.temperature
@@ -448,8 +448,8 @@
 	if(source.temperature == 0) return 0
 
 	//Make the approximation that the sink temperature is unchanged after transferring gas
-	var/source_volume = source.air_volume * source.group_multiplier
-	var/sink_volume = sink.air_volume * sink.group_multiplier
+	var/source_volume = source.total_volume * source.group_multiplier
+	var/sink_volume = sink.total_volume * sink.group_multiplier
 
 	var/source_pressure = source.return_pressure()
 	var/sink_pressure = sink.return_pressure()

--- a/code/modules/atmospherics/components/binary_devices/binary_atmos_base.dm
+++ b/code/modules/atmospherics/components/binary_devices/binary_atmos_base.dm
@@ -12,8 +12,8 @@
 	air1 = new
 	air2 = new
 
-	air1.volume = 200
-	air2.volume = 200
+	air1.air_volume = 200
+	air2.air_volume = 200
 	. = ..()
 
 /obj/machinery/atmospherics/binary/air_in_dir(direction)

--- a/code/modules/atmospherics/components/binary_devices/binary_atmos_base.dm
+++ b/code/modules/atmospherics/components/binary_devices/binary_atmos_base.dm
@@ -12,8 +12,8 @@
 	air1 = new
 	air2 = new
 
-	air1.air_volume = 200
-	air2.air_volume = 200
+	air1.total_volume = 200
+	air2.total_volume = 200
 	. = ..()
 
 /obj/machinery/atmospherics/binary/air_in_dir(direction)

--- a/code/modules/atmospherics/components/binary_devices/circulator.dm
+++ b/code/modules/atmospherics/components/binary_devices/circulator.dm
@@ -31,7 +31,7 @@
 /obj/machinery/atmospherics/binary/circulator/Initialize()
 	. = ..()
 	desc = initial(desc) + " Its outlet port is to the [dir2text(dir)]."
-	air1.air_volume = 400
+	air1.total_volume = 400
 
 /obj/machinery/atmospherics/binary/circulator/proc/return_transfer_air()
 	var/datum/gas_mixture/removed
@@ -45,11 +45,11 @@
 		if(air1.temperature > 0 && last_pressure_delta > 5)
 
 			//Calculate necessary moles to transfer using PV = nRT
-			recent_moles_transferred = (last_pressure_delta*input.air_volume/(air1.temperature * R_IDEAL_GAS_EQUATION))/3 //uses the volume of the whole network, not just itself
-			volume_capacity_used = min( (last_pressure_delta*input.air_volume/3)/(input_starting_pressure*air1.air_volume) , 1) //how much of the gas in the input air volume is consumed
+			recent_moles_transferred = (last_pressure_delta*input.total_volume/(air1.temperature * R_IDEAL_GAS_EQUATION))/3 //uses the volume of the whole network, not just itself
+			volume_capacity_used = min( (last_pressure_delta*input.total_volume/3)/(input_starting_pressure*air1.total_volume) , 1) //how much of the gas in the input air volume is consumed
 
 			//Calculate energy generated from kinetic turbine
-			stored_energy += 1/ADIABATIC_EXPONENT * min(last_pressure_delta * input.air_volume , input_starting_pressure*air1.air_volume) * (1 - volume_ratio**ADIABATIC_EXPONENT) * kinetic_efficiency
+			stored_energy += 1/ADIABATIC_EXPONENT * min(last_pressure_delta * input.total_volume , input_starting_pressure*air1.total_volume) * (1 - volume_ratio**ADIABATIC_EXPONENT) * kinetic_efficiency
 
 			//Actually transfer the gas
 			removed = air1.remove(recent_moles_transferred)

--- a/code/modules/atmospherics/components/binary_devices/circulator.dm
+++ b/code/modules/atmospherics/components/binary_devices/circulator.dm
@@ -31,7 +31,7 @@
 /obj/machinery/atmospherics/binary/circulator/Initialize()
 	. = ..()
 	desc = initial(desc) + " Its outlet port is to the [dir2text(dir)]."
-	air1.volume = 400
+	air1.air_volume = 400
 
 /obj/machinery/atmospherics/binary/circulator/proc/return_transfer_air()
 	var/datum/gas_mixture/removed
@@ -45,11 +45,11 @@
 		if(air1.temperature > 0 && last_pressure_delta > 5)
 
 			//Calculate necessary moles to transfer using PV = nRT
-			recent_moles_transferred = (last_pressure_delta*input.volume/(air1.temperature * R_IDEAL_GAS_EQUATION))/3 //uses the volume of the whole network, not just itself
-			volume_capacity_used = min( (last_pressure_delta*input.volume/3)/(input_starting_pressure*air1.volume) , 1) //how much of the gas in the input air volume is consumed
+			recent_moles_transferred = (last_pressure_delta*input.air_volume/(air1.temperature * R_IDEAL_GAS_EQUATION))/3 //uses the volume of the whole network, not just itself
+			volume_capacity_used = min( (last_pressure_delta*input.air_volume/3)/(input_starting_pressure*air1.air_volume) , 1) //how much of the gas in the input air volume is consumed
 
 			//Calculate energy generated from kinetic turbine
-			stored_energy += 1/ADIABATIC_EXPONENT * min(last_pressure_delta * input.volume , input_starting_pressure*air1.volume) * (1 - volume_ratio**ADIABATIC_EXPONENT) * kinetic_efficiency
+			stored_energy += 1/ADIABATIC_EXPONENT * min(last_pressure_delta * input.air_volume , input_starting_pressure*air1.air_volume) * (1 - volume_ratio**ADIABATIC_EXPONENT) * kinetic_efficiency
 
 			//Actually transfer the gas
 			removed = air1.remove(recent_moles_transferred)

--- a/code/modules/atmospherics/components/binary_devices/oxyregenerator.dm
+++ b/code/modules/atmospherics/components/binary_devices/oxyregenerator.dm
@@ -90,7 +90,7 @@
 		var/pressure_delta = target_pressure - air2.return_pressure()
 		if (pressure_delta > 0.01 && inner_tank.temperature > 0)
 			var/datum/pipe_network/output = network_in_dir(dir)
-			var/transfer_moles = calculate_transfer_moles(inner_tank, air2, pressure_delta, output?.volume)
+			var/transfer_moles = calculate_transfer_moles(inner_tank, air2, pressure_delta, output?.air_volume)
 			power_draw = pump_gas(src, inner_tank, air2, transfer_moles, power_rating*power_setting)
 			if (power_draw >= 0)
 				last_power_draw = power_draw

--- a/code/modules/atmospherics/components/binary_devices/oxyregenerator.dm
+++ b/code/modules/atmospherics/components/binary_devices/oxyregenerator.dm
@@ -90,7 +90,7 @@
 		var/pressure_delta = target_pressure - air2.return_pressure()
 		if (pressure_delta > 0.01 && inner_tank.temperature > 0)
 			var/datum/pipe_network/output = network_in_dir(dir)
-			var/transfer_moles = calculate_transfer_moles(inner_tank, air2, pressure_delta, output?.air_volume)
+			var/transfer_moles = calculate_transfer_moles(inner_tank, air2, pressure_delta, output?.total_volume)
 			power_draw = pump_gas(src, inner_tank, air2, transfer_moles, power_rating*power_setting)
 			if (power_draw >= 0)
 				last_power_draw = power_draw

--- a/code/modules/atmospherics/components/binary_devices/passive_gate.dm
+++ b/code/modules/atmospherics/components/binary_devices/passive_gate.dm
@@ -52,8 +52,8 @@
 
 /obj/machinery/atmospherics/binary/passive_gate/Initialize()
 	. = ..()
-	air1.air_volume = ATMOS_DEFAULT_VOLUME_PUMP * 2.5
-	air2.air_volume = ATMOS_DEFAULT_VOLUME_PUMP * 2.5
+	air1.total_volume = ATMOS_DEFAULT_VOLUME_PUMP * 2.5
+	air2.total_volume = ATMOS_DEFAULT_VOLUME_PUMP * 2.5
 
 /obj/machinery/atmospherics/binary/passive_gate/on_update_icon()
 	icon_state = (unlocked && flowing)? "on" : "off"
@@ -87,7 +87,7 @@
 		flowing = 1
 
 		//flow rate limit
-		var/transfer_moles = (set_flow_rate/air1.air_volume)*air1.total_moles
+		var/transfer_moles = (set_flow_rate/air1.total_volume)*air1.total_moles
 
 		//Figure out how much gas to transfer to meet the target pressure.
 		switch (regulate_mode)
@@ -95,7 +95,7 @@
 				transfer_moles = min(transfer_moles, air1.total_moles*(pressure_delta/input_starting_pressure))
 			if (REGULATE_OUTPUT)
 				var/datum/pipe_network/output = network_in_dir(dir)
-				transfer_moles = min(transfer_moles, calculate_transfer_moles(air1, air2, pressure_delta, output?.air_volume))
+				transfer_moles = min(transfer_moles, calculate_transfer_moles(air1, air2, pressure_delta, output?.total_volume))
 
 		//pump_gas() will return a negative number if no flow occurred
 		returnval = pump_gas_passive(src, air1, air2, transfer_moles)
@@ -174,11 +174,11 @@
 			set_flow_rate = 0
 			. = TOPIC_REFRESH
 		if ("max")
-			set_flow_rate = air1.air_volume
+			set_flow_rate = air1.total_volume
 			. = TOPIC_REFRESH
 		if ("set")
-			var/new_flow_rate = input(user, "Enter new flow rate limit (0-[air1.air_volume]kPa)","Flow Rate Control",set_flow_rate) as num
-			set_flow_rate = clamp(new_flow_rate, 0, air1.air_volume)
+			var/new_flow_rate = input(user, "Enter new flow rate limit (0-[air1.total_volume]kPa)","Flow Rate Control",set_flow_rate) as num
+			set_flow_rate = clamp(new_flow_rate, 0, air1.total_volume)
 			. = TOPIC_REFRESH
 
 /obj/machinery/atmospherics/binary/passive_gate/proc/toggle_unlocked()
@@ -219,7 +219,7 @@
 	return machine.set_flow_rate
 
 /decl/public_access/public_variable/passive_gate_flow_rate/write_var(obj/machinery/atmospherics/binary/passive_gate/machine, new_value)
-	new_value = clamp(new_value, 0, machine.air1?.air_volume)
+	new_value = clamp(new_value, 0, machine.air1?.total_volume)
 	. = ..()
 	if(.)
 		machine.set_flow_rate = new_value

--- a/code/modules/atmospherics/components/binary_devices/passive_gate.dm
+++ b/code/modules/atmospherics/components/binary_devices/passive_gate.dm
@@ -52,8 +52,8 @@
 
 /obj/machinery/atmospherics/binary/passive_gate/Initialize()
 	. = ..()
-	air1.volume = ATMOS_DEFAULT_VOLUME_PUMP * 2.5
-	air2.volume = ATMOS_DEFAULT_VOLUME_PUMP * 2.5
+	air1.air_volume = ATMOS_DEFAULT_VOLUME_PUMP * 2.5
+	air2.air_volume = ATMOS_DEFAULT_VOLUME_PUMP * 2.5
 
 /obj/machinery/atmospherics/binary/passive_gate/on_update_icon()
 	icon_state = (unlocked && flowing)? "on" : "off"
@@ -87,7 +87,7 @@
 		flowing = 1
 
 		//flow rate limit
-		var/transfer_moles = (set_flow_rate/air1.volume)*air1.total_moles
+		var/transfer_moles = (set_flow_rate/air1.air_volume)*air1.total_moles
 
 		//Figure out how much gas to transfer to meet the target pressure.
 		switch (regulate_mode)
@@ -95,7 +95,7 @@
 				transfer_moles = min(transfer_moles, air1.total_moles*(pressure_delta/input_starting_pressure))
 			if (REGULATE_OUTPUT)
 				var/datum/pipe_network/output = network_in_dir(dir)
-				transfer_moles = min(transfer_moles, calculate_transfer_moles(air1, air2, pressure_delta, output?.volume))
+				transfer_moles = min(transfer_moles, calculate_transfer_moles(air1, air2, pressure_delta, output?.air_volume))
 
 		//pump_gas() will return a negative number if no flow occurred
 		returnval = pump_gas_passive(src, air1, air2, transfer_moles)
@@ -174,11 +174,11 @@
 			set_flow_rate = 0
 			. = TOPIC_REFRESH
 		if ("max")
-			set_flow_rate = air1.volume
+			set_flow_rate = air1.air_volume
 			. = TOPIC_REFRESH
 		if ("set")
-			var/new_flow_rate = input(user, "Enter new flow rate limit (0-[air1.volume]kPa)","Flow Rate Control",set_flow_rate) as num
-			set_flow_rate = clamp(new_flow_rate, 0, air1.volume)
+			var/new_flow_rate = input(user, "Enter new flow rate limit (0-[air1.air_volume]kPa)","Flow Rate Control",set_flow_rate) as num
+			set_flow_rate = clamp(new_flow_rate, 0, air1.air_volume)
 			. = TOPIC_REFRESH
 
 /obj/machinery/atmospherics/binary/passive_gate/proc/toggle_unlocked()
@@ -219,7 +219,7 @@
 	return machine.set_flow_rate
 
 /decl/public_access/public_variable/passive_gate_flow_rate/write_var(obj/machinery/atmospherics/binary/passive_gate/machine, new_value)
-	new_value = clamp(new_value, 0, machine.air1?.volume)
+	new_value = clamp(new_value, 0, machine.air1?.air_volume)
 	. = ..()
 	if(.)
 		machine.set_flow_rate = new_value

--- a/code/modules/atmospherics/components/binary_devices/pipeturbine.dm
+++ b/code/modules/atmospherics/components/binary_devices/pipeturbine.dm
@@ -21,9 +21,9 @@
 
 /obj/machinery/atmospherics/pipeturbine/Initialize()
 	. = ..()
-	air_in.air_volume = 200
-	air_out.air_volume = 800
-	volume_ratio = air_in.air_volume / (air_in.air_volume + air_out.air_volume)
+	air_in.total_volume = 200
+	air_out.total_volume = 800
+	volume_ratio = air_in.total_volume / (air_in.total_volume + air_out.total_volume)
 
 /obj/machinery/atmospherics/pipeturbine/get_initialize_directions()
 	switch(dir)
@@ -48,11 +48,11 @@
 		kin_energy *= 1 - kin_loss
 		dP = max(air_in.return_pressure() - air_out.return_pressure(), 0)
 		if(dP > 10)
-			kin_energy += 1/ADIABATIC_EXPONENT * dP * air_in.air_volume * (1 - volume_ratio**ADIABATIC_EXPONENT) * efficiency
+			kin_energy += 1/ADIABATIC_EXPONENT * dP * air_in.total_volume * (1 - volume_ratio**ADIABATIC_EXPONENT) * efficiency
 			air_in.temperature *= volume_ratio**ADIABATIC_EXPONENT
 
 			var/datum/gas_mixture/air_all = new
-			air_all.air_volume = air_in.air_volume + air_out.air_volume
+			air_all.total_volume = air_in.total_volume + air_out.total_volume
 			air_all.merge(air_in.remove_ratio(1))
 			air_all.merge(air_out.remove_ratio(1))
 

--- a/code/modules/atmospherics/components/binary_devices/pipeturbine.dm
+++ b/code/modules/atmospherics/components/binary_devices/pipeturbine.dm
@@ -21,9 +21,9 @@
 
 /obj/machinery/atmospherics/pipeturbine/Initialize()
 	. = ..()
-	air_in.volume = 200
-	air_out.volume = 800
-	volume_ratio = air_in.volume / (air_in.volume + air_out.volume)
+	air_in.air_volume = 200
+	air_out.air_volume = 800
+	volume_ratio = air_in.air_volume / (air_in.air_volume + air_out.air_volume)
 
 /obj/machinery/atmospherics/pipeturbine/get_initialize_directions()
 	switch(dir)
@@ -48,11 +48,11 @@
 		kin_energy *= 1 - kin_loss
 		dP = max(air_in.return_pressure() - air_out.return_pressure(), 0)
 		if(dP > 10)
-			kin_energy += 1/ADIABATIC_EXPONENT * dP * air_in.volume * (1 - volume_ratio**ADIABATIC_EXPONENT) * efficiency
+			kin_energy += 1/ADIABATIC_EXPONENT * dP * air_in.air_volume * (1 - volume_ratio**ADIABATIC_EXPONENT) * efficiency
 			air_in.temperature *= volume_ratio**ADIABATIC_EXPONENT
 
 			var/datum/gas_mixture/air_all = new
-			air_all.volume = air_in.volume + air_out.volume
+			air_all.air_volume = air_in.air_volume + air_out.air_volume
 			air_all.merge(air_in.remove_ratio(1))
 			air_all.merge(air_out.remove_ratio(1))
 

--- a/code/modules/atmospherics/components/binary_devices/pump.dm
+++ b/code/modules/atmospherics/components/binary_devices/pump.dm
@@ -5,9 +5,9 @@ node1, air1, network1 correspond to input
 node2, air2, network2 correspond to output
 
 Thus, the two variables affect pump operation are set in New():
-	air1.air_volume
+	air1.total_volume
 		This is the volume of gas available to the pump that may be transfered to the output
-	air2.air_volume
+	air2.total_volume
 		Higher quantities of this cause more air to be perfected later
 			but overall network volume is also increased as this increases...
 */
@@ -61,8 +61,8 @@ Thus, the two variables affect pump operation are set in New():
 
 /obj/machinery/atmospherics/binary/pump/Initialize()
 	. = ..()
-	air1.air_volume = ATMOS_DEFAULT_VOLUME_PUMP
-	air2.air_volume = ATMOS_DEFAULT_VOLUME_PUMP
+	air1.total_volume = ATMOS_DEFAULT_VOLUME_PUMP
+	air2.total_volume = ATMOS_DEFAULT_VOLUME_PUMP
 
 /obj/machinery/atmospherics/binary/pump/on
 	icon_state = "map_on"
@@ -93,7 +93,7 @@ Thus, the two variables affect pump operation are set in New():
 	if(pressure_delta > 0.01 && air1.temperature > 0)
 		//Figure out how much gas to transfer to meet the target pressure.
 		var/datum/pipe_network/output = network_in_dir(dir)
-		var/transfer_moles = calculate_transfer_moles(air1, air2, pressure_delta, output?.air_volume)
+		var/transfer_moles = calculate_transfer_moles(air1, air2, pressure_delta, output?.total_volume)
 		power_draw = pump_gas(src, air1, air2, transfer_moles, power_rating)
 
 		if(transfer_moles > 0)

--- a/code/modules/atmospherics/components/binary_devices/pump.dm
+++ b/code/modules/atmospherics/components/binary_devices/pump.dm
@@ -5,9 +5,9 @@ node1, air1, network1 correspond to input
 node2, air2, network2 correspond to output
 
 Thus, the two variables affect pump operation are set in New():
-	air1.volume
+	air1.air_volume
 		This is the volume of gas available to the pump that may be transfered to the output
-	air2.volume
+	air2.air_volume
 		Higher quantities of this cause more air to be perfected later
 			but overall network volume is also increased as this increases...
 */
@@ -61,8 +61,8 @@ Thus, the two variables affect pump operation are set in New():
 
 /obj/machinery/atmospherics/binary/pump/Initialize()
 	. = ..()
-	air1.volume = ATMOS_DEFAULT_VOLUME_PUMP
-	air2.volume = ATMOS_DEFAULT_VOLUME_PUMP
+	air1.air_volume = ATMOS_DEFAULT_VOLUME_PUMP
+	air2.air_volume = ATMOS_DEFAULT_VOLUME_PUMP
 
 /obj/machinery/atmospherics/binary/pump/on
 	icon_state = "map_on"
@@ -93,7 +93,7 @@ Thus, the two variables affect pump operation are set in New():
 	if(pressure_delta > 0.01 && air1.temperature > 0)
 		//Figure out how much gas to transfer to meet the target pressure.
 		var/datum/pipe_network/output = network_in_dir(dir)
-		var/transfer_moles = calculate_transfer_moles(air1, air2, pressure_delta, output?.volume)
+		var/transfer_moles = calculate_transfer_moles(air1, air2, pressure_delta, output?.air_volume)
 		power_draw = pump_gas(src, air1, air2, transfer_moles, power_rating)
 
 		if(transfer_moles > 0)

--- a/code/modules/atmospherics/components/omni_devices/_omni_extras.dm
+++ b/code/modules/atmospherics/components/omni_devices/_omni_extras.dm
@@ -30,7 +30,7 @@
 	if(istype(M))
 		master = M
 	air = new
-	air.air_volume = 200
+	air.total_volume = 200
 
 /datum/omni_port/Destroy()
 	QDEL_NULL(network)

--- a/code/modules/atmospherics/components/omni_devices/_omni_extras.dm
+++ b/code/modules/atmospherics/components/omni_devices/_omni_extras.dm
@@ -30,7 +30,7 @@
 	if(istype(M))
 		master = M
 	air = new
-	air.volume = 200
+	air.air_volume = 200
 
 /datum/omni_port/Destroy()
 	QDEL_NULL(network)

--- a/code/modules/atmospherics/components/omni_devices/filter.dm
+++ b/code/modules/atmospherics/components/omni_devices/filter.dm
@@ -39,7 +39,7 @@
 
 	rebuild_filtering_list()
 	for(var/datum/omni_port/P in ports)
-		P.air.volume = ATMOS_DEFAULT_VOLUME_FILTER
+		P.air.air_volume = ATMOS_DEFAULT_VOLUME_FILTER
 
 /obj/machinery/atmospherics/omni/filter/Destroy()
 	input = null
@@ -57,7 +57,7 @@
 			if(P in gas_filters)
 				gas_filters -= P
 
-			P.air.volume = ATMOS_DEFAULT_VOLUME_FILTER
+			P.air.air_volume = ATMOS_DEFAULT_VOLUME_FILTER
 			switch(P.mode)
 				if(ATM_INPUT)
 					input = P
@@ -82,13 +82,13 @@
 	var/datum/gas_mixture/input_air = input.air		// it's completely happy with them if they're in a loop though i.e. "P.air.return_pressure()"... *shrug*
 
 	var/delta = clamp(0, (output_air ? (max_output_pressure - output_air.return_pressure()) : 0), max_output_pressure)
-	var/transfer_moles_max = calculate_transfer_moles(input_air, output_air, delta, (output && output.network && output.network.volume) ? output.network.volume : 0)
+	var/transfer_moles_max = calculate_transfer_moles(input_air, output_air, delta, (output && output.network && output.network.air_volume) ? output.network.air_volume : 0)
 	for(var/datum/omni_port/filter_output in gas_filters)
 		delta = clamp(0, (filter_output.air ? (max_output_pressure - filter_output.air.return_pressure()) : 0), max_output_pressure)
-		transfer_moles_max = min(transfer_moles_max, (calculate_transfer_moles(input_air, filter_output.air, delta, (filter_output && filter_output.network && filter_output.network.volume) ? filter_output.network.volume : 0)))
+		transfer_moles_max = min(transfer_moles_max, (calculate_transfer_moles(input_air, filter_output.air, delta, (filter_output && filter_output.network && filter_output.network.air_volume) ? filter_output.network.air_volume : 0)))
 
 	//Figure out the amount of moles to transfer
-	var/transfer_moles = clamp(0, ((set_flow_rate/input_air.volume)*input_air.total_moles), transfer_moles_max)
+	var/transfer_moles = clamp(0, ((set_flow_rate/input_air.air_volume)*input_air.total_moles), transfer_moles_max)
 
 	var/power_draw = -1
 	if (transfer_moles > MINIMUM_MOLES_TO_FILTER)

--- a/code/modules/atmospherics/components/omni_devices/filter.dm
+++ b/code/modules/atmospherics/components/omni_devices/filter.dm
@@ -39,7 +39,7 @@
 
 	rebuild_filtering_list()
 	for(var/datum/omni_port/P in ports)
-		P.air.air_volume = ATMOS_DEFAULT_VOLUME_FILTER
+		P.air.total_volume = ATMOS_DEFAULT_VOLUME_FILTER
 
 /obj/machinery/atmospherics/omni/filter/Destroy()
 	input = null
@@ -57,7 +57,7 @@
 			if(P in gas_filters)
 				gas_filters -= P
 
-			P.air.air_volume = ATMOS_DEFAULT_VOLUME_FILTER
+			P.air.total_volume = ATMOS_DEFAULT_VOLUME_FILTER
 			switch(P.mode)
 				if(ATM_INPUT)
 					input = P
@@ -82,13 +82,13 @@
 	var/datum/gas_mixture/input_air = input.air		// it's completely happy with them if they're in a loop though i.e. "P.air.return_pressure()"... *shrug*
 
 	var/delta = clamp(0, (output_air ? (max_output_pressure - output_air.return_pressure()) : 0), max_output_pressure)
-	var/transfer_moles_max = calculate_transfer_moles(input_air, output_air, delta, (output && output.network && output.network.air_volume) ? output.network.air_volume : 0)
+	var/transfer_moles_max = calculate_transfer_moles(input_air, output_air, delta, (output && output.network && output.network.total_volume) ? output.network.total_volume : 0)
 	for(var/datum/omni_port/filter_output in gas_filters)
 		delta = clamp(0, (filter_output.air ? (max_output_pressure - filter_output.air.return_pressure()) : 0), max_output_pressure)
-		transfer_moles_max = min(transfer_moles_max, (calculate_transfer_moles(input_air, filter_output.air, delta, (filter_output && filter_output.network && filter_output.network.air_volume) ? filter_output.network.air_volume : 0)))
+		transfer_moles_max = min(transfer_moles_max, (calculate_transfer_moles(input_air, filter_output.air, delta, (filter_output && filter_output.network && filter_output.network.total_volume) ? filter_output.network.total_volume : 0)))
 
 	//Figure out the amount of moles to transfer
-	var/transfer_moles = clamp(0, ((set_flow_rate/input_air.air_volume)*input_air.total_moles), transfer_moles_max)
+	var/transfer_moles = clamp(0, ((set_flow_rate/input_air.total_volume)*input_air.total_moles), transfer_moles_max)
 
 	var/power_draw = -1
 	if (transfer_moles > MINIMUM_MOLES_TO_FILTER)

--- a/code/modules/atmospherics/components/omni_devices/mixer.dm
+++ b/code/modules/atmospherics/components/omni_devices/mixer.dm
@@ -54,7 +54,7 @@
 						con += max(0, tag_west_con)
 
 	for(var/datum/omni_port/P in ports)
-		P.air.volume = ATMOS_DEFAULT_VOLUME_MIXER
+		P.air.air_volume = ATMOS_DEFAULT_VOLUME_MIXER
 
 /obj/machinery/atmospherics/omni/mixer/Destroy()
 	inputs.Cut()
@@ -80,7 +80,7 @@
 			P.concentration = 1 / max(1, inputs.len)
 
 	if(output)
-		output.air.volume = ATMOS_DEFAULT_VOLUME_MIXER * 0.75 * inputs.len
+		output.air.air_volume = ATMOS_DEFAULT_VOLUME_MIXER * 0.75 * inputs.len
 		output.concentration = 1
 
 	rebuild_mixing_inputs()
@@ -117,8 +117,8 @@
 	for (var/datum/omni_port/P in inputs)
 		if(!P.concentration)
 			continue
-		transfer_moles += (set_flow_rate*P.concentration/P.air.volume)*P.air.total_moles
-		transfer_moles_max = min(transfer_moles_max, calculate_transfer_moles(P.air, output.air, delta, (output && output.network && output.network.volume) ? output.network.volume : 0))
+		transfer_moles += (set_flow_rate*P.concentration/P.air.air_volume)*P.air.total_moles
+		transfer_moles_max = min(transfer_moles_max, calculate_transfer_moles(P.air, output.air, delta, (output && output.network && output.network.air_volume) ? output.network.air_volume : 0))
 	transfer_moles = clamp(0, transfer_moles, transfer_moles_max)
 
 	var/power_draw = -1

--- a/code/modules/atmospherics/components/omni_devices/mixer.dm
+++ b/code/modules/atmospherics/components/omni_devices/mixer.dm
@@ -54,7 +54,7 @@
 						con += max(0, tag_west_con)
 
 	for(var/datum/omni_port/P in ports)
-		P.air.air_volume = ATMOS_DEFAULT_VOLUME_MIXER
+		P.air.total_volume = ATMOS_DEFAULT_VOLUME_MIXER
 
 /obj/machinery/atmospherics/omni/mixer/Destroy()
 	inputs.Cut()
@@ -80,7 +80,7 @@
 			P.concentration = 1 / max(1, inputs.len)
 
 	if(output)
-		output.air.air_volume = ATMOS_DEFAULT_VOLUME_MIXER * 0.75 * inputs.len
+		output.air.total_volume = ATMOS_DEFAULT_VOLUME_MIXER * 0.75 * inputs.len
 		output.concentration = 1
 
 	rebuild_mixing_inputs()
@@ -117,8 +117,8 @@
 	for (var/datum/omni_port/P in inputs)
 		if(!P.concentration)
 			continue
-		transfer_moles += (set_flow_rate*P.concentration/P.air.air_volume)*P.air.total_moles
-		transfer_moles_max = min(transfer_moles_max, calculate_transfer_moles(P.air, output.air, delta, (output && output.network && output.network.air_volume) ? output.network.air_volume : 0))
+		transfer_moles += (set_flow_rate*P.concentration/P.air.total_volume)*P.air.total_moles
+		transfer_moles_max = min(transfer_moles_max, calculate_transfer_moles(P.air, output.air, delta, (output && output.network && output.network.total_volume) ? output.network.total_volume : 0))
 	transfer_moles = clamp(0, transfer_moles, transfer_moles_max)
 
 	var/power_draw = -1

--- a/code/modules/atmospherics/components/trinary_devices/trinary_base.dm
+++ b/code/modules/atmospherics/components/trinary_devices/trinary_base.dm
@@ -15,9 +15,9 @@
 	air2 = new
 	air3 = new
 
-	air1.air_volume = 200
-	air2.air_volume = 200
-	air3.air_volume = 200
+	air1.total_volume = 200
+	air2.total_volume = 200
+	air3.total_volume = 200
 	. = ..()
 
 /obj/machinery/atmospherics/trinary/air_in_dir(direction)

--- a/code/modules/atmospherics/components/trinary_devices/trinary_base.dm
+++ b/code/modules/atmospherics/components/trinary_devices/trinary_base.dm
@@ -15,9 +15,9 @@
 	air2 = new
 	air3 = new
 
-	air1.volume = 200
-	air2.volume = 200
-	air3.volume = 200
+	air1.air_volume = 200
+	air2.air_volume = 200
+	air3.air_volume = 200
 	. = ..()
 
 /obj/machinery/atmospherics/trinary/air_in_dir(direction)

--- a/code/modules/atmospherics/components/unary/cold_sink.dm
+++ b/code/modules/atmospherics/components/unary/cold_sink.dm
@@ -123,7 +123,7 @@
 
 	power_rating = initial(power_rating) * cap_rating / 2			//more powerful
 	heatsink_temperature = initial(heatsink_temperature) / ((manip_rating + bin_rating) / 2)	//more efficient
-	air_contents.air_volume = max(initial(internal_volume) - 200, 0) + 200 * bin_rating
+	air_contents.total_volume = max(initial(internal_volume) - 200, 0) + 200 * bin_rating
 	set_power_level(power_setting)
 
 /obj/machinery/atmospherics/unary/freezer/proc/set_power_level(var/new_power_setting)

--- a/code/modules/atmospherics/components/unary/cold_sink.dm
+++ b/code/modules/atmospherics/components/unary/cold_sink.dm
@@ -123,7 +123,7 @@
 
 	power_rating = initial(power_rating) * cap_rating / 2			//more powerful
 	heatsink_temperature = initial(heatsink_temperature) / ((manip_rating + bin_rating) / 2)	//more efficient
-	air_contents.volume = max(initial(internal_volume) - 200, 0) + 200 * bin_rating
+	air_contents.air_volume = max(initial(internal_volume) - 200, 0) + 200 * bin_rating
 	set_power_level(power_setting)
 
 /obj/machinery/atmospherics/unary/freezer/proc/set_power_level(var/new_power_setting)

--- a/code/modules/atmospherics/components/unary/heat_source.dm
+++ b/code/modules/atmospherics/components/unary/heat_source.dm
@@ -110,7 +110,7 @@
 
 	max_power_rating = initial(max_power_rating) * cap_rating / 2
 	max_temperature = max(initial(max_temperature) - T20C, 0) * ((bin_rating * 4 + cap_rating) / 5) + T20C
-	air_contents.volume = max(initial(internal_volume) - 200, 0) + 200 * bin_rating
+	air_contents.air_volume = max(initial(internal_volume) - 200, 0) + 200 * bin_rating
 	set_power_level(power_setting)
 
 /obj/machinery/atmospherics/unary/heater/proc/set_power_level(var/new_power_setting)

--- a/code/modules/atmospherics/components/unary/heat_source.dm
+++ b/code/modules/atmospherics/components/unary/heat_source.dm
@@ -110,7 +110,7 @@
 
 	max_power_rating = initial(max_power_rating) * cap_rating / 2
 	max_temperature = max(initial(max_temperature) - T20C, 0) * ((bin_rating * 4 + cap_rating) / 5) + T20C
-	air_contents.air_volume = max(initial(internal_volume) - 200, 0) + 200 * bin_rating
+	air_contents.total_volume = max(initial(internal_volume) - 200, 0) + 200 * bin_rating
 	set_power_level(power_setting)
 
 /obj/machinery/atmospherics/unary/heater/proc/set_power_level(var/new_power_setting)

--- a/code/modules/atmospherics/components/unary/outlet_injector.dm
+++ b/code/modules/atmospherics/components/unary/outlet_injector.dm
@@ -56,7 +56,7 @@
 /obj/machinery/atmospherics/unary/outlet_injector/Initialize()
 	. = ..()
 	//Give it a small reservoir for injecting. Also allows it to have a higher flow rate limit than vent pumps, to differentiate injectors a bit more.
-	air_contents.air_volume = ATMOS_DEFAULT_VOLUME_PUMP + 500
+	air_contents.total_volume = ATMOS_DEFAULT_VOLUME_PUMP + 500
 
 /obj/machinery/atmospherics/unary/outlet_injector/on_update_icon()
 	if(stat & NOPOWER)
@@ -94,7 +94,7 @@
 	var/datum/gas_mixture/environment = loc.return_air()
 
 	if(environment && air_contents.temperature > 0)
-		var/transfer_moles = (volume_rate/air_contents.air_volume)*air_contents.total_moles //apply flow rate limit
+		var/transfer_moles = (volume_rate/air_contents.total_volume)*air_contents.total_moles //apply flow rate limit
 		power_draw = pump_gas(src, air_contents, environment, transfer_moles, power_rating)
 		if(transfer_moles > 0)
 			update_networks()
@@ -147,7 +147,7 @@
 	return machine.volume_rate
 
 /decl/public_access/public_variable/volume_rate/write_var(obj/machinery/atmospherics/unary/outlet_injector/machine, new_value)
-	new_value = clamp(new_value, 0, machine.air_contents.air_volume)
+	new_value = clamp(new_value, 0, machine.air_contents.total_volume)
 	. = ..()
 	if(.)
 		machine.volume_rate = new_value

--- a/code/modules/atmospherics/components/unary/outlet_injector.dm
+++ b/code/modules/atmospherics/components/unary/outlet_injector.dm
@@ -56,7 +56,7 @@
 /obj/machinery/atmospherics/unary/outlet_injector/Initialize()
 	. = ..()
 	//Give it a small reservoir for injecting. Also allows it to have a higher flow rate limit than vent pumps, to differentiate injectors a bit more.
-	air_contents.volume = ATMOS_DEFAULT_VOLUME_PUMP + 500
+	air_contents.air_volume = ATMOS_DEFAULT_VOLUME_PUMP + 500
 
 /obj/machinery/atmospherics/unary/outlet_injector/on_update_icon()
 	if(stat & NOPOWER)
@@ -94,7 +94,7 @@
 	var/datum/gas_mixture/environment = loc.return_air()
 
 	if(environment && air_contents.temperature > 0)
-		var/transfer_moles = (volume_rate/air_contents.volume)*air_contents.total_moles //apply flow rate limit
+		var/transfer_moles = (volume_rate/air_contents.air_volume)*air_contents.total_moles //apply flow rate limit
 		power_draw = pump_gas(src, air_contents, environment, transfer_moles, power_rating)
 		if(transfer_moles > 0)
 			update_networks()
@@ -147,7 +147,7 @@
 	return machine.volume_rate
 
 /decl/public_access/public_variable/volume_rate/write_var(obj/machinery/atmospherics/unary/outlet_injector/machine, new_value)
-	new_value = clamp(new_value, 0, machine.air_contents.volume)
+	new_value = clamp(new_value, 0, machine.air_contents.air_volume)
 	. = ..()
 	if(.)
 		machine.volume_rate = new_value

--- a/code/modules/atmospherics/components/unary/tank.dm
+++ b/code/modules/atmospherics/components/unary/tank.dm
@@ -5,7 +5,7 @@
 	name = "Pressure Tank"
 	desc = "A large vessel containing pressurized gas."
 
-	var/air_volume = 10000 //in liters, 1 meters by 1 meters by 2 meters ~tweaked it a little to simulate a pressure tank without needing to recode them yet
+	var/gas_volume = 10000 //in liters, 1 meters by 1 meters by 2 meters ~tweaked it a little to simulate a pressure tank without needing to recode them yet
 	var/start_pressure = 25 ATM
 	var/filling // list of gas ratios to use.
 
@@ -25,12 +25,12 @@
 
 /obj/machinery/atmospherics/unary/tank/Initialize()
 	. = ..()
-	air_contents.air_volume = air_volume
+	air_contents.total_volume = gas_volume
 	air_contents.temperature = T20C
 
 	if(filling)
 		for(var/gas in filling)
-			air_contents.adjust_gas(gas, start_pressure * filling[gas] * (air_contents.air_volume)/(R_IDEAL_GAS_EQUATION*air_contents.temperature), FALSE)
+			air_contents.adjust_gas(gas, start_pressure * filling[gas] * (air_contents.total_volume)/(R_IDEAL_GAS_EQUATION*air_contents.temperature), FALSE)
 		air_contents.update_values()
 		update_icon()
 

--- a/code/modules/atmospherics/components/unary/tank.dm
+++ b/code/modules/atmospherics/components/unary/tank.dm
@@ -5,7 +5,7 @@
 	name = "Pressure Tank"
 	desc = "A large vessel containing pressurized gas."
 
-	var/volume = 10000 //in liters, 1 meters by 1 meters by 2 meters ~tweaked it a little to simulate a pressure tank without needing to recode them yet
+	var/air_volume = 10000 //in liters, 1 meters by 1 meters by 2 meters ~tweaked it a little to simulate a pressure tank without needing to recode them yet
 	var/start_pressure = 25 ATM
 	var/filling // list of gas ratios to use.
 
@@ -25,12 +25,12 @@
 
 /obj/machinery/atmospherics/unary/tank/Initialize()
 	. = ..()
-	air_contents.volume = volume
+	air_contents.air_volume = air_volume
 	air_contents.temperature = T20C
 
 	if(filling)
 		for(var/gas in filling)
-			air_contents.adjust_gas(gas, start_pressure * filling[gas] * (air_contents.volume)/(R_IDEAL_GAS_EQUATION*air_contents.temperature), FALSE)
+			air_contents.adjust_gas(gas, start_pressure * filling[gas] * (air_contents.air_volume)/(R_IDEAL_GAS_EQUATION*air_contents.temperature), FALSE)
 		air_contents.update_values()
 		update_icon()
 

--- a/code/modules/atmospherics/components/unary/unary_base.dm
+++ b/code/modules/atmospherics/components/unary/unary_base.dm
@@ -19,7 +19,7 @@
 
 /obj/machinery/atmospherics/unary/Initialize()
 	air_contents = new
-	air_contents.air_volume = 200
+	air_contents.total_volume = 200
 	if(controlled)
 		reset_area(null, get_area(src))
 	. = ..()

--- a/code/modules/atmospherics/components/unary/unary_base.dm
+++ b/code/modules/atmospherics/components/unary/unary_base.dm
@@ -19,7 +19,7 @@
 
 /obj/machinery/atmospherics/unary/Initialize()
 	air_contents = new
-	air_contents.volume = 200
+	air_contents.air_volume = 200
 	if(controlled)
 		reset_area(null, get_area(src))
 	. = ..()
@@ -34,7 +34,7 @@
 /obj/machinery/atmospherics/unary/physically_destroyed()
 	if(loc && air_contents)
 		loc.assume_air(air_contents)
-	. = ..()	
+	. = ..()
 
 /obj/machinery/atmospherics/unary/dismantle()
 	if(loc && air_contents)

--- a/code/modules/atmospherics/components/unary/vent_pump.dm
+++ b/code/modules/atmospherics/components/unary/vent_pump.dm
@@ -85,7 +85,7 @@
 			update_name()
 			events_repository.register(/decl/observ/name_set, A, src, PROC_REF(change_area_name))
 	. = ..()
-	air_contents.volume = ATMOS_DEFAULT_VOLUME_PUMP
+	air_contents.air_volume = ATMOS_DEFAULT_VOLUME_PUMP
 	update_sound()
 
 /obj/machinery/atmospherics/unary/vent_pump/proc/change_area_name(var/area/A, var/old_area_name, var/new_area_name)
@@ -170,7 +170,7 @@
 
 /obj/machinery/atmospherics/unary/vent_pump/high_volume/Initialize()
 	. = ..()
-	air_contents.volume = ATMOS_DEFAULT_VOLUME_PUMP + 800
+	air_contents.air_volume = ATMOS_DEFAULT_VOLUME_PUMP + 800
 
 /obj/machinery/atmospherics/unary/vent_pump/on_update_icon()
 	var/visible_directions = build_device_underlays()
@@ -223,7 +223,7 @@
 			power_draw = pump_gas(src, air_contents, environment, transfer_moles, power_rating)
 		else //external -> internal
 			var/datum/pipe_network/network = network_in_dir(dir)
-			transfer_moles = calculate_transfer_moles(environment, air_contents, pressure_delta, network?.volume) / environment.group_multiplier // limit it to just one turf's worth of gas per tick
+			transfer_moles = calculate_transfer_moles(environment, air_contents, pressure_delta, network?.air_volume) / environment.group_multiplier // limit it to just one turf's worth of gas per tick
 			power_draw = pump_gas(src, environment, air_contents, transfer_moles, power_rating)
 
 	else
@@ -562,7 +562,7 @@
 
 /obj/machinery/atmospherics/unary/vent_pump/engine/Initialize()
 	. = ..()
-	air_contents.volume = ATMOS_DEFAULT_VOLUME_PUMP + 500 //meant to match air injector
+	air_contents.air_volume = ATMOS_DEFAULT_VOLUME_PUMP + 500 //meant to match air injector
 
 /obj/machinery/atmospherics/unary/vent_pump/power_change()
 	. = ..()

--- a/code/modules/atmospherics/components/unary/vent_pump.dm
+++ b/code/modules/atmospherics/components/unary/vent_pump.dm
@@ -85,7 +85,7 @@
 			update_name()
 			events_repository.register(/decl/observ/name_set, A, src, PROC_REF(change_area_name))
 	. = ..()
-	air_contents.air_volume = ATMOS_DEFAULT_VOLUME_PUMP
+	air_contents.total_volume = ATMOS_DEFAULT_VOLUME_PUMP
 	update_sound()
 
 /obj/machinery/atmospherics/unary/vent_pump/proc/change_area_name(var/area/A, var/old_area_name, var/new_area_name)
@@ -170,7 +170,7 @@
 
 /obj/machinery/atmospherics/unary/vent_pump/high_volume/Initialize()
 	. = ..()
-	air_contents.air_volume = ATMOS_DEFAULT_VOLUME_PUMP + 800
+	air_contents.total_volume = ATMOS_DEFAULT_VOLUME_PUMP + 800
 
 /obj/machinery/atmospherics/unary/vent_pump/on_update_icon()
 	var/visible_directions = build_device_underlays()
@@ -223,7 +223,7 @@
 			power_draw = pump_gas(src, air_contents, environment, transfer_moles, power_rating)
 		else //external -> internal
 			var/datum/pipe_network/network = network_in_dir(dir)
-			transfer_moles = calculate_transfer_moles(environment, air_contents, pressure_delta, network?.air_volume) / environment.group_multiplier // limit it to just one turf's worth of gas per tick
+			transfer_moles = calculate_transfer_moles(environment, air_contents, pressure_delta, network?.total_volume) / environment.group_multiplier // limit it to just one turf's worth of gas per tick
 			power_draw = pump_gas(src, environment, air_contents, transfer_moles, power_rating)
 
 	else
@@ -562,7 +562,7 @@
 
 /obj/machinery/atmospherics/unary/vent_pump/engine/Initialize()
 	. = ..()
-	air_contents.air_volume = ATMOS_DEFAULT_VOLUME_PUMP + 500 //meant to match air injector
+	air_contents.total_volume = ATMOS_DEFAULT_VOLUME_PUMP + 500 //meant to match air injector
 
 /obj/machinery/atmospherics/unary/vent_pump/power_change()
 	. = ..()

--- a/code/modules/atmospherics/components/unary/vent_scrubber.dm
+++ b/code/modules/atmospherics/components/unary/vent_scrubber.dm
@@ -68,7 +68,7 @@
 			if(g != /decl/material/gas/oxygen && g != /decl/material/gas/nitrogen)
 				scrubbing_gas += g
 	. = ..()
-	air_contents.volume = ATMOS_DEFAULT_VOLUME_FILTER
+	air_contents.air_volume = ATMOS_DEFAULT_VOLUME_FILTER
 
 /obj/machinery/atmospherics/unary/vent_scrubber/reset_area(area/old_area, area/new_area)
 	if(!controlled)
@@ -151,17 +151,17 @@
 	var/transfer_moles = 0
 	if(scrubbing == SCRUBBER_SIPHON) //Just siphon all air
 		//limit flow rate from turfs
-		transfer_moles = min(environment.total_moles, environment.total_moles*MAX_SIPHON_FLOWRATE/environment.volume)	//group_multiplier gets divided out here
+		transfer_moles = min(environment.total_moles, environment.total_moles*MAX_SIPHON_FLOWRATE/environment.air_volume)	//group_multiplier gets divided out here
 		power_draw = pump_gas(src, environment, air_contents, transfer_moles, power_rating)
 	else //limit flow rate from turfs
-		transfer_moles = min(environment.total_moles, environment.total_moles*MAX_SCRUBBER_FLOWRATE/environment.volume)	//group_multiplier gets divided out here
+		transfer_moles = min(environment.total_moles, environment.total_moles*MAX_SCRUBBER_FLOWRATE/environment.air_volume)	//group_multiplier gets divided out here
 		power_draw = scrub_gas(src, scrubbing_gas, environment, air_contents, transfer_moles, power_rating)
 
 	if(scrubbing != SCRUBBER_SIPHON && power_draw <= 0)	//99% of all scrubbers
 		//Fucking hibernate because you ain't doing shit.
 		hibernate = world.time + (rand(100,200))
 	else if(scrubbing == SCRUBBER_EXCHANGE) // after sleep check so it only does an exchange if there are bad gasses that have been scrubbed
-		transfer_moles = min(environment.total_moles, environment.total_moles*MAX_SCRUBBER_FLOWRATE/environment.volume)
+		transfer_moles = min(environment.total_moles, environment.total_moles*MAX_SCRUBBER_FLOWRATE/environment.air_volume)
 		power_draw += pump_gas(src, environment, air_contents, transfer_moles / 4, power_rating)
 
 	if (power_draw >= 0)

--- a/code/modules/atmospherics/components/unary/vent_scrubber.dm
+++ b/code/modules/atmospherics/components/unary/vent_scrubber.dm
@@ -68,7 +68,7 @@
 			if(g != /decl/material/gas/oxygen && g != /decl/material/gas/nitrogen)
 				scrubbing_gas += g
 	. = ..()
-	air_contents.air_volume = ATMOS_DEFAULT_VOLUME_FILTER
+	air_contents.total_volume = ATMOS_DEFAULT_VOLUME_FILTER
 
 /obj/machinery/atmospherics/unary/vent_scrubber/reset_area(area/old_area, area/new_area)
 	if(!controlled)
@@ -151,17 +151,17 @@
 	var/transfer_moles = 0
 	if(scrubbing == SCRUBBER_SIPHON) //Just siphon all air
 		//limit flow rate from turfs
-		transfer_moles = min(environment.total_moles, environment.total_moles*MAX_SIPHON_FLOWRATE/environment.air_volume)	//group_multiplier gets divided out here
+		transfer_moles = min(environment.total_moles, environment.total_moles*MAX_SIPHON_FLOWRATE/environment.total_volume)	//group_multiplier gets divided out here
 		power_draw = pump_gas(src, environment, air_contents, transfer_moles, power_rating)
 	else //limit flow rate from turfs
-		transfer_moles = min(environment.total_moles, environment.total_moles*MAX_SCRUBBER_FLOWRATE/environment.air_volume)	//group_multiplier gets divided out here
+		transfer_moles = min(environment.total_moles, environment.total_moles*MAX_SCRUBBER_FLOWRATE/environment.total_volume)	//group_multiplier gets divided out here
 		power_draw = scrub_gas(src, scrubbing_gas, environment, air_contents, transfer_moles, power_rating)
 
 	if(scrubbing != SCRUBBER_SIPHON && power_draw <= 0)	//99% of all scrubbers
 		//Fucking hibernate because you ain't doing shit.
 		hibernate = world.time + (rand(100,200))
 	else if(scrubbing == SCRUBBER_EXCHANGE) // after sleep check so it only does an exchange if there are bad gasses that have been scrubbed
-		transfer_moles = min(environment.total_moles, environment.total_moles*MAX_SCRUBBER_FLOWRATE/environment.air_volume)
+		transfer_moles = min(environment.total_moles, environment.total_moles*MAX_SCRUBBER_FLOWRATE/environment.total_volume)
 		power_draw += pump_gas(src, environment, air_contents, transfer_moles / 4, power_rating)
 
 	if (power_draw >= 0)

--- a/code/modules/atmospherics/datum_pipe_network.dm
+++ b/code/modules/atmospherics/datum_pipe_network.dm
@@ -1,6 +1,6 @@
 /datum/pipe_network
 	var/list/datum/gas_mixture/gases = list() //All of the gas_mixtures continuously connected in this network
-	var/volume = 0	//caches the total volume for atmos machines to use in gas calculations
+	var/air_volume = 0	//caches the total volume for atmos machines to use in gas calculations
 
 	var/list/obj/machinery/atmospherics/normal_members = list()
 	var/list/datum/pipeline/line_members = list()
@@ -71,7 +71,7 @@
 	//Go through membership roster and make sure gases is up to date
 
 	gases = list()
-	volume = 0
+	air_volume = 0
 
 	for(var/obj/machinery/atmospherics/normal_member in normal_members)
 		var/result = normal_member.return_network_air(src)
@@ -81,4 +81,4 @@
 		gases += line_member.air
 
 	for(var/datum/gas_mixture/air in gases)
-		volume += air.volume
+		air_volume += air.air_volume

--- a/code/modules/atmospherics/datum_pipe_network.dm
+++ b/code/modules/atmospherics/datum_pipe_network.dm
@@ -1,6 +1,6 @@
 /datum/pipe_network
 	var/list/datum/gas_mixture/gases = list() //All of the gas_mixtures continuously connected in this network
-	var/air_volume = 0	//caches the total volume for atmos machines to use in gas calculations
+	var/total_volume = 0	//caches the total volume for atmos machines to use in gas calculations
 
 	var/list/obj/machinery/atmospherics/normal_members = list()
 	var/list/datum/pipeline/line_members = list()
@@ -71,7 +71,7 @@
 	//Go through membership roster and make sure gases is up to date
 
 	gases = list()
-	air_volume = 0
+	total_volume = 0
 
 	for(var/obj/machinery/atmospherics/normal_member in normal_members)
 		var/result = normal_member.return_network_air(src)
@@ -81,4 +81,4 @@
 		gases += line_member.air
 
 	for(var/datum/gas_mixture/air in gases)
-		air_volume += air.air_volume
+		total_volume += air.total_volume

--- a/code/modules/atmospherics/datum_pipeline.dm
+++ b/code/modules/atmospherics/datum_pipeline.dm
@@ -30,7 +30,7 @@
 	STOP_PROCESSING(SSprocessing, src)
 	QDEL_NULL(network)
 
-	if(air?.volume || liquid?.total_volume)
+	if(air?.air_volume || liquid?.total_volume)
 		temporarily_store_fluids()
 
 	QDEL_NULL(air)
@@ -62,15 +62,15 @@
 	//Update individual gas_mixtures by volume ratio
 
 	var/liquid_transfer_per_pipe = min(REAGENT_UNITS_PER_PIPE, (liquid && length(members)) ? (liquid.total_volume / length(members)) : 0)
-	if(!air?.volume && !liquid_transfer_per_pipe)
+	if(!air?.air_volume && !liquid_transfer_per_pipe)
 		return
 
 	for(var/obj/machinery/atmospherics/pipe/member in members)
-		if(air?.volume)
+		if(air?.air_volume)
 			member.air_temporary = new
 			member.air_temporary.copy_from(air)
-			member.air_temporary.volume = member.volume
-			member.air_temporary.multiply(member.volume / air.volume)
+			member.air_temporary.air_volume = member.air_volume
+			member.air_temporary.multiply(member.air_volume / air.air_volume)
 
 		if(liquid_transfer_per_pipe)
 			member.liquid_temporary = new(REAGENT_UNITS_PER_PIPE, member)
@@ -81,7 +81,7 @@
 	members = list(base)
 	edges = list()
 
-	var/volume = base.volume
+	var/temp_volume = base.air_volume
 	base.parent = src
 	maximum_pressure = base.maximum_pressure
 
@@ -110,7 +110,7 @@
 						members += item
 						possible_expansions += item
 
-						volume += item.volume
+						temp_volume += item.air_volume
 						item.parent = src
 
 						maximum_pressure = min(maximum_pressure, item.maximum_pressure)
@@ -134,7 +134,7 @@
 
 			possible_expansions -= borderline
 
-	air.volume = volume
+	air.air_volume = temp_volume
 	liquid.maximum_volume = length(members) * REAGENT_UNITS_PER_PIPE
 
 /datum/pipeline/proc/network_expand(datum/pipe_network/new_network, obj/machinery/atmospherics/pipe/reference)
@@ -194,11 +194,11 @@
 
 /datum/pipeline/proc/temperature_interact(turf/target, share_volume, thermal_conductivity)
 
-	if(air.volume <= 0) // Avoid div by zero.
+	if(air.air_volume <= 0) // Avoid div by zero.
 		return
 
 	var/total_heat_capacity = air.heat_capacity()
-	var/partial_heat_capacity = total_heat_capacity*(share_volume/air.volume)
+	var/partial_heat_capacity = total_heat_capacity*(share_volume/air.air_volume)
 	var/datum/gas_mixture/target_air = target.return_air()
 
 	if(total_heat_capacity <= 0) // Avoid div by zero.
@@ -225,7 +225,7 @@
 
 //surface must be the surface area in m^2
 /datum/pipeline/proc/radiate_heat_to_space(surface, thermal_conductivity)
-	var/gas_density = air.total_moles/air.volume
+	var/gas_density = air.total_moles/air.air_volume
 	thermal_conductivity *= min(gas_density / ( RADIATOR_OPTIMUM_PRESSURE/(R_IDEAL_GAS_EQUATION*GAS_CRITICAL_TEMPERATURE) ), 1) //mult by density ratio
 
 	var/heat_gain = get_thermal_radiation(air.temperature, surface, RADIATOR_EXPOSED_SURFACE_AREA_RATIO, thermal_conductivity)

--- a/code/modules/atmospherics/datum_pipeline.dm
+++ b/code/modules/atmospherics/datum_pipeline.dm
@@ -30,7 +30,7 @@
 	STOP_PROCESSING(SSprocessing, src)
 	QDEL_NULL(network)
 
-	if(air?.air_volume || liquid?.total_volume)
+	if(air?.total_volume || liquid?.total_volume)
 		temporarily_store_fluids()
 
 	QDEL_NULL(air)
@@ -62,15 +62,15 @@
 	//Update individual gas_mixtures by volume ratio
 
 	var/liquid_transfer_per_pipe = min(REAGENT_UNITS_PER_PIPE, (liquid && length(members)) ? (liquid.total_volume / length(members)) : 0)
-	if(!air?.air_volume && !liquid_transfer_per_pipe)
+	if(!air?.total_volume && !liquid_transfer_per_pipe)
 		return
 
 	for(var/obj/machinery/atmospherics/pipe/member in members)
-		if(air?.air_volume)
+		if(air?.total_volume)
 			member.air_temporary = new
 			member.air_temporary.copy_from(air)
-			member.air_temporary.air_volume = member.air_volume
-			member.air_temporary.multiply(member.air_volume / air.air_volume)
+			member.air_temporary.total_volume = member.gas_volume
+			member.air_temporary.multiply(member.gas_volume / air.total_volume)
 
 		if(liquid_transfer_per_pipe)
 			member.liquid_temporary = new(REAGENT_UNITS_PER_PIPE, member)
@@ -81,7 +81,7 @@
 	members = list(base)
 	edges = list()
 
-	var/temp_volume = base.air_volume
+	var/temp_volume = base.gas_volume
 	base.parent = src
 	maximum_pressure = base.maximum_pressure
 
@@ -110,7 +110,7 @@
 						members += item
 						possible_expansions += item
 
-						temp_volume += item.air_volume
+						temp_volume += item.gas_volume
 						item.parent = src
 
 						maximum_pressure = min(maximum_pressure, item.maximum_pressure)
@@ -134,7 +134,7 @@
 
 			possible_expansions -= borderline
 
-	air.air_volume = temp_volume
+	air.total_volume = temp_volume
 	liquid.maximum_volume = length(members) * REAGENT_UNITS_PER_PIPE
 
 /datum/pipeline/proc/network_expand(datum/pipe_network/new_network, obj/machinery/atmospherics/pipe/reference)
@@ -194,11 +194,11 @@
 
 /datum/pipeline/proc/temperature_interact(turf/target, share_volume, thermal_conductivity)
 
-	if(air.air_volume <= 0) // Avoid div by zero.
+	if(air.total_volume <= 0) // Avoid div by zero.
 		return
 
 	var/total_heat_capacity = air.heat_capacity()
-	var/partial_heat_capacity = total_heat_capacity*(share_volume/air.air_volume)
+	var/partial_heat_capacity = total_heat_capacity*(share_volume/air.total_volume)
 	var/datum/gas_mixture/target_air = target.return_air()
 
 	if(total_heat_capacity <= 0) // Avoid div by zero.
@@ -225,7 +225,7 @@
 
 //surface must be the surface area in m^2
 /datum/pipeline/proc/radiate_heat_to_space(surface, thermal_conductivity)
-	var/gas_density = air.total_moles/air.air_volume
+	var/gas_density = air.total_moles/air.total_volume
 	thermal_conductivity *= min(gas_density / ( RADIATOR_OPTIMUM_PRESSURE/(R_IDEAL_GAS_EQUATION*GAS_CRITICAL_TEMPERATURE) ), 1) //mult by density ratio
 
 	var/heat_gain = get_thermal_radiation(air.temperature, surface, RADIATOR_EXPOSED_SURFACE_AREA_RATIO, thermal_conductivity)

--- a/code/modules/atmospherics/he_pipes.dm
+++ b/code/modules/atmospherics/he_pipes.dm
@@ -73,7 +73,7 @@
 			var/datum/gas_mixture/environment = turf.return_air()
 			environment_temperature = environment?.temperature || 0
 		if(abs(environment_temperature-pipe_air.temperature) > minimum_temperature_difference)
-			parent.temperature_interact(turf, volume, thermal_conductivity)
+			parent.temperature_interact(turf, air_volume, thermal_conductivity)
 
 	// Burn mobs buckled to this pipe.
 	if(buckled_mob)

--- a/code/modules/atmospherics/he_pipes.dm
+++ b/code/modules/atmospherics/he_pipes.dm
@@ -73,7 +73,7 @@
 			var/datum/gas_mixture/environment = turf.return_air()
 			environment_temperature = environment?.temperature || 0
 		if(abs(environment_temperature-pipe_air.temperature) > minimum_temperature_difference)
-			parent.temperature_interact(turf, air_volume, thermal_conductivity)
+			parent.temperature_interact(turf, gas_volume, thermal_conductivity)
 
 	// Burn mobs buckled to this pipe.
 	if(buckled_mob)

--- a/code/modules/atmospherics/pipes.dm
+++ b/code/modules/atmospherics/pipes.dm
@@ -24,7 +24,7 @@
 	var/datum/gas_mixture/air_temporary    // used when reconstructing a pipeline that broke
 	var/datum/reagents/liquid_temporary // used when reconstructing a pipeline that broke
 	var/datum/pipeline/parent
-	var/air_volume = 0
+	var/gas_volume = 0
 	var/leaking = 0		// Do not set directly, use set_leaking(TRUE/FALSE)
 
 	//minimum pressure before check_pressure(...) should be called
@@ -210,7 +210,7 @@
 		update_sound(0)
 		. = PROCESS_KILL
 	else if(leaking)
-		parent.mingle_with_turf(loc, air_volume)
+		parent.mingle_with_turf(loc, gas_volume)
 		var/air = parent.air?.return_pressure()
 		if(!sound_token && air)
 			update_sound(1)
@@ -225,7 +225,7 @@
 	name = "pipe"
 	desc = "A one-meter section of regular pipe."
 
-	air_volume = ATMOS_DEFAULT_VOLUME_PIPE
+	gas_volume = ATMOS_DEFAULT_VOLUME_PIPE
 
 	dir = SOUTH
 	initialize_directions = SOUTH|NORTH
@@ -380,7 +380,7 @@
 	icon_state = "map"
 	name = "pipe manifold"
 	desc = "A manifold composed of regular pipes."
-	air_volume = ATMOS_DEFAULT_VOLUME_PIPE * 1.5
+	gas_volume = ATMOS_DEFAULT_VOLUME_PIPE * 1.5
 
 	dir = SOUTH
 	initialize_directions = EAST|NORTH|WEST
@@ -509,7 +509,7 @@
 	icon_state = ""
 	name = "4-way pipe manifold"
 	desc = "A manifold composed of regular pipes."
-	air_volume = ATMOS_DEFAULT_VOLUME_PIPE * 2
+	gas_volume = ATMOS_DEFAULT_VOLUME_PIPE * 2
 
 	dir = SOUTH
 	initialize_directions = NORTH|SOUTH|EAST|WEST
@@ -634,7 +634,7 @@
 	icon = 'icons/atmos/pipes.dmi'
 	icon_state = "cap"
 	level = LEVEL_ABOVE_PLATING
-	air_volume = 35
+	gas_volume = 35
 
 	pipe_class = PIPE_CLASS_UNARY
 	dir = SOUTH

--- a/code/modules/atmospherics/pipes.dm
+++ b/code/modules/atmospherics/pipes.dm
@@ -24,7 +24,7 @@
 	var/datum/gas_mixture/air_temporary    // used when reconstructing a pipeline that broke
 	var/datum/reagents/liquid_temporary // used when reconstructing a pipeline that broke
 	var/datum/pipeline/parent
-	var/volume = 0
+	var/air_volume = 0
 	var/leaking = 0		// Do not set directly, use set_leaking(TRUE/FALSE)
 
 	//minimum pressure before check_pressure(...) should be called
@@ -210,7 +210,7 @@
 		update_sound(0)
 		. = PROCESS_KILL
 	else if(leaking)
-		parent.mingle_with_turf(loc, volume)
+		parent.mingle_with_turf(loc, air_volume)
 		var/air = parent.air?.return_pressure()
 		if(!sound_token && air)
 			update_sound(1)
@@ -225,7 +225,7 @@
 	name = "pipe"
 	desc = "A one-meter section of regular pipe."
 
-	volume = ATMOS_DEFAULT_VOLUME_PIPE
+	air_volume = ATMOS_DEFAULT_VOLUME_PIPE
 
 	dir = SOUTH
 	initialize_directions = SOUTH|NORTH
@@ -380,7 +380,7 @@
 	icon_state = "map"
 	name = "pipe manifold"
 	desc = "A manifold composed of regular pipes."
-	volume = ATMOS_DEFAULT_VOLUME_PIPE * 1.5
+	air_volume = ATMOS_DEFAULT_VOLUME_PIPE * 1.5
 
 	dir = SOUTH
 	initialize_directions = EAST|NORTH|WEST
@@ -509,7 +509,7 @@
 	icon_state = ""
 	name = "4-way pipe manifold"
 	desc = "A manifold composed of regular pipes."
-	volume = ATMOS_DEFAULT_VOLUME_PIPE * 2
+	air_volume = ATMOS_DEFAULT_VOLUME_PIPE * 2
 
 	dir = SOUTH
 	initialize_directions = NORTH|SOUTH|EAST|WEST
@@ -634,7 +634,7 @@
 	icon = 'icons/atmos/pipes.dmi'
 	icon_state = "cap"
 	level = LEVEL_ABOVE_PLATING
-	volume = 35
+	air_volume = 35
 
 	pipe_class = PIPE_CLASS_UNARY
 	dir = SOUTH

--- a/code/modules/butchery/butchery_products.dm
+++ b/code/modules/butchery/butchery_products.dm
@@ -5,7 +5,7 @@
 	material            = /decl/material/solid/organic/meat
 	color               = /decl/material/solid/organic/meat::color
 	w_class             = ITEM_SIZE_NORMAL
-	volume              = 20
+	chem_volume         = 20
 	nutriment_type      = /decl/material/solid/organic/meat
 	nutriment_desc      = list("umami" = 10)
 	nutriment_amt       = 20

--- a/code/modules/clothing/gloves/jewelry/rings/ring_reagent.dm
+++ b/code/modules/clothing/gloves/jewelry/rings/ring_reagent.dm
@@ -3,18 +3,7 @@
 /obj/item/clothing/gloves/ring/reagent
 	atom_flags = ATOM_FLAG_OPEN_CONTAINER
 	origin_tech = @'{"materials":2,"esoteric":4}'
-	var/tmp/volume = 15
-
-/obj/item/clothing/gloves/ring/reagent/Initialize(ml, material_key)
-	. = ..()
-	initialize_reagents()
-
-/obj/item/clothing/gloves/ring/reagent/initialize_reagents(populate = TRUE)
-	if(!reagents)
-		create_reagents(volume)
-	else
-		reagents.maximum_volume = max(volume, reagents.maximum_volume)
-	. = ..()
+	chem_volume = 15
 
 /obj/item/clothing/gloves/ring/reagent/equipped(var/mob/living/human/H)
 	..()

--- a/code/modules/clothing/masks/chewable.dm
+++ b/code/modules/clothing/masks/chewable.dm
@@ -8,17 +8,11 @@
 	matter = null // no plastic/fiberglass
 
 	var/type_butt = null
-	var/chem_volume = 0
 	var/chewtime = 0
 	var/brand
 
 /obj/item/clothing/mask/chewable/Initialize()
-	. = ..()
 	atom_flags |= ATOM_FLAG_NO_CHEM_CHANGE // so it doesn't react until you light it
-	initialize_reagents()
-
-/obj/item/clothing/mask/chewable/initialize_reagents(populate = TRUE)
-	create_reagents(chem_volume) // making the cigarrete a chemical holder with a maximum volume of 15
 	. = ..()
 
 /obj/item/clothing/mask/chewable/equipped(var/mob/living/user, var/slot)
@@ -107,9 +101,9 @@
 	icon = 'icons/clothing/mask/chewables/gum_nicotine.dmi'
 	type_butt = /obj/item/trash/cigbutt/spitgum
 
-/obj/item/clothing/mask/chewable/tobacco/nico/initialize_reagents(populate = TRUE)
+/obj/item/clothing/mask/chewable/tobacco/nico/Initialize()
 	. = ..()
-	color = reagents.get_color()
+	color = reagents?.get_color()
 
 /obj/item/clothing/mask/chewable/tobacco/nico/populate_reagents()
 	add_to_reagents(/decl/material/liquid/nicotine, 2)
@@ -137,7 +131,7 @@
 /obj/item/clothing/mask/chewable/candy/proc/get_possible_initial_reagents()
 	return
 
-/obj/item/clothing/mask/chewable/candy/initialize_reagents()
+/obj/item/clothing/mask/chewable/candy/Initialize()
 	. = ..()
 	if(reagents?.total_volume)
 		set_color(reagents.get_color())

--- a/code/modules/clothing/masks/smokable.dm
+++ b/code/modules/clothing/masks/smokable.dm
@@ -9,7 +9,6 @@
 	var/lit = FALSE
 	var/waterproof = FALSE
 	var/type_butt = null
-	var/chem_volume = 0
 	var/smoketime = 0
 	var/genericmes = "<span class='notice'>USER lights their NAME with the FLAME.</span>"
 	var/matchmes = "USER lights NAME with FLAME"
@@ -38,7 +37,6 @@
 /obj/item/clothing/mask/smokable/Initialize()
 	. = ..()
 	atom_flags |= ATOM_FLAG_NO_CHEM_CHANGE // so it doesn't react until you light it
-	create_reagents(chem_volume) // making the cigarrete a chemical holder with a maximum volume of 15
 
 /obj/item/clothing/mask/smokable/Destroy()
 	. = ..()
@@ -223,7 +221,6 @@
 
 /obj/item/clothing/mask/smokable/cigarette/Initialize()
 	. = ..()
-	initialize_reagents()
 	set_extension(src, /datum/extension/tool, list(TOOL_CAUTERY = TOOL_QUALITY_MEDIOCRE))
 
 /obj/item/clothing/mask/smokable/cigarette/populate_reagents()
@@ -395,7 +392,7 @@
 		if(!ATOM_IS_OPEN_CONTAINER(glass))
 			to_chat(user, SPAN_NOTICE("You need to take the lid off first."))
 			return TRUE
-		var/transfered = glass.reagents.trans_to_obj(src, chem_volume)
+		var/transfered = glass.reagents.trans_to_obj(src, glass.reagents.total_volume)
 		if(transfered)	//if reagents were transfered, show the message
 			to_chat(user, SPAN_NOTICE("You dip \the [src] into \the [glass]."))
 		else			//if not, either the beaker was empty, or the cigarette was full

--- a/code/modules/crafting/handmade_fancy.dm
+++ b/code/modules/crafting/handmade_fancy.dm
@@ -10,7 +10,7 @@
 	desc = "A masterfully made decanter with a fluted neck and graceful handle."
 	icon = 'icons/obj/items/handmade/decanter.dmi'
 	amount_per_transfer_from_this = 10
-	volume = 120
+	chem_volume = 120
 	obj_flags = OBJ_FLAG_HOLLOW | OBJ_FLAG_INSULATED_HANDLE
 
 /obj/item/chems/glass/handmade/fancy/goblet
@@ -18,21 +18,21 @@
 	desc = "An elegant goblet with a flared base, likely handmade by some master artisan."
 	icon = 'icons/obj/items/handmade/cup_fancy.dmi'
 	amount_per_transfer_from_this = 10
-	volume = 60
+	chem_volume = 60
 
 /obj/item/chems/glass/handmade/fancy/bowl
 	name = "bowl"
 	desc = "A sleek, polished bowl, likely handmade by some master artisan."
 	icon = 'icons/obj/items/handmade/bowl_fancy.dmi'
 	amount_per_transfer_from_this = 10
-	volume = 60
+	chem_volume = 60
 
 /obj/item/chems/glass/handmade/fancy/vase
 	name = "vase"
 	desc = "An elegant masterwork vase."
 	icon = 'icons/obj/items/handmade/vase_fancy.dmi'
 	amount_per_transfer_from_this = 20
-	volume = 240
+	chem_volume = 240
 	material = /decl/material/solid/stone/ceramic
 
 /obj/item/chems/glass/handmade/fancy/vase/fluted

--- a/code/modules/crafting/handmade_items.dm
+++ b/code/modules/crafting/handmade_items.dm
@@ -21,7 +21,7 @@
 	desc = "A handmade, slightly lumpy teapot."
 	icon = 'icons/obj/items/handmade/teapot.dmi'
 	amount_per_transfer_from_this = 10
-	volume = 120
+	chem_volume = 120
 	obj_flags = OBJ_FLAG_HOLLOW | OBJ_FLAG_INSULATED_HANDLE
 
 /obj/item/chems/glass/handmade/cup
@@ -29,14 +29,14 @@
 	desc = "A handmade, slightly lumpy cup."
 	icon = 'icons/obj/items/handmade/cup.dmi'
 	amount_per_transfer_from_this = 10
-	volume = 30
+	chem_volume = 30
 
 /obj/item/chems/glass/handmade/mug
 	name = "mug"
 	desc = "A handmade, slightly lumpy mug."
 	icon = 'icons/obj/items/handmade/mug.dmi'
 	amount_per_transfer_from_this = 10
-	volume = 60
+	chem_volume = 60
 	obj_flags = OBJ_FLAG_HOLLOW | OBJ_FLAG_INSULATED_HANDLE
 
 /obj/item/chems/glass/handmade/vase
@@ -44,21 +44,21 @@
 	desc = "A handmade, slightly lumpy vase."
 	icon = 'icons/obj/items/handmade/vase.dmi'
 	amount_per_transfer_from_this = 20
-	volume = 240
+	chem_volume = 240
 
 /obj/item/chems/glass/handmade/jar
 	name = "jar"
 	desc = "A handmade, slightly lumpy jar."
 	icon = 'icons/obj/items/handmade/jar.dmi'
 	amount_per_transfer_from_this = 10
-	volume = 60
+	chem_volume = 60
 
 /obj/item/chems/glass/handmade/bottle
 	name = "bottle"
 	desc = "A handmade, slightly lumpy bottle."
 	icon = 'icons/obj/items/handmade/bottle.dmi'
 	amount_per_transfer_from_this = 10
-	volume = 120
+	chem_volume = 120
 
 /obj/item/chems/glass/handmade/bottle/tall
 	name = "tall bottle"
@@ -73,7 +73,7 @@
 	desc = "A handmade, slightly lumpy bowl."
 	icon = 'icons/obj/items/handmade/bowl.dmi'
 	amount_per_transfer_from_this = 10
-	volume = 60
+	chem_volume = 60
 
 /obj/item/chems/glass/handmade/cup/wood
 	material = /decl/material/solid/organic/wood/oak

--- a/code/modules/crafting/metalwork/metalwork_items.dm
+++ b/code/modules/crafting/metalwork/metalwork_items.dm
@@ -17,6 +17,7 @@
 	material_alteration = MAT_FLAG_ALTERATION_COLOR | MAT_FLAG_ALTERATION_NAME
 	storage = /datum/storage/crucible
 	obj_flags = OBJ_FLAG_NO_STORAGE
+	chem_volume = 300 * REAGENT_UNITS_PER_MATERIAL_SHEET
 
 /obj/item/chems/crucible/attackby(obj/item/used_item, mob/user)
 
@@ -66,7 +67,3 @@
 		I.alpha = 255 * primary_reagent.opacity
 		I.appearance_flags |= RESET_COLOR
 		add_overlay(I)
-
-/obj/item/chems/crucible/initialize_reagents()
-	create_reagents(300 * REAGENT_UNITS_PER_MATERIAL_SHEET) // holds a single full stack of 200 ore
-	return ..()

--- a/code/modules/crafting/pottery/pottery_moulds.dm
+++ b/code/modules/crafting/pottery/pottery_moulds.dm
@@ -44,11 +44,8 @@
 		required_volume += matter_for_product[mat]
 	required_volume = ceil(required_volume * REAGENT_UNITS_PER_MATERIAL_UNIT)
 	if(required_volume > 0)
-		if(reagents)
-			reagents.maximum_volume = required_volume
-			reagents.update_total()
-		else if(atom_flags & ATOM_FLAG_INITIALIZED)
-			create_reagents(required_volume)
+		if(atom_flags & ATOM_FLAG_INITIALIZED)
+			create_or_update_reagents(required_volume)
 		else
 			chem_volume = required_volume
 	else

--- a/code/modules/crafting/pottery/pottery_moulds.dm
+++ b/code/modules/crafting/pottery/pottery_moulds.dm
@@ -7,12 +7,14 @@
 	material_alteration = MAT_FLAG_ALTERATION_COLOR | MAT_FLAG_ALTERATION_NAME
 	max_health = 100
 	atom_flags = ATOM_FLAG_OPEN_CONTAINER
-	volume = 20 // updated in populate_reagents()
+	chem_volume = 20 // updated in Initialize()
 	var/product_type
 	var/list/product_metadata
 	var/work_skill = SKILL_CONSTRUCTION
 
 /obj/item/chems/mould/Initialize()
+	if(ispath(product_type, /obj))
+		update_volume_from_product()
 	. = ..()
 	var/datum/extension/labels/lext = get_or_create_extension(src, /datum/extension/labels)
 	if(ispath(product_type, /obj))
@@ -35,11 +37,6 @@
 	product_metadata = null
 	return ..()
 
-/obj/item/chems/mould/initialize_reagents()
-	if(ispath(product_type, /obj))
-		update_volume_from_product()
-	..()
-
 /obj/item/chems/mould/proc/update_volume_from_product()
 	var/required_volume = 0
 	var/list/matter_for_product = atom_info_repository.get_matter_for(product_type, /decl/material/placeholder, 1)
@@ -53,7 +50,7 @@
 		else if(atom_flags & ATOM_FLAG_INITIALIZED)
 			create_reagents(required_volume)
 		else
-			volume = required_volume
+			chem_volume = required_volume
 	else
 		QDEL_NULL(reagents)
 

--- a/code/modules/crafting/working/butter_churn.dm
+++ b/code/modules/crafting/working/butter_churn.dm
@@ -5,14 +5,7 @@
 	product_type = /obj/item/food/dairy/butter/stick
 	work_sound   = /datum/composite_sound/loom_working
 	atom_flags   = ATOM_FLAG_OPEN_CONTAINER
-
-/obj/structure/working/butter_churn/Initialize()
-	. = ..()
-	initialize_reagents()
-
-/obj/structure/working/butter_churn/initialize_reagents(populate)
-	create_reagents(200)
-	. = ..()
+	chem_volume  = 200
 
 /obj/structure/working/butter_churn/try_start_working(mob/user)
 

--- a/code/modules/detectivework/tools/luminol.dm
+++ b/code/modules/detectivework/tools/luminol.dm
@@ -6,7 +6,7 @@
 	item_state = "cleaner"
 	amount_per_transfer_from_this = 10
 	possible_transfer_amounts = @"[5,10]"
-	volume = 250
+	chem_volume = 250
 
 /obj/item/chems/spray/luminol/populate_reagents()
 	add_to_reagents(/decl/material/liquid/luminol, reagents.maximum_volume)

--- a/code/modules/detectivework/tools/rag.dm
+++ b/code/modules/detectivework/tools/rag.dm
@@ -6,7 +6,7 @@
 	icon_state = "rag"
 	amount_per_transfer_from_this = 5
 	possible_transfer_amounts = @"[5]"
-	volume = 10
+	chem_volume = 10
 	item_flags = ITEM_FLAG_NO_BLUDGEON
 	atom_flags = ATOM_FLAG_OPEN_CONTAINER
 	material = /decl/material/solid/organic/cloth

--- a/code/modules/food/cooking/cooking_vessels/baking_dish.dm
+++ b/code/modules/food/cooking/cooking_vessels/baking_dish.dm
@@ -2,7 +2,7 @@
 	name               = "baking dish"
 	desc               = "A large baking dish for baking things."
 	icon               = 'icons/obj/food/cooking_vessels/baking_dish.dmi'
-	volume             = 100
+	chem_volume        = 100
 	cooking_category   = RECIPE_CATEGORY_BAKING_DISH
 	presentation_flags = PRESENTATION_FLAG_NAME
 	obj_flags          = OBJ_FLAG_HOLLOW | OBJ_FLAG_INSULATED_HANDLE // TODO: dynamically add/remove OBJ_FLAG_INSULATED_HANDLE based on handle material?

--- a/code/modules/food/cooking/cooking_vessels/pot.dm
+++ b/code/modules/food/cooking/cooking_vessels/pot.dm
@@ -2,7 +2,7 @@
 	name               = "pot"
 	desc               = "A large pot for boiling things."
 	icon               = 'icons/obj/food/cooking_vessels/pot.dmi'
-	volume             = 100
+	chem_volume        = 100
 	cooking_category   = RECIPE_CATEGORY_POT
 	presentation_flags = PRESENTATION_FLAG_NAME
 	obj_flags          = OBJ_FLAG_HOLLOW | OBJ_FLAG_INSULATED_HANDLE
@@ -53,14 +53,14 @@
 		last_boil_status = null
 
 /obj/item/chems/cooking_vessel/cauldron
-	name     = "cauldron"
-	desc     = "A large round-bodied vessel for making large quantities of potion or soup."
-	material = /decl/material/solid/metal/iron
-	color    = /decl/material/solid/metal/iron::color
-	icon     = 'icons/obj/food/cooking_vessels/cauldron.dmi'
-	volume   = 1000
-	w_class  = ITEM_SIZE_STRUCTURE
-	density  = TRUE
+	name        = "cauldron"
+	desc        = "A large round-bodied vessel for making large quantities of potion or soup."
+	material    = /decl/material/solid/metal/iron
+	color       = /decl/material/solid/metal/iron::color
+	icon        = 'icons/obj/food/cooking_vessels/cauldron.dmi'
+	chem_volume = 1000
+	w_class     = ITEM_SIZE_STRUCTURE
+	density     = TRUE
 
 /obj/item/chems/cooking_vessel/cauldron/can_be_picked_up(mob/user)
 	return FALSE

--- a/code/modules/food/cooking/cooking_vessels/skillet.dm
+++ b/code/modules/food/cooking/cooking_vessels/skillet.dm
@@ -2,7 +2,7 @@
 	name               = "skillet"
 	desc               = "A shallow pan for frying food."
 	icon               = 'icons/obj/food/cooking_vessels/skillet.dmi'
-	volume             = 30
+	chem_volume        = 30
 	cooking_category   = RECIPE_CATEGORY_SKILLET
 	obj_flags          = OBJ_FLAG_HOLLOW | OBJ_FLAG_INSULATED_HANDLE
 

--- a/code/modules/food/utensils/_utensil.dm
+++ b/code/modules/food/utensils/_utensil.dm
@@ -12,13 +12,14 @@
 
 /obj/item/utensil
 
-	abstract_type                    = /obj/item/utensil
-	icon_state                       = ICON_STATE_WORLD
-	w_class                          = ITEM_SIZE_SMALL
-	origin_tech                      = @'{"materials":1}'
-	attack_verb                      = list("attacked", "stabbed", "poked")
-	material                         = /decl/material/solid/metal/aluminium
-	material_alteration              = MAT_FLAG_ALTERATION_COLOR | MAT_FLAG_ALTERATION_NAME
+	abstract_type       = /obj/item/utensil
+	icon_state          = ICON_STATE_WORLD
+	w_class             = ITEM_SIZE_SMALL
+	origin_tech         = @'{"materials":1}'
+	attack_verb         = list("attacked", "stabbed", "poked")
+	material            = /decl/material/solid/metal/aluminium
+	material_alteration = MAT_FLAG_ALTERATION_COLOR | MAT_FLAG_ALTERATION_NAME
+	chem_volume         = 5
 
 	var/obj/item/food/loaded_food
 	var/utensil_flags
@@ -32,7 +33,6 @@
 	if (prob(60))
 		default_pixel_y = rand(0, 4)
 		reset_offsets(0)
-	create_reagents(5)
 	set_extension(src, /datum/extension/tool/variable/simple, list(
 		TOOL_RETRACTOR = TOOL_QUALITY_BAD,
 		TOOL_HEMOSTAT =  TOOL_QUALITY_MEDIOCRE

--- a/code/modules/hydroponics/grown.dm
+++ b/code/modules/hydroponics/grown.dm
@@ -285,15 +285,9 @@ var/global/list/_wood_materials = list(
 			return TRUE
 
 		var/obj/item/clothing/mask/smokable/cigarette/rolled/R = new(get_turf(src))
-		R.chem_volume = max(R.reagents?.maximum_volume, reagents?.total_volume)
-		if(R.reagents)
-			R.reagents.maximum_volume = R.chem_volume
-			R.reagents.update_total()
-		else
-			R.create_reagents(R.chem_volume)
-
+		R.create_or_update_reagents(max(R.reagents?.maximum_volume, reagents?.total_volume))
 		R.brand = "[src] handrolled in \the [used_item]."
-		reagents.trans_to_holder(R.reagents, R.chem_volume)
+		reagents.trans_to_holder(R.reagents, R.reagents.total_volume)
 		to_chat(user, SPAN_NOTICE("You roll \the [src] into \the [used_item]."))
 		user.put_in_active_hand(R)
 		qdel(used_item)

--- a/code/modules/hydroponics/grown.dm
+++ b/code/modules/hydroponics/grown.dm
@@ -95,25 +95,18 @@
 
 	. = ..(mapload, material_key, skip_plate) //Init reagents
 
-/obj/item/food/grown/initialize_reagents(populate)
-	if(reagents)
-		reagents.clear_reagents()
-	if(!length(seed?.get_chemical_composition(_segment = plant_segment_type)))
-		return
-
-	. = ..() //create_reagent and populate_reagents
-
 	update_desc()
 	if(reagents.total_volume > 0)
 		bitesize = 1 + round(reagents.total_volume / 2, 1)
-
 	update_icon()
 
 /obj/item/food/grown/populate_reagents()
 	. = ..()
+	if(!length(seed?.get_chemical_composition(_segment = plant_segment_type)))
+		return
+
 	// Fill the object up with the appropriate reagents.
 	var/list/chems_to_fill
-
 	if(backyard_grilling_count > 0)
 		chems_to_fill ||= seed?.get_chemical_composition(_segment = plant_segment_type, _state = PLANT_STATE_ROASTED)
 	if(dry)

--- a/code/modules/hydroponics/seed_packets.dm
+++ b/code/modules/hydroponics/seed_packets.dm
@@ -7,6 +7,7 @@
 	abstract_type = /obj/item/seeds
 	max_health = 10 //Can't set a material, otherwise extracting seeds would generate free materials
 	material = /decl/material/solid/organic/plantmatter/pith
+	chem_volume = 3
 
 	var/seed_mask_icon = 'icons/obj/seeds/seed_masks.dmi'
 	var/seed_base_name = "packet"
@@ -17,11 +18,6 @@
 	if(isnull(seed) && !isnull(_seed))
 		seed = _seed
 	update_seed()
-	initialize_reagents()
-	. = ..()
-
-/obj/item/seeds/initialize_reagents()
-	create_reagents(3)
 	. = ..()
 
 /obj/item/seeds/populate_reagents()

--- a/code/modules/hydroponics/trays/tray.dm
+++ b/code/modules/hydroponics/trays/tray.dm
@@ -5,7 +5,7 @@
 	icon_state = "hydrotray3"
 	density = TRUE
 	anchored = TRUE
-	air_volume = 100
+	gas_volume = 100
 	construct_state = /decl/machine_construction/default/panel_closed
 	uncreated_component_parts = null
 	stat_immune = 0

--- a/code/modules/hydroponics/trays/tray.dm
+++ b/code/modules/hydroponics/trays/tray.dm
@@ -5,7 +5,7 @@
 	icon_state = "hydrotray3"
 	density = TRUE
 	anchored = TRUE
-	volume = 100
+	air_volume = 100
 	construct_state = /decl/machine_construction/default/panel_closed
 	uncreated_component_parts = null
 	stat_immune = 0

--- a/code/modules/hydroponics/trays/tray.dm
+++ b/code/modules/hydroponics/trays/tray.dm
@@ -10,6 +10,7 @@
 	uncreated_component_parts = null
 	stat_immune = 0
 	atom_flags = ATOM_FLAG_OPEN_CONTAINER | ATOM_FLAG_CLIMBABLE | ATOM_FLAG_NO_CHEM_CHANGE
+	chem_volume = 200
 
 	var/mechanical = 1         // Set to 0 to stop it from drawing the alert lights.
 	var/base_name = "tray"
@@ -38,7 +39,8 @@
 	var/lastproduce = 0        // Last time tray was harvested
 	var/closed_system          // If set, the tray will attempt to take atmos from a pipe.
 	var/force_update           // Set this to bypass the cycle time check.
-	var/obj/temp_chem_holder   // Something to hold reagents during process_reagents()
+	/// Something to hold reagents during process_reagents()
+	var/obj/effect/chem_holder/temp_chem_holder
 
 	// Counter used by bees.
 	var/pollen = 0
@@ -164,10 +166,7 @@
 	if(!mechanical)
 		construct_state = /decl/machine_construction/noninteractive
 	. = ..()
-	temp_chem_holder = new()
-	temp_chem_holder.create_reagents(10)
-	temp_chem_holder.atom_flags |= ATOM_FLAG_OPEN_CONTAINER
-	create_reagents(200)
+	temp_chem_holder = new(null, 10)
 	if(mechanical)
 		connect()
 	update_icon()

--- a/code/modules/implants/implant_types/chem.dm
+++ b/code/modules/implants/implant_types/chem.dm
@@ -5,6 +5,7 @@ var/global/list/chem_implants = list()
 	desc = "Injects things."
 	origin_tech = @'{"materials":1,"biotech":2}'
 	known = TRUE
+	chem_volume = 50
 
 /obj/item/implant/chem/get_data()
 	return {"
@@ -26,7 +27,6 @@ var/global/list/chem_implants = list()
 /obj/item/implant/chem/Initialize()
 	. = ..()
 	global.chem_implants += src
-	create_reagents(50)
 
 /obj/item/implant/chem/Destroy()
 	. = ..()

--- a/code/modules/materials/definitions/liquids/materials_liquid_water.dm
+++ b/code/modules/materials/definitions/liquids/materials_liquid_water.dm
@@ -89,9 +89,9 @@
 		touching_turf.assume_air(lowertemp)
 		qdel(hotspot)
 
-	var/volume = REAGENT_VOLUME(holder, src)
+	var/affect_volume = REAGENT_VOLUME(holder, src)
 	if (environment && environment.temperature > min_temperature) // Abstracted as steam or something
-		var/removed_heat = clamp(volume * WATER_LATENT_HEAT, 0, -environment.get_thermal_energy_change(min_temperature))
+		var/removed_heat = clamp(affect_volume * WATER_LATENT_HEAT, 0, -environment.get_thermal_energy_change(min_temperature))
 		environment.add_thermal_energy(-removed_heat)
 		if (prob(5) && environment && environment.temperature > T100C)
 			touching_turf.visible_message(SPAN_NOTICE("The water sizzles as it lands on \the [touching_turf]!"))

--- a/code/modules/materials/definitions/solids/materials_solid_elements.dm
+++ b/code/modules/materials/definitions/solids/materials_solid_elements.dm
@@ -109,8 +109,8 @@
 
 /decl/material/solid/potassium/affect_blood(var/mob/living/M, var/removed, var/datum/reagents/holder)
 	. = ..()
-	var/volume = REAGENT_VOLUME(holder, src)
-	if(volume > 3)
+	var/affect_volume = REAGENT_VOLUME(holder, src)
+	if(affect_volume > 3)
 		M.add_chemical_effect(CE_PULSE, 1)
-	if(volume > 10)
+	if(affect_volume > 10)
 		M.add_chemical_effect(CE_PULSE, 1)

--- a/code/modules/materials/definitions/solids/materials_solid_mineral.dm
+++ b/code/modules/materials/definitions/solids/materials_solid_mineral.dm
@@ -184,10 +184,10 @@
 
 /decl/material/solid/potash/affect_blood(var/mob/living/M, var/removed, var/datum/reagents/holder)
 	. = ..()
-	var/volume = REAGENT_VOLUME(holder, src)
-	if(volume > 3)
+	var/affect_volume = REAGENT_VOLUME(holder, src)
+	if(affect_volume > 3)
 		M.add_chemical_effect(CE_PULSE, 1)
-	if(volume > 10)
+	if(affect_volume > 10)
 		M.add_chemical_effect(CE_PULSE, 1)
 
 /decl/material/solid/bauxite

--- a/code/modules/materials/material_metabolism.dm
+++ b/code/modules/materials/material_metabolism.dm
@@ -56,11 +56,11 @@
 				touching_turf.wet_floor(slipperiness)
 
 	if(length(vapor_products))
-		var/volume = REAGENT_VOLUME(holder, src)
+		var/result_volume = REAGENT_VOLUME(holder, src)
 		var/temperature = holder?.my_atom?.temperature || T20C
 		for(var/vapor in vapor_products)
-			touching_turf.assume_gas(vapor, (volume * vapor_products[vapor]), temperature)
-		holder.remove_reagent(src, volume)
+			touching_turf.assume_gas(vapor, (result_volume * vapor_products[vapor]), temperature)
+		holder.remove_reagent(src, result_volume)
 
 /decl/material/proc/on_mob_life(var/mob/living/M, var/metabolism_class, var/datum/reagents/holder, var/list/life_dose_tracker)
 

--- a/code/modules/mechs/components/body.dm
+++ b/code/modules/mechs/components/body.dm
@@ -52,13 +52,13 @@
 		)
 	if(pilot_coverage >= 100) //Open cockpits dont get to have air
 		cockpit = new
-		cockpit.volume = 200
+		cockpit.air_volume = 200
 		if(loc)
 			var/datum/gas_mixture/air = loc.return_air()
 			if(air)
 				//Essentially at this point its like we created a vacuum, but realistically making a bottle doesnt actually increase volume of a room and neither should a mech
 				for(var/g in air.gas)
-					cockpit.gas[g] = (air.gas[g] / air.volume) * cockpit.volume
+					cockpit.gas[g] = (air.gas[g] / air.air_volume) * cockpit.air_volume
 
 				cockpit.temperature = air.temperature
 				cockpit.update_values()
@@ -107,7 +107,7 @@
 		if(pressure_delta > 0)
 			if(air_supply.air_contents.temperature > 0)
 				var/transfer_moles = calculate_transfer_moles(air_supply.air_contents, cockpit, pressure_delta)
-				transfer_moles = min(transfer_moles, (air_supply.release_flow_rate/air_supply.air_contents.volume)*air_supply.air_contents.total_moles)
+				transfer_moles = min(transfer_moles, (air_supply.release_flow_rate/air_supply.air_contents.air_volume)*air_supply.air_contents.total_moles)
 				pump_gas_passive(air_supply, air_supply.air_contents, cockpit, transfer_moles)
 				changed = TRUE
 		else if(pressure_delta < 0) //Release overpressure.

--- a/code/modules/mechs/components/body.dm
+++ b/code/modules/mechs/components/body.dm
@@ -52,13 +52,13 @@
 		)
 	if(pilot_coverage >= 100) //Open cockpits dont get to have air
 		cockpit = new
-		cockpit.air_volume = 200
+		cockpit.total_volume = 200
 		if(loc)
 			var/datum/gas_mixture/air = loc.return_air()
 			if(air)
 				//Essentially at this point its like we created a vacuum, but realistically making a bottle doesnt actually increase volume of a room and neither should a mech
 				for(var/g in air.gas)
-					cockpit.gas[g] = (air.gas[g] / air.air_volume) * cockpit.air_volume
+					cockpit.gas[g] = (air.gas[g] / air.total_volume) * cockpit.total_volume
 
 				cockpit.temperature = air.temperature
 				cockpit.update_values()
@@ -107,7 +107,7 @@
 		if(pressure_delta > 0)
 			if(air_supply.air_contents.temperature > 0)
 				var/transfer_moles = calculate_transfer_moles(air_supply.air_contents, cockpit, pressure_delta)
-				transfer_moles = min(transfer_moles, (air_supply.release_flow_rate/air_supply.air_contents.air_volume)*air_supply.air_contents.total_moles)
+				transfer_moles = min(transfer_moles, (air_supply.release_flow_rate/air_supply.air_contents.total_volume)*air_supply.air_contents.total_moles)
 				pump_gas_passive(air_supply, air_supply.air_contents, cockpit, transfer_moles)
 				changed = TRUE
 		else if(pressure_delta < 0) //Release overpressure.

--- a/code/modules/mechs/equipment/engineering.dm
+++ b/code/modules/mechs/equipment/engineering.dm
@@ -28,7 +28,7 @@
 	return null
 
 /obj/item/chems/spray/extinguisher/mech
-	volume = 4000 //Good is gooder
+	chem_volume = 4000 //Good is gooder
 	icon_state = "mech_exting"
 
 /obj/item/chems/spray/extinguisher/mech/get_hardpoint_maptext()

--- a/code/modules/mining/machinery/material_extractor.dm
+++ b/code/modules/mining/machinery/material_extractor.dm
@@ -17,15 +17,15 @@
 	var/dispense_amount = 50
 
 	// Since reactions and heating products may overfill the reagent tank, the reagent tank has 1.25x this volume.
-	var/static/max_liquid = 3000
+	var/const/MAX_LIQUID = 3000
 
 /obj/machinery/material_processing/extractor/Initialize()
+	chem_volume = round(MAX_LIQUID * 1.25)
 	. = ..()
 	if(!gas_contents)
 		gas_contents = new(800)
 	set_extension(src, /datum/extension/atmospherics_connection, FALSE, gas_contents)
 
-	create_reagents(round(1.25*max_liquid))
 	queue_temperature_atoms(src)
 
 	return INITIALIZE_HINT_LATELOAD
@@ -70,7 +70,7 @@
 	if(!use_power || (stat & (BROKEN|NOPOWER)))
 		return
 
-	if(reagents?.total_volume >= max_liquid)
+	if(reagents?.total_volume >= MAX_LIQUID)
 		return
 
 	if(input_turf)
@@ -245,7 +245,7 @@
 		var/is_liquid = reagent.phase_at_temperature(temperature, ONE_ATMOSPHERE) == MAT_PHASE_LIQUID
 		data["reagents"] += list(list("label" = "[reagent.liquid_name] ([reagents.reagent_volumes[reagent]] U)", "index" = index, "liquid" = is_liquid))
 
-	data["full"] = reagents.total_volume >= max_liquid
+	data["full"] = reagents.total_volume >= MAX_LIQUID
 	data["gas_pressure"] = gas_contents?.return_pressure()
 	return data
 

--- a/code/modules/mining/machinery/material_smelter.dm
+++ b/code/modules/mining/machinery/material_smelter.dm
@@ -5,6 +5,8 @@
 	icon_state = "furnace"
 	use_ui_template = "material_processing_smeltery.tmpl"
 	atom_flags = ATOM_FLAG_CLIMBABLE | ATOM_FLAG_OPEN_CONTAINER
+	chem_volume = INFINITY
+
 	var/show_all_materials = FALSE
 	var/list/casting
 	var/static/list/always_show_materials = list(
@@ -21,7 +23,6 @@
 /obj/machinery/material_processing/smeltery/Initialize()
 	show_materials = always_show_materials.Copy()
 	. = ..()
-	create_reagents(INFINITY)
 	queue_temperature_atoms(src)
 
 // Update displayed materials

--- a/code/modules/mob/living/human/life.dm
+++ b/code/modules/mob/living/human/life.dm
@@ -173,7 +173,7 @@
 			var/temperature_gain = heat_gain/HUMAN_HEAT_CAPACITY
 			bodytemperature += temperature_gain //temperature_gain will often be negative
 
-	var/relative_density = (environment.total_moles/environment.air_volume) / (MOLES_CELLSTANDARD/CELL_VOLUME)
+	var/relative_density = (environment.total_moles/environment.total_volume) / (MOLES_CELLSTANDARD/CELL_VOLUME)
 	if(relative_density > 0.02) //don't bother if we are in vacuum or near-vacuum
 		var/loc_temp = environment.temperature
 

--- a/code/modules/mob/living/human/life.dm
+++ b/code/modules/mob/living/human/life.dm
@@ -173,7 +173,7 @@
 			var/temperature_gain = heat_gain/HUMAN_HEAT_CAPACITY
 			bodytemperature += temperature_gain //temperature_gain will often be negative
 
-	var/relative_density = (environment.total_moles/environment.volume) / (MOLES_CELLSTANDARD/CELL_VOLUME)
+	var/relative_density = (environment.total_moles/environment.air_volume) / (MOLES_CELLSTANDARD/CELL_VOLUME)
 	if(relative_density > 0.02) //don't bother if we are in vacuum or near-vacuum
 		var/loc_temp = environment.temperature
 

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1672,23 +1672,23 @@ default behaviour is:
 		return
 
 	var/range = world.view - 2
-	var/volume = 70
+	var/step_volume = 70
 	if(MOVING_DELIBERATELY(src))
-		volume -= 45
+		step_volume -= 45
 		range -= 0.333
 
 	var/obj/item/clothing/shoes/shoes = get_equipped_item(slot_shoes_str)
-	volume = round(modify_footstep_volume(volume, shoes))
+	step_volume = round(modify_footstep_volume(step_volume, shoes))
 	range  = round(modify_footstep_range(range, shoes))
-	if(volume > 0 && range > 0)
-		playsound(T, footsound, volume, 1, range)
+	if(step_volume > 0 && range > 0)
+		playsound(T, footsound, step_volume, 1, range)
 
-/mob/living/proc/modify_footstep_volume(volume, obj/item/clothing/shoes/shoes)
+/mob/living/proc/modify_footstep_volume(step_volume, obj/item/clothing/shoes/shoes)
 	if(istype(shoes))
-		return volume * shoes.footstep_volume_mod
+		return step_volume * shoes.footstep_volume_mod
 	if(!shoes)
-		return volume - 60
-	return volume
+		return step_volume - 60
+	return step_volume
 
 /mob/living/proc/modify_footstep_range(range, obj/item/clothing/shoes/shoes)
 	if(istype(shoes))

--- a/code/modules/mob/living/living_breath.dm
+++ b/code/modules/mob/living/living_breath.dm
@@ -81,7 +81,7 @@
 		if(!can_breathe_air_above)
 			breath = new
 			if(!can_drown())
-				breath.air_volume = volume_needed
+				breath.total_volume = volume_needed
 				breath.temperature = my_turf.temperature
 				// TODO: species-breathable gas instead of oxygen default. Maybe base it on the reagents being breathed
 				breath.adjust_gas(/decl/material/gas/oxygen, ONE_ATMOSPHERE*volume_needed/(R_IDEAL_GAS_EQUATION*T20C))

--- a/code/modules/mob/living/living_breath.dm
+++ b/code/modules/mob/living/living_breath.dm
@@ -81,7 +81,7 @@
 		if(!can_breathe_air_above)
 			breath = new
 			if(!can_drown())
-				breath.volume = volume_needed
+				breath.air_volume = volume_needed
 				breath.temperature = my_turf.temperature
 				// TODO: species-breathable gas instead of oxygen default. Maybe base it on the reagents being breathed
 				breath.adjust_gas(/decl/material/gas/oxygen, ONE_ATMOSPHERE*volume_needed/(R_IDEAL_GAS_EQUATION*T20C))

--- a/code/modules/mob/living/living_powers.dm
+++ b/code/modules/mob/living/living_powers.dm
@@ -33,7 +33,6 @@
 
 	var/turf/T = get_turf(src)
 	var/obj/effect/effect/water/chempuff/chem = new(T)
-	chem.create_reagents(10)
 	chem.add_to_reagents(/decl/material/liquid/zombie, 2)
 	chem.set_up(get_step(T, dir), 2, 10)
 	playsound(T, 'sound/hallucinations/wail.ogg', 20, 1)

--- a/code/modules/mob/living/silicon/robot/flying/module_flying_emergency.dm
+++ b/code/modules/mob/living/silicon/robot/flying/module_flying_emergency.dm
@@ -70,8 +70,8 @@
 
 /obj/item/robot_module/flying/emergency/respawn_consumable(var/mob/living/silicon/robot/robot, var/amount)
 	var/obj/item/chems/spray/PS = emag
-	if(PS && PS.reagents.total_volume < PS.volume)
-		var/adding = min(PS.volume-PS.reagents.total_volume, 2*amount)
+	if(PS && PS.reagents.total_volume < PS.reagents.maximum_volume)
+		var/adding = min(PS.reagents.maximum_volume-PS.reagents.total_volume, 2*amount)
 		if(adding > 0)
 			PS.add_to_reagents(/decl/material/liquid/acid/polyacid, adding)
 	..()

--- a/code/modules/mob/living/silicon/robot/flying/module_flying_forensics.dm
+++ b/code/modules/mob/living/silicon/robot/flying/module_flying_forensics.dm
@@ -41,8 +41,8 @@
 	if(!luminol)
 		luminol = new(src)
 		equipment += luminol
-	if(luminol.reagents.total_volume < luminol.volume)
-		var/adding = min(luminol.volume-luminol.reagents.total_volume, 2*amount)
+	if(luminol.reagents.total_volume < luminol.reagents.maximum_volume)
+		var/adding = min(luminol.reagents.maximum_volume-luminol.reagents.total_volume, 2*amount)
 		if(adding > 0)
 			luminol.add_to_reagents(/decl/material/liquid/luminol, adding)
 	..()

--- a/code/modules/mob/living/silicon/robot/modules/module_clerical.dm
+++ b/code/modules/mob/living/silicon/robot/modules/module_clerical.dm
@@ -62,7 +62,7 @@
 /obj/item/robot_module/clerical/butler/finalize_emag()
 	. = ..()
 	if(emag)
-		var/datum/reagents/reagent = emag.create_reagents(50)
+		var/datum/reagents/reagent = emag.create_or_update_reagents(50)
 		reagent.add_reagent(/decl/material/liquid/paralytics, 10)
 		reagent.add_reagent(/decl/material/liquid/sedatives, 15)
 		reagent.add_reagent(/decl/material/liquid/alcohol/beer, 20)

--- a/code/modules/mob/living/silicon/robot/robot_items.dm
+++ b/code/modules/mob/living/silicon/robot/robot_items.dm
@@ -315,7 +315,7 @@
 /obj/item/chems/spray/cleaner/drone
 	name = "space cleaner"
 	desc = "BLAM!-brand non-foaming space cleaner!"
-	volume = 150
+	chem_volume = 150
 
 /obj/item/robot_rack
 	name = "a generic robot rack"

--- a/code/modules/multiz/pipes.dm
+++ b/code/modules/multiz/pipes.dm
@@ -8,7 +8,7 @@
 	name = "upwards pipe"
 	desc = "A pipe segment to connect upwards."
 
-	air_volume = 70
+	gas_volume = 70
 
 	dir = SOUTH
 	initialize_directions = SOUTH

--- a/code/modules/multiz/pipes.dm
+++ b/code/modules/multiz/pipes.dm
@@ -8,7 +8,7 @@
 	name = "upwards pipe"
 	desc = "A pipe segment to connect upwards."
 
-	volume = 70
+	air_volume = 70
 
 	dir = SOUTH
 	initialize_directions = SOUTH

--- a/code/modules/organs/internal/lungs.dm
+++ b/code/modules/organs/internal/lungs.dm
@@ -307,7 +307,7 @@
 		else
 			temp_adj /= (BODYTEMP_HEAT_DIVISOR * 5)	//don't raise temperature as much as if we were directly exposed
 
-		var/relative_density = breath.total_moles / (MOLES_CELLSTANDARD * breath.air_volume/CELL_VOLUME)
+		var/relative_density = breath.total_moles / (MOLES_CELLSTANDARD * breath.total_volume/CELL_VOLUME)
 		temp_adj *= relative_density
 
 		if (temp_adj > BODYTEMP_HEATING_MAX) temp_adj = BODYTEMP_HEATING_MAX

--- a/code/modules/organs/internal/lungs.dm
+++ b/code/modules/organs/internal/lungs.dm
@@ -307,7 +307,7 @@
 		else
 			temp_adj /= (BODYTEMP_HEAT_DIVISOR * 5)	//don't raise temperature as much as if we were directly exposed
 
-		var/relative_density = breath.total_moles / (MOLES_CELLSTANDARD * breath.volume/CELL_VOLUME)
+		var/relative_density = breath.total_moles / (MOLES_CELLSTANDARD * breath.air_volume/CELL_VOLUME)
 		temp_adj *= relative_density
 
 		if (temp_adj > BODYTEMP_HEATING_MAX) temp_adj = BODYTEMP_HEATING_MAX

--- a/code/modules/organs/organ.dm
+++ b/code/modules/organs/organ.dm
@@ -88,11 +88,11 @@
 
 //Third argument may be a dna datum; if null will be set to holder's dna.
 /obj/item/organ/Initialize(mapload, material_key, datum/mob_snapshot/supplied_appearance)
+	chem_volume = 5 * (w_class-1)**2
 	. = ..(mapload, material_key)
 	if(. == INITIALIZE_HINT_QDEL)
 		return .
 	setup_organ(supplied_appearance)
-	initialize_reagents()
 
 /obj/item/organ/proc/setup_organ(datum/mob_snapshot/supplied_appearance)
 	//Null DNA setup
@@ -122,14 +122,6 @@
 		copy_from_mob_snapshot(supplied_appearance)
 	else
 		set_species(owner?.get_species() || global.using_map.default_species)
-
-//Called on initialization to add the neccessary reagents
-
-/obj/item/organ/initialize_reagents(populate = TRUE)
-	if(reagents)
-		return
-	create_reagents(5 * (w_class-1)**2)
-	. = ..()
 
 // todo: make this redundant with matter shenanigans
 /obj/item/organ/populate_reagents()

--- a/code/modules/overmap/ships/computers/sensors.dm
+++ b/code/modules/overmap/ships/computers/sensors.dm
@@ -38,10 +38,10 @@
 
 	var/obj/machinery/shipsensors/sensors = get_sensors()
 	if(linked && sensors?.use_power && !(sensors.stat & NOPOWER))
-		var/volume = 10
+		var/ping_volume = 10
 		if(!sound_token)
-			sound_token = play_looping_sound(src, sound_id, working_sound, volume = volume, range = 10)
-		sound_token.SetVolume(volume)
+			sound_token = play_looping_sound(src, sound_id, working_sound, volume = ping_volume, range = 10)
+		sound_token.SetVolume(ping_volume)
 	else if(sound_token)
 		QDEL_NULL(sound_token)
 

--- a/code/modules/overmap/ships/device_types/gas_thruster.dm
+++ b/code/modules/overmap/ships/device_types/gas_thruster.dm
@@ -29,10 +29,10 @@
 
 /datum/extension/ship_engine/gas/proc/get_propellant(var/sample_only = TRUE, var/partial = 1)
 	var/obj/machinery/atmospherics/unary/engine/E = holder
-	if(istype(E) && E.air_contents?.air_volume > 0)
-		var/datum/gas_mixture/removed = E.air_contents.remove_ratio((volume_per_burn * thrust_limit * partial) / E.air_contents.air_volume)
+	if(istype(E) && E.air_contents?.total_volume > 0)
+		var/datum/gas_mixture/removed = E.air_contents.remove_ratio((volume_per_burn * thrust_limit * partial) / E.air_contents.total_volume)
 		if(removed && sample_only)
-			var/datum/gas_mixture/sample = new(removed.air_volume)
+			var/datum/gas_mixture/sample = new(removed.total_volume)
 			sample.copy_from(removed)
 			E.air_contents.merge(removed)
 			return sample

--- a/code/modules/overmap/ships/device_types/gas_thruster.dm
+++ b/code/modules/overmap/ships/device_types/gas_thruster.dm
@@ -29,10 +29,10 @@
 
 /datum/extension/ship_engine/gas/proc/get_propellant(var/sample_only = TRUE, var/partial = 1)
 	var/obj/machinery/atmospherics/unary/engine/E = holder
-	if(istype(E) && E.air_contents?.volume > 0)
-		var/datum/gas_mixture/removed = E.air_contents.remove_ratio((volume_per_burn * thrust_limit * partial) / E.air_contents.volume)
+	if(istype(E) && E.air_contents?.air_volume > 0)
+		var/datum/gas_mixture/removed = E.air_contents.remove_ratio((volume_per_burn * thrust_limit * partial) / E.air_contents.air_volume)
 		if(removed && sample_only)
-			var/datum/gas_mixture/sample = new(removed.volume)
+			var/datum/gas_mixture/sample = new(removed.air_volume)
 			sample.copy_from(removed)
 			E.air_contents.merge(removed)
 			return sample

--- a/code/modules/paperwork/pen/quill_and_ink.dm
+++ b/code/modules/paperwork/pen/quill_and_ink.dm
@@ -56,7 +56,7 @@
 	icon = 'icons/obj/items/inkwell.dmi'
 	icon_state = ICON_STATE_WORLD
 	desc = "An inkwell used to hold ink. Dip a quill pen into this to re-ink it."
-	volume = 30
+	chem_volume = 30
 	/// The minimum amount of ink in the inkwell when populating reagents.
 	var/starting_volume_low = 20
 	/// The maximum amount of ink in the inkwell when populating reagents.

--- a/code/modules/paperwork/pen/reagent_pen.dm
+++ b/code/modules/paperwork/pen/reagent_pen.dm
@@ -3,14 +3,7 @@
 	origin_tech = @'{"materials":2,"esoteric":5}'
 	sharp       = TRUE
 	pen_quality = TOOL_QUALITY_MEDIOCRE
-
-/obj/item/pen/reagent/Initialize()
-	. = ..()
-	initialize_reagents()
-
-/obj/item/pen/reagent/initialize_reagents(populate = TRUE)
-	create_reagents(30)
-	. = ..()
+	chem_volume = 30
 
 /obj/item/pen/reagent/use_on_mob(mob/living/target, mob/living/user, animate = TRUE)
 

--- a/code/modules/paperwork/toner_cartridge.dm
+++ b/code/modules/paperwork/toner_cartridge.dm
@@ -10,7 +10,7 @@
 	throw_speed                   = 4
 	w_class                       = ITEM_SIZE_NORMAL
 	material                      = /decl/material/solid/organic/plastic
-	volume                        = 60
+	chem_volume                   = 60
 	amount_per_transfer_from_this = 30
 	possible_transfer_amounts     = @"[30,60]"
 	atom_flags                    = ATOM_FLAG_OPEN_CONTAINER

--- a/code/modules/power/port_gen.dm
+++ b/code/modules/power/port_gen.dm
@@ -37,11 +37,10 @@
 	if(!sound_id)
 		sound_id = "[type]_[sequential_id(/obj/machinery/port_gen)]"
 	if(active && HasFuel() && !IsBroken())
-		var/volume = 10 + 15*power_output
+		var/work_volume = 10 + 15*power_output
 		if(!sound_token)
-
-			sound_token = play_looping_sound(src, sound_id, working_sound, volume = volume)
-		sound_token.SetVolume(volume)
+			sound_token = play_looping_sound(src, sound_id, working_sound, volume = work_volume)
+		sound_token.SetVolume(work_volume)
 	else if(sound_token)
 		QDEL_NULL(sound_token)
 

--- a/code/modules/power/port_gen.dm
+++ b/code/modules/power/port_gen.dm
@@ -457,10 +457,7 @@
 	rad_power = 12
 	atom_flags = ATOM_FLAG_OPEN_CONTAINER
 	anchored = TRUE
-
-/obj/machinery/port_gen/pacman/super/potato/Initialize()
-	create_reagents(120)
-	. = ..()
+	chem_volume = 120
 
 /obj/machinery/port_gen/pacman/super/potato/get_examine_strings(mob/user, distance, infix, suffix)
 	. = ..()

--- a/code/modules/power/stirling.dm
+++ b/code/modules/power/stirling.dm
@@ -225,7 +225,7 @@
 	slot_flags = null
 	starting_pressure = list(/decl/material/gas/hydrogen = 2 ATM)
 
-	air_volume = 30
+	gas_volume = 30
 	failure_temp = 1000
 
 /obj/item/tank/stirling/Initialize()

--- a/code/modules/power/stirling.dm
+++ b/code/modules/power/stirling.dm
@@ -196,10 +196,10 @@
 	if(!sound_id)
 		sound_id = "[type]_[sequential_id(/obj/machinery/atmospherics/binary/stirling)]"
 	if(active)
-		var/volume = 10 + 15*genlev
+		var/work_volume = 10 + 15*genlev
 		if(!sound_token)
-			sound_token = play_looping_sound(src, sound_id, 'sound/machines/engine.ogg', volume = volume)
-		sound_token.SetVolume(volume)
+			sound_token = play_looping_sound(src, sound_id, 'sound/machines/engine.ogg', volume = work_volume)
+		sound_token.SetVolume(work_volume)
 	else if(sound_token)
 		QDEL_NULL(sound_token)
 
@@ -225,7 +225,7 @@
 	slot_flags = null
 	starting_pressure = list(/decl/material/gas/hydrogen = 2 ATM)
 
-	volume = 30
+	air_volume = 30
 	failure_temp = 1000
 
 /obj/item/tank/stirling/Initialize()

--- a/code/modules/projectiles/ammunition/chemdart.dm
+++ b/code/modules/projectiles/ammunition/chemdart.dm
@@ -7,21 +7,13 @@
 	life_span = 15 //shorter range
 	muzzle_type = null
 	material = /decl/material/solid/glass
-	var/reagent_amount = 15
-
-/obj/item/projectile/bullet/chemdart/Initialize()
-	. = ..()
-	initialize_reagents()
-
-/obj/item/projectile/bullet/chemdart/initialize_reagents(populate = TRUE)
-	create_reagents(reagent_amount)
-	. = ..()
+	chem_volume = 15
 
 /obj/item/projectile/bullet/chemdart/on_hit(var/atom/target, var/blocked = 0, var/def_zone = null)
 	if(reagents?.total_volume && blocked < 100 && isliving(target))
 		var/mob/living/L = target
 		if(L.can_inject(null, def_zone) == CAN_INJECT)
-			reagents.trans_to_mob(L, reagent_amount, CHEM_INJECT)
+			reagents.trans_to_mob(L, reagents.total_volume, CHEM_INJECT)
 
 /obj/item/ammo_casing/chemdart
 	name = "chemical dart"

--- a/code/modules/projectiles/guns/launcher/pneumatic.dm
+++ b/code/modules/projectiles/guns/launcher/pneumatic.dm
@@ -111,7 +111,7 @@
 
 /obj/item/gun/launcher/pneumatic/update_release_force(obj/item/projectile)
 	if(tank)
-		release_force = ((fire_pressure*tank.air_volume)/projectile.w_class)/force_divisor //projectile speed.
+		release_force = ((fire_pressure*tank.gas_volume)/projectile.w_class)/force_divisor //projectile speed.
 		if(release_force > 80) release_force = 80 //damage cap.
 	else
 		release_force = 0

--- a/code/modules/projectiles/guns/launcher/pneumatic.dm
+++ b/code/modules/projectiles/guns/launcher/pneumatic.dm
@@ -111,7 +111,7 @@
 
 /obj/item/gun/launcher/pneumatic/update_release_force(obj/item/projectile)
 	if(tank)
-		release_force = ((fire_pressure*tank.volume)/projectile.w_class)/force_divisor //projectile speed.
+		release_force = ((fire_pressure*tank.air_volume)/projectile.w_class)/force_divisor //projectile speed.
 		if(release_force > 80) release_force = 80 //damage cap.
 	else
 		release_force = 0

--- a/code/modules/projectiles/guns/projectile/dartgun.dm
+++ b/code/modules/projectiles/guns/projectile/dartgun.dm
@@ -22,7 +22,7 @@
 	var/list/starting_chems = null
 
 /obj/item/gun/projectile/dartgun/Initialize()
-	initialize_reagents()
+	chem_volume = length(starting_chems) * 60
 	. = ..()
 	update_icon()
 
@@ -89,8 +89,8 @@
 
 //fills the given dart with reagents
 /obj/item/gun/projectile/dartgun/proc/fill_dart(var/obj/item/projectile/bullet/chemdart/dart)
-	if(mixing.len)
-		var/mix_amount = dart.reagent_amount/mixing.len
+	if(length(mixing))
+		var/mix_amount = dart.reagents?.total_volume/length(mixing)
 		for(var/obj/item/chems/glass/beaker/B in mixing)
 			B.reagents.trans_to_obj(dart, mix_amount)
 

--- a/code/modules/reagents/Chemistry-Holder.dm
+++ b/code/modules/reagents/Chemistry-Holder.dm
@@ -460,19 +460,19 @@ var/global/datum/reagents/sink/infinite_reagent_sink = new
 	for(var/decl/material/reagent as anything in liquid_volumes)
 		if(scannable_only && !reagent.scannable)
 			continue
-		var/volume = REAGENT_VOLUME(src, reagent)
+		var/scan_volume = REAGENT_VOLUME(src, reagent)
 		if(precision)
-			volume = round(volume, precision)
-		if(volume)
-			. += "[reagent.get_reagent_name(src, MAT_PHASE_LIQUID)] ([volume])"
+			scan_volume = round(scan_volume, precision)
+		if(scan_volume)
+			. += "[reagent.get_reagent_name(src, MAT_PHASE_LIQUID)] ([scan_volume])"
 	for(var/decl/material/reagent as anything in solid_volumes)
 		if(scannable_only && !reagent.scannable)
 			continue
-		var/volume = REAGENT_VOLUME(src, reagent)
+		var/scan_volume = REAGENT_VOLUME(src, reagent)
 		if(precision)
-			volume = round(volume, precision)
-		if(volume)
-			. += "[reagent.get_reagent_name(src, MAT_PHASE_SOLID)] ([volume])"
+			scan_volume = round(scan_volume, precision)
+		if(scan_volume)
+			. += "[reagent.get_reagent_name(src, MAT_PHASE_SOLID)] ([scan_volume])"
 	return english_list(., "EMPTY", "", ", ", ", ")
 
 /datum/reagents/proc/get_dirtiness()

--- a/code/modules/reagents/Chemistry-Holder.dm
+++ b/code/modules/reagents/Chemistry-Holder.dm
@@ -905,8 +905,7 @@ var/global/datum/reagents/sink/infinite_reagent_sink = new
 		qdel(reagent)
 		return
 
-	if(!target.reagents)
-		target.create_reagents(FLUID_MAX_DEPTH)
+	target.create_or_update_reagents(FLUID_MAX_DEPTH)
 
 	. = trans_to_holder(target.reagents, amount, multiplier, copy, defer_update = defer_update, transferred_phases = transferred_phases)
 	// Deferred updates are presumably being done by SSfluids.
@@ -986,6 +985,16 @@ var/global/datum/reagents/sink/infinite_reagent_sink = new
 	else
 		reagents = new/datum/reagents(max_vol, src)
 	return reagents
+
+/atom/proc/create_or_update_reagents(_vol, override_volume)
+	if(reagents)
+		if(override_volume)
+			reagents.maximum_volume = _vol // should we remove excess reagents here?
+		else
+			reagents.maximum_volume = max(reagents.maximum_volume, _vol)
+		reagents.update_total()
+		return reagents
+	return create_reagents(_vol)
 
 /// Infinite reagent sink: nothing is ever actually added to it, useful for complex, filtered deletion of reagents without holder churn.
 /datum/reagents/sink

--- a/code/modules/reagents/Chemistry-Machinery.dm
+++ b/code/modules/reagents/Chemistry-Machinery.dm
@@ -17,6 +17,7 @@
 	base_type = /obj/machinery/chem_master
 	atom_flags = ATOM_FLAG_OPEN_CONTAINER
 	core_skill = SKILL_CHEMISTRY
+	chem_volume = 120
 
 	var/obj/item/chems/beaker = null
 	var/obj/item/pill_bottle/loaded_pill_bottle = null
@@ -27,16 +28,11 @@
 	var/list/client/has_sprites = list()
 	var/max_pill_count = 20
 	var/sloppy = 1 //Whether reagents will not be fully purified (sloppy = 1) or there will be reagent loss (sloppy = 0) on reagent add.
-	var/reagent_limit = 120
 	var/bottle_label_color = COLOR_WHITE
 	var/bottle_lid_color = COLOR_OFF_WHITE
 
-/obj/machinery/chem_master/Initialize()
-	. = ..()
-	create_reagents(reagent_limit)
-
 /obj/machinery/chem_master/proc/get_remaining_volume()
-	return clamp(reagent_limit - reagents.total_volume, 0, reagent_limit)
+	return reagents ? clamp(reagents.maximum_volume - reagents.total_volume, 0, reagents.maximum_volume) : 0
 
 /obj/machinery/chem_master/attackby(var/obj/item/used_item, var/mob/user)
 

--- a/code/modules/reagents/chems/chems_blood.dm
+++ b/code/modules/reagents/chems/chems_blood.dm
@@ -65,10 +65,10 @@
 
 /decl/material/liquid/blood/affect_blood(var/mob/living/M, var/removed, var/datum/reagents/holder)
 	if(ishuman(M))
-		var/volume = REAGENT_VOLUME(holder, src)
+		var/affect_volume = REAGENT_VOLUME(holder, src)
 		var/mob/living/human/H = M
-		H.inject_blood(volume, holder)
-		holder.remove_reagent(type, volume)
+		H.inject_blood(affect_volume, holder)
+		holder.remove_reagent(type, affect_volume)
 	. = ..()
 
 /decl/material/liquid/blood/get_reagent_color(datum/reagents/holder)

--- a/code/modules/reagents/chems/chems_compounds.dm
+++ b/code/modules/reagents/chems/chems_compounds.dm
@@ -283,14 +283,14 @@
 
 /decl/material/liquid/lactate/affect_blood(var/mob/living/M, var/removed, var/datum/reagents/holder)
 	. = ..()
-	var/volume = REAGENT_VOLUME(holder, src)
+	var/affect_volume = REAGENT_VOLUME(holder, src)
 	M.add_chemical_effect(CE_PULSE, 1)
-	if(volume >= 10)
+	if(affect_volume >= 10)
 		M.add_chemical_effect(CE_PULSE, 1)
-		M.add_chemical_effect(CE_SLOWDOWN, (volume/15) ** 2)
+		M.add_chemical_effect(CE_SLOWDOWN, (affect_volume/15) ** 2)
 	else if(CHEM_DOSE(M, src) > 30) //after prolonged exertion
 		ADJ_STATUS(M, STAT_JITTER, 5)
-		M.add_chemical_effect(CE_BREATHLOSS, 0.02 * volume)
+		M.add_chemical_effect(CE_BREATHLOSS, 0.02 * affect_volume)
 
 /decl/material/liquid/nanoblood
 	name = "nanoblood"

--- a/code/modules/reagents/chems/chems_drinks.dm
+++ b/code/modules/reagents/chems/chems_drinks.dm
@@ -369,10 +369,10 @@
 	if(M.has_trait(/decl/trait/metabolically_inert))
 		return
 
-	var/volume = REAGENT_VOLUME(holder, src)
-	if(volume > 15)
+	var/affect_volume = REAGENT_VOLUME(holder, src)
+	if(affect_volume > 15)
 		M.add_chemical_effect(CE_PULSE, 1)
-	if(volume > 45)
+	if(affect_volume > 45)
 		M.add_chemical_effect(CE_PULSE, 1)
 
 /decl/material/liquid/drink/coffee/affect_blood(var/mob/living/M, var/removed, var/datum/reagents/holder)

--- a/code/modules/reagents/chems/chems_drugs.dm
+++ b/code/modules/reagents/chems/chems_drugs.dm
@@ -50,14 +50,14 @@
 	uid = "chem_nicotine"
 
 /decl/material/liquid/nicotine/affect_blood(var/mob/living/M, var/removed, var/datum/reagents/holder)
-	var/volume = REAGENT_VOLUME(holder, src)
+	var/affect_volume = REAGENT_VOLUME(holder, src)
 	. = ..()
-	if(prob(volume*20))
+	if(prob(affect_volume*20))
 		M.add_chemical_effect(CE_PULSE, 1)
 
 	var/update_data = FALSE
 	var/list/data = REAGENT_DATA(holder, src)
-	if(volume <= 0.02 && CHEM_DOSE(M, src) >= 0.05 && world.time > LAZYACCESS(data, DATA_COOLDOWN_TIME) + 3 MINUTES)
+	if(affect_volume <= 0.02 && CHEM_DOSE(M, src) >= 0.05 && world.time > LAZYACCESS(data, DATA_COOLDOWN_TIME) + 3 MINUTES)
 		update_data = TRUE
 		to_chat(M, "<span class='warning'>You feel antsy, your concentration wavers...</span>")
 	else if(world.time > LAZYACCESS(data, DATA_COOLDOWN_TIME) + 3 MINUTES)

--- a/code/modules/reagents/chems/chems_explosives.dm
+++ b/code/modules/reagents/chems/chems_explosives.dm
@@ -11,22 +11,22 @@
 /decl/material/liquid/anfo/explosion_act(obj/item/chems/holder, severity)
 	. = ..()
 	if(.)
-		var/volume = REAGENT_VOLUME(holder?.reagents, type)
-		var/activated_volume = volume
+		var/affect_volume = REAGENT_VOLUME(holder?.reagents, type)
+		var/activated_volume = affect_volume
 		switch(severity)
 			if(2)
-				if(prob(max(0, 2*(volume - 120))))
-					activated_volume = rand(volume/4, volume)
+				if(prob(max(0, 2*(affect_volume - 120))))
+					activated_volume = rand(affect_volume/4, affect_volume)
 			if(3)
-				if(prob(max(0, 2*(volume - 60))))
-					activated_volume = rand(volume, 120)
+				if(prob(max(0, 2*(affect_volume - 60))))
+					activated_volume = rand(affect_volume, 120)
 		if(activated_volume < 30) //whiff
 			return
 		var/turf/T = get_turf(holder)
 		if(T)
 			var/adj_power = round(boompower * activated_volume/60)
 			var/datum/gas_mixture/products = new(_temperature = 5 * FLAMMABLE_GAS_FLASHPOINT)
-			var/gas_moles = 3 * volume
+			var/gas_moles = 3 * affect_volume
 			products.adjust_gas(/decl/material/gas/carbon_dioxide, 0.5 * gas_moles, FALSE)
 			products.adjust_gas(/decl/material/gas/nitrogen, 0.3 * gas_moles, FALSE)
 			products.adjust_gas(/decl/material/liquid/water, 0.2 * gas_moles, TRUE)

--- a/code/modules/reagents/chems/chems_fuel.dm
+++ b/code/modules/reagents/chems/chems_fuel.dm
@@ -20,24 +20,24 @@
 /decl/material/liquid/fuel/explosion_act(obj/item/chems/holder, severity)
 	. = ..()
 	if(.)
-		var/volume = REAGENT_VOLUME(holder?.reagents, type)
-		if(volume <= 50)
+		var/product_volume = REAGENT_VOLUME(holder?.reagents, type)
+		if(product_volume <= 50)
 			return
 		var/turf/T = get_turf(holder)
 		var/datum/gas_mixture/products = new(_temperature = 5 * FLAMMABLE_GAS_FLASHPOINT)
-		var/gas_moles = 3 * volume
+		var/gas_moles = 3 * product_volume
 		products.adjust_gas(/decl/material/gas/nitricoxide, 0.1 * gas_moles, FALSE)
 		products.adjust_gas(/decl/material/gas/nitrodioxide, 0.1 * gas_moles, FALSE)
 		products.adjust_gas(/decl/material/gas/nitrogen, 0.6 * gas_moles, FALSE)
 		products.adjust_gas(/decl/material/gas/hydrogen, 0.02 * gas_moles, TRUE)
 		T.assume_air(products)
-		if(volume > 500)
+		if(product_volume > 500)
 			explosion(T,1,2,4)
-		else if(volume > 100)
+		else if(product_volume > 100)
 			explosion(T,0,1,3)
-		else if(volume > 50)
+		else if(product_volume > 50)
 			explosion(T,-1,1,2)
-		holder?.reagents?.remove_reagent(type, volume)
+		holder?.reagents?.remove_reagent(type, product_volume)
 
 /decl/material/liquid/fuel/hydrazine
 	name = "hydrazine"

--- a/code/modules/reagents/chems/chems_medicines.dm
+++ b/code/modules/reagents/chems/chems_medicines.dm
@@ -226,18 +226,18 @@
 	uid = "chem_adrenaline"
 
 /decl/material/liquid/adrenaline/affect_blood(var/mob/living/M, var/removed, var/datum/reagents/holder)
-	var/volume = REAGENT_VOLUME(holder, src)
+	var/affect_volume = REAGENT_VOLUME(holder, src)
 	var/dose = CHEM_DOSE(M, src)
 	. = ..()
 	if(dose < 0.2)	//not that effective after initial rush
-		M.add_chemical_effect(CE_PAINKILLER, min(30*volume, 80))
+		M.add_chemical_effect(CE_PAINKILLER, min(30*affect_volume, 80))
 		M.add_chemical_effect(CE_PULSE, 1)
 	else if(dose < 1)
-		M.add_chemical_effect(CE_PAINKILLER, min(10*volume, 20))
+		M.add_chemical_effect(CE_PAINKILLER, min(10*affect_volume, 20))
 	M.add_chemical_effect(CE_PULSE, 2)
 	if(dose > 10)
 		ADJ_STATUS(M, STAT_JITTER, 5)
-	if(volume >= 5 && M.is_asystole())
+	if(affect_volume >= 5 && M.is_asystole())
 		holder.remove_reagent(type, 5)
 		if(ishuman(M))
 			var/mob/living/human/H = M

--- a/code/modules/reagents/chems/chems_painkillers.dm
+++ b/code/modules/reagents/chems/chems_painkillers.dm
@@ -43,14 +43,14 @@
 	narcotic = TRUE
 
 /decl/material/liquid/painkillers/affect_blood(var/mob/living/M, var/removed, var/datum/reagents/holder)
-	var/volume = REAGENT_VOLUME(holder, src)
+	var/affect_volume = REAGENT_VOLUME(holder, src)
 	var/dose = CHEM_DOSE(M, src)
 	. = ..()
 	var/effectiveness = 1
 	if(dose < effective_dose) //some ease-in ease-out for the effect
 		effectiveness = dose/effective_dose
-	else if(volume < effective_dose)
-		effectiveness = volume/effective_dose
+	else if(affect_volume < effective_dose)
+		effectiveness = affect_volume/effective_dose
 
 	M.add_chemical_effect(CE_PAINKILLER, (pain_power * effectiveness))
 

--- a/code/modules/reagents/chems/chems_psychiatric.dm
+++ b/code/modules/reagents/chems/chems_psychiatric.dm
@@ -14,13 +14,13 @@
 	var/effect_cooldown = 5 MINUTES
 
 /decl/material/liquid/accumulated/affect_blood(mob/living/victim, removed, datum/reagents/holder)
-	var/volume = REAGENT_VOLUME(holder, src)
+	var/affect_volume = REAGENT_VOLUME(holder, src)
 	. = ..()
 
 	var/update_data = FALSE
 	var/list/data = REAGENT_DATA(holder, src)
 	var/is_off_cooldown = world.time > LAZYACCESS(data, DATA_COOLDOWN_TIME) + effect_cooldown
-	if(volume <= required_volume && CHEM_DOSE(victim, src) >= required_dose)
+	if(affect_volume <= required_volume && CHEM_DOSE(victim, src) >= required_dose)
 		update_data = discontinuation_effect(victim, removed, holder, is_off_cooldown)
 	else
 		update_data = positive_effect(victim, removed, holder, is_off_cooldown)

--- a/code/modules/reagents/dispenser/cartridge.dm
+++ b/code/modules/reagents/dispenser/cartridge.dm
@@ -9,11 +9,14 @@
 	material = /decl/material/solid/stone/ceramic
 	// Large, but inaccurate. Use a chem dispenser or beaker for accuracy.
 	possible_transfer_amounts = @"[50,100]"
+	var/_reagent_label
 
 /obj/item/chems/chem_disp_cartridge/Initialize()
 	. = ..()
-	if(reagents?.primary_reagent)
-		setLabel(reagents.get_primary_reagent_name())
+	if(reagents?.primary_reagent && !_reagent_label)
+		_reagent_label = reagents.get_primary_reagent_name()
+	if(_reagent_label)
+		setLabel(_reagent_label)
 
 /obj/item/chems/chem_disp_cartridge/get_examine_strings(mob/user, distance, infix, suffix)
 	. = ..()

--- a/code/modules/reagents/dispenser/cartridge.dm
+++ b/code/modules/reagents/dispenser/cartridge.dm
@@ -4,24 +4,24 @@
 	icon = 'icons/obj/items/chem/chem_cartridge.dmi'
 	icon_state = "cartridge"
 	w_class = ITEM_SIZE_NORMAL
-	volume = CARTRIDGE_VOLUME_LARGE
+	chem_volume = CARTRIDGE_VOLUME_LARGE
 	amount_per_transfer_from_this = 50
 	material = /decl/material/solid/stone/ceramic
 	// Large, but inaccurate. Use a chem dispenser or beaker for accuracy.
 	possible_transfer_amounts = @"[50,100]"
 
-/obj/item/chems/chem_disp_cartridge/initialize_reagents(populate = TRUE)
+/obj/item/chems/chem_disp_cartridge/Initialize()
 	. = ..()
-	if(populate && reagents.primary_reagent)
+	if(reagents?.primary_reagent)
 		setLabel(reagents.get_primary_reagent_name())
 
 /obj/item/chems/chem_disp_cartridge/get_examine_strings(mob/user, distance, infix, suffix)
 	. = ..()
-	. += "It has a capacity of [volume] units."
-	if(reagents.total_volume <= 0)
+	. += "It has a capacity of [reagents?.maximum_volume || 0] unit\s."
+	if(reagents?.total_volume <= 0)
 		. += "It is empty."
 	else
-		. += "It contains [reagents.total_volume] units of reagents."
+		. += "It contains [reagents?.total_volume || 0] unit\s of reagents."
 	if(!ATOM_IS_OPEN_CONTAINER(src))
 		. += "The cap is sealed."
 

--- a/code/modules/reagents/dispenser/cartridge_presets.dm
+++ b/code/modules/reagents/dispenser/cartridge_presets.dm
@@ -1,8 +1,8 @@
 /obj/item/chems/chem_disp_cartridge/small
-	volume = CARTRIDGE_VOLUME_SMALL
+	chem_volume = CARTRIDGE_VOLUME_SMALL
 
 /obj/item/chems/chem_disp_cartridge/medium
-	volume = CARTRIDGE_VOLUME_MEDIUM
+	chem_volume = CARTRIDGE_VOLUME_MEDIUM
 
 /**
  * Helper macro to define a new cartridge type for a given reagent.

--- a/code/modules/reagents/dispenser/cartridge_spawn.dm
+++ b/code/modules/reagents/dispenser/cartridge_spawn.dm
@@ -8,7 +8,7 @@
 		if("medium") cartridge_type = /obj/item/chems/chem_disp_cartridge/medium
 		if("large") cartridge_type = /obj/item/chems/chem_disp_cartridge
 	var/obj/item/chems/chem_disp_cartridge/cartridge = new cartridge_type(usr.loc)
-	cartridge.add_to_reagents(reagent_type, cartridge.volume)
+	cartridge.add_to_reagents(reagent_type, cartridge.reagents?.maximum_volume)
 	var/reagent_name = cartridge.reagents.get_primary_reagent_name()
 	cartridge.setLabel(reagent_name)
 	log_and_message_admins("spawned a [size] reagent container containing [reagent_name] ([reagent_type])")

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -8,10 +8,10 @@
 	obj_flags = OBJ_FLAG_HOLLOW
 	abstract_type = /obj/item/chems
 	watertight = TRUE
+	chem_volume = 30
 
 	var/amount_per_transfer_from_this = 5
 	var/possible_transfer_amounts = @"[5,10,15,25,30]"
-	var/volume = 30
 	var/label_text
 	var/presentation_flags = 0
 	var/detail_color
@@ -19,7 +19,6 @@
 
 /obj/item/chems/Initialize(ml, material_key)
 	. = ..()
-	initialize_reagents()
 	if(!possible_transfer_amounts)
 		src.verbs -= /obj/item/chems/verb/set_amount_per_transfer_from_this
 
@@ -149,13 +148,6 @@
 	//Skip splashing if we are in nullspace, since splash isn't null guarded
 	if(loc)
 		reagents.splash(get_turf(src), reagents.total_volume)
-	. = ..()
-
-/obj/item/chems/initialize_reagents(populate = TRUE)
-	if(!reagents)
-		create_reagents(volume)
-	else
-		reagents.maximum_volume = max(reagents.maximum_volume, volume)
 	. = ..()
 
 /obj/item/chems/proc/set_detail_color(var/new_color)

--- a/code/modules/reagents/reagent_containers/_glass.dm
+++ b/code/modules/reagents/reagent_containers/_glass.dm
@@ -9,7 +9,7 @@
 	item_state = "null"
 	amount_per_transfer_from_this = 10
 	possible_transfer_amounts = @"[5,10,15,25,30,60]"
-	volume = 60
+	chem_volume = 60
 	w_class = ITEM_SIZE_SMALL
 	atom_flags = ATOM_FLAG_OPEN_CONTAINER
 	obj_flags = OBJ_FLAG_HOLLOW

--- a/code/modules/reagents/reagent_containers/beaker.dm
+++ b/code/modules/reagents/reagent_containers/beaker.dm
@@ -15,7 +15,7 @@
 
 /obj/item/chems/glass/beaker/get_examine_strings(mob/user, distance, infix, suffix)
 	. = ..()
-	. += "It can hold up to [volume] units."
+	. += "It can hold up to [reagents?.maximum_volume] units."
 
 /obj/item/chems/glass/beaker/on_picked_up(mob/user, atom/old_loc)
 	. = ..()
@@ -33,7 +33,7 @@
 
 	if(reagents?.total_volume)
 		var/image/filling = mutable_appearance(icon, "[icon_state]1", reagents.get_color())
-		var/percent = round((reagents.total_volume / volume) * 100)
+		var/percent = round((reagents.total_volume / reagents.maximum_volume) * 100)
 		switch(percent)
 			if(0 to 9)			filling.icon_state = "[icon_state]1"
 			if(10 to 24) 		filling.icon_state = "[icon_state]10"
@@ -69,7 +69,7 @@
 	desc = "A large beaker."
 	icon = 'icons/obj/items/chem/beakers/large.dmi'
 	center_of_mass = @'{"x":16,"y":10}'
-	volume = 120
+	chem_volume = 120
 	amount_per_transfer_from_this = 10
 	possible_transfer_amounts = @"[5,10,15,25,30,60,120]"
 	w_class = ITEM_SIZE_LARGE
@@ -79,7 +79,7 @@
 	desc = "A large mixing bowl."
 	icon = 'icons/obj/items/chem/mixingbowl.dmi'
 	center_of_mass = @'{"x":16,"y":10}'
-	volume = 180
+	chem_volume = 180
 	amount_per_transfer_from_this = 10
 	possible_transfer_amounts = @"[5,10,15,25,30,60,180]"
 	atom_flags = ATOM_FLAG_OPEN_CONTAINER
@@ -96,7 +96,7 @@
 	desc = "A heavy kettle for heating water."
 	icon = 'icons/obj/items/chem/kettle.dmi'
 	icon_state = ICON_STATE_WORLD
-	volume = 180
+	chem_volume = 180
 	amount_per_transfer_from_this = 10
 	possible_transfer_amounts = @"[5,10,15,25,30,60,180]"
 	atom_flags = ATOM_FLAG_OPEN_CONTAINER
@@ -112,7 +112,7 @@
 	desc = "A cryostasis beaker that allows for chemical storage without reactions."
 	icon = 'icons/obj/items/chem/beakers/stasis.dmi'
 	center_of_mass = @'{"x":16,"y":8}'
-	volume = 60
+	chem_volume = 60
 	amount_per_transfer_from_this = 10
 	atom_flags = ATOM_FLAG_OPEN_CONTAINER | ATOM_FLAG_NO_CHEM_CHANGE
 	presentation_flags = PRESENTATION_FLAG_NAME
@@ -126,7 +126,7 @@
 	desc = "An advanced beaker, powered by experimental technology."
 	icon = 'icons/obj/items/chem/beakers/advanced.dmi'
 	center_of_mass = @'{"x":16,"y":10}'
-	volume = 300
+	chem_volume = 300
 	amount_per_transfer_from_this = 10
 	possible_transfer_amounts = @"[5,10,15,25,30,60,120,150,200,250,300]"
 	material_alteration = MAT_FLAG_ALTERATION_NONE
@@ -143,7 +143,7 @@
 	desc = "A small glass vial."
 	icon = 'icons/obj/items/chem/vial.dmi'
 	center_of_mass = @'{"x":15,"y":8}'
-	volume = 30
+	chem_volume = 30
 	w_class = ITEM_SIZE_TINY //half the volume of a bottle, half the size
 	amount_per_transfer_from_this = 10
 	possible_transfer_amounts = @"[5,10,15,30]"
@@ -178,7 +178,7 @@
 	icon = 'icons/obj/items/chem/beakers/insulated_large.dmi'
 	center_of_mass = @'{"x":16,"y":10}'
 	matter = list(/decl/material/solid/organic/plastic = MATTER_AMOUNT_REINFORCEMENT)
-	volume = 120
+	chem_volume = 120
 
 /obj/item/chems/glass/beaker/sulfuric/populate_reagents()
 	add_to_reagents(/decl/material/liquid/acid, reagents.maximum_volume)

--- a/code/modules/reagents/reagent_containers/blood_pack.dm
+++ b/code/modules/reagents/reagent_containers/blood_pack.dm
@@ -12,7 +12,7 @@
 	icon = 'icons/obj/bloodpack.dmi'
 	icon_state = "empty"
 	w_class = ITEM_SIZE_SMALL
-	volume = 120
+	chem_volume = 120
 	possible_transfer_amounts = @"[0.2,1,2]"
 	amount_per_transfer_from_this = REM
 	atom_flags = ATOM_FLAG_OPEN_CONTAINER
@@ -27,14 +27,14 @@
 /obj/item/chems/ivbag/on_reagent_change()
 	if(!(. = ..()))
 		return
-	if(reagents?.total_volume > volume/2)
+	if(reagents?.total_volume > reagents?.maximum_volume / 2)
 		w_class = ITEM_SIZE_NORMAL
 	else
 		w_class = ITEM_SIZE_SMALL
 
 /obj/item/chems/ivbag/on_update_icon()
 	. = ..()
-	var/percent = round(reagents?.total_volume / volume * 100)
+	var/percent = round(reagents?.total_volume / reagents?.maximum_volume * 100)
 	if(percent)
 		add_overlay(overlay_image(icon, "[round(percent,25)]", reagents.get_color()))
 	add_overlay(attached? "dongle" : "top")

--- a/code/modules/reagents/reagent_containers/borghypo.dm
+++ b/code/modules/reagents/reagent_containers/borghypo.dm
@@ -13,7 +13,7 @@
 	var/recharge_time = 5 //Time it takes for shots to recharge (in seconds)
 
 /obj/item/chems/borghypo/Initialize()
-	volume *= length(get_generated_reagents())
+	chem_volume *= length(get_generated_reagents())
 	. = ..()
 
 /obj/item/chems/borghypo/proc/get_generated_reagents()

--- a/code/modules/reagents/reagent_containers/borghypo.dm
+++ b/code/modules/reagents/reagent_containers/borghypo.dm
@@ -3,7 +3,7 @@
 	desc = "An advanced chemical synthesizer and injection system, designed for heavy-duty medical equipment."
 	icon = 'icons/obj/hypospray_borg.dmi'
 	amount_per_transfer_from_this = 5
-	volume = 30
+	chem_volume = 30
 	possible_transfer_amounts = null
 	max_health = ITEM_HEALTH_NO_DAMAGE
 
@@ -137,7 +137,7 @@
 	icon_state = "shaker"
 	charge_cost = 5
 	recharge_time = 3
-	volume = 60
+	chem_volume = 60
 	possible_transfer_amounts = @"[5,10,20,30]"
 
 /obj/item/chems/borghypo/service/get_generated_reagents()

--- a/code/modules/reagents/reagent_containers/bowl.dm
+++ b/code/modules/reagents/reagent_containers/bowl.dm
@@ -6,7 +6,7 @@
 	icon_state                    = ICON_STATE_WORLD
 	material_alteration           = MAT_FLAG_ALTERATION_COLOR | MAT_FLAG_ALTERATION_NAME
 	presentation_flags            = PRESENTATION_FLAG_NAME
-	volume                        = 30
+	chem_volume                   = 30
 	amount_per_transfer_from_this = 5
 
 /obj/item/chems/glass/bowl/can_lid()

--- a/code/modules/reagents/reagent_containers/bucket.dm
+++ b/code/modules/reagents/reagent_containers/bucket.dm
@@ -7,7 +7,7 @@
 	w_class = ITEM_SIZE_NORMAL
 	amount_per_transfer_from_this = 20
 	possible_transfer_amounts = @"[10,20,30,60,120,150,180]"
-	volume = 180
+	chem_volume = 180
 	atom_flags = ATOM_FLAG_OPEN_CONTAINER
 	presentation_flags = PRESENTATION_FLAG_NAME
 	material = /decl/material/solid/organic/plastic
@@ -44,14 +44,14 @@
 /obj/item/chems/glass/bucket/get_reagents_overlay(state_prefix)
 	if(!ATOM_IS_OPEN_CONTAINER(src))
 		return null // no overlay while closed!
-	if(!reagents || (reagents.total_volume / volume) < 0.8)
+	if(!reagents || (reagents.total_volume / reagents.maximum_volume) < 0.8)
 		return null // must be at least 80% full to show
 	return ..()
 
 /obj/item/chems/glass/bucket/wood
 	desc = "It's a wooden bucket. How rustic."
 	icon = 'icons/obj/items/wooden_bucket.dmi'
-	volume = 200
+	chem_volume = 200
 	material = /decl/material/solid/organic/wood/oak
 	material_alteration = MAT_FLAG_ALTERATION_NAME | MAT_FLAG_ALTERATION_COLOR //  name is already modified
 	/// The material used for the chain, belts, and rivets holding the wood together, typically iron or steel.

--- a/code/modules/reagents/reagent_containers/condiments/__condiment.dm
+++ b/code/modules/reagents/reagent_containers/condiments/__condiment.dm
@@ -7,7 +7,7 @@
 	possible_transfer_amounts = @"[1,5,10]"
 	center_of_mass = @'{"x":16,"y":6}'
 	randpixel = 6
-	volume = 50
+	chem_volume = 50
 	var/condiment_key
 	var/morphic_container = TRUE
 	var/use_condiment_name = TRUE

--- a/code/modules/reagents/reagent_containers/condiments/_condiment_large.dm
+++ b/code/modules/reagents/reagent_containers/condiments/_condiment_large.dm
@@ -1,6 +1,6 @@
 /obj/item/chems/condiment/large
 	name = "large condiment container"
 	possible_transfer_amounts = @"[1,5,10,20,50,100]"
-	volume = 500
+	chem_volume = 500
 	w_class = ITEM_SIZE_LARGE
 	use_condiment_name = FALSE

--- a/code/modules/reagents/reagent_containers/condiments/_condiment_small.dm
+++ b/code/modules/reagents/reagent_containers/condiments/_condiment_small.dm
@@ -3,5 +3,5 @@
 	name = "small condiment container"
 	possible_transfer_amounts = @"[1,2,5,8,10,20]"
 	amount_per_transfer_from_this = 1
-	volume = 20
+	chem_volume = 20
 	use_condiment_name = FALSE

--- a/code/modules/reagents/reagent_containers/condiments/condiments_small.dm
+++ b/code/modules/reagents/reagent_containers/condiments/condiments_small.dm
@@ -2,7 +2,7 @@
 	name = "small condiment container"
 	possible_transfer_amounts = @"[1,2,5,8,10,20]"
 	amount_per_transfer_from_this = 1
-	volume = 20
+	chem_volume = 20
 	condiment_key = "small"
 
 #define MAPPED_CONDIMENT_TYPE(ID, TYPE) \

--- a/code/modules/reagents/reagent_containers/drinkingglass/drinkingglass.dm
+++ b/code/modules/reagents/reagent_containers/drinkingglass/drinkingglass.dm
@@ -12,7 +12,7 @@ var/global/const/DRINK_ICON_NOISY = "noise"
 	icon_state = null
 	base_icon = "square" // Base icon name
 	filling_states = @"[20,40,60,80,100]"
-	volume = 30
+	chem_volume = 30
 	material = /decl/material/solid/glass
 	drop_sound = 'sound/foley/bottledrop1.ogg'
 	pickup_sound = 'sound/foley/bottlepickup1.ogg'
@@ -77,7 +77,7 @@ var/global/const/DRINK_ICON_NOISY = "noise"
 			for(var/decl/material/reagent as anything in reagents.reagent_volumes)
 				if("vapor" in reagent.glass_special)
 					totalvape += REAGENT_VOLUME(reagents, reagent)
-			if(totalvape >= volume * 0.6) // 60% vapor by container volume
+			if(totalvape >= reagents.maximum_volume * 0.6) // 60% vapor by container volume
 				return 1
 	return 0
 

--- a/code/modules/reagents/reagent_containers/drinkingglass/glass_types.dm
+++ b/code/modules/reagents/reagent_containers/drinkingglass/glass_types.dm
@@ -5,7 +5,7 @@
 	icon = 'icons/obj/drink_glasses/square.dmi'
 	desc = "Your standard drinking glass."
 	filling_states = @"[20,40,60,80,100]"
-	volume = 30
+	chem_volume = 30
 	possible_transfer_amounts = @"[5,10,15,30]"
 	rim_pos = @'{"y":23,"x_left":13,"x_right":20}'
 
@@ -16,7 +16,7 @@
 	icon_state = "rocks"
 	icon = 'icons/obj/drink_glasses/rocks.dmi'
 	filling_states = @"[25,50,75,100]"
-	volume = 20
+	chem_volume = 20
 	possible_transfer_amounts = @"[5,10,20]"
 	rim_pos = @'{"y":21,"x_left":10,"x_right":23}'
 
@@ -27,7 +27,7 @@
 	icon_state = "shake"
 	icon = 'icons/obj/drink_glasses/shake.dmi'
 	filling_states = @"[25,50,75,100]"
-	volume = 30
+	chem_volume = 30
 	possible_transfer_amounts = @"[5,10,15,30]"
 	rim_pos = @'{"y":25,"x_left":13,"x_right":21}'
 
@@ -38,7 +38,7 @@
 	icon_state = "cocktail"
 	icon = 'icons/obj/drink_glasses/cocktail.dmi'
 	filling_states = @"[33,66,100]"
-	volume = 15
+	chem_volume = 15
 	possible_transfer_amounts = @"[5,10,15]"
 	rim_pos = @'{"y":22,"x_left":13,"x_right":21}'
 
@@ -49,7 +49,7 @@
 	icon_state = "shot"
 	icon = 'icons/obj/drink_glasses/shot.dmi'
 	filling_states = @"[33,66,100]"
-	volume = 5
+	chem_volume = 5
 	possible_transfer_amounts = @"[1,2,5]"
 	rim_pos = @'{"y":17,"x_left":13,"x_right":21}'
 
@@ -59,7 +59,7 @@
 	icon_state = "pint"
 	icon = 'icons/obj/drink_glasses/pint.dmi'
 	filling_states = @"[16,33,50,66,83,100]"
-	volume = 60
+	chem_volume = 60
 	possible_transfer_amounts = @"[5,10,15,30,60]"
 	rim_pos = @'{"y":25,"x_left":12,"x_right":21}'
 
@@ -70,7 +70,7 @@
 	icon_state = "mug"
 	icon = 'icons/obj/drink_glasses/mug.dmi'
 	filling_states = @"[25,50,75,100]"
-	volume = 40
+	chem_volume = 40
 	possible_transfer_amounts = @"[5,10,20,40]"
 	rim_pos = @'{"y":22,"x_left":12,"x_right":20}'
 
@@ -81,7 +81,7 @@
 	icon_state = "wine"
 	icon = 'icons/obj/drink_glasses/wine.dmi'
 	filling_states = @"[20,40,60,80,100]"
-	volume = 25
+	chem_volume = 25
 	possible_transfer_amounts = @"[5,10,15,25]"
 	rim_pos = @'{"y":25,"x_left":12,"x_right":21}'
 
@@ -91,7 +91,7 @@
 	base_icon = "flute"
 	icon_state = "flute"
 	icon = 'icons/obj/drink_glasses/flute.dmi'
-	volume = 25
+	chem_volume = 25
 	filling_states = @"[20,40,60,80,100]"
 	possible_transfer_amounts = @"[5,10,15,25]"
 	rim_pos = @'{"y":24,"x_left":13,"x_right":19}'
@@ -103,7 +103,7 @@
 	icon_state = "carafe"
 	icon = 'icons/obj/drink_glasses/carafe.dmi'
 	filling_states = @"[10,20,30,40,50,60,70,80,90,100]"
-	volume = 120
+	chem_volume = 120
 	possible_transfer_amounts = @"[5,10,15,30,60,120]"
 	rim_pos = @'{"y":26,"x_left":12,"x_right":21}'
 	center_of_mass = @'{"x":16,"y":7}'
@@ -114,7 +114,7 @@
 	icon = 'icons/obj/drink_glasses/coffecup.dmi'
 	icon_state = "coffeecup"
 	item_state = "coffee"
-	volume = 30
+	chem_volume = 30
 	center_of_mass = @'{"x":15,"y":13}'
 	filling_states = @"[40,80,100]"
 	base_name = "cup"
@@ -187,7 +187,7 @@
 	desc = "An unreasonably tall coffee cup, for when you really need to wake up in the morning."
 	icon = 'icons/obj/drink_glasses/coffecup_tall.dmi'
 	icon_state = "coffeecup_tall"
-	volume = 60
+	chem_volume = 60
 	center_of_mass = @'{"x":15,"y":19}'
 	filling_states = @"[50,70,90,100]"
 	base_name = "tall cup"
@@ -200,7 +200,7 @@
 	icon = 'icons/obj/drink_glasses/teacup.dmi'
 	icon_state = "teacup"
 	item_state = "coffee"
-	volume = 20
+	chem_volume = 20
 	filling_states = @"[100]"
 	base_name = "teacup"
 	base_icon = "teacup"

--- a/code/modules/reagents/reagent_containers/drinkingglass/shaker.dm
+++ b/code/modules/reagents/reagent_containers/drinkingglass/shaker.dm
@@ -6,7 +6,7 @@
 	icon_state = "fitness-cup_black"
 	base_icon = "fitness-cup"
 	icon = 'icons/obj/drink_glasses/fitness.dmi'
-	volume = 100
+	chem_volume = 100
 	material = /decl/material/solid/organic/plastic
 	filling_states = @"[10,20,30,40,50,60,70,80,90,100]"
 	possible_transfer_amounts = @"[5,10,15,25]"

--- a/code/modules/reagents/reagent_containers/drinks.dm
+++ b/code/modules/reagents/reagent_containers/drinks.dm
@@ -11,7 +11,7 @@
 	possible_transfer_amounts = null
 	amount_per_transfer_from_this = 5
 	randpixel = 6
-	volume = 50
+	chem_volume = 50
 	abstract_type = /obj/item/chems/drinks
 	watertight = FALSE // /drinks uses the open container flag for this
 
@@ -69,17 +69,17 @@
 		return
 	if(!reagents || reagents.total_volume == 0)
 		. += SPAN_NOTICE("\The [src] is empty!")
-	else if (reagents.total_volume <= volume * 0.25)
+	else if (reagents.total_volume <= reagents.maximum_volume * 0.25)
 		. += SPAN_NOTICE("\The [src] is almost empty!")
-	else if (reagents.total_volume <= volume * 0.66)
+	else if (reagents.total_volume <= reagents.maximum_volume * 0.66)
 		. += SPAN_NOTICE("\The [src] is half full!")
-	else if (reagents.total_volume <= volume * 0.90)
+	else if (reagents.total_volume <= reagents.maximum_volume * 0.90)
 		. += SPAN_NOTICE("\The [src] is almost full!")
 	else
 		. += SPAN_NOTICE("\The [src] is full!")
 
 /obj/item/chems/drinks/proc/get_filling_state()
-	var/percent = round((reagents.total_volume / volume) * 100)
+	var/percent = round((reagents.total_volume / reagents.maximum_volume) * 100)
 	for(var/k in cached_json_decode(filling_states))
 		if(percent <= k)
 			return k
@@ -102,7 +102,7 @@
 	w_class = ITEM_SIZE_HUGE
 	amount_per_transfer_from_this = 20
 	possible_transfer_amounts = null
-	volume = 150
+	chem_volume = 150
 	atom_flags = ATOM_FLAG_OPEN_CONTAINER
 	obj_flags = OBJ_FLAG_CONDUCTIBLE
 	_base_attack_force = 14
@@ -134,7 +134,7 @@
 
 /obj/item/chems/drinks/milk/smallcarton
 	name = "small milk carton"
-	volume = 30
+	chem_volume = 30
 	icon_state = "mini-milk"
 
 /obj/item/chems/drinks/milk/smallcarton/populate_reagents()
@@ -190,7 +190,7 @@
 	desc = "A paper water cup."
 	icon_state = "water_cup_e"
 	possible_transfer_amounts = null
-	volume = 10
+	chem_volume = 10
 	center_of_mass = @'{"x":16,"y":12}'
 
 /obj/item/chems/drinks/sillycup/on_update_icon()
@@ -212,7 +212,7 @@
 	icon_state = "teapot"
 	item_state = "teapot"
 	amount_per_transfer_from_this = 10
-	volume = 120
+	chem_volume = 120
 	center_of_mass = @'{"x":17,"y":7}'
 	material = /decl/material/solid/stone/ceramic
 	obj_flags = OBJ_FLAG_HOLLOW | OBJ_FLAG_INSULATED_HANDLE
@@ -221,7 +221,7 @@
 	name = "insulated pitcher"
 	desc = "A stainless steel insulated pitcher. Everyone's best friend in the morning."
 	icon_state = "pitcher"
-	volume = 120
+	chem_volume = 120
 	amount_per_transfer_from_this = 10
 	center_of_mass = @'{"x":16,"y":9}'
 	filling_states = @"[15,30,50,70,85,100]"
@@ -233,7 +233,7 @@
 	name = "\improper Captain's flask"
 	desc = "A metal flask belonging to the captain."
 	icon_state = "flask"
-	volume = 60
+	chem_volume = 60
 	center_of_mass = @'{"x":17,"y":7}'
 
 /obj/item/chems/drinks/flask/shiny
@@ -250,21 +250,21 @@
 	name = "\improper Detective's flask"
 	desc = "A metal flask with a leather band and golden badge belonging to the detective."
 	icon_state = "detflask"
-	volume = 60
+	chem_volume = 60
 	center_of_mass = @'{"x":17,"y":8}'
 
 /obj/item/chems/drinks/flask/barflask
 	name = "flask"
 	desc = "For those who can't be bothered to hang out at the bar to drink."
 	icon_state = "barflask"
-	volume = 60
+	chem_volume = 60
 	center_of_mass = @'{"x":17,"y":7}'
 
 /obj/item/chems/drinks/flask/vacuumflask
 	name = "vacuum flask"
 	desc = "Keeping your drinks at the perfect temperature since 1892."
 	icon_state = "vacuumflask"
-	volume = 60
+	chem_volume = 60
 	center_of_mass = @'{"x":15,"y":4}'
 
 //tea and tea accessories
@@ -276,7 +276,7 @@
 	center_of_mass = @'{"x":16,"y":14}'
 	filling_states = @"[100]"
 	base_icon = "cup"
-	volume = 30
+	chem_volume = 30
 
 /obj/item/chems/drinks/tea/black
 	name = "cup of black tea"

--- a/code/modules/reagents/reagent_containers/drinks/bottle.dm
+++ b/code/modules/reagents/reagent_containers/drinks/bottle.dm
@@ -5,7 +5,7 @@
 //#TODO: Maybe merge this with /obj/item/glass/bottle?
 /obj/item/chems/drinks/bottle
 	amount_per_transfer_from_this = 10
-	volume = 100
+	chem_volume = 100
 	item_state = "broken_beer" //Generic held-item sprite until unique ones are made.
 	material = /decl/material/solid/glass
 	drop_sound = 'sound/foley/bottledrop1.ogg'
@@ -600,7 +600,7 @@
 
 //Small bottles
 /obj/item/chems/drinks/bottle/small
-	volume = 50
+	chem_volume = 50
 	smash_duration = 1
 	atom_flags = 0 //starts closed
 	rag_underlay = "rag_small"

--- a/code/modules/reagents/reagent_containers/drinks/cans.dm
+++ b/code/modules/reagents/reagent_containers/drinks/cans.dm
@@ -1,5 +1,5 @@
 /obj/item/chems/drinks/cans
-	volume = 40 //just over one and a half cups
+	chem_volume = 40 //just over one and a half cups
 	amount_per_transfer_from_this = 5
 	atom_flags = 0 //starts closed
 	material = /decl/material/solid/metal/aluminium

--- a/code/modules/reagents/reagent_containers/drinks/cocktailshaker.dm
+++ b/code/modules/reagents/reagent_containers/drinks/cocktailshaker.dm
@@ -4,7 +4,7 @@
 	icon_state = "shaker"
 	amount_per_transfer_from_this = 10
 	possible_transfer_amounts = @"[5,10,15,25,30,60]" //Professional bartender should be able to transfer as much as needed
-	volume = 120
+	chem_volume = 120
 	center_of_mass = @'{"x":17,"y":10}'
 	atom_flags = ATOM_FLAG_OPEN_CONTAINER | ATOM_FLAG_NO_REACT
 

--- a/code/modules/reagents/reagent_containers/drinks/juicebox.dm
+++ b/code/modules/reagents/reagent_containers/drinks/juicebox.dm
@@ -3,7 +3,7 @@
 	icon_state = "juicebox_base"
 	name = "juicebox"
 	desc = "A small cardboard juicebox. Cheap and flimsy."
-	volume = 30
+	chem_volume = 30
 	amount_per_transfer_from_this = 5
 	atom_flags = 0
 	material = /decl/material/solid/organic/cardboard

--- a/code/modules/reagents/reagent_containers/dropper.dm
+++ b/code/modules/reagents/reagent_containers/dropper.dm
@@ -10,7 +10,7 @@
 	possible_transfer_amounts = @"[1,2,3,4,5]"
 	w_class = ITEM_SIZE_TINY
 	slot_flags = SLOT_EARS
-	volume = 5
+	chem_volume = 5
 	item_flags = ITEM_FLAG_NO_BLUDGEON
 
 /obj/item/chems/dropper/afterattack(var/obj/target, var/mob/user, var/proximity)
@@ -96,7 +96,7 @@
 	desc = "A larger dropper. Transfers 10 units."
 	amount_per_transfer_from_this = 10
 	possible_transfer_amounts = @"[1,2,3,4,5,6,7,8,9,10]"
-	volume = 10
+	chem_volume = 10
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Droppers. END

--- a/code/modules/reagents/reagent_containers/food.dm
+++ b/code/modules/reagents/reagent_containers/food.dm
@@ -21,9 +21,8 @@
 	w_class = ITEM_SIZE_SMALL
 	abstract_type = /obj/item/food
 	needs_attack_dexterity = DEXTERITY_NONE
+	chem_volume = 50
 
-	/// The maximum reagent volume of this food. Used in initialize_reagents.
-	var/volume = 50
 	/// Indicates the food should give a stress effect on eating.
 	// This is set to 1 if the food is created by a recipe, -1 if the food is raw.
 	var/cooked_food = FOOD_PREPARED
@@ -59,18 +58,10 @@
 	else if(!istype(plate))
 		plate = null
 
-	initialize_reagents()
 	if(isnull(_utensil_food_type))
 		_utensil_food_type = type
 	if(slice_path && slice_num)
 		utensil_flags |= UTENSIL_FLAG_SLICE
-
-/obj/item/food/initialize_reagents(populate = TRUE)
-	if(!reagents)
-		create_reagents(volume)
-	else
-		reagents.maximum_volume = max(reagents.maximum_volume, volume)
-	return ..()
 
 // Dummy type used solely for soup bowls/soup spoons.
 /obj/item/food/lump

--- a/code/modules/reagents/reagent_containers/food/burgers.dm
+++ b/code/modules/reagents/reagent_containers/food/burgers.dm
@@ -108,7 +108,7 @@
 	desc = "This massive patty looks like poison. Beep."
 	icon = 'icons/obj/food/burgers/roburger.dmi'
 	filling_color = COLOR_GRAY80
-	volume = 100
+	chem_volume = 100
 	center_of_mass = @'{"x":16,"y":11}'
 	bitesize = 0.1
 

--- a/code/modules/reagents/reagent_containers/food/eggs.dm
+++ b/code/modules/reagents/reagent_containers/food/eggs.dm
@@ -8,7 +8,7 @@
 	icon = 'icons/obj/food/eggs/egg.dmi'
 	icon_state = ICON_STATE_WORLD
 	filling_color = "#fdffd1"
-	volume = 10
+	chem_volume = 10
 	center_of_mass = @'{"x":16,"y":13}'
 	material = /decl/material/solid/organic/bone/eggshell
 	obj_flags = OBJ_FLAG_HOLLOW

--- a/code/modules/reagents/reagent_containers/glass/bottle.dm
+++ b/code/modules/reagents/reagent_containers/glass/bottle.dm
@@ -14,7 +14,7 @@
 	w_class = ITEM_SIZE_SMALL
 	item_flags = 0
 	obj_flags = 0
-	volume = 60
+	chem_volume = 60
 	material = /decl/material/solid/glass
 	material_alteration = MAT_FLAG_ALTERATION_COLOR | MAT_FLAG_ALTERATION_NAME
 
@@ -39,7 +39,7 @@
 
 /obj/item/chems/glass/bottle/update_overlays()
 	if(reagents?.total_volume)
-		var/percent = round(reagents.total_volume / volume * 100, 25)
+		var/percent = round(reagents.total_volume / reagents.maximum_volume * 100, 25)
 		add_overlay(mutable_appearance(icon, "[icon_state]_filling_[percent]", reagents.get_color()))
 	var/image/overglass = mutable_appearance(icon, "[icon_state]_over", color)
 	overglass.alpha = alpha * ((alpha/255) ** 3)

--- a/code/modules/reagents/reagent_containers/glass/bottle/robot.dm
+++ b/code/modules/reagents/reagent_containers/glass/bottle/robot.dm
@@ -5,7 +5,7 @@
 	amount_per_transfer_from_this = 10
 	possible_transfer_amounts = @"[5,10,15,25,30,50,100]"
 	atom_flags = ATOM_FLAG_OPEN_CONTAINER
-	volume = 60
+	chem_volume = 60
 
 /obj/item/chems/glass/bottle/robot/Initialize()
 	. = ..()

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -115,8 +115,8 @@
 		V.update_icon()
 
 	loaded_vial = V
-	reagents.maximum_volume = loaded_vial.reagents.maximum_volume
-	loaded_vial.reagents.trans_to_holder(reagents, chem_volume)
+	create_or_update_reagents(loaded_vial.reagents.maximum_volume, override_volume = TRUE)
+	loaded_vial.reagents.trans_to_holder(reagents, reagents.maximum_volume)
 
 	if(user)
 		user.visible_message(SPAN_NOTICE("[user] has loaded [V] into \the [src]."), SPAN_NOTICE("[usermessage]"))
@@ -128,7 +128,7 @@
 /obj/item/chems/hypospray/vial/proc/remove_vial(var/mob/user, var/swap_mode, var/should_update_icon = TRUE)
 	if(!loaded_vial)
 		return
-	reagents.trans_to_holder(loaded_vial.reagents,chem_volume)
+	reagents.trans_to_holder(loaded_vial.reagents, reagents.maximum_volume)
 	reagents.maximum_volume = 0
 	loaded_vial.update_icon()
 	if(user)

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -10,7 +10,7 @@
 	abstract_type = /obj/item/chems/hypospray
 	origin_tech = @'{"materials":4,"biotech":5}'
 	amount_per_transfer_from_this = 5
-	volume = 30
+	chem_volume = 30
 	possible_transfer_amounts = null
 	atom_flags = ATOM_FLAG_OPEN_CONTAINER
 	slot_flags = SLOT_LOWER_BODY
@@ -86,7 +86,7 @@
 	desc = "A sterile, air-needle autoinjector for rapid administration of drugs to patients. Uses a replaceable 30u vial."
 	possible_transfer_amounts = @"[1,2,5,10,15,20,30]"
 	amount_per_transfer_from_this = 5
-	volume = 0
+	chem_volume = 0
 	time = 0 // hyposprays are instant for conscious people
 	single_use = FALSE
 	material = /decl/material/solid/metal/steel
@@ -116,7 +116,7 @@
 
 	loaded_vial = V
 	reagents.maximum_volume = loaded_vial.reagents.maximum_volume
-	loaded_vial.reagents.trans_to_holder(reagents, volume)
+	loaded_vial.reagents.trans_to_holder(reagents, chem_volume)
 
 	if(user)
 		user.visible_message(SPAN_NOTICE("[user] has loaded [V] into \the [src]."), SPAN_NOTICE("[usermessage]"))
@@ -128,7 +128,7 @@
 /obj/item/chems/hypospray/vial/proc/remove_vial(var/mob/user, var/swap_mode, var/should_update_icon = TRUE)
 	if(!loaded_vial)
 		return
-	reagents.trans_to_holder(loaded_vial.reagents,volume)
+	reagents.trans_to_holder(loaded_vial.reagents,chem_volume)
 	reagents.maximum_volume = 0
 	loaded_vial.update_icon()
 	if(user)
@@ -172,7 +172,7 @@
 	desc = "A rapid and safe way to administer small amounts of drugs by untrained or trained personnel."
 	icon = 'icons/obj/autoinjector.dmi'
 	amount_per_transfer_from_this = 5
-	volume = 5
+	chem_volume = 5
 	origin_tech = @'{"materials":2,"biotech":2}'
 	slot_flags = SLOT_LOWER_BODY | SLOT_EARS
 	w_class = ITEM_SIZE_SMALL

--- a/code/modules/reagents/reagent_containers/inhaler.dm
+++ b/code/modules/reagents/reagent_containers/inhaler.dm
@@ -7,7 +7,7 @@
 	icon_state = ICON_STATE_WORLD
 	center_of_mass = @'{"x":16,"y":11}'
 	amount_per_transfer_from_this = 5
-	volume = 5
+	chem_volume = 5
 	w_class = ITEM_SIZE_SMALL
 	possible_transfer_amounts = null
 	atom_flags = ATOM_FLAG_OPEN_CONTAINER

--- a/code/modules/reagents/reagent_containers/mortar.dm
+++ b/code/modules/reagents/reagent_containers/mortar.dm
@@ -3,7 +3,7 @@
 	desc = "A hard, sturdy bowl used to hold organic matter for crushing."
 	icon = 'icons/obj/items/chem/mortar.dmi'
 	icon_state = ICON_STATE_WORLD
-	volume = 40
+	chem_volume = 40
 	material = /decl/material/solid/stone/basalt
 	color = /decl/material/solid/stone/basalt::color
 	material_alteration = MAT_FLAG_ALTERATION_ALL

--- a/code/modules/reagents/reagent_containers/packets.dm
+++ b/code/modules/reagents/reagent_containers/packets.dm
@@ -5,7 +5,7 @@
 	w_class = ITEM_SIZE_TINY
 	possible_transfer_amounts = @"[1,2,5,10]"
 	amount_per_transfer_from_this = 1
-	volume = 10
+	chem_volume = 10
 
 /obj/item/chems/packet/attack_self(mob/user)
 	if(!ATOM_IS_OPEN_CONTAINER(src))

--- a/code/modules/reagents/reagent_containers/pill.dm
+++ b/code/modules/reagents/reagent_containers/pill.dm
@@ -12,7 +12,7 @@
 	possible_transfer_amounts = null
 	w_class = ITEM_SIZE_TINY
 	slot_flags = SLOT_EARS
-	volume = 30
+	chem_volume = 30
 	material = /decl/material/solid/organic/plantmatter
 	var/autolabel = TRUE  		// if set, will add label with the name of the first initial reagent
 	var/static/list/colorizable_icon_states = list("pill1", "pill2", "pill3", "pill4", "pill5") // if using an icon state from here, color will be derived from reagents
@@ -74,7 +74,7 @@
 /obj/item/chems/pill/bromide
 	desc = "Highly toxic."
 	icon_state = "pill4"
-	volume = 50
+	chem_volume = 50
 
 /obj/item/chems/pill/bromide/populate_reagents()
 	add_to_reagents(/decl/material/liquid/bromide, reagents.maximum_volume)
@@ -84,7 +84,7 @@
 	name = "strange pill"
 	desc = "It's marked 'KCN'. Smells vaguely of almonds."
 	icon_state = "pillC"
-	volume = 50
+	chem_volume = 50
 	autolabel = FALSE
 
 /obj/item/chems/pill/cyanide/populate_reagents()

--- a/code/modules/reagents/reagent_containers/retort.dm
+++ b/code/modules/reagents/reagent_containers/retort.dm
@@ -1,11 +1,11 @@
 /obj/item/chems/glass/retort
-	name       = "retort"
-	base_name  = "retort"
-	desc       = "A strangely-shaped vessel for separating chemicals when heated."
-	icon       = 'icons/obj/items/retort.dmi'
-	icon_state = ICON_STATE_WORLD
-	volume     = 120
-	material   = /decl/material/solid/glass
+	name        = "retort"
+	base_name   = "retort"
+	desc        = "A strangely-shaped vessel for separating chemicals when heated."
+	icon        = 'icons/obj/items/retort.dmi'
+	icon_state  = ICON_STATE_WORLD
+	chem_volume = 120
+	material    = /decl/material/solid/glass
 	material_alteration = MAT_FLAG_ALTERATION_ALL
 
 /obj/item/chems/glass/retort/can_lid()

--- a/code/modules/reagents/reagent_containers/spray.dm
+++ b/code/modules/reagents/reagent_containers/spray.dm
@@ -73,7 +73,6 @@
 	set waitfor = FALSE
 
 	var/obj/effect/effect/water/chempuff/D = new(get_turf(src))
-	D.create_reagents(amount_per_transfer_from_this)
 	if(QDELETED(src))
 		return
 	reagents.trans_to_obj(D, amount_per_transfer_from_this)

--- a/code/modules/reagents/reagent_containers/spray.dm
+++ b/code/modules/reagents/reagent_containers/spray.dm
@@ -12,7 +12,7 @@
 	throw_range                       = 10
 	attack_cooldown                   = DEFAULT_QUICK_COOLDOWN
 	material                          = /decl/material/solid/organic/plastic
-	volume                            = 250
+	chem_volume                       = 250
 	amount_per_transfer_from_this     = 10
 	possible_transfer_amounts         = @"[5,10]"
 	var/tmp/possible_particle_amounts = @"[1,3]"                    ///Possible chempuff particles amount for each transfer amount setting
@@ -160,7 +160,7 @@
 	icon = 'icons/obj/items/weapon/pepperspray.dmi'
 	icon_state = ICON_STATE_WORLD
 	possible_transfer_amounts = null
-	volume = 60
+	chem_volume = 60
 	particle_move_delay = 1
 	safety = TRUE
 
@@ -178,7 +178,7 @@
 	item_state = "sunflower"
 	amount_per_transfer_from_this = 1
 	possible_transfer_amounts = null
-	volume = 10
+	chem_volume = 10
 
 /obj/item/chems/spray/waterflower/populate_reagents()
 	add_to_reagents(/decl/material/liquid/water, reagents.maximum_volume)
@@ -191,7 +191,7 @@
 	item_state = "chemsprayer"
 	w_class = ITEM_SIZE_LARGE
 	possible_transfer_amounts = null
-	volume = 600
+	chem_volume = 600
 	origin_tech = @'{"combat":3,"materials":3,"engineering":3}'
 	particle_move_delay = 2 //Was hardcoded to 2 before, and 8 was slower than most mob's move speed
 	material = /decl/material/solid/metal/steel
@@ -216,7 +216,7 @@
 	icon = 'icons/obj/hydroponics/hydroponics_machines.dmi'
 	icon_state = "plantbgone"
 	item_state = "plantbgone"
-	volume = 100
+	chem_volume = 100
 
 /obj/item/chems/spray/plantbgone/populate_reagents()
 	add_to_reagents(/decl/material/liquid/weedkiller, reagents.maximum_volume)
@@ -225,7 +225,7 @@
 	name = "deodorant"
 	desc = "A can of Gold Standard spray deodorant - for when you're too lazy to shower."
 	gender = PLURAL
-	volume = 35
+	chem_volume = 35
 	icon = 'icons/obj/items/deodorant.dmi'
 	icon_state = "deodorant"
 	item_state = "deodorant"

--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -14,7 +14,7 @@
 	material = /decl/material/solid/glass
 	amount_per_transfer_from_this = 5
 	possible_transfer_amounts = @"[1,2,5]"
-	volume = 15
+	chem_volume = 15
 	w_class = ITEM_SIZE_TINY
 	slot_flags = SLOT_EARS
 	sharp = TRUE
@@ -100,7 +100,7 @@
 		return
 	var/rounded_vol = 0
 	if (reagents?.total_volume > 0)
-		rounded_vol = clamp(round((reagents.total_volume / volume * 15),5), 5, 15)
+		rounded_vol = clamp(round((reagents.total_volume / max(1, reagents.maximum_volume * 15)),5), 5, 15)
 	if(ismob(loc))
 		add_overlay((mode == SYRINGE_DRAW)? "[icon_state]_draw" : "[icon_state]_inject")
 	icon_state = "[icon_state]_[rounded_vol]"
@@ -317,7 +317,7 @@
 	name = "lethal injection syringe"
 	desc = "A syringe used for lethal injections."
 	amount_per_transfer_from_this = 60
-	volume = 60
+	chem_volume = 60
 	visible_name = "a giant syringe"
 	time = 30 SECONDS
 	mode = SYRINGE_INJECT
@@ -389,7 +389,7 @@
 	name = "advanced syringe"
 	desc = "An advanced syringe that can hold 60 units of chemicals."
 	amount_per_transfer_from_this = 20
-	volume = 60
+	chem_volume = 60
 	icon = 'icons/obj/syringe_advanced.dmi'
 	material = /decl/material/solid/glass
 	matter = list(
@@ -401,7 +401,7 @@
 /obj/item/chems/syringe/noreact
 	name = "cryostasis syringe"
 	desc = "An advanced syringe that stops reagents inside from reacting. It can hold up to 20 units."
-	volume = 20
+	chem_volume = 20
 	atom_flags = ATOM_FLAG_NO_CHEM_CHANGE
 	icon = 'icons/obj/syringe_cryo.dmi'
 	material = /decl/material/solid/glass

--- a/code/modules/reagents/reagent_dispenser.dm
+++ b/code/modules/reagents/reagent_dispenser.dm
@@ -10,17 +10,16 @@
 	matter                            = list(/decl/material/solid/metal/steel = MATTER_AMOUNT_SECONDARY)
 	max_health                        = 100
 	tool_interaction_flags            = TOOL_INTERACTION_DECONSTRUCT
+	chem_volume                       = 1000
 
 	var/wrenchable                    = TRUE
 	var/unwrenched                    = FALSE
-	var/tmp/volume                    = 1000
 	var/amount_dispensed              = 10
 	var/can_toggle_open               = TRUE
 	var/tmp/possible_transfer_amounts = @"[10,25,50,100,500]"
 
 /obj/structure/reagent_dispensers/Initialize(ml, _mat, _reinf_mat)
 	. = ..()
-	initialize_reagents()
 	if (!possible_transfer_amounts)
 		verbs -= /obj/structure/reagent_dispensers/verb/set_amount_dispensed
 
@@ -41,13 +40,6 @@
 		tool_interaction_flags &= ~TOOL_INTERACTION_DECONSTRUCT
 	else
 		tool_interaction_flags |= TOOL_INTERACTION_DECONSTRUCT
-
-/obj/structure/reagent_dispensers/initialize_reagents(populate = TRUE)
-	if(!reagents)
-		create_reagents(volume)
-	else
-		reagents.maximum_volume = max(reagents.maximum_volume, volume)
-	. = ..()
 
 /obj/structure/reagent_dispensers/proc/leak()
 	var/turf/T = get_turf(src)
@@ -126,7 +118,7 @@
 	icon_state                = "watertank"
 	amount_dispensed          = 10
 	possible_transfer_amounts = @"[10,25,50,100]"
-	volume                    = 7500
+	chem_volume               = 7500
 	atom_flags                = ATOM_FLAG_CLIMBABLE
 	movable_flags             = MOVABLE_FLAG_WHEELED
 
@@ -140,8 +132,8 @@
 	icon_state = ICON_STATE_WORLD
 
 /obj/structure/reagent_dispensers/watertank/firefighter
-	name   = "firefighting water reserve"
-	volume = 50000
+	name        = "firefighting water reserve"
+	chem_volume = 50000
 
 /obj/structure/reagent_dispensers/watertank/attackby(obj/item/used_item, mob/user)
 	//FIXME: Maybe this should be handled differently? Since it can essentially make the tank unusable.
@@ -254,7 +246,7 @@
 	possible_transfer_amounts = null
 	amount_dispensed          = 5
 	anchored                  = TRUE
-	volume                    = 500
+	chem_volume               = 500
 	tool_interaction_flags    = (TOOL_INTERACTION_ANCHOR | TOOL_INTERACTION_DECONSTRUCT)
 	var/cups                  = 12
 	var/tmp/max_cups          = 12

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -364,7 +364,7 @@ var/global/list/diversion_junctions = list()
 
 	var/power_draw = -1
 	if(env && env.temperature > 0)
-		var/transfer_moles = (PUMP_MAX_FLOW_RATE/env.volume)*env.total_moles	//group_multiplier is divided out here
+		var/transfer_moles = (PUMP_MAX_FLOW_RATE/env.air_volume)*env.total_moles	//group_multiplier is divided out here
 		power_draw = pump_gas(src, env, air_contents, transfer_moles, active_power_usage)
 
 	if (power_draw > 0)

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -364,7 +364,7 @@ var/global/list/diversion_junctions = list()
 
 	var/power_draw = -1
 	if(env && env.temperature > 0)
-		var/transfer_moles = (PUMP_MAX_FLOW_RATE/env.air_volume)*env.total_moles	//group_multiplier is divided out here
+		var/transfer_moles = (PUMP_MAX_FLOW_RATE/env.total_volume)*env.total_moles	//group_multiplier is divided out here
 		power_draw = pump_gas(src, env, air_contents, transfer_moles, active_power_usage)
 
 	if (power_draw > 0)

--- a/code/modules/scanners/gas.dm
+++ b/code/modules/scanners/gas.dm
@@ -79,7 +79,7 @@
 				. += "[capitalize(mat.gas_name)]: [percentage]%[perGas_add_string]"
 			var/totalGas_add_string = ""
 			if(mode == MV_MODE)
-				totalGas_add_string = ", Total moles: [round(mixture.total_moles, 0.01)], Volume: [mixture.volume]L"
+				totalGas_add_string = ", Total moles: [round(mixture.total_moles, 0.01)], Volume: [mixture.air_volume]L"
 			. += "Temperature: [round(mixture.temperature-T0C)]&deg;C / [round(mixture.temperature)]K[totalGas_add_string]"
 
 			return

--- a/code/modules/scanners/gas.dm
+++ b/code/modules/scanners/gas.dm
@@ -79,7 +79,7 @@
 				. += "[capitalize(mat.gas_name)]: [percentage]%[perGas_add_string]"
 			var/totalGas_add_string = ""
 			if(mode == MV_MODE)
-				totalGas_add_string = ", Total moles: [round(mixture.total_moles, 0.01)], Volume: [mixture.air_volume]L"
+				totalGas_add_string = ", Total moles: [round(mixture.total_moles, 0.01)], Volume: [mixture.total_volume]L"
 			. += "Temperature: [round(mixture.temperature-T0C)]&deg;C / [round(mixture.temperature)]K[totalGas_add_string]"
 
 			return

--- a/code/modules/scanners/mass_spectrometer.dm
+++ b/code/modules/scanners/mass_spectrometer.dm
@@ -7,11 +7,8 @@
 	window_width = 550
 	window_height = 300
 	scan_sound = 'sound/effects/scanbeep.ogg'
+	chem_volume = 5
 	var/details = 0
-
-/obj/item/scanner/spectrometer/Initialize()
-	. = ..()
-	create_reagents(5)
 
 /obj/item/scanner/spectrometer/on_reagent_change()
 	if((. = ..()))

--- a/code/modules/sealant_gun/sealant_tank.dm
+++ b/code/modules/sealant_gun/sealant_tank.dm
@@ -17,8 +17,8 @@
 		. += SPAN_NOTICE("\The [src] has about [foam_charges] liter\s of sealant left.")
 
 /obj/item/sealant_tank/Initialize(ml, material_key)
+	chem_volume = max_foam_charges
 	. = ..()
-	create_reagents(max_foam_charges)
 
 /obj/item/sealant_tank/mapped/Initialize()
 	. = ..()

--- a/code/modules/synthesized_instruments/real_instruments.dm
+++ b/code/modules/synthesized_instruments/real_instruments.dm
@@ -79,7 +79,7 @@
 				src.usage_info = new (owner, src.player)
 			src.usage_info.ui_interact(user)
 		if ("volume")
-			src.player.volume = min(max(min(player.volume+text2num(value), 100), 0), player.max_volume)
+			src.player.play_volume = min(max(min(player.play_volume+text2num(value), 100), 0), player.max_volume)
 		if ("transposition")
 			src.player.song.transposition = max(min(player.song.transposition+value, global.musical_config.highest_transposition), global.musical_config.lowest_transposition)
 		if ("min_octave")
@@ -151,7 +151,7 @@
 		),
 		"basic_options" = list(
 			"cur_instrument" = src.player.song.instrument_data.name,
-			"volume" = src.player.volume,
+			"volume" = src.player.play_volume,
 			"BPM" = round(600 / src.player.song.tempo),
 			"transposition" = src.player.song.transposition,
 			"octave_range" = list(

--- a/code/modules/synthesized_instruments/real_instruments/Synthesizer/synthesizer.dm
+++ b/code/modules/synthesized_instruments/real_instruments/Synthesizer/synthesizer.dm
@@ -1,7 +1,7 @@
 //Synthesizer and minimoog. They work the same
 
 /datum/sound_player/synthesizer
-	volume = 40
+	play_volume = 40
 
 /obj/structure/synthesized_instrument/synthesizer
 	name = "The Synthesizer 3.0"

--- a/code/modules/synthesized_instruments/real_instruments/Violin/violin.dm
+++ b/code/modules/synthesized_instruments/real_instruments/Violin/violin.dm
@@ -1,5 +1,5 @@
 /datum/sound_player/violin
-	volume = 25
+	play_volume = 25
 	range = 10 //Kinda don't want this horrible thing to be heard from far away
 
 /obj/item/synthesized_instrument/violin

--- a/code/modules/synthesized_instruments/song.dm
+++ b/code/modules/synthesized_instruments/song.dm
@@ -82,7 +82,7 @@
 	var/current_volume = clamp(sound_copy.volume, 0, 100)
 	sound_copy.volume = current_volume //Sanitize volume
 	var/datum/sound_token/token = new /datum/sound_token/instrument(src.player.actual_instrument, src.sound_id, sound_copy, src.player.range, FALSE, use_env, player)
-	var/delta_volume = player.volume / src.sustain_timer
+	var/delta_volume = player.play_volume / src.sustain_timer
 
 	var/tick = duration
 	while ((current_volume > 0) && token)

--- a/code/modules/synthesized_instruments/sound_player.dm
+++ b/code/modules/synthesized_instruments/sound_player.dm
@@ -3,7 +3,7 @@
 	// Virtual object
 	// It's the one used to modify shit
 	var/range = 15
-	var/volume = 30
+	var/play_volume = 30
 	var/max_volume = 50
 	var/falloff = 2
 	var/apply_echo = 0
@@ -64,7 +64,7 @@
 		I.PrivLocateListeners(prior_turfs.Copy(), current_turfs.Copy())
 
 /datum/sound_player/proc/apply_modifications(sound/what, note_num, which_line, which_note) // You don't need to override this
-	what.volume = volume
+	what.volume = play_volume
 	what.falloff = falloff
 	if (global.musical_config.env_settings_available)
 		what.environment = global.musical_config.is_custom_env(src.virtual_environment_selected) ? src.env : src.virtual_environment_selected

--- a/code/modules/vehicles/engine.dm
+++ b/code/modules/vehicles/engine.dm
@@ -79,6 +79,7 @@
 	icon_state = "engine_fuel"
 	trail_type = /datum/effect/effect/system/trail/thermal
 	atom_flags = ATOM_FLAG_OPEN_CONTAINER
+	chem_volume = 500
 	var/datum/reagents/combustion_chamber
 	var/fuel_points = 0
 	//fuel points are determined by differing reagents
@@ -88,7 +89,6 @@
 
 /obj/item/engine/thermal/Initialize()
 	. = ..()
-	create_reagents(500)
 	combustion_chamber = new(15, global.temp_reagents_holder)
 
 /obj/item/engine/thermal/attackby(var/obj/item/used_item, var/mob/user)

--- a/code/modules/xenoarcheaology/machinery/geosample_scanner.dm
+++ b/code/modules/xenoarcheaology/machinery/geosample_scanner.dm
@@ -12,6 +12,7 @@
 	uncreated_component_parts = null
 	maximum_component_parts   = list(/obj/item/stock_parts = 15)
 	stat_immune               = 0
+	chem_volume               = 500
 
 	//var/obj/item/chems/glass/coolant_container
 	var/scanning = 0
@@ -51,10 +52,6 @@
 		/decl/material/liquid/amphetamines = 0.8,
 		/decl/material/liquid/adminordrazine = 2
 	)
-
-/obj/machinery/radiocarbon_spectrometer/Initialize()
-	. = ..()
-	create_reagents(500)
 
 /obj/machinery/radiocarbon_spectrometer/interface_interact(var/mob/user)
 	ui_interact(user)

--- a/code/modules/xgm/xgm_gas_mixture.dm
+++ b/code/modules/xgm/xgm_gas_mixture.dm
@@ -8,7 +8,7 @@
 	//Sum of all the gas moles in this mix.  Updated by update_values()
 	var/total_moles = 0
 	//Volume of this mix.
-	var/volume = CELL_VOLUME
+	var/air_volume = CELL_VOLUME
 	//Size of the group this gas_mixture is representing.  1 for singletons.
 	var/group_multiplier = 1
 
@@ -21,14 +21,14 @@
 
 /datum/gas_mixture/New(_volume, _temperature, _group_multiplier)
 	if(!isnull(_volume))
-		volume = _volume
+		air_volume = _volume
 	if(!isnull(_temperature))
 		temperature = _temperature
 	if(!isnull(_group_multiplier))
 		group_multiplier = _group_multiplier
 
 	//Since we may have values defined on creation, update everything.
-	if(volume && length(gas))
+	if(air_volume && length(gas))
 		update_values()
 
 /datum/gas_mixture/proc/get_gas(gasid)
@@ -107,9 +107,9 @@
 
 	for(var/g in gas|sharer.gas)
 		var/comb = gas[g] + sharer.gas[g]
-		comb /= volume + sharer.volume
-		gas[g] = comb * volume
-		sharer.gas[g] = comb * sharer.volume
+		comb /= air_volume + sharer.air_volume
+		gas[g] = comb * air_volume
+		sharer.gas[g] = comb * sharer.air_volume
 
 	if(our_heatcap + share_heatcap)
 		temperature = ((temperature * our_heatcap) + (sharer.temperature * share_heatcap)) / (our_heatcap + share_heatcap)
@@ -188,7 +188,7 @@
 	var/molar_mass = mat.molar_mass
 	var/specific_heat = mat.gas_specific_heat
 	var/safe_temp = max(temperature, TCMB) // We're about to divide by this.
-	return R_IDEAL_GAS_EQUATION * ( log( (IDEAL_GAS_ENTROPY_CONSTANT*volume/(gas[gasid] * safe_temp)) * (molar_mass*specific_heat*safe_temp)**(2/3) + 1 ) +  15 )
+	return R_IDEAL_GAS_EQUATION * ( log( (IDEAL_GAS_ENTROPY_CONSTANT*air_volume/(gas[gasid] * safe_temp)) * (molar_mass*specific_heat*safe_temp)**(2/3) + 1 ) +  15 )
 
 	//alternative, simpler equation
 	//var/partial_pressure = gas[gasid] * R_IDEAL_GAS_EQUATION * temperature / volume
@@ -209,8 +209,8 @@
 
 //Returns the pressure of the gas mix.  Only accurate if there have been no gas modifications since update_values() has been called.
 /datum/gas_mixture/proc/return_pressure()
-	if(volume)
-		return total_moles * R_IDEAL_GAS_EQUATION * temperature / volume
+	if(air_volume)
+		return total_moles * R_IDEAL_GAS_EQUATION * temperature / air_volume
 	return 0
 
 
@@ -249,7 +249,7 @@
 		gas[g] = gas[g] * (1 - ratio)
 
 	removed.temperature = temperature
-	removed.volume = volume * group_multiplier / out_group_multiplier
+	removed.air_volume = air_volume * group_multiplier / out_group_multiplier
 	update_values()
 	removed.update_values()
 
@@ -257,8 +257,8 @@
 
 //Removes a volume of gas from the mixture and returns a gas_mixture containing the removed air with the given volume
 /datum/gas_mixture/proc/remove_volume(removed_volume)
-	var/datum/gas_mixture/removed = remove_ratio(removed_volume/(volume*group_multiplier), 1)
-	removed.volume = removed_volume
+	var/datum/gas_mixture/removed = remove_ratio(removed_volume/(air_volume*group_multiplier), 1)
+	removed.air_volume = removed_volume
 	return removed
 
 //Removes moles from the gas mixture, limited by a given flag.  Returns a gax_mixture containing the removed air.
@@ -305,7 +305,7 @@
 	return 1
 
 /datum/gas_mixture/GetCloneArgs()
-	return list(volume, temperature, group_multiplier)
+	return list(air_volume, temperature, group_multiplier)
 
 /datum/gas_mixture/PopulateClone(datum/gas_mixture/clone)
 	clone.gas         = gas.Copy()
@@ -461,7 +461,7 @@
 
 	var/list/total_gas = list()
 	for(var/datum/gas_mixture/gasmix in gases)
-		total_volume += gasmix.volume
+		total_volume += gasmix.air_volume
 		var/temp_heatcap = gasmix.heat_capacity()
 		total_thermal_energy += gasmix.temperature * temp_heatcap
 		total_heat_capacity += temp_heatcap
@@ -488,7 +488,7 @@
 		for(var/datum/gas_mixture/gasmix in gases)
 			gasmix.gas = combined.gas.Copy()
 			gasmix.temperature = combined.temperature
-			gasmix.multiply(gasmix.volume)
+			gasmix.multiply(gasmix.air_volume)
 
 	return 1
 

--- a/code/modules/xgm/xgm_gas_mixture.dm
+++ b/code/modules/xgm/xgm_gas_mixture.dm
@@ -8,7 +8,7 @@
 	//Sum of all the gas moles in this mix.  Updated by update_values()
 	var/total_moles = 0
 	//Volume of this mix.
-	var/air_volume = CELL_VOLUME
+	var/total_volume = CELL_VOLUME
 	//Size of the group this gas_mixture is representing.  1 for singletons.
 	var/group_multiplier = 1
 
@@ -21,14 +21,14 @@
 
 /datum/gas_mixture/New(_volume, _temperature, _group_multiplier)
 	if(!isnull(_volume))
-		air_volume = _volume
+		total_volume = _volume
 	if(!isnull(_temperature))
 		temperature = _temperature
 	if(!isnull(_group_multiplier))
 		group_multiplier = _group_multiplier
 
 	//Since we may have values defined on creation, update everything.
-	if(air_volume && length(gas))
+	if(total_volume && length(gas))
 		update_values()
 
 /datum/gas_mixture/proc/get_gas(gasid)
@@ -107,9 +107,9 @@
 
 	for(var/g in gas|sharer.gas)
 		var/comb = gas[g] + sharer.gas[g]
-		comb /= air_volume + sharer.air_volume
-		gas[g] = comb * air_volume
-		sharer.gas[g] = comb * sharer.air_volume
+		comb /= total_volume + sharer.total_volume
+		gas[g] = comb * total_volume
+		sharer.gas[g] = comb * sharer.total_volume
 
 	if(our_heatcap + share_heatcap)
 		temperature = ((temperature * our_heatcap) + (sharer.temperature * share_heatcap)) / (our_heatcap + share_heatcap)
@@ -188,7 +188,7 @@
 	var/molar_mass = mat.molar_mass
 	var/specific_heat = mat.gas_specific_heat
 	var/safe_temp = max(temperature, TCMB) // We're about to divide by this.
-	return R_IDEAL_GAS_EQUATION * ( log( (IDEAL_GAS_ENTROPY_CONSTANT*air_volume/(gas[gasid] * safe_temp)) * (molar_mass*specific_heat*safe_temp)**(2/3) + 1 ) +  15 )
+	return R_IDEAL_GAS_EQUATION * ( log( (IDEAL_GAS_ENTROPY_CONSTANT*total_volume/(gas[gasid] * safe_temp)) * (molar_mass*specific_heat*safe_temp)**(2/3) + 1 ) +  15 )
 
 	//alternative, simpler equation
 	//var/partial_pressure = gas[gasid] * R_IDEAL_GAS_EQUATION * temperature / volume
@@ -209,8 +209,8 @@
 
 //Returns the pressure of the gas mix.  Only accurate if there have been no gas modifications since update_values() has been called.
 /datum/gas_mixture/proc/return_pressure()
-	if(air_volume)
-		return total_moles * R_IDEAL_GAS_EQUATION * temperature / air_volume
+	if(total_volume)
+		return total_moles * R_IDEAL_GAS_EQUATION * temperature / total_volume
 	return 0
 
 
@@ -249,7 +249,7 @@
 		gas[g] = gas[g] * (1 - ratio)
 
 	removed.temperature = temperature
-	removed.air_volume = air_volume * group_multiplier / out_group_multiplier
+	removed.total_volume = total_volume * group_multiplier / out_group_multiplier
 	update_values()
 	removed.update_values()
 
@@ -257,8 +257,8 @@
 
 //Removes a volume of gas from the mixture and returns a gas_mixture containing the removed air with the given volume
 /datum/gas_mixture/proc/remove_volume(removed_volume)
-	var/datum/gas_mixture/removed = remove_ratio(removed_volume/(air_volume*group_multiplier), 1)
-	removed.air_volume = removed_volume
+	var/datum/gas_mixture/removed = remove_ratio(removed_volume/(total_volume*group_multiplier), 1)
+	removed.total_volume = removed_volume
 	return removed
 
 //Removes moles from the gas mixture, limited by a given flag.  Returns a gax_mixture containing the removed air.
@@ -305,7 +305,7 @@
 	return 1
 
 /datum/gas_mixture/GetCloneArgs()
-	return list(air_volume, temperature, group_multiplier)
+	return list(total_volume, temperature, group_multiplier)
 
 /datum/gas_mixture/PopulateClone(datum/gas_mixture/clone)
 	clone.gas         = gas.Copy()
@@ -461,7 +461,7 @@
 
 	var/list/total_gas = list()
 	for(var/datum/gas_mixture/gasmix in gases)
-		total_volume += gasmix.air_volume
+		total_volume += gasmix.total_volume
 		var/temp_heatcap = gasmix.heat_capacity()
 		total_thermal_energy += gasmix.temperature * temp_heatcap
 		total_heat_capacity += temp_heatcap
@@ -488,7 +488,7 @@
 		for(var/datum/gas_mixture/gasmix in gases)
 			gasmix.gas = combined.gas.Copy()
 			gasmix.temperature = combined.temperature
-			gasmix.multiply(gasmix.air_volume)
+			gasmix.multiply(gasmix.total_volume)
 
 	return 1
 

--- a/code/unit_tests/chemistry_tests.dm
+++ b/code/unit_tests/chemistry_tests.dm
@@ -11,7 +11,7 @@
 	var/turf/test_loc = get_safe_turf()
 
 	var/atom/from = new donor_type(test_loc)
-	from.create_reagents(container_volume)
+	from.create_or_update_reagents(container_volume)
 	from.add_to_reagents(/decl/material/liquid/water, container_volume)
 
 	var/atom/target
@@ -22,7 +22,7 @@
 	else
 		target = new recipient_type(test_loc)
 	if(!target.reagents)
-		target.create_reagents(container_volume)
+		target.create_or_update_reagents(container_volume)
 	if(ismob(target))
 		var/mob/victim = target
 		victim.death() // to prevent reagent processing

--- a/code/unit_tests/food_tests.dm
+++ b/code/unit_tests/food_tests.dm
@@ -63,8 +63,7 @@
 		seeds_by_tag[seed.grown_tag] = seed_name
 
 	var/failures = list()
-	var/obj/container = new // dummy container for holding ingredients
-	container.create_reagents(1000)
+	var/obj/effect/chem_holder/container = new(null, 1000) // dummy container for holding ingredients
 	var/static/list/all_recipe_categories = list(
 		RECIPE_CATEGORY_MICROWAVE,
 		RECIPE_CATEGORY_POT,

--- a/maps/away/lost_supply_base/lost_supply_base.dmm
+++ b/maps/away/lost_supply_base/lost_supply_base.dmm
@@ -1426,7 +1426,7 @@
 /area/lost_supply_base/common)
 "eD" = (
 /obj/machinery/atmospherics/unary/tank/hydrogen{
-	volume = 3200
+	air_volume = 3200
 	},
 /turf/floor/plating/airless,
 /area/lost_supply_base)

--- a/maps/away/lost_supply_base/lost_supply_base.dmm
+++ b/maps/away/lost_supply_base/lost_supply_base.dmm
@@ -1426,7 +1426,7 @@
 /area/lost_supply_base/common)
 "eD" = (
 /obj/machinery/atmospherics/unary/tank/hydrogen{
-	air_volume = 3200
+	gas_volume = 3200
 	},
 /turf/floor/plating/airless,
 /area/lost_supply_base)

--- a/maps/away/unishi/unishi-1.dmm
+++ b/maps/away/unishi/unishi-1.dmm
@@ -251,7 +251,7 @@
 /area/unishi/engineering)
 "aO" = (
 /obj/machinery/atmospherics/unary/tank/oxygen{
-	volume = 3200
+	air_volume = 3200
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/floor,

--- a/maps/away/unishi/unishi-1.dmm
+++ b/maps/away/unishi/unishi-1.dmm
@@ -251,7 +251,7 @@
 /area/unishi/engineering)
 "aO" = (
 /obj/machinery/atmospherics/unary/tank/oxygen{
-	air_volume = 3200
+	gas_volume = 3200
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/floor,

--- a/maps/exodus/exodus-2.dmm
+++ b/maps/exodus/exodus-2.dmm
@@ -48513,7 +48513,7 @@
 /area/exodus/engineering/storage)
 "bXs" = (
 /obj/machinery/atmospherics/unary/tank/oxygen{
-	volume = 3200
+	air_volume = 3200
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/floor/tiled/steel_grid,
@@ -48544,7 +48544,7 @@
 /area/exodus/engineering/break_room)
 "bXv" = (
 /obj/machinery/atmospherics/unary/tank/hydrogen{
-	volume = 3200
+	air_volume = 3200
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/floor/tiled/steel_grid,

--- a/maps/exodus/exodus-2.dmm
+++ b/maps/exodus/exodus-2.dmm
@@ -48513,7 +48513,7 @@
 /area/exodus/engineering/storage)
 "bXs" = (
 /obj/machinery/atmospherics/unary/tank/oxygen{
-	air_volume = 3200
+	gas_volume = 3200
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/floor/tiled/steel_grid,
@@ -48544,7 +48544,7 @@
 /area/exodus/engineering/break_room)
 "bXv" = (
 /obj/machinery/atmospherics/unary/tank/hydrogen{
-	air_volume = 3200
+	gas_volume = 3200
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/floor/tiled/steel_grid,

--- a/mods/content/beekeeping/hive_frame.dm
+++ b/mods/content/beekeeping/hive_frame.dm
@@ -3,15 +3,8 @@
 	icon_state = ICON_STATE_WORLD
 	w_class = ITEM_SIZE_SMALL
 	material_alteration = MAT_FLAG_ALTERATION_ALL
+	chem_volume = 20
 	var/destroy_on_centrifuge = FALSE
-
-/obj/item/hive_frame/Initialize(ml, material_key)
-	. = ..()
-	initialize_reagents()
-
-/obj/item/hive_frame/initialize_reagents(populate = TRUE)
-	create_reagents(20)
-	. = ..()
 
 /obj/item/hive_frame/on_reagent_change()
 	. = ..()

--- a/mods/content/integrated_electronics/components/input.dm
+++ b/mods/content/integrated_electronics/components/input.dm
@@ -1109,7 +1109,7 @@
 	set_pin_data(IC_OUTPUT, 3, round(air_contents.get_total_moles(), 0.001))
 	set_pin_data(IC_OUTPUT, 4, round(air_contents.return_pressure(), 0.001))
 	set_pin_data(IC_OUTPUT, 5, round(air_contents.temperature, 0.001))
-	set_pin_data(IC_OUTPUT, 6, round(air_contents.volume, 0.001))
+	set_pin_data(IC_OUTPUT, 6, round(air_contents.air_volume, 0.001))
 	push_data()
 	activate_pin(2)
 

--- a/mods/content/integrated_electronics/components/input.dm
+++ b/mods/content/integrated_electronics/components/input.dm
@@ -1109,7 +1109,7 @@
 	set_pin_data(IC_OUTPUT, 3, round(air_contents.get_total_moles(), 0.001))
 	set_pin_data(IC_OUTPUT, 4, round(air_contents.return_pressure(), 0.001))
 	set_pin_data(IC_OUTPUT, 5, round(air_contents.temperature, 0.001))
-	set_pin_data(IC_OUTPUT, 6, round(air_contents.air_volume, 0.001))
+	set_pin_data(IC_OUTPUT, 6, round(air_contents.total_volume, 0.001))
 	push_data()
 	activate_pin(2)
 

--- a/mods/content/integrated_electronics/components/power_passive.dm
+++ b/mods/content/integrated_electronics/components/power_passive.dm
@@ -95,7 +95,8 @@
 	outputs = list("volume used" = IC_PINTYPE_NUMBER, "self reference" = IC_PINTYPE_REF)
 	activators = list("push ref" = IC_PINTYPE_PULSE_IN)
 	spawn_flags = IC_SPAWN_DEFAULT|IC_SPAWN_RESEARCH
-	var/volume = 60
+	chem_volume = 60
+
 	var/list/fuel = list(
 		/decl/material/gas/hydrogen           = 50000,
 		/decl/material/gas/hydrogen/deuterium = 50000,
@@ -109,7 +110,6 @@
 
 /obj/item/integrated_circuit/passive/power/chemical_cell/Initialize()
 	. = ..()
-	create_reagents(volume)
 	extended_desc +="But no fuel can be compared with blood of living human."
 
 

--- a/mods/content/integrated_electronics/components/reagents.dm
+++ b/mods/content/integrated_electronics/components/reagents.dm
@@ -115,7 +115,7 @@
 	else
 		direction_mode = IC_REAGENTS_INJECT
 	if(isnum(new_amount))
-		new_amount = clamp(new_amount, 0, chem_volume)
+		new_amount = clamp(new_amount, 0, reagents.maximum_volume)
 		transfer_amount = new_amount
 
 

--- a/mods/content/integrated_electronics/components/reagents.dm
+++ b/mods/content/integrated_electronics/components/reagents.dm
@@ -7,15 +7,13 @@
 /obj/item/integrated_circuit/reagent
 	category_text = "Reagent"
 	cooldown_per_use = 10
-	var/volume = 0
 
 /obj/item/integrated_circuit/reagent/solvent_can_melt(var/solvent_power = MAT_SOLVENT_STRONG)
 	return FALSE
 
 /obj/item/integrated_circuit/reagent/Initialize()
 	. = ..()
-	if(volume)
-		create_reagents(volume)
+	if(reagents?.maximum_volume)
 		push_vol()
 
 /obj/item/integrated_circuit/reagent/proc/push_vol()
@@ -30,7 +28,7 @@
 	into the smoke clouds when activated. The reagents are consumed when the smoke is made."
 	ext_cooldown = 1
 	atom_flags = ATOM_FLAG_OPEN_CONTAINER
-	volume = 100
+	chem_volume = 100
 
 	complexity = 20
 	cooldown_per_use = 1 SECONDS
@@ -81,7 +79,7 @@
 	must be adjacent to the machine, and if it is a person, they cannot be wearing thick clothing. Negative given amounts makes the injector suck out reagents instead."
 
 	atom_flags = ATOM_FLAG_OPEN_CONTAINER
-	volume = 30
+	chem_volume = 30
 
 	complexity = 20
 	cooldown_per_use = 6 SECONDS
@@ -117,7 +115,7 @@
 	else
 		direction_mode = IC_REAGENTS_INJECT
 	if(isnum(new_amount))
-		new_amount = clamp(new_amount, 0, volume)
+		new_amount = clamp(new_amount, 0, chem_volume)
 		transfer_amount = new_amount
 
 
@@ -304,7 +302,7 @@
 	extended_desc = "This is effectively an internal beaker."
 
 	atom_flags = ATOM_FLAG_OPEN_CONTAINER
-	volume = 60
+	chem_volume = 60
 
 	complexity = 4
 	inputs = list()
@@ -326,7 +324,7 @@
 	icon_state = "reagent_storage_big"
 	desc = "Stores liquid inside the device away from electrical components. Can store up to 180u."
 
-	volume = 180
+	chem_volume = 180
 
 	complexity = 16
 	spawn_flags = IC_SPAWN_RESEARCH
@@ -359,7 +357,7 @@
 		"on fail" = IC_PINTYPE_PULSE_OUT,
 		"push ref" = IC_PINTYPE_PULSE_IN
 		)
-	volume = 100
+	chem_volume = 100
 	power_draw_per_use = 150
 	complexity = 16
 	spawn_flags = IC_SPAWN_RESEARCH
@@ -552,7 +550,7 @@
 	complexity = 12
 	cooldown_per_use = 1
 	power_draw_per_use = 50
-	volume = 30
+	chem_volume = 30
 
 	var/active = 0
 	var/min_temp = 40 CELSIUS

--- a/mods/content/plant_dissection/grown.dm
+++ b/mods/content/plant_dissection/grown.dm
@@ -27,7 +27,7 @@
 	for(var/datum/plant_segment/segment as anything in segments)
 		if(segment.contributes_to_reagents)
 			segment_amount += LAZYACCESS(segment.total_reagent_volume_by_state, (PLANT_STATE_FRESH))
-	volume = max(volume, segment_amount)
+	chem_volume = max(chem_volume, segment_amount)
 	return ..()
 
 /obj/item/food/grown/Destroy()

--- a/mods/content/supermatter/datums/sm_looping_sound.dm
+++ b/mods/content/supermatter/datums/sm_looping_sound.dm
@@ -1,4 +1,4 @@
 /datum/composite_sound/supermatter
 	mid_sounds = list('sound/machines/sm/loops/calm.ogg'=1)
 	mid_length = 60
-	volume = 40
+	play_volume = 40

--- a/mods/content/supermatter/structures/supermatter_crystal.dm
+++ b/mods/content/supermatter/structures/supermatter_crystal.dm
@@ -454,7 +454,7 @@ var/global/list/supermatter_delam_accent_sounds = list(
 		// (this is probably wrong since hydrogen heat cap is changed from phoron)
 		// Capped to 20 volume since higher volumes get annoying and it sounds worse.
 		// Formula previously was min(round(power/10)+1, 20)
-		soundloop.volume = clamp((50 + (power / 50)), 50, 100)
+		soundloop.play_volume = clamp((50 + (power / 50)), 50, 100)
 
 	// Swap loops between calm and delamming.
 	if(damage >= explosion_point * 0.25)

--- a/mods/content/xenobiology/slime/items.dm
+++ b/mods/content/xenobiology/slime/items.dm
@@ -10,6 +10,7 @@
 	atom_flags = ATOM_FLAG_OPEN_CONTAINER
 	material = /decl/material/liquid/slimejelly
 	_base_attack_force = 1
+	chem_volume = 100
 	var/slime_type = /decl/slime_colour/grey
 	var/Uses = 1 // uses before it goes inert
 	var/enhanced = 0 //has it been enhanced before?
@@ -38,12 +39,7 @@
 	if(!ispath(slime_type, /decl/slime_colour))
 		PRINT_STACK_TRACE("Slime extract initialized with non-decl slime colour: [slime_type || "NULL"].")
 	SSstatistics.extracted_slime_cores_amount++
-	initialize_reagents()
 	update_icon()
-
-/obj/item/slime_extract/initialize_reagents(populate)
-	create_reagents(100)
-	. = ..()
 
 /obj/item/slime_extract/populate_reagents()
 	add_to_reagents(/decl/material/liquid/slimejelly, 30)

--- a/mods/species/ascent/items/rig.dm
+++ b/mods/species/ascent/items/rig.dm
@@ -135,7 +135,7 @@
 	name = "mantid gas tank"
 	icon = 'mods/species/ascent/icons/tank.dmi'
 	distribute_pressure = ONE_ATMOSPHERE*O2STANDARD
-	volume = 180
+	air_volume = 180
 
 /obj/item/tank/mantid/methyl_bromide
 	starting_pressure = list(/decl/material/gas/methyl_bromide = 6 ATM)

--- a/mods/species/ascent/items/rig.dm
+++ b/mods/species/ascent/items/rig.dm
@@ -135,7 +135,7 @@
 	name = "mantid gas tank"
 	icon = 'mods/species/ascent/icons/tank.dmi'
 	distribute_pressure = ONE_ATMOSPHERE*O2STANDARD
-	air_volume = 180
+	gas_volume = 180
 
 /obj/item/tank/mantid/methyl_bromide
 	starting_pressure = list(/decl/material/gas/methyl_bromide = 6 ATM)

--- a/nebula.dme
+++ b/nebula.dme
@@ -1017,6 +1017,7 @@
 #include "code\game\objects\compass\compass_waypoint.dm"
 #include "code\game\objects\effects\_effect.dm"
 #include "code\game\objects\effects\bump_teleporter.dm"
+#include "code\game\objects\effects\chem_holder.dm"
 #include "code\game\objects\effects\cig_smoke.dm"
 #include "code\game\objects\effects\dirty_floor.dm"
 #include "code\game\objects\effects\effect_system.dm"


### PR DESCRIPTION
## Description of changes
- Various uses of `volume` changed to more specific names (like `gas_volume` and `total_volume`)
- `/obj/item/chem` volume var converted to `chem_volume` on `/obj`.
- Various bespoke volume vars outside of `/obj/item/chem` converted to `chem_volume`.
- `/obj/Initialize()` will call `initialize_reagents()` if `chem_volume` > 0.
- Many `initialize_reagents()` overrides condensed into `Initialize()` or simply setting `chem_volume`.
- Changes several uses of `volume` to properly refer to `reagents.maximum_volume`.
- Formalizes the 'dummy chem holder' idea as `/obj/effect/chem_holder`.
- Turns most uses of `create_reagents()` into `chem_volume` setting.
- Adds `create_or_update_reagents()` to replace most remaining uses of `create_reagents()`

## Why and what will this PR improve
- Unifies chem reagent holder creation on /obj.
- Simplifies reagent serde (future work).
- Makes it a lot less annoying to tell at a glance what `volume` is referring to in a given context.

## TODO
- [x] Test beakers in IVs and ChemMaster.
- [x] Fix pill name behavior to allow serde.

## Authorship
Myself.

## Changelog
Nothing player-facing.