### PR TITLE
Moves material references onto /atom

### DIFF
--- a/code/datums/repositories/atom_info.dm
+++ b/code/datums/repositories/atom_info.dm
@@ -9,79 +9,79 @@ var/global/repository/atom_info/atom_info_repository = new()
 	var/list/matter_mult_cache =    list()
 	var/list/origin_tech_cache =    list()
 
-/repository/atom_info/proc/create_key_for(var/path, var/material, var/amount)
-	. = "[path]"
-	if(ispath(path, /obj) && material) // only objects take material as an arg
-		. = "[.]-[material]"
-	if(ispath(path, /obj/item/stack) && !isnull(amount)) // similarly for stacks and amount
-		. = "[.]-[amount]"
+/repository/atom_info/proc/create_key_for(var/_path, var/_mat, var/_amount)
+	. = "[_path]"
+	if(ispath(_path, /obj) && _mat) // only objects take material as an arg
+		. = "[.]-[_mat]"
+	if(ispath(_path, /obj/item/stack) && !isnull(_amount)) // similarly for stacks and amount
+		. = "[.]-[_amount]"
 
-/repository/atom_info/proc/get_instance_of(var/path, var/material, var/amount)
-	if(ispath(path, /obj/item/stack))
-		. = new path(null, amount, material)
-	else if(ispath(path, /obj))
-		. = new path(null, material)
+/repository/atom_info/proc/get_instance_of(var/_path, var/_mat, var/_amount)
+	if(ispath(_path, /obj/item/stack))
+		. = new _path(null, _amount, _mat)
+	else if(ispath(_path, /obj))
+		. = new _path(null, _mat)
 	else
-		. = new path
+		. = new _path
 
-/repository/atom_info/proc/update_cached_info_for(var/path, var/material, var/amount, var/key)
+/repository/atom_info/proc/update_cached_info_for(var/_path, var/_mat, var/_amount, var/key)
 	var/atom/instance
 	if(!matter_cache[key])
-		instance = get_instance_of(path, material, amount)
+		instance = get_instance_of(_path, _mat, _amount)
 		matter_cache[key] = instance.get_contained_matter() || list()
 	if(!combined_worth_cache[key])
-		instance = instance || get_instance_of(path, material, amount)
+		instance = instance || get_instance_of(_path, _mat, _amount)
 		combined_worth_cache[key] = instance.get_combined_monetary_worth()
 	if(!single_worth_cache[key])
-		instance = instance || get_instance_of(path, material, amount)
+		instance = instance || get_instance_of(_path, _mat, _amount)
 		single_worth_cache[key] = instance.get_single_monetary_worth()
 	if(!name_cache[key])
-		instance = instance || get_instance_of(path, material, amount)
+		instance = instance || get_instance_of(_path, _mat, _amount)
 		name_cache[key] = instance.name
 	if(!description_cache[key])
-		instance = instance || get_instance_of(path, material, amount)
+		instance = instance || get_instance_of(_path, _mat, _amount)
 		description_cache[key] = instance.desc
-	if(!matter_mult_cache[key] && ispath(path, /obj))
-		var/obj/obj_instance = instance || get_instance_of(path, material, amount)
+	if(!matter_mult_cache[key] && ispath(_path, /obj))
+		var/obj/obj_instance = instance || get_instance_of(_path, _mat, _amount)
 		matter_mult_cache[key] = obj_instance.get_matter_amount_modifier()
-	if(!origin_tech_cache[key] && ispath(path, /obj/item))
-		var/obj/item/item_instance = instance || get_instance_of(path, material, amount)
+	if(!origin_tech_cache[key] && ispath(_path, /obj/item))
+		var/obj/item/item_instance = instance || get_instance_of(_path, _mat, _amount)
 		origin_tech_cache[key] = cached_json_decode(item_instance.get_origin_tech())
 	if(!QDELETED(instance))
 		qdel(instance)
 
-/repository/atom_info/proc/get_matter_for(var/path, var/material, var/amount)
+/repository/atom_info/proc/get_matter_for(var/_path, var/_mat, var/_amount)
 	RETURN_TYPE(/list)
-	var/key = create_key_for(path, material, amount)
-	update_cached_info_for(path, material, amount, key)
+	var/key = create_key_for(_path, _mat, _amount)
+	update_cached_info_for(_path, _mat, _amount, key)
 	. = matter_cache[key]
 
-/repository/atom_info/proc/get_combined_worth_for(var/path, var/material, var/amount)
-	var/key = create_key_for(path, material, amount)
-	update_cached_info_for(path, material, amount, key)
+/repository/atom_info/proc/get_combined_worth_for(var/_path, var/_mat, var/_amount)
+	var/key = create_key_for(_path, _mat, _amount)
+	update_cached_info_for(_path, _mat, _amount, key)
 	. = combined_worth_cache[key]
 
-/repository/atom_info/proc/get_single_worth_for(var/path, var/material, var/amount)
-	var/key = create_key_for(path, material, amount)
-	update_cached_info_for(path, material, amount, key)
+/repository/atom_info/proc/get_single_worth_for(var/_path, var/_mat, var/_amount)
+	var/key = create_key_for(_path, _mat, _amount)
+	update_cached_info_for(_path, _mat, _amount, key)
 	. = single_worth_cache[key]
 
-/repository/atom_info/proc/get_name_for(var/path, var/material, var/amount)
-	var/key = create_key_for(path, material, amount)
-	update_cached_info_for(path, material, amount, key)
+/repository/atom_info/proc/get_name_for(var/_path, var/_mat, var/_amount)
+	var/key = create_key_for(_path, _mat, _amount)
+	update_cached_info_for(_path, _mat, _amount, key)
 	. = name_cache[key]
 
-/repository/atom_info/proc/get_description_for(var/path, var/material, var/amount)
-	var/key = create_key_for(path, material, amount)
-	update_cached_info_for(path, material, amount, key)
+/repository/atom_info/proc/get_description_for(var/_path, var/_mat, var/_amount)
+	var/key = create_key_for(_path, _mat, _amount)
+	update_cached_info_for(_path, _mat, _amount, key)
 	. = description_cache[key]
 
-/repository/atom_info/proc/get_matter_multiplier_for(var/path, var/material, var/amount)
-	var/key = create_key_for(path, material, amount)
-	update_cached_info_for(path, material, amount, key)
+/repository/atom_info/proc/get_matter_multiplier_for(var/_path, var/_mat, var/_amount)
+	var/key = create_key_for(_path, _mat, _amount)
+	update_cached_info_for(_path, _mat, _amount, key)
 	. = matter_mult_cache[key]
 
-/repository/atom_info/proc/get_origin_tech_for(var/path, var/material, var/amount)
-	var/key = create_key_for(path, material, amount)
-	update_cached_info_for(path, material, amount, key)
+/repository/atom_info/proc/get_origin_tech_for(var/_path, var/_mat, var/_amount)
+	var/key = create_key_for(_path, _mat, _amount)
+	update_cached_info_for(_path, _mat, _amount, key)
 	. = origin_tech_cache[key]

--- a/code/game/atom_material.dm
+++ b/code/game/atom_material.dm
@@ -2,7 +2,7 @@
 //Will we ever need to return more than one value here? Or should we just return the "dominant" material.
 /atom/proc/get_material()
 	RETURN_TYPE(/decl/material)
-	return
+	return material
 
 //mostly for convenience
 /atom/proc/get_material_type()

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -67,6 +67,12 @@
 	/// (STRING) A color applied over the top of any material color. Implemented on /obj/item, /obj/structure and /turf.
 	var/paint_color
 
+	/// (DATUM) Reference to material decl. If set to a /decl/material path, will init the item with that material.
+	/// Implemented on /mob/living/exosuit, /turf/wall, /obj/item and /obj/structure
+	var/decl/material/material
+	/// (DATUM) Similar to above, but largely used by /turf/wall, /obj/structure and /obj/item/stack/material
+	var/decl/material/reinf_material
+
 /atom/proc/get_max_health()
 	return max_health
 

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -42,7 +42,7 @@
 	var/aiDisabledIdScanner = 0
 	var/aiHacking = 0
 	autoclose = 1
-	var/mineral = null
+	var/mineral = null // TODO: replace with material and get_material()
 	var/justzap = 0
 	var/safe = 1
 	var/speaker = 1

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -15,14 +15,12 @@
 	icon_state = "preview"
 	power_channel = ENVIRON
 	interact_offline = FALSE
-
 	explosion_resistance = 10
-
 	base_type = /obj/machinery/door/airlock
 	frame_type = /obj/structure/door_assembly
-
 	icon_state_open   = "open"
 	icon_state_closed = "closed"
+	material = /decl/material/solid/metal/steel
 
 	var/aiControlDisabled = 0 //If 1, AI control is disabled until the AI hacks back in and disables the lock. If 2, the AI has bypassed the lock. If -1, the control is enabled but the AI had bypassed it earlier, so if it is disabled again the AI would have no trouble getting back in.
 	var/hackProof = 0 // if 1, this door can't be hacked by the AI
@@ -42,7 +40,7 @@
 	var/aiDisabledIdScanner = 0
 	var/aiHacking = 0
 	autoclose = 1
-	var/mineral = null // TODO: replace with material and get_material()
+
 	var/justzap = 0
 	var/safe = 1
 	var/speaker = 1
