### PR TITLE
Adding maniple organ category.

### DIFF
--- a/code/__defines/damage_organs.dm
+++ b/code/__defines/damage_organs.dm
@@ -77,6 +77,8 @@
 #define ORGAN_CATEGORY_STANCE      "stance"
 /// Limb is considered the 'root' of a given stance limb (leg) - also counted for stance damage a la ORGAN_CATEGORY_STANCE
 #define ORGAN_CATEGORY_STANCE_ROOT "stance_root"
+// Limb is considered a manipulator, currently only used when trying to pilot a wheelchair.
+#define ORGAN_CATEGORY_MANIPLE     "maniple"
 
 // Droplimb types.
 #define DISMEMBER_METHOD_EDGE  0

--- a/code/_helpers/global_lists.dm
+++ b/code/_helpers/global_lists.dm
@@ -37,12 +37,15 @@ var/global/list/string_slot_flags = list(
 )
 
 // Used to avoid constantly generating new lists during movement.
+var/global/list/all_maniple_limbs   = list(
+	(ORGAN_CATEGORY_MANIPLE)
+)
 var/global/list/all_stance_limbs   = list(
-	ORGAN_CATEGORY_STANCE,
-	ORGAN_CATEGORY_STANCE_ROOT
+	(ORGAN_CATEGORY_STANCE),
+	(ORGAN_CATEGORY_STANCE_ROOT)
 )
 var/global/list/child_stance_limbs = list(
-	ORGAN_CATEGORY_STANCE
+	(ORGAN_CATEGORY_STANCE)
 )
 
 // TODO: Replace keybinding datums with keybinding decls to make this unnecessary.

--- a/code/controllers/subsystems/jobs.dm
+++ b/code/controllers/subsystems/jobs.dm
@@ -556,7 +556,7 @@ SUBSYSTEM_DEF(jobs)
 	if(job.req_admin_notify)
 		to_chat(H, "<b>You are playing a job that is important for Game Progression. If you have to disconnect, please notify the admins via adminhelp.</b>")
 
-	if(H.needs_wheelchair())
+	if(H.cannot_stand())
 		equip_wheelchair(H)
 
 	BITSET(H.hud_updateflag, ID_HUD)

--- a/code/modules/bodytype/_bodytype.dm
+++ b/code/modules/bodytype/_bodytype.dm
@@ -415,20 +415,19 @@ var/global/list/bodytypes_by_category = list()
 		var/list/organ_data = has_limbs[organ_tag]
 		var/obj/item/organ/organ = organ_data["path"]
 		organ_data["descriptor"] = initial(organ.name)
-		var/organ_cat = initial(organ.organ_category)
-		if(organ_cat)
+		for(var/organ_cat in cached_json_decode(initial(organ.organ_categories)))
 			LAZYINITLIST(_organs_by_category)
 			LAZYADD(_organs_by_category[organ_cat], organ)
 			LAZYINITLIST(_organ_tags_by_category)
 			LAZYADD(_organ_tags_by_category[organ_cat], organ_tag)
+
 		var/list/parent_organ_data = has_limbs[organ::parent_organ]
 		if(parent_organ_data)
 			parent_organ_data["has_children"]++
 
 	for(var/organ_tag in has_organ)
 		var/obj/item/organ/organ = has_organ[organ_tag]
-		var/organ_cat = initial(organ.organ_category)
-		if(organ_cat)
+		for(var/organ_cat in cached_json_decode(initial(organ.organ_categories)))
 			LAZYINITLIST(_organs_by_category)
 			LAZYADD(_organs_by_category[organ_cat], organ)
 			LAZYINITLIST(_organ_tags_by_category)

--- a/code/modules/mob/living/human/human_movement.dm
+++ b/code/modules/mob/living/human/human_movement.dm
@@ -25,20 +25,25 @@
 	if(can_feel_pain() && get_shock() >= 10)
 		tally += (get_shock() / 10) //pain shouldn't slow you down if you can't even feel it
 
+	var/list/limbs_to_check
 	if(istype(buckled, /obj/structure/chair/wheelchair))
