### PR TITLE
Simplifying hand offset logic.

### DIFF
--- a/code/_onclick/hud/hud_elements/hud_robot.dm
+++ b/code/_onclick/hud/hud_elements/hud_robot.dm
@@ -1,5 +1,4 @@
 /datum/hud/robot
-	offset_hands_vertically = FALSE
 	gun_mode_toggle_type    = /obj/screen/gun/mode
 	omit_hud_elements       = list(
 		/decl/hud_element/health,

--- a/code/_onclick/hud/hud_types/_hud.dm
+++ b/code/_onclick/hud/hud_types/_hud.dm
@@ -99,8 +99,6 @@
 	VAR_PRIVATE/obj/screen/gun/item/gun_item_use_toggle
 	VAR_PRIVATE/obj/screen/gun/radio/gun_radio_use_toggle
 
-	var/offset_hands_vertically = TRUE
-
 /datum/hud/New(mob/_owner)
 	if(istype(_owner))
 		owner = weakref(_owner)
@@ -353,30 +351,18 @@
 			qdel(inv_box)
 
 	// Rebuild offsets for the hand elements.
+	var/const/elems_per_row = 4
 	var/hand_y_offset = 21
 	var/list/elements = hud_elements_hands?.Copy()
-	if(length(elements))
-		if(offset_hands_vertically)
-			while(length(elements))
-				var/copy_index = min(length(elements), 2)+1
-				var/list/sublist = elements.Copy(1, copy_index)
-				elements.Cut(1, copy_index)
-				var/obj/screen/inventory/inv_box
-				if(length(sublist) == 1)
-					inv_box = sublist[1]
-					inv_box.screen_loc = "CENTER,BOTTOM:[hand_y_offset]"
-				else
-					inv_box = sublist[1]
-					inv_box.screen_loc = "CENTER:-[world.icon_size/2],BOTTOM:[hand_y_offset]"
-					inv_box = sublist[2]
-					inv_box.screen_loc = "CENTER:[world.icon_size/2],BOTTOM:[hand_y_offset]"
-				hand_y_offset += world.icon_size
-		else
-			var/hand_x_offset = -((length(elements) * world.icon_size) / 2) + (world.icon_size/2)
-			for(var/obj/screen/inventory/inv_box in elements)
-				inv_box.screen_loc = "CENTER:[hand_x_offset],BOTTOM:[hand_y_offset]"
-				hand_x_offset += world.icon_size
-			hand_y_offset += world.icon_size
+	while(length(elements))
+		var/copy_index = min(length(elements), elems_per_row)+1
+		var/list/sublist = elements.Copy(1, copy_index)
+		elements.Cut(1, copy_index)
+		var/hand_x_offset = (world.icon_size/2) * (1 - length(sublist))
+		for(var/obj/screen/inventory/inv_box in sublist)
+			inv_box.screen_loc = "CENTER:[hand_x_offset],BOTTOM:[hand_y_offset]"
+			hand_x_offset += world.icon_size
+		hand_y_offset += world.icon_size
 
 	if(mymob.client && islist(hud_elements_hands) && length(hud_elements_hands))
 		mymob.client.screen |= hud_elements_hands


### PR DESCRIPTION
## Description of changes
- Expands hands per row to 4 from 2, since we have more space after condensing intents/inv stuff.
- Reworks hands positioning logic to allow for any number of slots and any number of slots per row.

## Why and what will this PR improve
Octopodes PR looks terrible due to doing a 2x4 stack of inventory slots.

## Authorship
Myself.

## Changelog
Nothing player-facing.