@@ -75,29 +73,21 @@
 	var/stripe_color = null
 	var/symbol_color = null
 	var/window_color = null
-	var/window_material = /decl/material/solid/glass
 
-	var/fill_file = 'icons/obj/doors/station/fill_steel.dmi'
-	var/color_file = 'icons/obj/doors/station/color.dmi'
-	var/color_fill_file = 'icons/obj/doors/station/fill_color.dmi'
-	var/stripe_file = 'icons/obj/doors/station/stripe.dmi'
-	var/stripe_fill_file = 'icons/obj/doors/station/fill_stripe.dmi'
-	var/glass_file = 'icons/obj/doors/station/fill_glass.dmi'
-	var/bolts_file = 'icons/obj/doors/station/lights_bolts.dmi'
-	var/deny_file = 'icons/obj/doors/station/lights_deny.dmi'
-	var/lights_file = 'icons/obj/doors/station/lights_green.dmi'
-	var/panel_file = 'icons/obj/doors/station/panel.dmi'
+	var/fill_file           = 'icons/obj/doors/station/fill_steel.dmi'
+	var/color_file          = 'icons/obj/doors/station/color.dmi'
+	var/color_fill_file     = 'icons/obj/doors/station/fill_color.dmi'
+	var/stripe_file         = 'icons/obj/doors/station/stripe.dmi'
+	var/stripe_fill_file    = 'icons/obj/doors/station/fill_stripe.dmi'
+	var/glass_file          = 'icons/obj/doors/station/fill_glass.dmi'
+	var/bolts_file          = 'icons/obj/doors/station/lights_bolts.dmi'
+	var/deny_file           = 'icons/obj/doors/station/lights_deny.dmi'
+	var/lights_file         = 'icons/obj/doors/station/lights_green.dmi'
+	var/panel_file          = 'icons/obj/doors/station/panel.dmi'
 	var/sparks_damaged_file = 'icons/obj/doors/station/sparks_damaged.dmi'
-	var/sparks_broken_file = 'icons/obj/doors/station/sparks_broken.dmi'
-	var/welded_file = 'icons/obj/doors/station/welded.dmi'
-	var/emag_file = 'icons/obj/doors/station/emag.dmi'
-
-/obj/machinery/door/airlock/get_material()
-	RETURN_TYPE(/decl/material)
-	return GET_DECL(mineral ? mineral : /decl/material/solid/metal/steel)
-
-/obj/machinery/door/airlock/proc/get_window_material()
-	return GET_DECL(window_material)
+	var/sparks_broken_file  = 'icons/obj/doors/station/sparks_broken.dmi'
+	var/welded_file         = 'icons/obj/doors/station/welded.dmi'
+	var/emag_file           = 'icons/obj/doors/station/emag.dmi'
 
 /obj/machinery/door/airlock/Process()
 	if(main_power_lost_until > 0 && world.time >= main_power_lost_until)
@@ -324,15 +314,15 @@ About the new airlock wires panel:
 
 	set_light(0)
 
-	if(door_color && !(door_color == "none"))
+	if(door_color)
 		var/ikey = "[airlock_type]-[door_color]-color"
 		color_overlay = airlock_icon_cache["[ikey]"]
 		if(!color_overlay)
 			color_overlay = new(color_file)
 			color_overlay.Blend(door_color, ICON_MULTIPLY)
 			airlock_icon_cache["[ikey]"] = color_overlay
-	if(glass)
-		if (window_color && window_color != "none")
+	if(reinf_material)
+		if (window_color)
 			var/ikey = "[airlock_type]-[window_color]-windowcolor"
 			filling_overlay = airlock_icon_cache["[ikey]"]
 			if (!filling_overlay)
@@ -342,7 +332,7 @@ About the new airlock wires panel:
 		else
 			filling_overlay = glass_file
 	else
-		if(door_color && !(door_color == "none"))
+		if(door_color)
 			var/ikey = "[airlock_type]-[door_color]-fillcolor"
 			filling_overlay = airlock_icon_cache["[ikey]"]
 			if(!filling_overlay)
@@ -866,9 +856,8 @@ About the new airlock wires panel:
 	var/obj/structure/door_assembly/da = ..() // Note that we're deleted here already. Don't do unsafe stuff.
 	. = da
 
-	if(mineral)
-		da.glass_material = mineral
-		da.glass = 1
+	if(da.can_install_glass)
+		da.reinf_material = reinf_material
 
 	da.paintable = paintable
 	da.door_color = door_color
@@ -1026,6 +1015,10 @@ About the new airlock wires panel:
 	return ..(M)
 
 /obj/machinery/door/airlock/Initialize(var/mapload, var/d, var/populate_parts = TRUE, obj/structure/door_assembly/assembly = null)
+
+	material = RESOLVE_TO_DECL(material)
+	reinf_material = RESOLVE_TO_DECL(reinf_material)
+
 	. = ..()
 
 	//wires
@@ -1048,27 +1041,22 @@ About the new airlock wires panel:
 	else if(!begins_closed)
 		queue_icon_update()
 
-	if (glass)
+	if(reinf_material)
 		paintable |= PAINT_WINDOW_PAINTABLE
-		if (!window_color)
-			var/decl/material/window = get_window_material()
-			window_color = window.color
+		paint_window(reinf_material.color)
 
 /obj/machinery/door/airlock/inherit_from_assembly(obj/structure/door_assembly/assembly)
 	//if assembly is given, create the new door from the assembly
 	if (..(assembly))
-		var/decl/material/mat = GET_DECL(assembly.glass_material)
-
-		if(assembly.glass == 1) // supposed to use material in this case
-			mineral = assembly.glass_material
-			if(mat.opacity <= 0.7)
-				glass = TRUE
+		if(assembly.reinf_material && assembly.can_install_glass)
+			material = assembly.reinf_material
+			if(assembly.reinf_material.opacity <= 0.7)
 				set_opacity(0)
 				hitsound = 'sound/effects/Glasshit.ogg'
 				max_health = 300
 				explosion_resistance = 5
 			else
-				door_color = mat.color
+				door_color = assembly.reinf_material.color
 		else
 			door_color = assembly.door_color
 
@@ -1076,7 +1064,7 @@ About the new airlock wires panel:
 		if(assembly.created_name)
 			SetName(assembly.created_name)
 		else
-			SetName("[mineral ? "[mat.solid_name || mat.name] airlock" : assembly.base_name]")
+			SetName("[material ? "[material.solid_name || material.name] airlock" : assembly.base_name]")
 
 		paintable = assembly.paintable
 		stripe_color = assembly.stripe_color
@@ -1149,9 +1137,8 @@ About the new airlock wires panel:
 /obj/machinery/door/airlock/proc/paint_window(new_color)
 	if (new_color)
 		window_color = new_color
-	else if (window_material)
-		var/decl/material/window = get_window_material()
-		window_color = window.color
+	else if (reinf_material)
+		window_color = reinf_material.color
 	else
 		window_color = GLASS_COLOR
 	queue_icon_update()

--- a/code/game/machinery/doors/airlock_subtypes.dm
+++ b/code/game/machinery/doors/airlock_subtypes.dm
@@ -11,7 +11,6 @@
 	stripe_color = COLOR_NT_RED
 
 /obj/machinery/door/airlock/engineering
-	name = "Maintenance Hatch"
 	door_color = COLOR_AMBER
 
 /obj/machinery/door/airlock/medical
@@ -27,7 +26,6 @@
 	stripe_color = COLOR_GREEN
 
 /obj/machinery/door/airlock/mining
-	name = "Mining Airlock"
 	door_color = COLOR_PALE_ORANGE
 	stripe_color = COLOR_BEASTY_BROWN
 
@@ -53,24 +51,20 @@
 	stripe_color = COLOR_GRAY20
 
 /obj/machinery/door/airlock/freezer
-	name = "Freezer Airlock"
 	door_color = COLOR_WHITE
 
 /obj/machinery/door/airlock/maintenance
-	name = "Maintenance Access"
 	stripe_color = COLOR_AMBER
 
 
 // Glass airlock presets
-
 /obj/machinery/door/airlock/glass
-	name = "Glass Airlock"
 	icon_state = "preview_glass"
 	hitsound = 'sound/effects/Glasshit.ogg'
 	max_health = 300
 	explosion_resistance = 5
 	opacity = FALSE
-	glass = TRUE
+	reinf_material = /decl/material/solid/glass
 
 /obj/machinery/door/airlock/glass/command
 	door_color = COLOR_COMMAND_BLUE
@@ -120,7 +114,6 @@
 	door_color = COLOR_WHITE
 
 /obj/machinery/door/airlock/glass/maintenance
-	name = "Maintenance Access"
 	stripe_color = COLOR_AMBER
 
 /obj/machinery/door/airlock/glass/civilian
@@ -130,8 +123,7 @@
 // External airlock presets
 
 /obj/machinery/door/airlock/external
-	airlock_type = "External"
-	name = "External Airlock"
+	airlock_type = "external"
 	icon = 'icons/obj/doors/external/door.dmi'
 	fill_file = 'icons/obj/doors/external/fill_steel.dmi'
 	color_file = 'icons/obj/doors/external/color.dmi'