-		for(var/organ_name in list(BP_L_HAND, BP_R_HAND, BP_L_ARM, BP_R_ARM))
-			var/obj/item/organ/external/E = GET_EXTERNAL_ORGAN(src, organ_name)
-			tally += E ? E.get_movement_delay(4) : 4
-	else
 		for(var/obj/item/I in get_equipped_items(include_carried = TRUE))
 			var/slot = get_equipped_slot_for_item(I)
 			tally += LAZYACCESS(I.slowdown_per_slot, slot)
 			tally += I.slowdown_general
 			tally += I.slowdown_accessory
+		limbs_to_check = global.all_maniple_limbs
+	else
+		limbs_to_check = global.all_stance_limbs
 
-		for(var/organ_name in list(BP_L_LEG, BP_R_LEG, BP_L_FOOT, BP_R_FOOT))
-			var/obj/item/organ/external/E = GET_EXTERNAL_ORGAN(src, organ_name)
-			tally += E ? E.get_movement_delay(4) : 4
+	var/missing_limbs = H ? H.bodytype.get_expected_organ_count_for_categories(limbs_to_check) : 4
+	if(missing_limbs > 0)
+		var/max_delay_per_limb = ceil(16/missing_limbs)
+		for(var/obj/item/organ/external/limb in get_organs_by_categories(limbs_to_check))
+			tally += limb.get_movement_delay(max_delay_per_limb)
+			missing_limbs--
+		if(missing_limbs > 0)
+			tally += missing_limbs * max_delay_per_limb
 
 	if(shock_stage >= 10 || get_stamina() <= 0)
 		tally += 3
@@ -95,6 +100,11 @@
 
 		handle_leg_damage()
 		species.handle_post_move(src)
+
+/mob/living/human/forceMove()
+	. = ..()
+	if(.)
+		species.handle_post_move(src, exertion = FALSE)
 
 /mob/living/human/proc/handle_leg_damage()
 	if(!can_feel_pain())

--- a/code/modules/mob/living/human/human_organs.dm
+++ b/code/modules/mob/living/human/human_organs.dm
@@ -70,9 +70,10 @@
 		LAZYDISTINCTADD(external_organs, O)
 
 	// Update our organ category lists, if neeed.
-	if(O.organ_category)
-		LAZYINITLIST(organs_by_category)
-		LAZYDISTINCTADD(organs_by_category[O.organ_category], O)
+	if(O.organ_categories)
+		for(var/category in cached_json_decode(O.organ_categories))
+			LAZYINITLIST(organs_by_category)
+			LAZYDISTINCTADD(organs_by_category[category], O)
 
 	// Update stat organs as well
 	if(O.has_stat_info)
@@ -112,10 +113,11 @@
 		LAZYREMOVE(external_organs, O)
 
 	// Update our organ category lists, if neeed.
-	if(O.organ_category && islist(organs_by_category))
-		organs_by_category[O.organ_category] -= O
-		if(LAZYLEN(organs_by_category[O.organ_category]) <= 0)
-			LAZYREMOVE(organs_by_category, O.organ_category)
+	if(O.organ_categories && islist(organs_by_category))
+		for(var/category in cached_json_decode(O.organ_categories))
+			organs_by_category[category] -= O
+			if(LAZYLEN(organs_by_category[category]) <= 0)
+				LAZYREMOVE(organs_by_category, category)
 
 	// Update stat organs as well
 	if(O.has_stat_info && stat_organs)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -838,14 +838,6 @@ default behaviour is:
 		if(saturation > 0)
 			fluids.trans_to_holder(touching_reagents, saturation)
 
-/mob/living/proc/needs_wheelchair()
-	var/tmp_stance_damage = 0
-	for(var/limb_tag in list(BP_L_LEG, BP_R_LEG, BP_L_FOOT, BP_R_FOOT))
-		var/obj/item/organ/external/E = GET_EXTERNAL_ORGAN(src, limb_tag)
-		if(!E || !E.is_usable())
-			tmp_stance_damage += 2
-	return tmp_stance_damage >= 4
-
 /mob/living/proc/seizure()
 	set waitfor = 0
 	sleep(rand(5,10))

--- a/code/modules/organs/external/quadruped.dm
+++ b/code/modules/organs/external/quadruped.dm
@@ -20,7 +20,7 @@
 	amputation_point = "front left knee"
 	tendon_name = "cruciate ligament"
 	artery_name = "femoral artery"
