### PR TITLE
Cleaning up current_health setting in atom definitions.

### DIFF
--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -6,7 +6,6 @@
 	min_force = 4
 	hitsound = 'sound/effects/Glasshit.ogg'
 	max_health = 150 //If you change this, consider changing ../door/window/brigdoor/ health at the bottom of this .dm file
-	current_health = 150
 	visible = 0.0
 	use_power = POWER_USE_OFF
 	stat_immune = NOSCREEN | NOINPUT | NOPOWER
@@ -213,10 +212,8 @@
 	icon = 'icons/obj/doors/windoor.dmi'
 	icon_state = "leftsecure"
 	base_state = "leftsecure"
-	max_health = 300
-	current_health = 300.0 //Stronger doors for prison (regular window door health is 150)
+	max_health = 300 //Stronger doors for prison (regular window door health is 150)
 	pry_mod = 0.65
-
 
 /obj/machinery/door/window/northleft
 	dir = NORTH

--- a/code/game/objects/__objs.dm
+++ b/code/game/objects/__objs.dm
@@ -30,8 +30,10 @@
 	//Only apply directional offsets if the mappers haven't set any offsets already
 	if(!pixel_x && !pixel_y && !pixel_w && !pixel_z)
 		update_directional_offset()
-	if(isnull(current_health))
+	if(isnull(current_health) || current_health == INFINITY)
 		current_health = get_max_health()
+	else
+		current_health = min(current_health, get_max_health())
 
 /obj/object_shaken()
 	shake_animation()

--- a/code/game/objects/items/weapons/tape.dm
+++ b/code/game/objects/items/weapons/tape.dm
@@ -11,7 +11,6 @@
 	max_amount        = 32
 	w_class           = ITEM_SIZE_SMALL
 	material          = /decl/material/solid/organic/plastic
-	current_health    = 10
 	max_health        = 10
 	matter_multiplier = 0.25
 

--- a/code/game/objects/items/welding/weldingtool_tank.dm
+++ b/code/game/objects/items/welding/weldingtool_tank.dm
@@ -12,7 +12,6 @@
 	obj_flags          = OBJ_FLAG_HOLLOW
 	volume             = 20
 	presentation_flags = PRESENTATION_FLAG_NAME
-	current_health     = 40
 	max_health         = 40
 	material           = /decl/material/solid/metal/steel
 	var/can_refuel     = TRUE

--- a/code/game/objects/structures/__structure.dm
+++ b/code/game/objects/structures/__structure.dm
@@ -125,7 +125,7 @@
 	return FALSE
 
 /obj/structure/take_damage(damage, damage_type = BRUTE, damage_flags, inflicter, armor_pen = 0, silent, do_update_health)
-	if(current_health == -1) // This object does not take damage.
+	if(current_health == ITEM_HEALTH_NO_DAMAGE) // This object does not take damage.
 		return
 
 	if(material && material.is_brittle())

--- a/code/game/objects/structures/crates_lockers/closets/secure/_secure_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/_secure_closets.dm
@@ -1,13 +1,11 @@
 /obj/structure/closet/secure_closet
 	name = "secure locker"
 	desc = "It's a card-locked storage unit."
-
 	closet_appearance = /decl/closet_appearance/secure_closet
 	setup = CLOSET_HAS_LOCK | CLOSET_CAN_BE_WELDED
 	locked = TRUE
-
 	wall_mounted = 0 //never solid (You can always pass over it)
-	current_health = 200
+	max_health = 200
 
 /obj/structure/closet/secure_closet/slice_into_parts(obj/item/weldingtool/welder, mob/user)
 	to_chat(user, "<span class='notice'>\The [src] is too strong to be taken apart.</span>")

--- a/code/game/objects/structures/crates_lockers/closets/statue.dm
+++ b/code/game/objects/structures/crates_lockers/closets/statue.dm
@@ -6,7 +6,7 @@
 	density = TRUE
 	anchored = TRUE
 	setup = 0