@@ -160,7 +152,6 @@
 		LAZYADD(., access_external_airlocks)
 
 /obj/machinery/door/airlock/external/escapepod
-	name = "Escape Pod"
 	locked = TRUE
 
 /obj/machinery/door/airlock/external/escapepod/attackby(obj/item/used_item, mob/user)
@@ -210,14 +201,12 @@
 
 /obj/machinery/door/airlock/centcom
 	airlock_type = "centcomm"
-	name = "\improper Airlock"
 	icon = 'icons/obj/doors/centcomm/door.dmi'
 	fill_file = 'icons/obj/doors/centcomm/fill_steel.dmi'
 	paintable = PAINT_PAINTABLE|PAINT_STRIPABLE
 
 /obj/machinery/door/airlock/highsecurity
 	airlock_type = "secure"
-	name = "Secure Airlock"
 	icon = 'icons/obj/doors/secure/door.dmi'
 	fill_file = 'icons/obj/doors/secure/fill_steel.dmi'
 	explosion_resistance = 20
@@ -232,7 +221,6 @@
 
 /obj/machinery/door/airlock/hatch
 	airlock_type = "hatch"
-	name = "\improper Airtight Hatch"
 	icon = 'icons/obj/doors/hatch/door.dmi'
 	fill_file = 'icons/obj/doors/hatch/fill_steel.dmi'
 	stripe_file = 'icons/obj/doors/hatch/stripe.dmi'
@@ -249,7 +237,6 @@
 	paintable = PAINT_STRIPABLE
 
 /obj/machinery/door/airlock/hatch/maintenance
-	name = "Maintenance Hatch"
 	stripe_color = COLOR_AMBER
 
 /obj/machinery/door/airlock/hatch/maintenance/bolted
@@ -257,7 +244,6 @@
 
 /obj/machinery/door/airlock/vault
 	airlock_type = "vault"
-	name = "Vault"
 	icon = 'icons/obj/doors/vault/door.dmi'
 	fill_file = 'icons/obj/doors/vault/fill_steel.dmi'
 	explosion_resistance = 20

--- a/code/game/machinery/doors/blast_door.dm
+++ b/code/game/machinery/doors/blast_door.dm
@@ -36,7 +36,6 @@
 	//turning this off prevents awkward zone geometry in places like medbay lobby, for example.
 	block_air_zones = 0
 
-	var/decl/material/implicit_material // TODO: replace with material and get_material()
 	autoset_access = FALSE // Uses different system with buttons.
 	pry_mod = 1.35
 
@@ -54,7 +53,7 @@
 	base_type = /obj/machinery/door/blast
 
 /obj/machinery/door/blast/Initialize()
-	implicit_material = GET_DECL(/decl/material/solid/metal/plasteel)
+	material = GET_DECL(/decl/material/solid/metal/plasteel)
 	. = ..()
 
 /obj/machinery/door/blast/get_examine_strings(mob/user, distance, infix, suffix)
@@ -136,10 +135,6 @@
 		force_open()
 	else
 		force_close()
-
-/obj/machinery/door/blast/get_material()
-	RETURN_TYPE(/decl/material)
-	return implicit_material
 
 // Proc: attackby()
 // Parameters: 2 (used_item - Item this object was clicked with, user - Mob which clicked this object)

--- a/code/game/machinery/doors/blast_door.dm
+++ b/code/game/machinery/doors/blast_door.dm
@@ -36,7 +36,7 @@
 	//turning this off prevents awkward zone geometry in places like medbay lobby, for example.
 	block_air_zones = 0
 
-	var/decl/material/implicit_material
+	var/decl/material/implicit_material // TODO: replace with material and get_material()
 	autoset_access = FALSE // Uses different system with buttons.
 	pry_mod = 1.35
 

--- a/code/game/machinery/doors/double.dm
+++ b/code/game/machinery/doors/double.dm
@@ -84,7 +84,6 @@
 	door_color = COLOR_NT_RED
 
 /obj/machinery/door/airlock/double/engineering
-	name = "Maintenance Hatch"
 	door_color = COLOR_AMBER
 
 /obj/machinery/door/airlock/double/medical
@@ -96,7 +95,6 @@
 	stripe_color = COLOR_GREEN
 
 /obj/machinery/door/airlock/double/mining
-	name = "Mining Airlock"
 	door_color = COLOR_PALE_ORANGE
 	stripe_color = COLOR_BEASTY_BROWN
 
@@ -116,18 +114,15 @@
 	door_color = COLOR_BLUE_GRAY
 
 /obj/machinery/door/airlock/double/maintenance
-	name = "Maintenance Access"
 	stripe_color = COLOR_AMBER
 
 /obj/machinery/door/airlock/double/civilian
 	stripe_color = COLOR_CIVIE_GREEN
 
 /obj/machinery/door/airlock/double/freezer
-	name = "Freezer Airlock"
 	door_color = COLOR_WHITE
 
 /obj/machinery/door/airlock/double/glass
-	name = "Glass Airlock"
 	opacity = FALSE
 	glass = TRUE
 
@@ -175,7 +170,6 @@
 	door_color = COLOR_WHITE
 
 /obj/machinery/door/airlock/double/glass/maintenance
-	name = "Maintenance Access"
 	stripe_color = COLOR_AMBER
 
 /obj/machinery/door/airlock/double/glass/civilian

--- a/code/game/objects/items/__item.dm
+++ b/code/game/objects/items/__item.dm
@@ -90,8 +90,6 @@
 	/// Assoc list of bodytype category to icon for producing onmob overlays when this item is held or worn.
 	var/list/sprite_sheets
 
-	// Material handling for material weapons (not used by default, unless material is supplied or set)
-	var/decl/material/material                      // Reference to material decl. If set to a string corresponding to a material ID, will init the item with that material.
 	///Will apply the flagged modifications to the object
 	var/material_alteration = MAT_FLAG_ALTERATION_NONE
 	var/anomaly_shielding					   // 0..1 value of how well it shields against xenoarch anomalies

--- a/code/game/objects/items/_item_drying.dm
+++ b/code/game/objects/items/_item_drying.dm
@@ -77,9 +77,9 @@
 	if(!length(matter))
 		return FALSE
 	for(var/mat in matter)
-		var/decl/material/material = GET_DECL(mat)
+		var/decl/material/heated_material = GET_DECL(mat)
 		// We should burn if we're above the temperature damage threshold.
-		if(!isnull(material.temperature_damage_threshold) && exposed_temperature >= material.temperature_damage_threshold)
+		if(!isnull(heated_material.temperature_damage_threshold) && exposed_temperature >= heated_material.temperature_damage_threshold)
 			return TRUE
 	return FALSE
 

--- a/code/game/objects/items/_item_materials.dm
+++ b/code/game/objects/items/_item_materials.dm
@@ -53,10 +53,6 @@
 		material.place_shards(T)
 	qdel(src)
 
-/obj/item/get_material()
-	RETURN_TYPE(/decl/material)
-	return material
-
 // TODO: Refactor more code to use this where necessary, and then make this use
 // some sort of generalized system for hitting with different parts of an item
 // e.g. pommel vs blade, rifle butt vs bayonet, knife hilt vs blade

--- a/code/game/objects/structures/_structure_materials.dm
+++ b/code/game/objects/structures/_structure_materials.dm
@@ -1,6 +1,4 @@
 /obj/structure
-	var/decl/material/material
-	var/decl/material/reinf_material
 	var/material_alteration
 	var/dismantled
 	var/name_prefix

--- a/code/game/objects/structures/_structure_materials.dm
+++ b/code/game/objects/structures/_structure_materials.dm
@@ -5,10 +5,6 @@
 	/// The base alpha used to calculate material-based alpha in update_material_color().
 	var/base_alpha = 50
 
-/obj/structure/get_material()
-	RETURN_TYPE(/decl/material)
-	return material
-
 /obj/structure/proc/get_material_health_modifier()
 	. = 1
 

--- a/code/game/objects/structures/door_assembly.dm
+++ b/code/game/objects/structures/door_assembly.dm
@@ -5,21 +5,42 @@
 	anchored = FALSE
 	density = TRUE
 	obj_flags = OBJ_FLAG_MOVES_UNSUPPORTED
+
+	material = /decl/material/solid/metal/steel
+	material_alteration = MAT_FLAG_ALTERATION_NAME
+
+	var/can_install_glass = TRUE
 	var/state = 0
-	var/base_name = "Airlock"
+	var/base_name = "airlock assembly"
 	var/obj/item/stock_parts/circuitboard/airlock_electronics/electronics = null
 	var/airlock_type = /obj/machinery/door/airlock //the type path of the airlock once completed
-	var/glass = 0 // 0 = glass can be installed. -1 = glass can't be installed. 1 = glass is already installed.
-	var/glass_material = /decl/material/solid/glass // if this door was to built right now and be made of glass, what material should the glass be?
 	var/created_name = null
 	var/panel_icon = 'icons/obj/doors/station/panel.dmi'
 	var/fill_icon = 'icons/obj/doors/station/fill_steel.dmi'
 	var/glass_icon = 'icons/obj/doors/station/fill_glass.dmi'
 	var/paintable = PAINT_PAINTABLE|PAINT_STRIPABLE