-	organ_category = ORGAN_CATEGORY_STANCE_ROOT
+	organ_categories = @"['" + ORGAN_CATEGORY_STANCE_ROOT + "']"
 	limb_flags = ORGAN_FLAG_CAN_AMPUTATE | ORGAN_FLAG_CAN_STAND | ORGAN_FLAG_HAS_TENDON | ORGAN_FLAG_CAN_BREAK | ORGAN_FLAG_CAN_DISLOCATE
 
 /obj/item/organ/external/arm/right/quadruped
@@ -29,7 +29,7 @@
 	amputation_point = "front right knee"
 	tendon_name = "cruciate ligament"
 	artery_name = "femoral artery"
-	organ_category = ORGAN_CATEGORY_STANCE_ROOT
+	organ_categories = @"['" + ORGAN_CATEGORY_STANCE_ROOT + "']"
 	limb_flags = ORGAN_FLAG_CAN_AMPUTATE | ORGAN_FLAG_CAN_STAND | ORGAN_FLAG_HAS_TENDON | ORGAN_FLAG_CAN_BREAK | ORGAN_FLAG_CAN_DISLOCATE
 
 /obj/item/organ/external/hand/quadruped
@@ -38,7 +38,7 @@
 	amputation_point = "front left ankle"
 	tendon_name = "Achilles tendon"
 	limb_flags = ORGAN_FLAG_CAN_AMPUTATE | ORGAN_FLAG_CAN_STAND | ORGAN_FLAG_HAS_TENDON | ORGAN_FLAG_CAN_BREAK | ORGAN_FLAG_CAN_DISLOCATE
-	organ_category = ORGAN_CATEGORY_STANCE
+	organ_categories = @"['" + ORGAN_CATEGORY_STANCE + "']"
 	gripper_type = null
 
 /obj/item/organ/external/hand/right/quadruped
@@ -47,5 +47,5 @@
 	amputation_point = "front right ankle"
 	tendon_name = "Achilles tendon"
 	limb_flags = ORGAN_FLAG_CAN_AMPUTATE | ORGAN_FLAG_CAN_STAND | ORGAN_FLAG_HAS_TENDON | ORGAN_FLAG_CAN_BREAK | ORGAN_FLAG_CAN_DISLOCATE
-	organ_category = ORGAN_CATEGORY_STANCE
+	organ_categories = @"['" + ORGAN_CATEGORY_STANCE + "']"
 	gripper_type = null

--- a/code/modules/organs/external/standard.dm
+++ b/code/modules/organs/external/standard.dm
@@ -61,6 +61,7 @@
 	artery_name = "basilic vein"
 	arterial_bleed_severity = 0.75
 	limb_flags = ORGAN_FLAG_CAN_AMPUTATE | ORGAN_FLAG_HAS_TENDON | ORGAN_FLAG_CAN_BREAK | ORGAN_FLAG_CAN_DISLOCATE
+	organ_categories = @"['" + ORGAN_CATEGORY_MANIPLE + "']"
 
 /obj/item/organ/external/arm/right
 	organ_tag = BP_R_ARM
@@ -83,7 +84,7 @@
 	tendon_name = "cruciate ligament"
 	artery_name = "femoral artery"
 	arterial_bleed_severity = 0.75
-	organ_category = ORGAN_CATEGORY_STANCE_ROOT
+	organ_categories = @"['" + ORGAN_CATEGORY_STANCE_ROOT + "']"
 	limb_flags = ORGAN_FLAG_CAN_AMPUTATE | ORGAN_FLAG_CAN_STAND | ORGAN_FLAG_HAS_TENDON | ORGAN_FLAG_CAN_BREAK | ORGAN_FLAG_CAN_DISLOCATE
 
 /obj/item/organ/external/leg/right
@@ -108,7 +109,7 @@
 	tendon_name = "Achilles tendon"
 	arterial_bleed_severity = 0.5
 	limb_flags = ORGAN_FLAG_CAN_AMPUTATE | ORGAN_FLAG_CAN_STAND | ORGAN_FLAG_HAS_TENDON | ORGAN_FLAG_CAN_BREAK | ORGAN_FLAG_CAN_DISLOCATE