-	current_health = 0 //destroying the statue kills the mob within
+	max_health = 1 //destroying the statue kills the mob within
 	var/intialTox = 0 	//these are here to keep the mob from taking damage from things that logically wouldn't affect a rock
 	var/intialFire = 0	//it's a little sloppy I know but it was this or the GODMODE flag. Lesser of two evils.
 	var/intialBrute = 0

--- a/code/game/objects/structures/pit.dm
+++ b/code/game/objects/structures/pit.dm
@@ -1,13 +1,13 @@
 /obj/structure/pit
-	name           = "pit"
-	desc           = "Watch your step, partner."
-	icon           = 'icons/obj/structures/pit.dmi'
-	icon_state     = "pit1"
-	blend_mode     = BLEND_MULTIPLY
-	density        = FALSE
-	anchored       = TRUE
-	current_health = ITEM_HEALTH_NO_DAMAGE //You can't break a hole in the ground.
-	var/open       = TRUE
+	name       = "pit"
+	desc       = "Watch your step, partner."
+	icon       = 'icons/obj/structures/pit.dmi'
+	icon_state = "pit1"
+	blend_mode = BLEND_MULTIPLY
+	density    = FALSE
+	anchored   = TRUE
+	max_health = ITEM_HEALTH_NO_DAMAGE //You can't break a hole in the ground.
+	var/open   = TRUE
 
 /obj/structure/pit/attackby(obj/item/used_item, mob/user)
 	if(IS_SHOVEL(used_item))

--- a/code/modules/barricade_tape/barricade_tape.dm
+++ b/code/modules/barricade_tape/barricade_tape.dm
@@ -25,7 +25,7 @@ var/global/list/image/hazard_overlays //Cached hazard floor overlays for the bar
 	pass_flags       = PASS_FLAG_TABLE                //About the height of table
 	anchored         = TRUE
 	material         = /decl/material/solid/organic/plastic
-	current_health   = 5
+	max_health       = 5
 	var/neighbors    = 0                              //Contains all the direction flags of all the neighboring tape_barricades
 	var/is_lifted    = 0                              //Whether the tape is lifted and we're allowing everyone passage.
 	var/is_crumpled  = 0                              //Whether the tape was damaged

--- a/code/modules/hydroponics/spreading/spreading.dm
+++ b/code/modules/hydroponics/spreading/spreading.dm
@@ -45,9 +45,7 @@
 	icon_state = ""
 	pass_flags = PASS_FLAG_TABLE
 	mouse_opacity = MOUSE_OPACITY_NORMAL
-
-	current_health = 10
-	max_health = 100
+	max_health = 10
 	var/growth_threshold = 0
 	var/growth_type = 0
 	var/max_growth = 0
@@ -82,7 +80,7 @@
 	max_health = round(seed.get_trait(TRAIT_ENDURANCE)/2)
 	if(start_matured)
 		mature_time = 0
-		current_health = max_health
+		current_health = get_max_health()
 
 	if(seed.get_trait(TRAIT_SPREAD) == 2)
 		mouse_opacity = MOUSE_OPACITY_PRIORITY

--- a/code/modules/mob/living/human/human.dm
+++ b/code/modules/mob/living/human/human.dm
@@ -9,7 +9,7 @@
 
 /mob/living/human/Initialize(mapload, species_uid, datum/mob_snapshot/supplied_appearance)
 
-	current_health = max_health
+	current_health = get_max_health()
 	reset_hud_overlays()
 	var/list/newargs = args.Copy(2)
 	setup_human(arglist(newargs))

--- a/code/modules/mob/living/silicon/robot/component.dm
+++ b/code/modules/mob/living/silicon/robot/component.dm
@@ -224,7 +224,6 @@
 	icon = 'icons/obj/robot_component.dmi'
 	icon_state = "working"
 	material = /decl/material/solid/metal/steel
-	current_health = 30
 	max_health = 30
 	var/burn_damage = 0
 	var/brute_damage = 0

--- a/code/modules/mob/living/simple_animal/hostile/carp.dm
+++ b/code/modules/mob/living/simple_animal/hostile/carp.dm
@@ -45,7 +45,7 @@
 
 /mob/living/simple_animal/hostile/carp/proc/carp_randomify()
 	max_health = rand(initial(max_health), (1.5 * initial(max_health)))