-	var/door_color = "none"
-	var/stripe_color = "none"
-	var/symbol_color = "none"
+	var/door_color
+	var/stripe_color
+	var/symbol_color
 	var/width = 1 // For multi-tile doors
+
+/obj/structure/door_assembly/update_material_name(override_name)
+	var/modifier
+	switch (state)
+		if(0)
+			if(anchored)
+				modifier = "secured "
+		if(1)
+			modifier = "wired "
+		if(2)
+			modifier = "near-finished "
+	if(reinf_material)
+		SetName("[modifier][reinf_material.solid_name] window [base_name]")
+	else
+		SetName("[modifier][base_name]")
+
+/obj/structure/door_assembly/window
+	reinf_material = /decl/material/solid/glass
 
 /obj/structure/door_assembly/Initialize(mapload, _mat, _reinf_mat, _dir)
 	. = ..(mapload, _mat, _reinf_mat)
@@ -52,10 +73,9 @@
 		if(0)
 			LAZYADD(., "Use a wrench to [anchored ? "un" : ""]anchor it.")
 			if(!anchored)
-				if(glass == 1)
-					var/decl/material/glass_material_datum = GET_DECL(glass_material)
-					if(glass_material_datum)
-						var/mat_name = glass_material_datum.solid_name || glass_material_datum.name
+				if(can_install_glass)
+					if(reinf_material)
+						var/mat_name = reinf_material.solid_name || reinf_material.name
 						LAZYADD(., "Use a welder to remove the [mat_name] plating currently attached.")
 				else
 					LAZYADD(., "Use a welder to disassemble completely.")
@@ -72,23 +92,23 @@
 	icon = 'icons/obj/doors/hatch/door.dmi'
 	panel_icon = 'icons/obj/doors/hatch/panel.dmi'
 	fill_icon = 'icons/obj/doors/hatch/fill_steel.dmi'
-	base_name = "Airtight Hatch"
+	base_name = "airtight hatch"
 	airlock_type = /obj/machinery/door/airlock/hatch
-	glass = -1
+	can_install_glass = FALSE
 
 /obj/structure/door_assembly/door_assembly_highsecurity // Borrowing this until WJohnston makes sprites for the assembly
 	icon = 'icons/obj/doors/secure/door.dmi'
 	fill_icon = 'icons/obj/doors/secure/fill_steel.dmi'
-	base_name = "High Security Airlock"
+	base_name = "high security airlock"
 	airlock_type = /obj/machinery/door/airlock/highsecurity
-	glass = -1
+	can_install_glass = FALSE
 	paintable = 0
 
 /obj/structure/door_assembly/door_assembly_ext
 	icon = 'icons/obj/doors/external/door.dmi'
 	fill_icon = 'icons/obj/doors/external/fill_steel.dmi'
 	glass_icon = 'icons/obj/doors/external/fill_glass.dmi'
-	base_name = "External Airlock"
+	base_name = "external airlock"
 	airlock_type = /obj/machinery/door/airlock/external
 	paintable = 0
 
@@ -105,7 +125,7 @@
 	icon = 'icons/obj/doors/rapid_pdoor.dmi'
 	icon_state = "pdoor1"
 	airlock_type = /obj/machinery/door/blast/regular
-	glass = -1
+	can_install_glass = FALSE
 	paintable = 0
 
 /obj/structure/door_assembly/blast/on_update_icon()
@@ -135,23 +155,21 @@
 		created_name = t
 		return TRUE
 
-	if(IS_WELDER(used_item) && (glass == 1 || !anchored))
+	if(IS_WELDER(used_item) && (can_install_glass || !anchored))
 		var/obj/item/weldingtool/welder = used_item
 		if (welder.weld(0, user))
 			playsound(src.loc, 'sound/items/Welder2.ogg', 50, 1)
-			if(glass == 1)
-				var/decl/material/glass_material_datum = GET_DECL(glass_material)
-				if(glass_material_datum)
-					var/mat_name = glass_material_datum.solid_name || glass_material_datum.name
-					user.visible_message("[user] welds the [mat_name] plating off the airlock assembly.", "You start to weld the [mat_name] plating off the airlock assembly.")
-					if(do_after(user, 4 SECONDS, src))
-						if(!welder.isOn())
-							return TRUE
-						to_chat(user, "<span class='notice'>You welded the [mat_name] plating off!</span>")
-						glass_material_datum.create_object(get_turf(src), 2)
-						glass = 0
-						update_icon()
-					return TRUE
+			if(reinf_material)
+				var/mat_name = reinf_material.solid_name
+				user.visible_message("[user] welds the [mat_name] plating off the airlock assembly.", "You start to weld the [mat_name] plating off the airlock assembly.")
+				if(do_after(user, 4 SECONDS, src))
+					if(!welder.isOn())
+						return TRUE
+					to_chat(user, "<span class='notice'>You welded the [mat_name] plating off!</span>")
+					reinf_material.create_object(get_turf(src), 2)
+					reinf_material = null
+					update_icon()
+				return TRUE
 			if(!anchored)
 				user.visible_message("[user] dissassembles the airlock assembly.", "You start to dissassemble the airlock assembly.")
 				if(do_after(user, 4 SECONDS, src))
@@ -243,17 +261,16 @@
 			update_icon()
 		return TRUE
 
-	else if(istype(used_item, /obj/item/stack/material) && !glass)
+	else if(istype(used_item, /obj/item/stack/material) && can_install_glass && !reinf_material)
 		var/obj/item/stack/material/S = used_item
-		var/material_name = S.get_material_type()
+		var/decl/material/sheet_material = S.get_material()
 		if (S.get_amount() >= 2)
 			playsound(src.loc, 'sound/items/Crowbar.ogg', 100, 1)
 			user.visible_message("[user] adds [S.name] to the airlock assembly.", "You start to install [S.name] into the airlock assembly.")
-			if(do_after(user, 4 SECONDS, src) && !glass)
+			if(do_after(user, 4 SECONDS, src) && can_install_glass && !reinf_material)
 				if (S.use(2))
-					to_chat(user, "<span class='notice'>You installed reinforced glass windows into the airlock assembly.</span>")
-					glass = 1
-					glass_material = material_name
+					reinf_material = sheet_material
+					to_chat(user, "<span class='notice'>You installed [reinf_material.solid_name] windows into the airlock assembly.</span>")
 					update_icon()
 			return TRUE
 		return FALSE
@@ -274,24 +291,22 @@
 
 /obj/structure/door_assembly/on_update_icon()
 	..()
+
 	var/image/filling_overlay
-	var/image/panel_overlay
-	var/final_name = ""
-	if(glass == 1)
+	if(reinf_material)
 		filling_overlay = image(glass_icon, "construction")
+		filling_overlay.color = reinf_material.color
+		filling_overlay.appearance_flags |= RESET_COLOR
 	else
 		filling_overlay = image(fill_icon, "construction")
-	switch (state)
-		if(0)
-			if (anchored)
-				final_name = "Secured "
+	if(filling_overlay)
+		add_overlay(filling_overlay)
+
+	var/image/panel_overlay
+	switch(state)
 		if(1)
-			final_name = "Wired "
 			panel_overlay = image(panel_icon, "construction0")
 		if(2)
-			final_name = "Near Finished "
 			panel_overlay = image(panel_icon, "construction1")
-	final_name += "[glass == 1 ? "Window " : ""][istext(glass) ? "[glass] Airlock" : base_name] Assembly"
-	SetName(final_name)
-	add_overlay(filling_overlay)
-	add_overlay(panel_overlay)
+	if(panel_overlay)
+		add_overlay(panel_overlay)

--- a/code/game/turfs/flooring/flooring_path.dm
+++ b/code/game/turfs/flooring/flooring_path.dm
@@ -16,11 +16,11 @@
 	var/paver_noun = "stones"
 
 /decl/flooring/path/update_turf_strings(turf/floor/target)
-	var/decl/material/material = target?.get_material()
-	ASSERT(material?.adjective_name)
+	var/decl/material/floor_material = target?.get_material()
+	ASSERT(floor_material?.adjective_name)
 	ASSERT(paver_noun)
-	target.SetName("[material.adjective_name] [name]")
-	target.desc = "[jointext_no_nulls(list("A", paving_adjective, "path made of", paver_adjective, material.adjective_name, paver_noun), " ")]."
+	target.SetName("[floor_material.adjective_name] [name]")
+	target.desc = "[jointext_no_nulls(list("A", paving_adjective, "path made of", paver_adjective, floor_material.adjective_name, paver_noun), " ")]."
 
 /decl/flooring/path/cobblestone
 	name            = "cobblestones"

--- a/code/game/turfs/flooring/flooring_rock.dm
+++ b/code/game/turfs/flooring/flooring_rock.dm
@@ -10,7 +10,7 @@
 	uid             = "floor_reinf_shuttle_rock"
 
 /decl/flooring/rock/update_turf_strings(turf/floor/target)
-	var/decl/material/material = target?.get_material()
-	ASSERT(material?.adjective_name)
-	target.SetName("[material.adjective_name] [name]")
-	target.desc = "An expanse of bare [material.solid_name]."
+	var/decl/material/turf_material = target?.get_material()
+	ASSERT(turf_material?.adjective_name)
+	target.SetName("[turf_material.adjective_name] [name]")
+	target.desc = "An expanse of bare [turf_material.solid_name]."