-	organ_category = ORGAN_CATEGORY_STANCE
+	organ_categories = @"['" + ORGAN_CATEGORY_STANCE + "']"
 
 /obj/item/organ/external/foot/get_natural_attacks()
 	var/static/list/unarmed_attacks = list(
@@ -141,6 +142,7 @@
 	arterial_bleed_severity = 0.5
 	limb_flags = ORGAN_FLAG_CAN_AMPUTATE | ORGAN_FLAG_FINGERPRINT | ORGAN_FLAG_HAS_TENDON | ORGAN_FLAG_CAN_BREAK | ORGAN_FLAG_CAN_DISLOCATE
 	is_washable = TRUE
+	organ_categories = @"['" + ORGAN_CATEGORY_MANIPLE + "']"
 	var/gripper_type = /datum/inventory_slot/gripper/left_hand
 
 /obj/item/organ/external/hand/get_natural_attacks()

--- a/code/modules/organs/organ.dm
+++ b/code/modules/organs/organ.dm
@@ -13,15 +13,15 @@
 	// Strings.
 	/// Unique identifier.
 	var/organ_tag = "organ"
-	/// Identifier for use in organ collections, unused if unset. Would be nice to make this a list, but bodytypes rely on initial() with it.
-	var/organ_category
+	/// Identifiers for use in organ collections, unused if unset. Must be formatted as a JSON list string.
+	var/organ_categories
 	/// Organ holding this object.
 	var/parent_organ = BP_CHEST
 
 	// Status tracking.
 	/// Various status flags (such as robotic)
 	var/status = 0
-	/// A flag for telling what capabilities this organ has. ORGAN_PROP_PROSTHETIC, ORGAN_PROP_CRYSTAL, etc..
+	/// A flag for telling what capabilities this organ has. ORGAN_PROP_PROSTHETIC, ORGAN_PROP_CRYSTAL, etc.
 	var/organ_properties = 0
 	/// Cache var for vitality to current owner.
 	var/vital_to_owner

--- a/code/modules/species/species.dm
+++ b/code/modules/species/species.dm
@@ -664,8 +664,9 @@ var/global/const/DEFAULT_SPECIES_HEALTH = 200
 			// This assumes that if a pain-level has been defined it also has a list of emotes to go with it
 			return pick(pain_emotes)
 
-/decl/species/proc/handle_post_move(var/mob/living/human/H)
-	handle_exertion(H)
+/decl/species/proc/handle_post_move(var/mob/living/human/H, exertion = TRUE)
+	if(exertion)
+		handle_exertion(H)
 
 /decl/species/proc/handle_exertion(mob/living/human/H)
 	if (!exertion_effect_chance)

--- a/code/modules/submaps/submap_join.dm
+++ b/code/modules/submaps/submap_join.dm
@@ -112,7 +112,8 @@
 		global.universe.OnPlayerLatejoin(character)
 		log_and_message_admins("has joined the round as offsite role [character.mind.assigned_role].", character)
 		RAISE_EVENT(/decl/observ/submap_join, src, character, job)
-		if(character.cannot_stand()) equip_wheelchair(character)
+		if(character.cannot_stand())
+			equip_wheelchair(character)
 		job.post_equip_job_title(character, job.title)
 		qdel(joining)
 

--- a/code/unit_tests/codex.dm
+++ b/code/unit_tests/codex.dm
@@ -1,5 +1,5 @@
 /datum/unit_test/codex_string_uniqueness
-	name = "CODEX:  All Codex Associated Strings Shall Be Unique"
+	name = "CODEX: All Codex Associated Strings Shall Be Unique"
 
 /datum/unit_test/codex_string_uniqueness/start_test()
 	var/list/failures = list()


### PR DESCRIPTION
## Description of changes
- Adds a maniple organ category for retrieving 'hand' limbs similarly to 'stance' limbs.
- Replaces hardcoded organ list in wheelchair movement code with maniple category.
- Adds an overlooked case for human post-move proc.
- Unifies wheelchair spawn checking under `cannot_stand()`.

Dependency for octopus port.

## Why and what will this PR improve
- Ease of retrieving arbitrary organ lists from species.
- More complete calling of post-move hooks.

## Authorship
Myself.

## Changelog
Nothing player-facing.