-	current_health = max_health
+	current_health = get_max_health()
 	if(prob(1))
 		carp_color = pick(COLOR_WHITE, COLOR_BLACK)
 	else

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/king_of_goats.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/king_of_goats.dm
@@ -222,7 +222,7 @@
 	phase3 = TRUE
 	spellscast = 0
 	max_health = 750
-	current_health = max_health
+	current_health = get_max_health()
 	new /obj/item/grenade/flashbang/instant(src.loc)
 	QDEL_NULL(boss_theme)
 	boss_theme = play_looping_sound(src, sound_id, 'sound/music/Visager-Miniboss_Fight.ogg', volume = 10, range = 8, falloff = 4, prefer_mute = TRUE)

--- a/code/modules/organs/organ.dm
+++ b/code/modules/organs/organ.dm
@@ -620,9 +620,9 @@ var/global/list/ailment_reference_cache = list()
 
 	max_health = max_damage
 	if(current_health == ITEM_HEALTH_NO_DAMAGE)
-		current_health = max_health
+		current_health = get_max_health()
 	else
-		current_health = min(current_health, max_health)
+		current_health = min(current_health, get_max_health())
 
 	action_button_name = null
 	screen_loc = null

--- a/code/modules/paperwork/paper_bundle.dm
+++ b/code/modules/paperwork/paper_bundle.dm
@@ -18,8 +18,7 @@
 	drop_sound        = 'sound/foley/paperpickup1.ogg'
 	pickup_sound      = 'sound/foley/paperpickup2.ogg'
 	item_flags        = ITEM_FLAG_CAN_TAPE
-	current_health    = 10
-	max_health = 10
+	max_health        = 10
 	var/tmp/cur_page  = 1           // current page
 	var/tmp/max_pages = 100         //Maximum number of papers that can be in the bundle
 	var/list/pages                  // Ordered list of pages as they are to be displayed. Can be different order than src.contents.

--- a/code/modules/projectiles/guns/launcher/bows/bow_string.dm
+++ b/code/modules/projectiles/guns/launcher/bows/bow_string.dm
@@ -12,7 +12,7 @@
 	. = ..()
 	if(material)
 		max_health = max(1, round(initial(max_health) * material.tensile_strength))
-		current_health = max_health
+		current_health = get_max_health()
 
 /obj/item/bowstring/Destroy()
 	if(istype(loc, /obj/item/gun/launcher/bow))

--- a/code/modules/vehicles/bike.dm
+++ b/code/modules/vehicles/bike.dm
@@ -4,12 +4,9 @@
 	icon = 'icons/obj/bike.dmi'
 	icon_state = "bike_off"
 	dir = SOUTH
-
 	load_item_visible = 1
 	buckle_pixel_shift = list("x" = 0, "y" = 0, "z" = 5)
-	current_health = 100
 	max_health = 100
-
 	locked = 0
 	fire_dam_coeff = 0.6
 	brute_dam_coeff = 0.5

--- a/code/modules/vehicles/train.dm
+++ b/code/modules/vehicles/train.dm
@@ -1,10 +1,7 @@
 /obj/vehicle/train
 	name = "train"
 	dir = EAST
-
 	move_delay = 1
-
-	current_health = 100
 	max_health = 100
 	fire_dam_coeff = 0.7
 	brute_dam_coeff = 0.5

--- a/mods/species/ascent/mobs/insectoid_egg.dm
+++ b/mods/species/ascent/mobs/insectoid_egg.dm
@@ -18,7 +18,6 @@ var/global/default_gyne
 /obj/structure/insectoid_egg
 	name = "alien egg"
 	desc = "A semi-translucent alien egg."
-	current_health = 100
 	max_health = 100
 	icon = 'mods/species/ascent/icons/egg.dmi'
 	icon_state = "egg"


### PR DESCRIPTION
`current_health` is set in Initialize() if not null, generally (mobs might do bespoke behavior) - having it set in the definition makes serde stuff harder.