--- a/code/game/turfs/floors/_floor.dm
+++ b/code/game/turfs/floors/_floor.dm
@@ -32,7 +32,7 @@
 
 	. = ..(ml)
 
-	set_turf_materials(floor_material, skip_update = TRUE)
+	set_turf_materials(material, skip_update = TRUE)
 
 	if(!floortype && (ispath(_flooring) || islist(_flooring)))
 		floortype = _flooring
@@ -44,7 +44,7 @@
 
 	fill_to_zero_height() // try to refill turfs that act as fluid sources
 
-	if(floor_material || get_topmost_flooring())
+	if(material || get_topmost_flooring())
 		update_from_flooring(skip_update = ml)
 		if(ml) // We skipped the update above to avoid updating our neighbors, but we need to update ourselves.
 			lazy_update_icon()

--- a/code/game/turfs/floors/floor_materials.dm
+++ b/code/game/turfs/floors/floor_materials.dm
@@ -1,17 +1,14 @@
-/turf/floor
-	VAR_PROTECTED/decl/material/floor_material
-
 /turf/floor/set_turf_materials(decl/material/new_material, decl/material/new_reinf_material, force, decl/material/new_girder_material, skip_update)
 
 	if(ispath(new_material))
 		new_material = GET_DECL(new_material)
 
-	if(floor_material != new_material || force)
-		floor_material = new_material
-		if(!istype(floor_material))
-			if(floor_material)
-				PRINT_STACK_TRACE("Floor turf has been supplied non-material '[istype(floor_material, /datum) ? floor_material.type : (floor_material || "NULL")]'.")
-			floor_material = get_default_material()
+	if(material != new_material || force)
+		material = new_material
+		if(!istype(material))
+			if(material)
+				PRINT_STACK_TRACE("Floor turf has been supplied non-material '[istype(material, /datum) ? material.type : (material || "NULL")]'.")
+			material = get_default_material()
 		. = TRUE
 
 	if(. && !skip_update)
@@ -21,4 +18,4 @@
 	var/decl/flooring/flooring = get_topmost_flooring()
 	if(istype(flooring) && istype(flooring.force_material))
 		return flooring.force_material
-	return floor_material
+	return material

--- a/code/game/turfs/floors/subtypes/floor_concrete.dm
+++ b/code/game/turfs/floors/subtypes/floor_concrete.dm
@@ -4,7 +4,7 @@
 	icon_state     = "inset"
 	_flooring      = /decl/flooring/concrete
 	_base_flooring = /decl/flooring/dirt
-	floor_material = /decl/material/solid/stone/concrete
+	material       = /decl/material/solid/stone/concrete
 
 /turf/floor/concrete/smooth
 	icon_state     = "concrete"

--- a/code/game/turfs/floors/subtypes/floor_path.dm
+++ b/code/game/turfs/floors/subtypes/floor_path.dm
@@ -1,18 +1,18 @@
 
 /turf/floor/path
-	name            = "path"
-	gender          = NEUTER
-	desc            = "A cobbled path made of loose stones."
-	color           = COLOR_GRAY
-	icon            = 'icons/turf/flooring/path.dmi'
-	icon_state      = "cobble0"
-	_flooring       = /decl/flooring/path/cobblestone
-	floor_material  = /decl/material/solid/stone/sandstone
-	_base_flooring  = /decl/flooring/dirt
+	name           = "path"
+	gender         = NEUTER
+	desc           = "A cobbled path made of loose stones."
+	color          = COLOR_GRAY
+	icon           = 'icons/turf/flooring/path.dmi'
+	icon_state     = "cobble0"
+	_flooring      = /decl/flooring/path/cobblestone
+	material       = /decl/material/solid/stone/sandstone
+	_base_flooring = /decl/flooring/dirt
 
 /turf/floor/path/Initialize(mapload, no_update_icon)
 	. = ..()
-	set_turf_materials(floor_material || get_strata_material_type() || /decl/material/solid/stone/sandstone, skip_update = no_update_icon)
+	set_turf_materials(material || get_strata_material_type() || /decl/material/solid/stone/sandstone, skip_update = no_update_icon)
 	if(mapload && is_outside() && prob(20))
 		var/image/moss = image('icons/effects/decals/plant_remains.dmi', "leafy_bits", DECAL_LAYER)
 		moss.pixel_x = rand(-6, 6)
@@ -39,15 +39,15 @@
 #define PATH_MATERIAL_SUBTYPES(material_name) \
 /turf/floor/path/##material_name { \
 	color             = /decl/material/solid/stone/##material_name::color; \
-	floor_material    = /decl/material/solid/stone/##material_name; \
+	material          = /decl/material/solid/stone/##material_name; \
 } \
 /turf/floor/path/herringbone/##material_name { \
 	color             = /decl/material/solid/stone/##material_name::color; \
-	floor_material    = /decl/material/solid/stone/##material_name; \
+	material          = /decl/material/solid/stone/##material_name; \
 } \
 /turf/floor/path/running_bond/##material_name { \
 	color             = /decl/material/solid/stone/##material_name::color; \
-	floor_material    = /decl/material/solid/stone/##material_name; \
+	material          = /decl/material/solid/stone/##material_name; \
 } \
 /turf/floor/path/##material_name/water { \
 	color             = COLOR_SKY_BLUE; \

--- a/code/game/turfs/floors/subtypes/floor_rock.dm
+++ b/code/game/turfs/floors/subtypes/floor_rock.dm
@@ -6,12 +6,12 @@
 
 /turf/floor/rock/Initialize(mapload, no_update_icon)
 	. = ..()
-	set_turf_materials(floor_material || get_strata_material_type() || /decl/material/solid/stone/sandstone, skip_update = no_update_icon)
+	set_turf_materials(material || get_strata_material_type() || /decl/material/solid/stone/sandstone, skip_update = no_update_icon)
 
 /turf/floor/rock/volcanic
-	name           = "volcanic floor"
-	floor_material = /decl/material/solid/stone/basalt
+	name     = "volcanic floor"
+	material = /decl/material/solid/stone/basalt
 
 /turf/floor/rock/basalt
-	color          = /decl/material/solid/stone/basalt::color
-	floor_material = /decl/material/solid/stone/basalt
+	color    = /decl/material/solid/stone/basalt::color
+	material = /decl/material/solid/stone/basalt

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -272,8 +272,8 @@
 			try_dig_farm(user, used_item)
 			return TRUE
 
-		var/decl/material/material = get_material()
-		if(IS_PICK(used_item) && material)
+		var/decl/material/digging_material = get_material()
+		if(IS_PICK(used_item) && digging_material)
 
 			// TODO: move these checks into the interaction handlers.
 			var/atom/platform = get_supporting_platform()
@@ -281,7 +281,7 @@
 				to_chat(user, SPAN_WARNING("\The [platform] [platform.get_pronouns().is] in the way!"))
 				return TRUE
 
-			if(material?.hardness <= MAT_VALUE_FLEXIBLE)
+			if(digging_material?.hardness <= MAT_VALUE_FLEXIBLE)
 				to_chat(user, SPAN_WARNING("\The [src] is too soft to be excavated with \the [used_item]. Use a shovel."))
 				return TRUE
 
@@ -823,12 +823,7 @@
 	return null
 
 /turf/get_color()
-	if(paint_color)
-		return paint_color
-	var/decl/material/material = get_material()
-	if(material)
-		return material.color
-	return color
+	return paint_color || get_material()?.color || color
 
 /turf/proc/get_fishing_result(obj/item/food/bait)
 	var/area/A = get_area(src)
@@ -908,8 +903,8 @@
 		if(T.can_dig_trench(prop?.material?.hardness))
 			T.try_dig_trench(user, prop)
 	else if(IS_PICK(prop))
-		var/decl/material/material = T.get_material()
-		if(material?.hardness > MAT_VALUE_FLEXIBLE && T.can_dig_trench(prop?.material?.hardness, using_tool = TOOL_PICK))
+		var/decl/material/digging_material = T.get_material()
+		if(digging_material?.hardness > MAT_VALUE_FLEXIBLE && T.can_dig_trench(prop?.material?.hardness, using_tool = TOOL_PICK))
 			T.try_dig_trench(user, prop, using_tool = TOOL_PICK)
 
 /decl/interaction_handler/dig/pit

--- a/code/game/turfs/turf_digging.dm
+++ b/code/game/turfs/turf_digging.dm
@@ -57,8 +57,8 @@
 	return get_plant_growth_rate() > 0 && can_be_dug(tool_hardness, using_tool) && !(locate(/obj/machinery/portable_atmospherics/hydroponics/soil) in src)
 
 /turf/proc/try_dig_farm(mob/user, obj/item/tool, using_tool = TOOL_HOE)
-	var/decl/material/material = get_material()
-	if(!material?.tillable)
+	var/decl/material/turf_material = get_material()
+	if(!turf_material?.tillable)
 		return
 	if((!user && !tool) || tool.do_tool_interaction(using_tool, user, src, 5 SECONDS, set_cooldown = TRUE, check_skill = SKILL_BOTANY))
 		return dig_farm(user, tool?.material?.hardness, using_tool)

--- a/code/game/turfs/walls/_wall.dm
+++ b/code/game/turfs/walls/_wall.dm
@@ -121,10 +121,6 @@ var/global/list/wall_fullblend_objects = list(
 	if(!radiate())
 		return PROCESS_KILL
 
-/turf/wall/get_material()
-	RETURN_TYPE(/decl/material)
-	return material
-
 /turf/wall/bullet_act(var/obj/item/projectile/Proj)
 	if(istype(Proj,/obj/item/projectile/beam))
 		burn(2500)

--- a/code/game/turfs/walls/_wall.dm
+++ b/code/game/turfs/walls/_wall.dm
@@ -36,8 +36,6 @@ var/global/list/wall_fullblend_objects = list(
 	var/unique_merge_identifier
 	var/damage = 0
 	var/can_open = 0
-	var/decl/material/material
-	var/decl/material/reinf_material
 	var/decl/material/girder_material = /decl/material/solid/metal/steel
 	var/construction_stage
 	var/hitsound = 'sound/weapons/Genhit.ogg'

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -425,10 +425,9 @@
 	set name = "Spawn Material Stack"
 	if(!check_rights(R_DEBUG)) return
 
-	var/decl/material/material = input("Select material to spawn") as null|anything in decls_repository.get_decls_of_subtype_unassociated(/decl/material)
-	if(!istype(material))
-		return
-	material.create_object(get_turf(mob), 50)
+	var/decl/material/spawn_material = input("Select material to spawn") as null|anything in decls_repository.get_decls_of_subtype_unassociated(/decl/material)
+	if(istype(spawn_material))
+		spawn_material.create_object(get_turf(mob), 50)
 
 /client/proc/force_ghost_trap_trigger()
 	set category = "Debug"

--- a/code/modules/client/preference_setup/loadout/loadout.dm
+++ b/code/modules/client/preference_setup/loadout/loadout.dm
@@ -491,10 +491,10 @@
 	var/location
 	var/material
 
-/datum/gear_data/New(var/path, var/location, var/material)
-	src.path = path
-	src.location = location
-	src.material = material
+/datum/gear_data/New(var/_path, var/_location, var/_mat)
+	src.path = _path
+	src.location = _location
+	src.material = _mat
 
 /datum/gear_data/proc/can_replace_existing(obj/item/candidate)
 	return istype(candidate, path)

--- a/code/modules/codex/categories/category_substances.dm
+++ b/code/modules/codex/categories/category_substances.dm
@@ -66,10 +66,10 @@
 		if(mat.dissolves_in != MAT_SOLVENT_IMMUNE && LAZYLEN(mat.dissolves_into))
 			var/chems = list()
 			for(var/chemical in mat.dissolves_into)
-				var/decl/material/material = GET_DECL(chemical)
-				var/material_link = "<span codexlink='[material.codex_name || material.name] (substance)'>[material.name]</span>"
-				if(material.hidden_from_codex)
-					material_link = material.name
+				var/decl/material/chemical_decl = GET_DECL(chemical)
+				var/material_link = "<span codexlink='[chemical_decl.codex_name || chemical_decl.name] (substance)'>[chemical_decl.name]</span>"
+				if(chemical_decl.hidden_from_codex)
+					material_link = chemical_decl.name
 				chems += "[material_link] ([mat.dissolves_into[chemical]*100]%)"
 			var/solvent_needed
 			if(mat.dissolves_in <= MAT_SOLVENT_NONE)

--- a/code/modules/fabrication/designs/_design.dm
+++ b/code/modules/fabrication/designs/_design.dm
@@ -17,7 +17,7 @@
 
 // Populate name and resources from the product type.
 /datum/fabricator_recipe/proc/get_product_name()
-	. = atom_info_repository.get_name_for(path, amount = 1)
+	. = atom_info_repository.get_name_for(path, _amount = 1)
 
 /datum/fabricator_recipe/New()
 	..()
@@ -29,7 +29,7 @@
 		name = get_product_name()
 	if(required_technology == TRUE)
 		if(ispath(path, /obj/item))
-			required_technology = atom_info_repository.get_origin_tech_for(path, amount = 1)
+			required_technology = atom_info_repository.get_origin_tech_for(path, _amount = 1)
 		if(!islist(required_technology))
 			required_technology = list()
 	if(!resources)

--- a/code/modules/fabrication/fabricator_intake.dm
+++ b/code/modules/fabrication/fabricator_intake.dm
@@ -40,22 +40,22 @@
 	var/mat_colour = thing.color
 	for(var/mat in thing.matter)
 
-		var/decl/material/material_def = GET_DECL(mat)
-		if(!material_def || !base_storage_capacity[material_def.type])
+		var/decl/material/ingest_material = GET_DECL(mat)
+		if(!ingest_material || !base_storage_capacity[mat])
 			continue
 
-		var/taking_material = min(thing.matter[mat], storage_capacity[material_def.type] - stored_material[material_def.type])
+		var/taking_material = min(thing.matter[mat], storage_capacity[mat] - stored_material[mat])
 		if(taking_material <= 0)
 			continue
 
 		if(!mat_colour)
-			mat_colour = material_def.color
+			mat_colour = ingest_material.color
 
-		stored_material[material_def.type] += taking_material
+		stored_material[mat] += taking_material
 		if(stack_ref)
 			stacks_used = max(stacks_used, ceil(taking_material/stack_matter_div))
 
-		if(storage_capacity[material_def.type] == stored_material[material_def.type])
+		if(storage_capacity[mat] == stored_material[mat])
 			. = SUBSTANCE_TAKEN_FULL
 		else if(. != SUBSTANCE_TAKEN_FULL)
 			. = SUBSTANCE_TAKEN_ALL

--- a/code/modules/fabrication/recycler.dm
+++ b/code/modules/fabrication/recycler.dm
@@ -83,8 +83,8 @@
 		visible_message("[capitalize(english_list(fell_out))] fall out of \the overflowing [src]!")
 
 	for(var/mat in munched_matter)
-		var/decl/material/material = GET_DECL(mat)
-		switch(material.phase_at_temperature())
+		var/decl/material/munched_material = GET_DECL(mat)
+		switch(munched_material.phase_at_temperature())
 			if(MAT_PHASE_SOLID)
 
 				// Dump the material out as a stack.

--- a/code/modules/maps/template_types/random_exoplanet/planet_types/meat.dm
+++ b/code/modules/maps/template_types/random_exoplanet/planet_types/meat.dm
@@ -132,7 +132,7 @@
 	icon              = 'icons/turf/flooring/flesh.dmi'
 	icon_state        = "meat"
 	_base_flooring    = /decl/flooring/meat
-	floor_material    = /decl/material/solid/organic/meat
+	material          = /decl/material/solid/organic/meat
 
 /turf/floor/meat/acid
 	name              = "juices"

--- a/code/modules/materials/_material_stack.dm
+++ b/code/modules/materials/_material_stack.dm
@@ -18,7 +18,6 @@
 	material_alteration = MAT_FLAG_ALTERATION_COLOR
 	var/can_be_pulverized = FALSE
 	var/can_be_reinforced = FALSE
-	var/decl/material/reinf_material
 
 /obj/item/stack/material/Initialize(mapload, var/amount, var/_material, var/_reinf_material)
 

--- a/code/modules/materials/_materials.dm
+++ b/code/modules/materials/_materials.dm
@@ -545,25 +545,25 @@ var/global/list/_descriptive_temperature_strings
 	if(!_descriptive_temperature_strings)
 		_descriptive_temperature_strings = list()
 
-		for(var/decl/material/material as anything in decls_repository.get_decls_of_subtype_unassociated(/decl/material))
+		for(var/decl/material/desc_material as anything in decls_repository.get_decls_of_subtype_unassociated(/decl/material))
 
-			if(material.type != material.temperature_burn_milestone_material)
+			if(desc_material.type != desc_material.temperature_burn_milestone_material)
 				continue
 
-			if(!isnull(material.bakes_into_at_temperature) && material.bakes_into_material)
-				var/decl/material/cook = GET_DECL(material.bakes_into_material)
-				global._descriptive_temperature_strings["bake [material.name] into [cook.name]"] = material.bakes_into_at_temperature
+			if(!isnull(desc_material.bakes_into_at_temperature) && desc_material.bakes_into_material)
+				var/decl/material/cook = GET_DECL(desc_material.bakes_into_material)
+				global._descriptive_temperature_strings["bake [desc_material.name] into [cook.name]"] = desc_material.bakes_into_at_temperature
 				continue
 
-			switch(material.phase_at_temperature())
+			switch(desc_material.phase_at_temperature())
 				if(MAT_PHASE_SOLID)
-					if(!isnull(material.ignition_point))
-						global._descriptive_temperature_strings["ignite [material.name]"] = material.ignition_point
-					else if(!isnull(material.melting_point))
-						global._descriptive_temperature_strings["melt [material.name]"] = material.melting_point
+					if(!isnull(desc_material.ignition_point))
+						global._descriptive_temperature_strings["ignite [desc_material.name]"] = desc_material.ignition_point
+					else if(!isnull(desc_material.melting_point))
+						global._descriptive_temperature_strings["melt [desc_material.name]"] = desc_material.melting_point
 				if(MAT_PHASE_LIQUID)
-					if(!isnull(material.boiling_point))
-						global._descriptive_temperature_strings["boil [material.name]"] = material.boiling_point
+					if(!isnull(desc_material.boiling_point))
+						global._descriptive_temperature_strings["boil [desc_material.name]"] = desc_material.boiling_point
 
 	for(var/burn_string in global._descriptive_temperature_strings)
 		if(temperature >= global._descriptive_temperature_strings[burn_string])

--- a/code/modules/materials/definitions/solids/materials_solid_alien.dm
+++ b/code/modules/materials/definitions/solids/materials_solid_alien.dm
@@ -26,5 +26,5 @@
 	melting_point = rand(400,11000)
 	. = ..()
 
-/decl/material/solid/metal/aliumium/place_dismantled_girder(var/turf/target, var/decl/material/reinf_material)
+/decl/material/solid/metal/aliumium/place_dismantled_girder(var/turf/target, var/decl/material/r_mat)
 	return

--- a/code/modules/materials/material_debris.dm
+++ b/code/modules/materials/material_debris.dm
@@ -21,8 +21,8 @@
 		var/mat_amt = matter[mat]
 		if(!highest_mat || matter[highest_mat] < mat_amt)
 			highest_mat = mat
-		var/decl/material/material_decl = GET_DECL(mat)
-		mat_names += material_decl.solid_name
+		var/decl/material/scrap_material = GET_DECL(mat)
+		mat_names += scrap_material.solid_name
 		total_matter += mat_amt
 
 	// Safety check, although this should be prevented for player side interactions

--- a/code/modules/materials/material_gas_overlay.dm
+++ b/code/modules/materials/material_gas_overlay.dm
@@ -6,7 +6,6 @@
 	layer = FIRE_LAYER
 	appearance_flags = RESET_COLOR
 	mouse_opacity = MOUSE_OPACITY_UNCLICKABLE
-	var/decl/material/material
 
 INITIALIZE_IMMEDIATE(/obj/effect/gas_overlay)
 

--- a/code/modules/materials/material_product_spawning.dm
+++ b/code/modules/materials/material_product_spawning.dm
@@ -27,8 +27,8 @@
 			placed.dropInto(target)
 
 // Places a girder object when a wall is dismantled, also applies reinforced material.
-/decl/material/proc/place_dismantled_girder(var/turf/target, var/decl/material/reinf_material)
-	return create_object(target, 1, /obj/structure/girder, ispath(reinf_material) ? reinf_material : reinf_material?.type)
+/decl/material/proc/place_dismantled_girder(var/turf/target, var/decl/material/r_mat)
+	return create_object(target, 1, /obj/structure/girder, ispath(r_mat) ? r_mat : r_mat?.type)
 
 // General wall debris product placement.
 // Not particularly necessary aside from snowflakey cult girders.

--- a/code/modules/mechs/mech.dm
+++ b/code/modules/mechs/mech.dm
@@ -47,9 +47,6 @@
 	var/hardpoints_locked
 	var/maintenance_protocols
 
-	// Material
-	var/decl/material/material
-
 	// Cockpit access vars.
 	var/hatch_closed = FALSE
 	var/hatch_locked = FALSE

--- a/code/modules/power/fusion/kinetic_harvester.dm
+++ b/code/modules/power/fusion/kinetic_harvester.dm
@@ -65,9 +65,9 @@
 	data["status"] = (use_power >= POWER_USE_ACTIVE)
 	data["materials"] = list()
 	for(var/mat in stored)
-		var/decl/material/material = GET_DECL(mat)
+		var/decl/material/stored_material = GET_DECL(mat)
 		var/sheets = floor(stored[mat]/(SHEET_MATERIAL_AMOUNT * 1.5))
-		data["materials"] += list(list("name" = material.solid_name, "amount" = sheets, "harvest" = harvesting[mat], "mat_ref" = "\ref[material]"))
+		data["materials"] += list(list("name" = stored_material.solid_name, "amount" = sheets, "harvest" = harvesting[mat], "mat_ref" = "\ref[stored_material]"))
 
 	ui = SSnano.try_update_ui(user, src, ui_key, ui, data, force_open)
 	if (!ui)
@@ -109,15 +109,15 @@
 /obj/machinery/kinetic_harvester/OnTopic(var/mob/user, var/href_list, var/datum/topic_state/state)
 
 	if(href_list["remove_mat"])
-		var/decl/material/material = locate(href_list["remove_mat"])
-		if(istype(material))
+		var/decl/material/remove_material = locate(href_list["remove_mat"])
+		if(istype(remove_material))
 			var/sheet_cost = (SHEET_MATERIAL_AMOUNT * 1.5)
-			var/sheets = floor(stored[material.type]/sheet_cost)
+			var/sheets = floor(stored[remove_material.type]/sheet_cost)
 			if(sheets > 0)
-				material.create_object(loc, sheets)
-				stored[material.type] -= (sheets * sheet_cost)
-				if(stored[material.type] <= 0)
-					stored -= material.type
+				remove_material.create_object(loc, sheets)
+				stored[remove_material.type] -= (sheets * sheet_cost)
+				if(stored[remove_material.type] <= 0)
+					stored -= remove_material.type
 				return TOPIC_REFRESH
 
 	if(href_list["toggle_power"])
@@ -126,12 +126,12 @@
 		return TOPIC_REFRESH
 
 	if(href_list["toggle_harvest"])
-		var/decl/material/material = locate(href_list["toggle_harvest"])
-		if(istype(material))
-			if(harvesting[material.type])
-				harvesting -= material.type
+		var/decl/material/harvest_material = locate(href_list["toggle_harvest"])
+		if(istype(harvest_material))
+			if(harvesting[harvest_material.type])
+				harvesting -= harvest_material.type
 			else
-				harvesting[material.type] = TRUE
-				if(!(material.type in stored))
-					stored[material.type] = 0
+				harvesting[harvest_material.type] = TRUE
+				if(!(harvest_material.type in stored))
+					stored[harvest_material.type] = 0
 		return TOPIC_REFRESH

--- a/code/modules/reagents/Chemistry-Grinder.dm
+++ b/code/modules/reagents/Chemistry-Grinder.dm
@@ -100,9 +100,9 @@
 		return
 
 	if(istype(used_item,/obj/item/stack/material))
-		var/decl/material/material = used_item.get_material()
-		if(!material)
-			to_chat(user, SPAN_NOTICE("\The [material.solid_name] cannot be ground down to any usable reagents."))
+		var/decl/material/grind_material = used_item.get_material()
+		if(!grind_material)
+			to_chat(user, SPAN_NOTICE("\The [grind_material.solid_name] cannot be ground down to any usable reagents."))
 			return TRUE
 
 	else if(!used_item.reagents?.total_volume)
@@ -203,8 +203,8 @@
 
 		var/obj/item/stack/material/stack = thing
 		if(istype(stack))
-			var/decl/material/material = stack.get_material()
-			if(!material)
+			var/decl/material/grind_material = stack.get_material()
+			if(!grind_material)
 				break
 
 			var/amount_to_take = max(0,min(stack.amount, floor(remaining_volume / REAGENT_UNITS_PER_MATERIAL_SHEET)))
@@ -212,7 +212,7 @@
 				stack.use(amount_to_take)
 				if(QDELETED(stack))
 					holdingitems -= stack
-				beaker.add_to_reagents(material.type, (amount_to_take * REAGENT_UNITS_PER_MATERIAL_SHEET * skill_factor))
+				beaker.add_to_reagents(grind_material.type, (amount_to_take * REAGENT_UNITS_PER_MATERIAL_SHEET * skill_factor))
 				continue
 
 		else if(thing.reagents)

--- a/code/modules/reagents/Chemistry-Holder.dm
+++ b/code/modules/reagents/Chemistry-Holder.dm
@@ -30,8 +30,8 @@ var/global/datum/reagents/sink/infinite_reagent_sink = new
 	var/obj/item/debris/scraps/scraps
 	for(var/mat in materials)
 		var/amount = materials[mat]
-		var/decl/material/material_data = GET_DECL(mat)
-		switch(material_data.phase_at_temperature(exposed_temperature, ambient_pressure))
+		var/decl/material/burn_material = GET_DECL(mat)
+		switch(burn_material.phase_at_temperature(exposed_temperature, ambient_pressure))
 
 			if(MAT_PHASE_SOLID)
 				if(!scraps)

--- a/code/unit_tests/food_tests.dm
+++ b/code/unit_tests/food_tests.dm
@@ -127,8 +127,8 @@
 							grown = grown.dry_out(null, grown.get_max_drying_wetness() + 1)
 							grown.forceMove(container)
 
-			for(var/material_key in recipe.reagents)
-				container.add_to_reagents(material_key, recipe.reagents[material_key])
+			for(var/mat in recipe.reagents)
+				container.add_to_reagents(mat, recipe.reagents[mat])
 
 			if(!recipe_is_valid)
 				QDEL_LIST(container.contents) // clean up prematurely

--- a/code/unit_tests/materials.dm
+++ b/code/unit_tests/materials.dm
@@ -60,11 +60,11 @@
 	// This is obscene, but completeness requires it.
 	for(var/stack_type in stack_types)
 		for(var/tool_type in tool_types)
-			for(var/decl/material/material in test_materials)
+			for(var/decl/material/test_material in test_materials)
 				for(var/decl/material/reinforced as anything in (test_materials + null))
 
 					// Get a linear list of all recipes available to this combination.
-					var/list/recipes = get_stack_recipes(material, reinforced, stack_type, tool_type, flat = TRUE)
+					var/list/recipes = get_stack_recipes(test_material, reinforced, stack_type, tool_type, flat = TRUE)
 					if(!length(recipes))
 						continue
 
@@ -72,7 +72,7 @@
 					for(var/decl/stack_recipe/recipe as anything in recipes)
 						if(!recipe.result_type || ispath(recipe.result_type, /turf)) // Cannot exist without a loc and doesn't have matter, cannot assess here.
 							continue
-						var/list/results = recipe.spawn_result(null, null, 1, material, reinforced, null)
+						var/list/results = recipe.spawn_result(null, null, 1, test_material, reinforced, null)
 						var/atom/product = LAZYACCESS(results, 1)
 						var/list/failed = list()
 						if(!product)
@@ -83,21 +83,21 @@
 							var/list/product_matter = list()
 							for(var/obj/product_obj in results)
 								product_matter = MERGE_ASSOCS_WITH_NUM_VALUES(product_matter, product_obj.get_contained_matter(include_reagents = FALSE))
-							if(!material && !reinforced)
+							if(!test_material && !reinforced)
 								if(length(product_matter))
 									failed += "unsupplied material types"
-							else if(material && (product_matter[material.type]) > recipe.req_amount)
-								failed += "excessive base material ([recipe.req_amount]/[ceil(product_matter[material.type])])"
+							else if(test_material && (product_matter[test_material.type]) > recipe.req_amount)
+								failed += "excessive base material ([recipe.req_amount]/[ceil(product_matter[test_material.type])])"
 							else if(reinforced && (product_matter[reinforced.type]) > recipe.req_amount)
 								failed += "excessive reinf material ([recipe.req_amount]/[ceil(product_matter[reinforced.type])])"
 							else
 								for(var/mat in product_matter)
-									if(mat != material?.type && mat != reinforced?.type)
+									if(mat != test_material?.type && mat != reinforced?.type)
 										failed += "extra material type ([mat])"
 
 						if(length(failed)) // Try to prune out some duplicate error spam, we have too many materials now
 							if(!(recipe.type in seen_design_types))
-								failed_designs += "[material?.type || "null mat"] - [reinforced?.type || "null reinf"] - [tool_type] - [stack_type] - [recipe.type] - [english_list(failed)]"
+								failed_designs += "[test_material?.type || "null mat"] - [reinforced?.type || "null reinf"] - [tool_type] - [stack_type] - [recipe.type] - [english_list(failed)]"
 								seen_design_types += recipe.type
 								failed_count++
 						else

--- a/mods/content/integrated_electronics/circuit_serialization.dm
+++ b/mods/content/integrated_electronics/circuit_serialization.dm
@@ -293,8 +293,8 @@
 		// Update estimated assembly complexity, taken space and material cost
 		blocks["complexity"] += component.complexity
 		blocks["used_space"] += component.size
-		for(var/material in component.matter)
-			blocks["cost"][material] += component.matter[material]
+		for(var/mat in component.matter)
+			blocks["cost"][mat] += component.matter[mat]
 
 		// Check if the assembly requires printer upgrades
 		if(!(component.spawn_flags & IC_SPAWN_DEFAULT))

--- a/mods/content/integrated_electronics/components/input.dm
+++ b/mods/content/integrated_electronics/components/input.dm
@@ -299,8 +299,8 @@
 		set_pin_data(IC_OUTPUT, i, null)
 	if(plant.seed && (plant in view(get_turf(src)))) // Like the medbot's analyzer it can be used at range.
 		for(var/chem_path in plant.seed.chems)
-			var/decl/material/material = GET_DECL(chem_path)
-			greagents.Add(material.use_name)
+			var/decl/material/seed_chem = GET_DECL(chem_path)
+			greagents.Add(seed_chem.use_name)
 
 	set_pin_data(IC_OUTPUT, 1, greagents)
 	push_data()

--- a/mods/content/integrated_electronics/tools/printer.dm
+++ b/mods/content/integrated_electronics/tools/printer.dm
@@ -49,14 +49,14 @@
 /obj/item/integrated_circuit_printer/proc/recycle(obj/item/used_item, mob/user, obj/item/electronic_assembly/assembly)
 	if(!used_item.canremove) //in case we have an augment circuit
 		return
-	for(var/material in used_item.matter)
-		if(materials[material] + used_item.matter[material] > metal_max)
-			var/decl/material/material_datum = GET_DECL(material)
-			if(material_datum)
-				to_chat(user, "<span class='notice'>[src] can't hold any more [material_datum.name]!</span>")
+	for(var/mat in used_item.matter)
+		if(materials[mat] + used_item.matter[mat] > metal_max)
+			var/decl/material/recycle_material = GET_DECL(mat)
+			if(recycle_material)
+				to_chat(user, "<span class='notice'>[src] can't hold any more [recycle_material.name]!</span>")
 			return
-	for(var/material in used_item.matter)
-		materials[material] += used_item.matter[material]
+	for(var/mat in used_item.matter)
+		materials[mat] += used_item.matter[mat]
 	if(assembly)
 		assembly.remove_component(used_item)
 	if(user)
@@ -152,9 +152,9 @@
 	else
 		HTML += "Materials: "
 		var/list/dat = list()
-		for(var/material in materials)
-			var/decl/material/material_datum = GET_DECL(material)
-			dat += "[materials[material]]/[metal_max] [material_datum.name]"
+		for(var/mat in materials)
+			var/decl/material/print_material = GET_DECL(mat)
+			dat += "[materials[mat]]/[metal_max] [print_material.name]"
 		HTML += jointext(dat, "; ")
 		HTML += ".<br><br>"
 
@@ -296,8 +296,8 @@
 					if(!subtract_material_costs(cost, usr))
 						return
 					var/cloning_time = 0
-					for(var/material in cost)
-						cloning_time += cost[material]
+					for(var/mat in cost)
+						cloning_time += cost[mat]
 					cloning_time = round(cloning_time/15)
 					cloning_time = min(cloning_time, MAX_CIRCUIT_CLONE_TIME)
 					cloning = TRUE
@@ -313,19 +313,19 @@
 				to_chat(usr, "<span class='notice'>Cloning has been canceled. Cost has been refunded.</span>")
 				cloning = FALSE
 				var/cost = program["cost"]
-				for(var/material in cost)
-					materials[material] = min(metal_max, materials[material] + cost[material])
+				for(var/mat in cost)
+					materials[mat] = min(metal_max, materials[mat] + cost[mat])
 
 	interact(usr)
 
 /obj/item/integrated_circuit_printer/proc/subtract_material_costs(var/list/cost, var/mob/user)
-	for(var/material in cost)
-		if(materials[material] < cost[material])
-			var/decl/material/material_datum = GET_DECL(material)
-			to_chat(user, "<span class='warning'>You need [cost[material]] [material_datum.name] to build that!</span>")
+	for(var/mat in cost)
+		if(materials[mat] < cost[mat])
+			var/decl/material/print_material = GET_DECL(mat)
+			to_chat(user, "<span class='warning'>You need [cost[mat]] [print_material.name] to build that!</span>")
 			return FALSE
-	for(var/material in cost) //Iterate twice to make sure it's going to work before deducting
-		materials[material] -= cost[material]
+	for(var/mat in cost) //Iterate twice to make sure it's going to work before deducting
+		materials[mat] -= cost[mat]
 	return TRUE
 
 // FUKKEN UPGRADE DISKS

--- a/mods/content/xenobiology/slime/items.dm
+++ b/mods/content/xenobiology/slime/items.dm
@@ -32,8 +32,8 @@
 		return TRUE
 	. = ..()
 
-/obj/item/slime_extract/Initialize(var/ml, var/material, var/_stype = /decl/slime_colour/grey)
-	. = ..(ml, material)
+/obj/item/slime_extract/Initialize(var/ml, var/mat, var/_stype = /decl/slime_colour/grey)
+	. = ..(ml, mat)
 	slime_type = _stype
 	if(!ispath(slime_type, /decl/slime_colour))
 		PRINT_STACK_TRACE("Slime extract initialized with non-decl slime colour: [slime_type || "NULL"].")

--- a/mods/gamemodes/cult/materials.dm
+++ b/mods/gamemodes/cult/materials.dm
@@ -12,7 +12,7 @@
 	exoplanet_rarity_plant = MAT_RARITY_NOWHERE
 	exoplanet_rarity_gas = MAT_RARITY_NOWHERE
 
-/decl/material/solid/stone/cult/place_dismantled_girder(var/turf/target)
+/decl/material/solid/stone/cult/place_dismantled_girder(var/turf/target, var/decl/material/r_mat)
 	return list(new /obj/structure/girder/cult(target))
 
 /decl/material/solid/stone/cult/reinforced


### PR DESCRIPTION
## Description of changes
- `material` and `reinf_material` are now on `/atom`. Actually initializing/using the vars is handled on the respective types, only the references are shared.
- Bunch of 'material' args and vars renamed for clarity.
- Replaces `floor_material` on /turf/floor with `material`.

## Why and what will this PR improve
Makes material serde a lot more straightforward and eases future work around unifying materials.

## Authorship
Myself.

## Changelog
Nothing player-facing.