### PR TITLE
Overhaul a lot of visible_message messages to use grammar helpers

### DIFF
--- a/code/_onclick/other_mobs.dm
+++ b/code/_onclick/other_mobs.dm
@@ -31,10 +31,7 @@
 	if(!LAZYLEN(climbers) || (user in climbers) || !user.check_dexterity(DEXTERITY_HOLD_ITEM, silent = TRUE))
 		return FALSE
 
-	user.visible_message(
-		SPAN_DANGER("\The [user] shakes \the [src]!"),
-		SPAN_DANGER("You shake \the [src]!")
-	)
+	user.visible_action_message("shake", "\the [src]!", dangerous = ACTION_DANGER_ALL)
 
 	object_shaken()
 	return TRUE

--- a/code/datums/extensions/cell/cell.dm
+++ b/code/datums/extensions/cell/cell.dm
@@ -136,10 +136,7 @@
 		return TRUE // technically a valid interaction.
 
 	// Unload the cell.
-	user.visible_message(
-		SPAN_NOTICE("\The [user] removes \the [existing_cell] from \the [holder]."),
-		SPAN_NOTICE("You remove \the [existing_cell] from \the [holder].")
-	)
+	user.visible_action_message("remove", "\the [existing_cell] from \the [holder].")
 	existing_cell.dropInto(get_turf(holder))
 	user.put_in_active_hand(existing_cell)
 	holder_item.update_icon()

--- a/code/datums/extensions/holster/holster.dm
+++ b/code/datums/extensions/holster/holster.dm
@@ -52,7 +52,7 @@
 		if(isobj(storage?.holder))
 			var/obj/obj_holder = storage.holder
 			obj_holder.w_class = max(obj_holder.w_class, holstered.w_class)
-		user.visible_message("<span class='notice'>\The [user] holsters \the [holstered].</span>", "<span class='notice'>You holster \the [holstered].</span>")
+		user.visible_action_message("holster", "\the [holstered].")
 		atom_holder.SetName("occupied [initial(atom_holder.name)]")
 		atom_holder.update_icon()
 		events_repository.register(/decl/observ/moved, holstered, src, PROC_REF(check_holster))
@@ -82,15 +82,9 @@
 				G.check_accidents(user)
 				if(G.safety() && !user.skill_fail_prob(SKILL_WEAPONS, 100, SKILL_EXPERT, 0.5)) //Experienced shooter will disable safety before shooting.
 					G.toggle_safety(user)
-			user.visible_message(
-				"<span class='danger'>\The [user] draws \the [holstered], ready to go!</span>",
-				"<span class='warning'>You draw \the [holstered], ready to go!</span>"
-				)
+			user.visible_action_message("draw", "\the [holstered], ready to go!", dangerous = ACTION_DANGER_OTHERS)
 		else
-			user.visible_message(
-				"<span class='notice'>\The [user] draws \the [holstered], pointing it at the ground.</span>",
-				"<span class='notice'>You draw \the [holstered], pointing it at the ground.</span>"
-				)
+			user.visible_action_message("draw", "\the [holstered], pointing it at the ground.")
 		if(sound_out)
 			playsound(get_turf(atom_holder), sound_out, sound_vol)
 		holstered.add_fingerprint(user)

--- a/code/datums/extensions/label.dm
+++ b/code/datums/extensions/label.dm
@@ -43,8 +43,8 @@
 		return
 
 	if(user)
-		user.visible_message(SPAN_NOTICE("\The [user] removes a label from \the [atom_holder]."), \
-							 SPAN_NOTICE("You remove a label, '[label]', from \the [atom_holder]."))
+		// The infix usage here is a little clunky but I'm not sure how else to make it work
+		user.visible_action_message("remove", "from \the [atom_holder]", ACTION_DANGER_NONE, self_infix = "a label, '[label]'", other_infix = "a label")
 
 	var/old_name = atom_holder.name
 	// We find and replace the first instance, since that's the one we removed from the list

--- a/code/datums/extensions/milkable/milkable.dm
+++ b/code/datums/extensions/milkable/milkable.dm
@@ -94,15 +94,9 @@
 		handle_milking_failure(user, critter)
 		return TRUE
 
-	user.visible_message(
-		SPAN_NOTICE("\The [user] starts milking \the [critter] into \the [container]."),
-		SPAN_NOTICE("You start milking \the [critter] into \the [container].")
-	)
+	user.visible_action_message("start", "milking \the [critter] into \the [container].")
 	if(!user.do_skilled(4 SECONDS, milking_skill, target = critter, check_holding = TRUE))
-		user.visible_message(
-			SPAN_NOTICE("\The [user] stops milking \the [critter]."),
-			SPAN_NOTICE("You stop milking \the [critter].")
-		)
+		user.visible_action_message("stop", "milking \the [critter].")
 		return TRUE
 
 	if(critter.stat == DEAD)
@@ -120,10 +114,7 @@
 		to_chat(user, SPAN_WARNING("Wait for \the [critter] to stop moving before you try milking it."))
 		return TRUE
 
-	user.visible_message(
-		SPAN_NOTICE("\The [user] milks \the [critter] into \the [container]."),
-		SPAN_NOTICE("You milk \the [critter] into \the [container].")
-	)
+	user.visible_action_message("milk", "\the [critter] into \the [container].")
 	udder.trans_to(container, min(REAGENTS_FREE_SPACE(container.reagents), rand(15, 20)))
 	return TRUE
 

--- a/code/datums/extensions/resistable/resistable.dm
+++ b/code/datums/extensions/resistable/resistable.dm
@@ -22,11 +22,7 @@
 	breakouttime = max(5, breakouttime * user.get_restraint_breakout_mod())
 	user.setClickCooldown(breakouttime)
 
-	user.visible_message(
-		SPAN_DANGER("\The [user] attempts to remove \the [restraint]!"),
-		SPAN_DANGER("You attempt to remove \the [restraint] (This will take around [ceil(breakouttime / (1 SECOND))] second\s and you need to stand still)."),
-		range = 2
-	)
+	user.visible_action_message("attempt", "to remove \the [restraint]!", ACTION_DANGER_ALL, range = 2, self_postfix = "(This will take around [ceil(breakouttime / (1 SECOND))] second\s and you need to stand still).")
 
 	var/static/resist_stages = 4
 	for(var/i = 1 to resist_stages)

--- a/code/datums/extensions/shearable/shearable.dm
+++ b/code/datums/extensions/shearable/shearable.dm
@@ -62,15 +62,9 @@
 		handle_shearing_failure(user, critter)
 		return TRUE
 
-	user.visible_message(
-		SPAN_NOTICE("\The [user] starts shearing \the [critter]."),
-		SPAN_NOTICE("You start shearing \the [critter].")
-	)
+	user.visible_action_message("start", "shearing \the [critter].")
 	if(!user.do_skilled(4 SECONDS, shearing_skill))
-		user.visible_message(
-			SPAN_NOTICE("\The [user] stops shearing \the [critter]."),
-			SPAN_NOTICE("You stop shearing \the [critter].")
-		)
+		user.visible_action_message("stop", "shearing \the [critter].")
 		return TRUE
 
 	if(QDELETED(user) || QDELETED(critter) || QDELETED(shears) || user.get_active_held_item() != shears)

--- a/code/datums/storage/subtypes_misc.dm
+++ b/code/datums/storage/subtypes_misc.dm
@@ -55,10 +55,7 @@
 
 /datum/storage/med_pouch/open(mob/user)
 	if(!opened)
-		user.visible_message(
-			SPAN_NOTICE("\The [user] tears open \the [holder], breaking the vacuum seal!"),
-			SPAN_NOTICE("You tear open \the [holder], breaking the vacuum seal!")
-		)
+		user.visible_action_message("tear", "open \the [holder], breaking the vacuum seal!")
 	. = ..()
 
 /datum/storage/cigpapers

--- a/code/datums/uplink/services.dm
+++ b/code/datums/uplink/services.dm
@@ -94,7 +94,7 @@
 		return
 	state = CURRENTLY_ACTIVE
 	update_icon()
-	user.visible_message("<span class='notice'>\The [user] activates \the [src].</span>", "<span class='notice'>You activate \the [src].</span>")
+	user.visible_action_message("activate", "\the [src].")
 	log_and_message_admins("has activated the service '[service_label]'", user)
 
 	if(service_duration)

--- a/code/game/machinery/OpTable.dm
+++ b/code/game/machinery/OpTable.dm
@@ -99,9 +99,7 @@
 
 /obj/machinery/optable/proc/take_victim(mob/living/target, mob/living/user)
 	if (target == user)
-		user.visible_message( \
-		SPAN_NOTICE("\The [user] climbs on \the [src]."), \
-		SPAN_NOTICE("You climb on \the [src]."))
+		user.visible_action_message("climb", "on \the [src].")
 	else
 		visible_message(SPAN_NOTICE("\The [target] has been laid on \the [src] by \the [user]."))
 	target.dropInto(loc)

--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -315,7 +315,7 @@
 			if(!user.try_unequip(used_item, src))
 				return TRUE
 			beaker = used_item
-			user.visible_message(SPAN_NOTICE("\The [user] adds \a [used_item] to \the [src]."), SPAN_NOTICE("You add \a [used_item] to \the [src]."))
+			user.visible_action_message("add", "\a [used_item] to \the [src].")
 		else
 			to_chat(user, SPAN_WARNING("\The [src] has a beaker already."))
 		return TRUE

--- a/code/game/machinery/_machines_base/machine_construction/wall_frame.dm
+++ b/code/game/machinery/_machines_base/machine_construction/wall_frame.dm
@@ -92,7 +92,7 @@
 	if(IS_WIRECUTTER(used_item))
 		TRANSFER_STATE(diconnected_state)
 		playsound(get_turf(machine), 'sound/items/Wirecutter.ogg', 50, 1)
-		user.visible_message(SPAN_WARNING("\The [user] has cut the wires inside \the [machine]!"), "You have cut the wires inside \the [machine].")
+		user.visible_action_message("cut", "the wires inside \the [machine]!", dangerous = ACTION_DANGER_WARNING)
 		new /obj/item/stack/cable_coil(get_turf(machine), 5)
 		machine.set_broken(TRUE, MACHINE_BROKEN_CONSTRUCT)
 		machine.queue_icon_update()

--- a/code/game/machinery/_machines_base/machine_construction/wall_frame.dm
+++ b/code/game/machinery/_machines_base/machine_construction/wall_frame.dm
@@ -215,7 +215,7 @@
 		TRANSFER_STATE(diconnected_state)
 		user.try_unequip(board, machine)
 		machine.install_component(board)
-		user.visible_message(SPAN_NOTICE("\The [user] inserts \the [board] into \the [machine]!"), SPAN_NOTICE("You insert \the [board] into \the [machine]!"))
+		user.visible_action_message("insert", "\the [board] into \the [machine]!")
 		machine.queue_icon_update()
 		return TRUE
 

--- a/code/game/machinery/_machines_base/machinery_components.dm
+++ b/code/game/machinery/_machines_base/machinery_components.dm
@@ -312,7 +312,7 @@ Standard helpers for users interacting with machinery parts.
 	else
 		user.try_unequip(part, src)
 		install_component(part)
-	user.visible_message(SPAN_NOTICE("\The [user] installs \the [part] in \the [src]!"), SPAN_NOTICE("You install \the [part] in \the [src]!"))
+	user.visible_action_message("install", "\the [part] in \the [src]!")
 	return TRUE
 
 /obj/machinery/proc/part_removal(mob/user)
@@ -341,7 +341,7 @@ Standard helpers for users interacting with machinery parts.
 	var/obj/item/stock_parts/part = uninstall_component(get_component_of_type(path, TRUE))
 	if(part)
 		user.put_in_hands(part) // Already dropped at loc, so that's the fallback.
-		user.visible_message(SPAN_NOTICE("\The [user] removes \the [part] from \the [src]."), SPAN_NOTICE("You remove \the [part] from \the [src]."))
+		user.visible_action_message("remove", "\the [part] from \the [src].")
 
 /obj/machinery/proc/missing_parts(var/only_functional)
 	if(!construct_state)

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -677,31 +677,19 @@ About the new airlock wires panel:
 		return FALSE
 
 	if (src.lock_cut_state == BOLTS_FINE)
-		user.visible_message(
-			SPAN_NOTICE("\The [user] begins [cut_verb] through the bolt cover on [src]."),
-			SPAN_NOTICE("You begin [cut_verb] through the bolt cover.")
-			)
+		user.visible_action_message("begin", "[cut_verb] through the bolt cover on \the [src].")
 
 		playsound(src, cut_sound, 100, 1)
 		if (do_after(user, cut_delay, src))
-			user.visible_message(
-				SPAN_NOTICE("\The [user] removes the bolt cover from [src]."),
-				SPAN_NOTICE("You remove the cover and expose the door bolts.")
-				)
+			user.visible_action_message("remove", "the bolt cover from \the [src]", self_postfix = "and expose$USER_S$ the door bolts.", other_postfix = ".")
 			src.lock_cut_state = BOLTS_EXPOSED
 		return TRUE
 
 	if (src.lock_cut_state == BOLTS_EXPOSED)
-		user.visible_message(
-			SPAN_NOTICE("\The [user] begins [cut_verb] through [src]'s bolts."),
-			SPAN_NOTICE("You begin [cut_verb] through the door bolts.")
-			)
+		user.visible_action_message("begin", "[cut_verb] through \the [src]'s bolts.")
 		playsound(src, cut_sound, 100, 1)
 		if (do_after(user, cut_delay, src))
-			user.visible_message(
-				SPAN_NOTICE("\The [user] severs the door bolts, unlocking [src]."),
-				SPAN_NOTICE("You sever the door bolts, unlocking the door.")
-				)
+			user.visible_action_message("sever", "the door bolts, unlocking \the [src].")
 			src.lock_cut_state = BOLTS_CUT
 			src.unlock(1) //force it
 		return TRUE
@@ -747,8 +735,7 @@ About the new airlock wires panel:
 			to_chat(user, SPAN_NOTICE("Your [welder.name] doesn't have enough fuel."))
 			return TRUE
 		playsound(src, 'sound/items/Welder.ogg', 50, 1)
-		user.visible_message(SPAN_WARNING("\The [user] begins welding \the [src] [welded ? "open" : "closed"]!"),
-							SPAN_NOTICE("You begin welding \the [src] [welded ? "open" : "closed"]."))
+		user.visible_action_message("begin", "welding \the [src] [welded ? "open" : "closed"].")
 		if(do_after(user, (rand(3,5)) SECONDS, src))
 			if(density && !operating && !repairing)
 				playsound(src, 'sound/items/Welder2.ogg', 50, 1)
@@ -825,11 +812,11 @@ About the new airlock wires panel:
 			playsound(src, 'sound/weapons/smash.ogg', 100, 1)
 			current_health -= F.expend_attack_force(user) * 2
 			if(current_health <= 0)
-				user.visible_message(SPAN_DANGER("[user] smashes \the [weapon] into the airlock's control panel! It explodes in a shower of sparks!"), SPAN_DANGER("You smash \the [weapon] into the airlock's control panel! It explodes in a shower of sparks!"))
+				user.visible_action_message("smash", "\the [weapon] into \the [src]'s control panel! It explodes in a shower of sparks!", dangerous = ACTION_DANGER_ALL)
 				current_health = 0
 				set_broken(TRUE)
 			else
-				user.visible_message(SPAN_DANGER("[user] smashes \the [weapon] into the airlock's control panel!"))
+				user.visible_action_message("smash", "\the [weapon] into \the [src]'s control panel!", dangerous = ACTION_DANGER_ALL)
 			return TRUE
 	return ..()
 

--- a/code/game/machinery/doors/airlock_subtypes.dm
+++ b/code/game/machinery/doors/airlock_subtypes.dm
@@ -158,8 +158,8 @@
 	if(panel_open && !arePowerSystemsOn())
 		if(IS_WRENCH(used_item))
 			playsound(src.loc, 'sound/items/Ratchet.ogg', 50, 1)
-			user.visible_message(SPAN_WARNING("[user.name] starts frantically pumping the bolt override mechanism!"), SPAN_WARNING("You start frantically pumping the bolt override mechanism!"))
-			if(do_after(user, 160) && locked)
+			user.visible_action_message("start", "frantically pumping the bolt override mechanism!", dangerous = ACTION_DANGER_WARNING)
+			if(do_after(user, 16 SECONDS) && locked)
 				visible_message("\The [src] bolts disengage!")
 				locked = FALSE
 				return TRUE

--- a/code/game/machinery/flasher.dm
+++ b/code/game/machinery/flasher.dm
@@ -39,10 +39,7 @@
 	if(IS_WIRECUTTER(used_item))
 		add_fingerprint(user, 0, used_item)
 		src.disable = !src.disable
-		if (src.disable)
-			user.visible_message("<span class='warning'>[user] has disconnected \the [src]'s flashbulb!</span>", "<span class='warning'>You disconnect \the [src]'s flashbulb!</span>")
-		if (!src.disable)
-			user.visible_message("<span class='warning'>[user] has connected \the [src]'s flashbulb!</span>", "<span class='warning'>You connect \the [src]'s flashbulb!</span>")
+		user.visible_action_message(disable ? "disconnect" : "connect", "\the [src]'s flashbulb!", dangerous = ACTION_DANGER_WARNING)
 		return TRUE
 	else
 		return ..()

--- a/code/game/machinery/igniter.dm
+++ b/code/game/machinery/igniter.dm
@@ -123,10 +123,7 @@
 	if(panel_open && IS_WIRECUTTER(used_item))
 		add_fingerprint(user)
 		disable = !disable
-		if(disable)
-			user.visible_message(SPAN_WARNING("[user] has disabled \the [src]!"), SPAN_WARNING("You disable the connection to \the [src]."))
-		else
-			user.visible_message(SPAN_WARNING("[user] has reconnected \the [src]!"), SPAN_WARNING("You fix the connection to \the [src]."))
+		user.visible_action_message(disable ? "disable" : "fix", "the connection to \the [src]!", dangerous = ACTION_DANGER_WARNING)
 		update_icon()
 		return TRUE
 	else

--- a/code/game/machinery/kitchen/microwave.dm
+++ b/code/game/machinery/kitchen/microwave.dm
@@ -57,10 +57,7 @@
 /obj/machinery/microwave/attackby(var/obj/item/used_item, var/mob/user)
 	if(broken > 0)
 		if(broken == 2 && IS_SCREWDRIVER(used_item)) // If it's broken and they're using a screwdriver
-			user.visible_message(
-				SPAN_NOTICE("\The [user] starts to fix part of [src]."),
-				SPAN_NOTICE("You start to fix part of [src].")
-			)
+			user.visible_action_message("start", "to fix part of [src].")
 			if (do_after(user, 20, src))
 				user.visible_message(
 					SPAN_NOTICE("\The [user] fixes part of [src]."),
@@ -68,10 +65,7 @@
 				)
 				broken = 1 // Fix it a bit
 		else if(broken == 1 && IS_WRENCH(used_item)) // If it's broken and they're doing the wrench
-			user.visible_message(
-				SPAN_NOTICE("\The [user] starts to fix part of [src]."),
-				SPAN_NOTICE("You start to fix part of [src].")
-			)
+			user.visible_action_message("start", "to fix part of [src].")
 			if (do_after(user, 20, src))
 				user.visible_message(
 					SPAN_NOTICE("\The [user] fixes [src]."),
@@ -89,10 +83,7 @@
 		return
 	else if(dirty==100) // The microwave is all dirty so can't be used!
 		if(istype(used_item, /obj/item/chems/spray/cleaner) || istype(used_item, /obj/item/chems/rag)) // If they're trying to clean it then let them
-			user.visible_message(
-				SPAN_NOTICE("\The [user] starts to clean [src]."),
-				SPAN_NOTICE("You start to clean [src].")
-			)
+			user.visible_action_message("start", "to clean [src].")
 			if (do_after(user, 20, src))
 				user.visible_message(
 					SPAN_NOTICE("\The [user] has cleaned [src]."),

--- a/code/game/machinery/kitchen/microwave.dm
+++ b/code/game/machinery/kitchen/microwave.dm
@@ -284,7 +284,7 @@
 
 	START_PROCESSING_MACHINE(src, MACHINERY_PROCESS_SELF)
 	addtimer(CALLBACK(src, PROC_REF(half_time_process)), cook_time / 2)
-	visible_message(SPAN_NOTICE("[src] turns on."), SPAN_NOTICE("You hear a microwave."))
+	visible_message(SPAN_NOTICE("[src] turns on."), null, SPAN_NOTICE("You hear a microwave."))
 
 	if(cook_dirty)
 		playsound(loc, 'sound/effects/splat.ogg', 50, 1) // Play a splat sound

--- a/code/game/machinery/newscaster.dm
+++ b/code/game/machinery/newscaster.dm
@@ -755,7 +755,7 @@ var/global/list/allCasters = list() //Global list that will contain reference to
 	icon = 'icons/obj/bureaucracy.dmi'
 	icon_state = "newspaper"
 	w_class = ITEM_SIZE_SMALL	//Let's make it fit in trashbags!
-	attack_verb = list("bapped","thwapped","smacked")
+	attack_verb = list("bap","thwap","smack")
 	_base_attack_force = 0
 	material = /decl/material/solid/organic/paper
 

--- a/code/game/machinery/nuclear_bomb.dm
+++ b/code/game/machinery/nuclear_bomb.dm
@@ -90,21 +90,21 @@ var/global/bomb_set
 						to_chat(user, "<span class='warning'>You need more fuel to complete this task.</span>")
 						return TRUE
 
-					user.visible_message("[user] starts cutting loose the anchoring bolt covers on [src].", "You start cutting loose the anchoring bolt covers with [used_item]...")
+					user.visible_action_message("start", "cutting loose the anchoring bolt covers on \the [src] with \the [used_item]...")
 
 					if(do_after(user, 4 SECONDS, src))
 						if(QDELETED(src) || QDELETED(user) || !welder.weld(5, user)) return TRUE
-						user.visible_message("\The [user] cuts through the bolt covers on \the [src].", "You cut through the bolt cover.")
+						user.visible_action_message("cut", "through the bolt covers on \the [src].")
 						removal_stage = 1
 				return TRUE
 
 			if(1)
 				if(IS_CROWBAR(used_item))
-					user.visible_message("[user] starts forcing open the bolt covers on [src].", "You start forcing open the anchoring bolt covers with [used_item]...")
+					user.visible_action_message("start", "forcing open the bolt covers on \the [src] with \the [used_item].")
 
 					if(do_after(user, 1.5 SECONDS, src))
 						if(QDELETED(src) || QDELETED(user)) return TRUE
-						user.visible_message("\The [user] forces open the bolt covers on \the [src].", "You force open the bolt covers.")
+						user.visible_action_message("force", "open the bolt covers on \the [src].")
 						removal_stage = 2
 				return TRUE
 
@@ -113,32 +113,32 @@ var/global/bomb_set
 					var/obj/item/weldingtool/welder = used_item
 					if(!welder.isOn()) return TRUE
 					if (welder.get_fuel() < 5) // uses up 5 fuel.
-						to_chat(user, "<span class='warning'>You need more fuel to complete this task.</span>")
+						to_chat(user, SPAN_WARNING("You need more fuel to complete this task."))
 						return TRUE
 
-					user.visible_message("[user] starts cutting apart the anchoring system sealant on [src].", "You start cutting apart the anchoring system's sealant with [used_item]...")
+					user.visible_action_message("start", "cutting apart the anchoring system sealant on \the [src] with \the [used_item]...")
 
 					if(do_after(user, 4 SECONDS, src))
 						if(QDELETED(src) || QDELETED(user) || !welder.weld(5, user)) return TRUE
-						user.visible_message("\The [user] cuts apart the anchoring system sealant on \the [src].", "You cut apart the anchoring system's sealant.")
+						user.visible_action_message("cut", "apart the anchoring system sealant on \the [src].")
 						removal_stage = 3
 				return TRUE
 
 			if(3)
 				if(IS_WRENCH(used_item))
-					user.visible_message("[user] begins unwrenching the anchoring bolts on [src].", "You begin unwrenching the anchoring bolts...")
+					user.visible_action_message("start", "unwrenching the anchoring bolts on \the [src] with \the [used_item]...")
 					if(do_after(user, 5 SECONDS, src))
 						if(QDELETED(src) || QDELETED(user)) return TRUE
-						user.visible_message("[user] unwrenches the anchoring bolts on [src].", "You unwrench the anchoring bolts.")
+						user.visible_action_message("unwrench", "the anchoring bolts on \the [src].")
 						removal_stage = 4
 				return TRUE
 
 			if(4)
 				if(IS_CROWBAR(used_item))
-					user.visible_message("[user] begins lifting [src] off of the anchors.", "You begin lifting the device off the anchors...")
+					user.visible_action_message("start", "lifting \the [src] off of its anchors.")
 					if(do_after(user, 8 SECONDS, src))
 						if(QDELETED(src) || QDELETED(user)) return TRUE
-						user.visible_message("\The [user] crowbars \the [src] off of the anchors. It can now be moved.", "You jam the crowbar under the nuclear device and lift it off its anchors. You can now move it!")
+						user.visible_action_message("crowbar", "\the [src] off of its anchors. It can now be moved.")
 						anchored = FALSE
 						removal_stage = 5
 				return TRUE

--- a/code/game/machinery/oxygen_pump.dm
+++ b/code/game/machinery/oxygen_pump.dm
@@ -54,7 +54,7 @@
 
 /obj/machinery/oxygen_pump/physical_attack_hand(mob/user)
 	if((stat & MAINT) && tank)
-		user.visible_message(SPAN_NOTICE("\The [user] removes \the [tank] from \the [src]."), SPAN_NOTICE("You remove \the [tank] from \the [src]."))
+		user.visible_action_message("remove", "\the [tank] from \the [src].")
 		user.put_in_hands(tank)
 		src.add_fingerprint(user)
 		tank.add_fingerprint(user)
@@ -160,7 +160,7 @@
 		if(!user.try_unequip(used_item, src))
 			return TRUE
 		tank = used_item
-		user.visible_message(SPAN_NOTICE("\The [user] installs \the [tank] into \the [src]."), SPAN_NOTICE("You install \the [tank] into \the [src]."))
+		user.visible_action_message("install", "\the [tank] into \the [src].")
 		src.add_fingerprint(user)
 		return TRUE
 	return FALSE // TODO: should this be a parent call? do we want this to be (de)constructable?

--- a/code/game/machinery/pipe/pipelayer.dm
+++ b/code/game/machinery/pipe/pipelayer.dm
@@ -44,7 +44,7 @@
 	if(IS_WRENCH(used_item))
 		P_type_t = input("Choose pipe type", "Pipe type") as null|anything in Pipes
 		P_type = Pipes[P_type_t]
-		user.visible_message("<span class='notice'>[user] has set \the [src] to manufacture [P_type_t].</span>", "<span class='notice'>You set \the [src] to manufacture [P_type_t].</span>")
+		user.visible_action_message("set", "\the [src] to manufacture [P_type_t].")
 		return TRUE
 
 	if(IS_CROWBAR(used_item))
@@ -60,7 +60,7 @@
 		else if(!result)
 			to_chat(user, "<span class='notice'>\The [src] is full.</span>")
 		else
-			user.visible_message("<span class='notice'>[user] has loaded metal into \the [src].</span>", "<span class='notice'>You load metal into \the [src]</span>")
+			user.visible_action_message("load", "metal into \the [src]")
 
 		return TRUE
 

--- a/code/game/machinery/pipe/pipelayer.dm
+++ b/code/game/machinery/pipe/pipelayer.dm
@@ -73,7 +73,7 @@
 			if(m)
 				use_metal(m)
 				SSmaterials.create_object(/decl/material/solid/metal/steel, get_turf(src), m)
-				user.visible_message(SPAN_NOTICE("[user] removes [m] sheet\s of metal from \the [src]."), SPAN_NOTICE("You remove [m] sheet\s of metal from \the [src]"))
+				user.visible_action_message("remove", "[m] sheet\s of metal from \the [src].")
 		else
 			to_chat(user, "\The [src] is empty.")
 		return TRUE

--- a/code/game/machinery/self_destruct.dm
+++ b/code/game/machinery/self_destruct.dm
@@ -14,11 +14,11 @@
 		if(!damaged)
 			return FALSE
 		user.visible_message("[user] begins to repair [src].", "You begin repairing [src].")
-		if(do_after(user, 100, src))
+		if(do_after(user, 10 SECONDS, src))
 			var/obj/item/weldingtool/w = used_item
 			if(w.weld(10))
 				damaged = 0
-				user.visible_message("[user] repairs [src].", "You repair [src].")
+				user.visible_action_message("repair", "\the [src].")
 			else
 				to_chat(user, "<span class='warning'>There is not enough fuel to repair [src].</span>")
 		return TRUE
@@ -29,11 +29,11 @@
 		if(cylinder)
 			to_chat(user, "There is already a cylinder here.")
 			return TRUE
-		user.visible_message("[user] begins to carefully place [used_item] onto [src].", "You begin to carefully place [used_item] onto [src].")
-		if(do_after(user, 80, src) && user.try_unequip(used_item, src))
+		user.visible_action_message("begin", "to carefully place \the [used_item] onto \the [src].")
+		if(do_after(user, 8 SECONDS, src) && user.try_unequip(used_item, src))
 			cylinder = used_item
 			density = TRUE
-			user.visible_message("[user] places [used_item] onto [src].", "You place [used_item] onto [src].")
+			user.visible_action_message("place", "\the [used_item] onto \the [src].")
 			update_icon()
 		return TRUE
 	return ..()
@@ -53,18 +53,18 @@
 			if(nuke.timing)
 				to_chat(user, "<span class='warning'>The self-destruct sequence is in progress, unable to disarm.</span>")
 				return
-			user.visible_message("[user] begins extracting [cylinder].", "You begin extracting [cylinder].")
-			if(do_after(user, 40, src))
-				user.visible_message("[user] extracts [cylinder].", "You extract [cylinder].")
+			user.visible_action_message("begin", "extracting \the [cylinder].")
+			if(do_after(user, 4 SECONDS, src))
+				user.visible_action_message("extract", "\the [cylinder].")
 				armed = 0
 				density = TRUE
 				flick("unloading", src)
 		else if(!damaged)
-			user.visible_message("[user] begins to arm [cylinder].", "You begin to arm [cylinder].")
-			if(do_after(user, 40, src))
+			user.visible_action_message("begin", "to arm \the [cylinder].")
+			if(do_after(user, 4 SECONDS, src))
 				armed = 1
 				density = FALSE
-				user.visible_message("[user] arms [cylinder].", "You arm [cylinder].")
+				user.visible_action_message("arm", "\the [cylinder].")
 				flick("loading", src)
 				playsound(src.loc,'sound/effects/caution.ogg',50,1,5)
 		update_icon()
@@ -75,15 +75,11 @@
 		if(armed)
 			to_chat(user, SPAN_WARNING("Disarm the cylinder first."))
 			return TRUE
-		user.visible_message( \
-			SPAN_NOTICE("\The [user] beings to carefully pick up \the [cylinder]."), \
-			SPAN_NOTICE("You begin to carefully pick up \the [cylinder]."))
-		if(!do_after(user, 70, src) || !cylinder)
+		user.visible_action_message("begin", "to carefully pick up \the [cylinder].")
+		if(!do_after(user, 7 SECONDS, src) || !cylinder)
 			return TRUE
 		user.put_in_hands(cylinder)
-		user.visible_message( \
-			SPAN_NOTICE("\The [user] picks up \the [cylinder]."), \
-			SPAN_NOTICE("You pick up \the [cylinder]."))
+		user.visible_action_message("pick", "up \the [cylinder].")
 		density = FALSE
 		cylinder = null
 		update_icon()

--- a/code/game/machinery/self_destruct.dm
+++ b/code/game/machinery/self_destruct.dm
@@ -13,7 +13,7 @@
 	if(IS_WELDER(used_item))
 		if(!damaged)
 			return FALSE
-		user.visible_message("[user] begins to repair [src].", "You begin repairing [src].")
+		user.visible_action_message("begin", "repairing [src].")
 		if(do_after(user, 10 SECONDS, src))
 			var/obj/item/weldingtool/w = used_item
 			if(w.weld(10))

--- a/code/game/machinery/self_destruct_storage.dm
+++ b/code/game/machinery/self_destruct_storage.dm
@@ -85,9 +85,9 @@
 			return TRUE
 		if(operable() && check_access(user))
 			locked = FALSE
-			user.visible_message(
-				"\The [user] unlocks \the [src].",
-				"You unlock \the [src]."
+			user.visible_action_message(
+				"unlock",
+				"\the [src]."
 			)
 			update_icon()
 			return TRUE
@@ -117,15 +117,9 @@
 			to_chat(user, SPAN_WARNING("\The [src] is currently in maintenance mode!"))
 			return TRUE
 
-		user.visible_message(
-			"\The [user] begins inserting \the [used_item] into storage.",
-			"You begin inserting \the [used_item] into storage."
-		)
+		user.visible_action_message("begin", "inserting \the [used_item] into storage.")
 		if(do_after(user, interact_time, src) && open && (length(cylinders) < max_cylinders) && user.try_unequip(used_item, src))
-			user.visible_message(
-				"\The [user] places \the [used_item] into storage.",
-				"You place \the [used_item] into storage."
-			)
+			user.visible_action_message("place", "\the [used_item] into storage.")
 			cylinders.Add(used_item)
 			update_icon()
 		return TRUE
@@ -135,15 +129,9 @@
 /obj/machinery/nuclear_cylinder_storage/handle_mouse_drop(atom/over, mob/user, params)
 	if(over == user && open && !panel_open && length(cylinders))
 		var/cylinder = cylinders[1]
-		user.visible_message(
-			"\The [user] begins to extract \the [cylinder].",
-			"You begin to extract \the [cylinder]."
-		)
+		user.visible_action_message("begin", "to extract \the [cylinder].")
 		if(do_after(user, interact_time, src) && open && cylinders.Find(cylinder))
-			user.visible_message(
-				"\The [user] picks up \the [cylinder].",
-				"You pick up \the [cylinder]."
-			)
+			user.visible_action_message("pick", "up \the [cylinder].")
 			user.put_in_hands(cylinder)
 			cylinders.Remove(cylinder)
 			update_icon()

--- a/code/game/machinery/smartfridge/_smartfridge.dm
+++ b/code/game/machinery/smartfridge/_smartfridge.dm
@@ -147,7 +147,7 @@
 		used_item.storage.finish_bulk_removal()
 
 		if(plants_loaded)
-			user.visible_message("<span class='notice'>\The [user] loads \the [src] with the contents of \the [used_item].</span>", "<span class='notice'>You load \the [src] with the contents of \the [used_item].</span>")
+			user.visible_action_message("load", "\the [src] with the contents of \the [used_item].")
 			if(length(used_item.storage.get_contents()) > 0)
 				to_chat(user, "<span class='notice'>Some items were refused.</span>")
 		return TRUE

--- a/code/game/objects/_objs_edibility.dm
+++ b/code/game/objects/_objs_edibility.dm
@@ -26,10 +26,7 @@
 				)
 
 		else
-			user.visible_message(
-				SPAN_NOTICE("\The [user] feeds the last of \the [src] to \the [target]."),
-				SPAN_NOTICE("You feed the last of \the [src] to \the [target].")
-			)
+			user.visible_action_message("feed", "the last of \the [src] to \the [target].")
 
 /obj/proc/handle_consumed(mob/feeder, mob/eater, consumption_method = EATING_METHOD_EAT)
 	if(eater)

--- a/code/game/objects/effects/chem/foam.dm
+++ b/code/game/objects/effects/chem/foam.dm
@@ -153,27 +153,25 @@
 /obj/structure/foamedmetal/attack_hand(var/mob/user)
 	SHOULD_CALL_PARENT(FALSE)
 	if (prob(75 - metal * 25))
-		user.visible_message("<span class='warning'>[user] smashes through the foamed metal.</span>", "<span class='notice'>You smash through the metal foam wall.</span>")
+		user.visible_action_message("smash", "through \the [src].", dangerous = ACTION_DANGER_WARNING)
 		qdel(src)
 	else
-		to_chat(user, "<span class='notice'>You hit the metal foam but bounce off it.</span>")
+		user.visible_action_message("hit", "\the [src] but bounce$USER_S$ off of it.")
 	return TRUE
 
 
 /obj/structure/foamedmetal/grab_attack(obj/item/grab/grab, mob/user)
 	grab.affecting.forceMove(loc)
-	visible_message(SPAN_DANGER("\The [user] smashes \the [grab.affecting] through the foamed metal wall!"))
+	if(ismob(grab.affecting))
+		user.targeted_visible_action_message(grab.affecting, "smash", "$TARGET$ through \the [src]!", dangerous = ACTION_DANGER_ALL)
 	qdel(grab)
 	physically_destroyed()
 	return TRUE
 
 /obj/structure/foamedmetal/attackby(var/obj/item/used_item, var/mob/user)
 	if(prob(used_item.expend_attack_force(user) * 20 - metal * 25))
-		user.visible_message(
-			SPAN_WARNING("\The [user] smashes through the foamed metal."),
-			SPAN_NOTICE("You smash through the foamed metal with \the [used_item].")
-		)
+		user.visible_action_message("smash", "through \the [src] with \the [used_item].", dangerous = ACTION_DANGER_WARNING)
 		physically_destroyed()
 	else
-		to_chat(user, SPAN_WARNING("You hit \the [src] to no effect."))
+		user.visible_action_message("hit", "\the [src] with \the [used_item] to no effect.", dangerous = ACTION_DANGER_WARNING)
 	return TRUE

--- a/code/game/objects/items/__item.dm
+++ b/code/game/objects/items/__item.dm
@@ -23,7 +23,7 @@
 	var/no_attack_log = FALSE
 	var/obj/item/master = null
 	var/origin_tech                    //Used by R&D to determine what research bonuses it grants.
-	VAR_PROTECTED/list/attack_verb = "hit" //Used in attackby() to say how something was attacked "[x] has been [z.attack_verb] by [y] with [z]"
+	VAR_PROTECTED/list/attack_verb = "hit" //Used in attackby() to say how something was attacked "[y] [z.attack_verb]s [x] with [z]"
 	var/lock_picking_level = 0 //used to determine whether something can pick a lock, and how well.
 	var/attack_cooldown = DEFAULT_WEAPON_COOLDOWN
 	var/melee_accuracy_bonus = 0

--- a/code/game/objects/items/devices/boombox.dm
+++ b/code/game/objects/items/devices/boombox.dm
@@ -93,7 +93,7 @@
 /obj/item/boombox/attackby(var/obj/item/used_item, var/mob/user)
 	if(IS_SCREWDRIVER(used_item))
 		if(!panel)
-			user.visible_message(SPAN_NOTICE("\The [user] re-attaches \the [src]'s front panel with \the [used_item]."), SPAN_NOTICE("You re-attach \the [src]'s front panel with \the [used_item]."))
+			user.visible_action_message("reattach", "\the [src]'s front panel with \the [used_item].")
 			playsound(src.loc, 'sound/items/Screwdriver.ogg', 50, 1)
 			panel = TRUE
 			return TRUE
@@ -108,7 +108,7 @@
 		var/obj/item/stack/S = used_item
 		if(broken && !panel)
 			if(S.use(1))
-				user.visible_action_message("pour", "some of \the [S] onto \the [src]", self_postfix = "'s internals and watch as it retraces and resolders paths.", other_postfix = ".")
+				user.visible_action_message("pour", "some of \the [S] onto \the [src]", self_postfix = "'s internals and watch$USER_ES$ as it retraces and resolders paths.", other_postfix = ".")
 				broken = FALSE
 			else
 				to_chat(user, SPAN_NOTICE("\The [S] is empty."))

--- a/code/game/objects/items/devices/boombox.dm
+++ b/code/game/objects/items/devices/boombox.dm
@@ -93,7 +93,7 @@
 /obj/item/boombox/attackby(var/obj/item/used_item, var/mob/user)
 	if(IS_SCREWDRIVER(used_item))
 		if(!panel)
-			user.visible_message(SPAN_NOTICE("\The [user] re-attaches \the [src]'s front panel with \the [used_item]."), SPAN_NOTICE("You re-attach \the [src]'s front panel."))
+			user.visible_message(SPAN_NOTICE("\The [user] re-attaches \the [src]'s front panel with \the [used_item]."), SPAN_NOTICE("You re-attach \the [src]'s front panel with \the [used_item]."))
 			playsound(src.loc, 'sound/items/Screwdriver.ogg', 50, 1)
 			panel = TRUE
 			return TRUE
@@ -101,14 +101,14 @@
 			AdjustFrequency(used_item, user)
 			return TRUE
 		else if(panel)
-			user.visible_message(SPAN_NOTICE("\The [user] unhinges \the [src]'s front panel with \the [used_item]."), SPAN_NOTICE("You unhinge \the [src]'s front panel."))
+			user.visible_action_message("unhinge", "\the [src]'s front panel with \the [used_item].")
 			playsound(src.loc, 'sound/items/Screwdriver.ogg', 50, 1)
 			panel = FALSE
 	if(istype(used_item,/obj/item/stack/nanopaste))
 		var/obj/item/stack/S = used_item
 		if(broken && !panel)
 			if(S.use(1))
-				user.visible_message(SPAN_NOTICE("\The [user] pours some of \the [S] onto \the [src]."), SPAN_NOTICE("You pour some of \the [S] over \the [src]'s internals and watch as it retraces and resolders paths."))
+				user.visible_action_message("pour", "some of \the [S] onto \the [src]", self_postfix = "'s internals and watch as it retraces and resolders paths.", other_postfix = ".")
 				broken = FALSE
 			else
 				to_chat(user, SPAN_NOTICE("\The [S] is empty."))
@@ -148,7 +148,7 @@
 		frequency -= 0.1
 	frequency = clamp(frequency, MIN_FREQUENCY, MAX_FREQUENCY)
 
-	user.visible_message(SPAN_NOTICE("\The [user] adjusts \the [src]'s player head."), SPAN_NOTICE("You adjust \the [src]'s player head."))
+	user.visible_action_message("adjust", "\the [src]'s player head.")
 	playsound(src.loc, 'sound/items/Screwdriver.ogg', 50, 1)
 
 	if(frequency > 1.0)

--- a/code/game/objects/items/devices/inducer.dm
+++ b/code/game/objects/items/devices/inducer.dm
@@ -71,7 +71,7 @@
 			to_chat(user, "<span class='notice'>\The [A] is fully charged!</span>")
 			recharging = FALSE
 			return TRUE
-		user.visible_message("\The [user] starts recharging \the [A] with \the [src].","<span class='notice'>You start recharging \the [A] with \the [src].</span>")
+		user.visible_action_message("start", "recharging \the [A] with \the [src].")
 		if (istype(A, /obj/item/gun/energy))
 			charge_length = 30
 			if (user.get_skill_value(SKILL_WEAPONS) <= SKILL_ADEPT)
@@ -92,7 +92,7 @@
 			else
 				break
 		if(done_any) // Only show a message if we succeeded at least once
-			user.visible_message("\The [user] recharged \the [A]!","<span class='notice'>You recharged \the [A]!</span>")
+			user.visible_action_message("successfully recharge", "\the [A]!")
 		recharging = FALSE
 		return TRUE
 	else

--- a/code/game/objects/items/flame/_flame.dm
+++ b/code/game/objects/items/flame/_flame.dm
@@ -87,10 +87,7 @@
 		loc.update_icon()
 
 	if(!no_message && user)
-		user.visible_message(
-			SPAN_NOTICE("\The [user] lights \the [src]."),
-			SPAN_NOTICE("You light \the [src].")
-		)
+		user.visible_action_message("light", "\the [src].")
 	if(!is_processing)
 		START_PROCESSING(SSobj, src)
 	if(scent)

--- a/code/game/objects/items/flashlights/_flashlight.dm
+++ b/code/game/objects/items/flashlights/_flashlight.dm
@@ -123,10 +123,7 @@
 			to_chat(user, SPAN_WARNING("\The [target] is missing [pronouns.his] [initial(vision.name)]!"))
 			return TRUE
 
-		user.visible_message(
-			SPAN_NOTICE("\The [user] directs [src] into [target]'s [vision.name]."),
-			SPAN_NOTICE("You direct [src] into [target]'s [vision.name].")
-		)
+		user.visible_action_message("direct", "\the [src] into [target]'s [vision.name].")
 		inspect_vision(vision, user)
 
 		user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN) //can be used offensively

--- a/code/game/objects/items/flashlights/flare.dm
+++ b/code/game/objects/items/flashlights/flare.dm
@@ -60,7 +60,7 @@
 
 /obj/item/flashlight/flare/proc/activate(var/mob/user)
 	if(istype(user))
-		user.visible_message("<span class='notice'>[user] pulls the cord on \the [src], activating it.</span>", "<span class='notice'>You pull the cord on \the [src], activating it!</span>")
+		user.visible_action_message("pull", "the cord on \the [src], activating it!")
 
 /obj/item/flashlight/flare/proc/update_damage()
 	if(on)

--- a/code/game/objects/items/flashlights/glowstick.dm
+++ b/code/game/objects/items/flashlights/glowstick.dm
@@ -19,7 +19,7 @@
 
 /obj/item/flashlight/flare/glowstick/activate(var/mob/user)
 	if(istype(user))
-		user.visible_message("<span class='notice'>[user] cracks and shakes \the [src].</span>", "<span class='notice'>You crack and shake \the [src], turning it on!</span>")
+		user.visible_action_message("crack", "and shake$USER_S$ \the [src], turning it on!")
 
 /obj/item/flashlight/flare/glowstick/red
 	name = "red glowstick"

--- a/code/game/objects/items/glassjar.dm
+++ b/code/game/objects/items/glassjar.dm
@@ -32,14 +32,14 @@
 			to_chat(user, "[A] doesn't fit into \the [src].")
 			return
 		var/mob/L = A
-		user.visible_message("<span class='notice'>[user] scoops [L] into \the [src].</span>", "<span class='notice'>You scoop [L] into \the [src].</span>")
+		user.visible_action_message("scoop", "\the [L] into \the [src].")
 		L.forceMove(src)
 		contains = 2
 		update_icon()
 		return
 	else if(istype(A, /obj/effect/spider/spiderling))
 		var/obj/effect/spider/spiderling/S = A
-		user.visible_message("<span class='notice'>[user] scoops [S] into \the [src].</span>", "<span class='notice'>You scoop [S] into \the [src].</span>")
+		user.visible_action_message("scoop", "\the [S] into \the [src].")
 		S.forceMove(src)
 		STOP_PROCESSING(SSobj, S) // No growing inside jars
 		contains = 3
@@ -58,14 +58,14 @@
 		if(2)
 			for(var/mob/M in src)
 				M.dropInto(user.loc)
-				user.visible_message("<span class='notice'>[user] releases [M] from \the [src].</span>", "<span class='notice'>You release [M] from \the [src].</span>")
+				user.visible_action_message("release", "\the [M] from \the [src].")
 			contains = 0
 			update_icon()
 			return
 		if(3)
 			for(var/obj/effect/spider/spiderling/S in src)
 				S.dropInto(user.loc)
-				user.visible_message("<span class='notice'>[user] releases [S] from \the [src].</span>", "<span class='notice'>You release [S] from \the [src].</span>")
+				user.visible_action_message("release", "\the [S] from \the [src].")
 				START_PROCESSING(SSobj, S) // They can grow after being let out though
 			contains = 0
 			update_icon()

--- a/code/game/objects/items/instruments.dm
+++ b/code/game/objects/items/instruments.dm
@@ -11,7 +11,5 @@
 /obj/item/guitar/attack_self(mob/user)
 	. = ..()
 	if(!.)
-		user.visible_message(
-			SPAN_NOTICE("\The [user] strums \the [src]!"),
-			SPAN_NOTICE("You strum \the [src]!"))
+		user.visible_action_message("strum", "\the [src]!")
 		return TRUE

--- a/code/game/objects/items/passport.dm
+++ b/code/game/objects/items/passport.dm
@@ -27,9 +27,5 @@
 	info = "\icon[src] [src]:\nName: [H.real_name]\nSpecies: [H.get_species_name()]\nGender: [capitalize(pronouns.name)]\nAge: [H.get_age()]\nPlace of Birth: [pob]\nFingerprint: [fingerprint]"
 
 /obj/item/passport/attack_self(mob/user)
-	user.visible_message(
-		SPAN_ITALIC("\The [user] checks over \the [src]."),
-		SPAN_ITALIC("You check over \the [src]."),
-		SPAN_ITALIC("You hear the faint rustle of pages."),
-		5)
+	user.visible_action_message("check", "over \the [src].", dangerous = "italic", blind_message = "You hear the faint rustle of pages.", range = 5)
 	to_chat(user, info || SPAN_WARNING("\The [src] is completely blank!"))

--- a/code/game/objects/items/stacks/medical/_medical.dm
+++ b/code/game/objects/items/stacks/medical/_medical.dm
@@ -94,10 +94,7 @@
 		return TRUE
 
 	target.heal_organ_damage((src.heal_brute/2), (src.heal_burn/2))
-	user.visible_message(
-		SPAN_NOTICE("\The [user] treats \the [target] with \the [src]."),
-		SPAN_NOTICE("You treat \the [target] with \the [src].")
-	)
+	user.visible_action_message("treat", "\the [target] with \the [src].")
 	play_apply_sound()
 	use(1)
 	return TRUE

--- a/code/game/objects/items/stacks/medical/medical_bandage.dm
+++ b/code/game/objects/items/stacks/medical/medical_bandage.dm
@@ -73,10 +73,7 @@
 	return !affecting.is_bandaged()
 
 /obj/item/stack/medical/bandage/proc/bandage_wound(mob/user, mob/target, obj/item/organ/external/affecting, datum/wound/wound)
-	user.visible_message(
-		SPAN_NOTICE("\The [user] bandages \a [wound.desc] on \the [target]'s [affecting.name]."),
-		SPAN_NOTICE("You bandage \a [wound.desc] on \the [target]'s [affecting.name].")
-	)
+	user.visible_action_message("bandage", "\a [wound.desc] on \the [target]'s [affecting.name].")
 	wound.bandage()
 
 /obj/item/stack/medical/bandage/try_treat_limb(mob/living/target, mob/living/user, obj/item/organ/external/affecting)
@@ -85,10 +82,7 @@
 		to_chat(user, SPAN_WARNING("The wounds on [target]'s [affecting.name] have already been bandaged."))
 		return FALSE
 
-	user.visible_message(
-		SPAN_NOTICE("\The [user] starts treating [target]'s [affecting.name]."),
-		SPAN_NOTICE("You start treating [target]'s [affecting.name].")
-	)
+	user.visible_action_message("start", "treating [target]'s [affecting.name].")
 
 	. = 0
 	for (var/datum/wound/wound in affecting.wounds)
@@ -161,15 +155,9 @@
 		    SPAN_NOTICE("You clean and seal \a [wound.desc] on [target]'s [affecting.name].")
 		)
 	else if (wound.damage_type == BRUISE)
-		user.visible_message(
-			SPAN_NOTICE("\The [user] places a medical patch over \a [wound.desc] on [target]'s [affecting.name]."),
-			SPAN_NOTICE("You place a medical patch over \a [wound.desc] on [target]'s [affecting.name].")
-		)
+		user.visible_action_message("place", "a medical patch over \a [wound.desc] on [target]'s [affecting.name].")
 	else
-		user.visible_message(
-			SPAN_NOTICE("\The [user] smears some bioglue over \a [wound.desc] on [target]'s [affecting.name]."),
-		    SPAN_NOTICE("You smear some bioglue over \a [wound.desc] on [target]'s [affecting.name].")
-		)
+		user.visible_action_message("smear", "some bioglue over \a [wound.desc] on [target]'s [affecting.name].")
 	wound.bandage()
 	wound.disinfect()
 	wound.heal_damage(heal_brute)

--- a/code/game/objects/items/stacks/medical/medical_ointment.dm
+++ b/code/game/objects/items/stacks/medical/medical_ointment.dm
@@ -18,10 +18,7 @@
 	if(affecting.is_salved())
 		to_chat(user, SPAN_WARNING("The wounds on [target]'s [affecting.name] have already been salved."))
 		return 0
-	user.visible_message(
-		SPAN_NOTICE("\The [user] starts salving wounds on [target]'s [affecting.name]."),
-		SPAN_NOTICE("You start salving the wounds on [target]'s [affecting.name].")
-	)
+	show_limb_salve_start_message(user, target, affecting)
 	play_apply_sound()
 	if(!do_mob(user, target, 1 SECOND))
 		to_chat(user, SPAN_WARNING("You must stand still to salve wounds."))
@@ -31,11 +28,11 @@
 	affecting.disinfect()
 	return 1 // consume 1 stack
 
+/obj/item/stack/medical/ointment/proc/show_limb_salve_start_message(mob/living/user, mob/living/target, obj/item/organ/external/affecting)
+	user.visible_action_message("start", "salving the wounds on \the [target]'s [affecting.name].")
+
 /obj/item/stack/medical/ointment/proc/show_limb_salve_message(mob/living/user, mob/living/target, obj/item/organ/external/affecting)
-	user.visible_message(
-		SPAN_NOTICE("\The [user] salves the wounds on \the [target]'s [affecting.name]."),
-	    SPAN_NOTICE("You salve the wounds on \the [target]'s [affecting.name].")
-	)
+	user.visible_action_message("salve", "the wounds on \the [target]'s [affecting.name].")
 
 /obj/item/stack/medical/ointment/crafted
 	name = "poultice"
@@ -65,8 +62,8 @@
 	var/static/list/apply_sounds = list('sound/effects/ointment.ogg')
 	return apply_sounds
 
+/obj/item/stack/medical/ointment/advanced/show_limb_salve_start_message(mob/living/user, mob/living/target, obj/item/organ/external/affecting)
+	user.visible_action_message("start", "covering the wounds on \the [target]'s [affecting.name] with regenerative membrane.")
+
 /obj/item/stack/medical/ointment/advanced/show_limb_salve_message(mob/living/user, mob/living/target, obj/item/organ/external/affecting)
-	user.visible_message(
-		SPAN_NOTICE("[user] covers wounds on [target]'s [affecting.name] with regenerative membrane."),
-		SPAN_NOTICE("You cover wounds on [target]'s [affecting.name] with regenerative membrane.")
-	)
+	user.visible_action_message("cover", "wounds on [target]'s [affecting.name] with regenerative membrane.")

--- a/code/game/objects/items/stacks/medical/medical_resin.dm
+++ b/code/game/objects/items/stacks/medical/medical_resin.dm
@@ -28,10 +28,7 @@
 	if((affecting.brute_dam + affecting.burn_dam) <= 0)
 		to_chat(user, SPAN_WARNING("\The [target]'s [affecting.name] is undamaged."))
 		return 0
-	user.visible_message(
-		SPAN_NOTICE("\The [user] starts patching fractures on \the [target]'s [affecting.name]."),
-		SPAN_NOTICE("You start patching fractures on \the [target]'s [affecting.name].")
-	)
+	user.visible_action_message("start", "patching fractures on \the [target]'s [affecting.name].")
 	play_apply_sound()
 	if(!do_mob(user, target, 1 SECOND))
 		to_chat(user, SPAN_WARNING("You must stand still to patch fractures."))

--- a/code/game/objects/items/stacks/medical/medical_splint.dm
+++ b/code/game/objects/items/stacks/medical/medical_splint.dm
@@ -32,55 +32,26 @@
 		to_chat(user, SPAN_WARNING("\The [target]'s [limb] is already splinted!"))
 		return 0
 
-	if (target != user)
-		user.visible_message(
-			SPAN_NOTICE("\The [user] starts to apply \the [src] to [target]'s [limb]."),
-			SPAN_DANGER("You start to apply \the [src] to [target]'s [limb]."),
-			SPAN_DANGER("You hear something being wrapped.")
-		)
-	else
+	if (target == user)
 		var/obj/item/organ/external/using = GET_EXTERNAL_ORGAN(user, user.get_active_held_item_slot())
 		if(istype(using) && (affecting == using || (affecting in using.children) || affecting.organ_tag == using.parent_organ))
 			to_chat(user, SPAN_WARNING("You can't apply a splint to the arm you're using!"))
 			return 0
-		user.visible_message(
-			SPAN_NOTICE("\The [user] starts to apply \the [src] to their [limb]."),
-			SPAN_DANGER("You start to apply \the [src] to your [limb]."),
-			SPAN_DANGER("You hear something being wrapped.")
-		)
+	user.targeted_visible_action_message(target, "start", "to apply \the [src] to $TARGET'S$ [limb].", ACTION_DANGER_ALL, SPAN_DANGER("You hear something being wrapped."))
 
 	if(user.do_skilled(5 SECONDS, SKILL_MEDICAL, target))
 		if((target == user && prob(75)) || prob(user.skill_fail_chance(SKILL_MEDICAL,50, SKILL_ADEPT)))
-			user.visible_message(
-				SPAN_DANGER("\The [user] fumbles \the [src]."),
-				SPAN_DANGER("You fumble \the [src]."),
-				SPAN_DANGER("You hear something being wrapped.")
-			)
+			user.visible_action_message("fumble", "\the [src].", ACTION_DANGER_ALL, SPAN_DANGER("You hear something being wrapped."))
 			return 0
 		var/obj/item/stack/medical/splint/splint = split(1, TRUE)
 		if(splint)
 			if(affecting.apply_splint(splint))
 				target.verbs += /mob/living/human/proc/remove_splints
 				splint.forceMove(affecting)
-				if (target != user)
-					user.visible_message(
-						SPAN_NOTICE("\The [user] finishes applying \the [src] to \the [target]'s [limb]."),
-						SPAN_DANGER("You finish applying \the [src] to \the [target]'s [limb]."),
-						SPAN_DANGER("You hear something being wrapped.")
-					)
-				else
-					user.visible_message(
-						SPAN_NOTICE("\The [user] successfully applies \the [src] to their [limb]."),
-						SPAN_DANGER("You successfully apply \the [src] to your [limb]."),
-						SPAN_DANGER("You hear something being wrapped.")
-					)
+				user.targeted_visible_action_message(target, "successfully apply", "\the [src] to $TARGET'S$ [limb].", ACTION_DANGER_ALL, SPAN_DANGER("You hear something being wrapped."))
 				return 0
 			splint.dropInto(src.loc) //didn't get applied, so just drop it
-		user.visible_message(
-			SPAN_DANGER("\The [user] fails to apply \the [src]."),
-			SPAN_DANGER("You fail to apply \the [src]."),
-			SPAN_DANGER("You hear something being wrapped.")
-		)
+		user.targeted_visible_action_message(target, "fail", "to apply \the [src] to $TARGET'S$ [limb].", ACTION_DANGER_ALL, SPAN_DANGER("You hear something being wrapped."))
 	// We handle using the stack via split() above, so don't ever return a numeric value.
 	return 0
 

--- a/code/game/objects/items/tools/wirecutter.dm
+++ b/code/game/objects/items/tools/wirecutter.dm
@@ -45,12 +45,8 @@
 
 	var/obj/item/handcuffs/cable/cuffs = target.get_equipped_item(slot_handcuffed_str)
 	if(user.check_intent(I_FLAG_HELP) && istype(cuffs) && target.try_unequip(cuffs))
-		user.visible_message(
-			"\The [user] cuts \the [target]'s restraints with \the [src]!",
-			"You cut \the [target]'s restraints with \the [src]!",
-			"You hear cable being cut."
-		)
-		qdel(cuffs)
+		user.visible_action_message("cut", "\the [target]'s restraints with \the [src]!", dangerous = ACTION_DANGER_OTHERS, blind_message = "You hear cable being cut.")
+		cuffs.physically_destroyed()
 		if(target.buckled?.buckle_require_restraints)
 			target.buckled.unbuckle_mob()
 		return TRUE

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -527,8 +527,7 @@
 /obj/item/marshalling_wand/attack_self(mob/user)
 	playsound(src.loc, 'sound/effects/rustle1.ogg', 100, 1)
 	if (user.check_intent(I_FLAG_HELP))
-		user.visible_message("<span class='notice'>[user] beckons with \the [src], signalling forward motion.</span>",
-							"<span class='notice'>You beckon with \the [src], signalling forward motion.</span>")
+		user.visible_action_message("beckon", "with \the [src], signalling forward motion.")
 	else if (user.check_intent(I_FLAG_DISARM))
 		user.visible_message("<span class='notice'>[user] holds \the [src] above their head, signalling a stop.</span>",
 							"<span class='notice'>You hold \the [src] above your head, signalling a stop.</span>")
@@ -540,8 +539,7 @@
 			wand_dir = "right"
 		else
 			wand_dir = pick("left", "right")
-		user.visible_message("<span class='notice'>[user] waves \the [src] to the [wand_dir], signalling a turn.</span>",
-							"<span class='notice'>You wave \the [src] to the [wand_dir], signalling a turn.</span>")
+		user.visible_action_message("wave", "\the [src] to the [wand_dir], signalling a turn.")
 	else if (user.check_intent(I_FLAG_HARM))
 		user.visible_message("<span class='warning'>[user] frantically waves \the [src] above their head!</span>",
 							"<span class='warning'>You frantically wave \the [src] above your head!</span>")

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -529,8 +529,7 @@
 	if (user.check_intent(I_FLAG_HELP))
 		user.visible_action_message("beckon", "with \the [src], signalling forward motion.")
 	else if (user.check_intent(I_FLAG_DISARM))
-		user.visible_message("<span class='notice'>[user] holds \the [src] above their head, signalling a stop.</span>",
-							"<span class='notice'>You hold \the [src] above your head, signalling a stop.</span>")
+		user.visible_action_message("hold", "\the [src] above $USER_THEIR$ head, signalling a stop.")
 	else if (user.check_intent(I_FLAG_GRAB))
 		var/wand_dir
 		if(user.get_equipped_item(BP_L_HAND) == src)
@@ -541,8 +540,7 @@
 			wand_dir = pick("left", "right")
 		user.visible_action_message("wave", "\the [src] to the [wand_dir], signalling a turn.")
 	else if (user.check_intent(I_FLAG_HARM))
-		user.visible_message("<span class='warning'>[user] frantically waves \the [src] above their head!</span>",
-							"<span class='warning'>You frantically wave \the [src] above your head!</span>")
+		user.visible_action_message("frantically wave", "\the [src] above $USER_HEAD$ head!")
 
 /obj/item/toy/shipmodel
 	name = "table-top spaceship model"
@@ -561,13 +559,13 @@
 	if(!user.check_dexterity(DEXTERITY_SIMPLE_MACHINES, TRUE))
 		return ..()
 	if (user.check_intent(I_FLAG_HELP))
-		user.visible_message("<span class='notice'>[user] rings \the [src], signalling the beginning of the contest.</span>")
+		user.visible_action_message("ring", "\the [src], signalling the beginning of the contest.")
 		playsound(user.loc, 'sound/items/oneding.ogg', 60)
 	else if (user.check_intent(I_FLAG_DISARM))
-		user.visible_message("<span class='notice'>[user] rings \the [src] three times, signalling the end of the contest!</span>")
+		user.visible_action_message("ring", "\the [src] three times, signalling the end of the contest.")
 		playsound(user.loc, 'sound/items/threedings.ogg', 60)
 	else if (user.check_intent(I_FLAG_HARM))
-		user.visible_message("<span class='warning'>[user] rings \the [src] repeatedly, signalling a disqualification!</span>")
+		user.visible_action_message("ring", "\the [src] repeatedly, signalling a disqualification!", dangerous = ACTION_DANGER_WARNING)
 		playsound(user.loc, 'sound/items/manydings.ogg', 60)
 	return TRUE
 
@@ -643,12 +641,12 @@
 		"Very doubtful")
 
 /obj/item/toy/eightball/attack_self(mob/user)
-	user.visible_message("<span class='notice'>\The [user] shakes \the [src] for a moment, and it says, \"[pick(possible_answers) ].\"</span>")
+	user.visible_action_message("shake", "\the [src] for a moment, and it says, \"[pick(possible_answers)].\"")
 
 /obj/item/toy/eightball/afterattack(obj/O, mob/user, var/proximity)
 	. = ..()
 	if (proximity)
-		visible_message("<span class='warning'>\The [src] says, \"[pick(possible_answers) ]\" as it hits \the [O]!</span>")
+		visible_message(SPAN_WARNING("\The [src] says, \"[pick(possible_answers)]\" as it hits \the [O]!"))
 
 
 //////////////////////////////////////////////////////

--- a/code/game/objects/items/weapons/clothingbag.dm
+++ b/code/game/objects/items/weapons/clothingbag.dm
@@ -10,7 +10,7 @@
 
 /obj/item/clothingbag/attack_self(mob/user)
 	if(!opened)
-		user.visible_message("<span class='notice'>\The [user] tears open \the [src]!</span>", "<span class='notice'>You tear open \the [src]!</span>")
+		user.visible_action_message("tear", "open \the [src]!")
 		opened = 1
 		icon_state = icon_used
 		for(var/obj/item in contents)

--- a/code/game/objects/items/weapons/cosmetics.dm
+++ b/code/game/objects/items/weapons/cosmetics.dm
@@ -87,15 +87,9 @@
 		to_chat(user, SPAN_WARNING("You need to wipe off the old makeup first!"))
 		return TRUE
 
-	user.visible_message(
-		SPAN_NOTICE("\The [user] begins to do \the [target]'s makeup with \the [src]."),
-		SPAN_NOTICE("You begin to apply \the [src] to \the [target].")
-	)
+	user.visible_action_message("begin", "to do \the [target]'s makeup with \the [src].")
 	if(do_after(user, 2 SECONDS, target))
-		user.visible_message(
-			SPAN_NOTICE("\The [user] does \the [target]'s makeup with \the [src]."),
-			SPAN_NOTICE("You apply \the [src] to \the [target].")
-		)
+		user.visible_action_message("do", "\the [target]'s makeup with \the [src].")
 		if(target.get_organ_sprite_accessory_metadata(cosmetic_type, apply_marking_to_limb))
 			return TRUE
 		target.set_organ_sprite_accessory(cosmetic_type, SAC_COSMETICS, list(SAM_COLOR = makeup_color), apply_marking_to_limb)

--- a/code/game/objects/items/weapons/material/coins.dm
+++ b/code/game/objects/items/weapons/material/coins.dm
@@ -66,18 +66,15 @@
 	playsound(src, 'sound/effects/coin_flip.ogg', 75, 1)
 
 	if(user && !thrown)
-		user.visible_message(
-			SPAN_NOTICE("[user] flips \the [src] into the air."),
-			SPAN_NOTICE("You flip \the [src] into the air."),
-			"You hear a coin ring.")
+		user.visible_action_message("flip", "\the [src] into the air.", blind_message = SPAN_NOTICE("You hear a coin ring."))
 
 	sleep(1.5 SECOND)
 
 	if(!QDELETED(src))
 		if(!QDELETED(user) && loc == user && !thrown)
-			user.visible_message(SPAN_NOTICE("...and catches it, revealing that \the [src] landed on [rigged ? "on the side" : pick(faces)]!"))
+			user.visible_message(SPAN_NOTICE("...and catches it, revealing that \the [src] landed on [rigged ? "the side" : pick(faces)]!"))
 		else
-			visible_message(SPAN_NOTICE("\The [src] landed on [rigged ? "on the side" : pick(faces)]!"))
+			visible_message(SPAN_NOTICE("\The [src] landed on [rigged ? "the side" : pick(faces)]!"))
 
 	can_flip = TRUE
 

--- a/code/game/objects/items/weapons/material/stick.dm
+++ b/code/game/objects/items/weapons/material/stick.dm
@@ -18,7 +18,7 @@
 /obj/item/stick/attackby(obj/item/used_item, mob/user)
 
 	if(used_item.is_sharp() && used_item.has_edge() && !sharp)
-		user.visible_message("<span class='warning'>[user] sharpens [src] with [used_item].</span>", "<span class='warning'>You sharpen [src] using [used_item].</span>")
+		user.visible_action_message("sharpen", "[src] with \the [used_item].")
 		set_sharp(TRUE)
 		SetName("sharpened " + name)
 		update_attack_force()

--- a/code/game/objects/items/weapons/material/stick.dm
+++ b/code/game/objects/items/weapons/material/stick.dm
@@ -66,10 +66,7 @@
 /obj/item/stick/use_on_mob(mob/living/target, mob/living/user, animate = TRUE)
 	if(user != target && user.check_intent(I_FLAG_HELP))
 		//Playful poking is its own thing
-		user.visible_message(
-			SPAN_NOTICE("\The [user] pokes \the [target] with \the [src]."),
-			SPAN_NOTICE("You poke \the [target] with \the [src].")
-		)
+		user.visible_action_message("poke", "\the [target] with \the [src].")
 		//Consider adding a check to see if target is dead
 		user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
 		user.do_attack_animation(target)

--- a/code/game/objects/items/weapons/material/urn.dm
+++ b/code/game/objects/items/weapons/material/urn.dm
@@ -14,7 +14,7 @@
 		if(contents.len)
 			to_chat(user, "<span class='warning'>\The [src] is already full!</span>")
 			return
-		user.visible_message("\The [user] scoops \the [A] into \the [src], securing the lid.", "You scoop \the [A] into \the [src], securing the lid.")
+		user.visible_action_message("scoop", "\the [A] into \the [src], securing the lid.")
 		A.forceMove(src)
 
 /obj/item/urn/attack_self(mob/user)
@@ -24,7 +24,7 @@
 	else
 		for(var/obj/effect/decal/cleanable/ash/A in contents)
 			A.dropInto(loc)
-			user.visible_message("\The [user] pours \the [A] out from \the [src].", "You pour \the [A] out from \the [src].")
+			user.visible_action_message("pour", "\the [A] out from \the [src].")
 
 /obj/item/urn/get_examine_strings(mob/user, distance, infix, suffix)
 	. = ..()

--- a/code/game/objects/items/weapons/storage/bible.dm
+++ b/code/game/objects/items/weapons/storage/bible.dm
@@ -101,9 +101,9 @@
 		return
 	var/mob/living/human/preacher = user
 	if(preacher.mind?.assigned_job?.is_holy)
-		preacher.visible_message("\The [preacher] begins to read a passage from \the [src]...", "You begin to read a passage from \the [src]...")
+		preacher.visible_action_message("begin", "to read a passage from \the [src]...")
 		if(do_after(preacher, 5 SECONDS))
-			preacher.visible_message("\The [preacher] reads a passage from \the [src].", "You read a passage from \the [src].")
+			preacher.visible_action_message("read", "a passage from \the [src].")
 			for(var/mob/living/human/H in view(preacher))
 				if(preacher.get_background_datum_by_flag(BACKGROUND_FLAG_RELIGION) == H.get_background_datum_by_flag(BACKGROUND_FLAG_RELIGION))
 					to_chat(H, SPAN_NOTICE("You feel calm and relaxed, at one with the universe."))

--- a/code/game/objects/items/weapons/storage/matches.dm
+++ b/code/game/objects/items/weapons/storage/matches.dm
@@ -16,10 +16,7 @@
 		var/obj/item/flame/match/match = used_item
 		if(match.light(null, no_message = TRUE))
 			playsound(src.loc, 'sound/items/match.ogg', 60, 1, -4)
-			user.visible_message(
-				SPAN_NOTICE("[user] strikes [used_item] on \the [src]."),
-				SPAN_NOTICE("You strike [used_item] on \the [src].")
-			)
+			user.visible_action_message("strike", "\the [used_item] on \the [src].")
 			used_item.update_icon()
 			return TRUE
 	return ..()

--- a/code/game/objects/items/weapons/storage/parachute.dm
+++ b/code/game/objects/items/weapons/storage/parachute.dm
@@ -29,10 +29,7 @@
 		"You hear the shuffling of cloth."
 	)
 	if(!do_after(user, 5 SECONDS))
-		user.visible_message(
-			SPAN_NOTICE("\The [user] gives up on [pack_msg]ing \the [src]."),
-			SPAN_NOTICE("You give up on [pack_msg]ing \the [src].")
-		)
+		user.visible_action_message("give", "up on [pack_msg]ing \the [src].")
 		return TRUE
 	if(packed != initial_pack)
 		return TRUE

--- a/code/game/objects/items/weapons/towels.dm
+++ b/code/game/objects/items/weapons/towels.dm
@@ -201,9 +201,7 @@
 		return FALSE
 	if(!user.drop_from_inventory(src))
 		return FALSE
-	user.visible_message(
-		SPAN_NOTICE("[user] lays out \the [src] on the ground."),
-		SPAN_NOTICE("You lay out \the [src] on the ground."))
+	user.visible_action_message("lay", "out \the [src] on the ground.")
 	laid_out = TRUE
 	set_dir(user.dir)
 	reset_offsets()

--- a/code/game/objects/items/welding/weldingtool.dm
+++ b/code/game/objects/items/welding/weldingtool.dm
@@ -87,7 +87,7 @@
 	w_class = tank.size_in_use
 	set_base_attack_force(tank.unlit_force)
 	if(user && !quiet)
-		user.visible_message("[user] slots \a [T] into \the [src].", "You slot \a [T] into \the [src].")
+		user.visible_action_message("slot", "\a [T] into \the [src].")
 
 	if(!quiet)
 		playsound(loc, 'sound/effects/hypospray.ogg', 50, TRUE)
@@ -113,7 +113,7 @@
 
 	if(user)
 		user.put_in_hands(tank)
-		user.visible_message("[user] removes \the [tank] from \the [src].", "You remove \the [tank] from \the [src].")
+		user.visible_action_message("remove", "\the [tank] from \the [src].")
 	else
 		tank.dropInto(get_turf(src))
 

--- a/code/game/objects/structures/beds/bedroll.dm
+++ b/code/game/objects/structures/beds/bedroll.dm
@@ -59,32 +59,15 @@
 
 /obj/structure/bed/bedroll/show_buckle_message(var/mob/buckled, var/mob/buckling)
 	if(buckled == buckling)
-		visible_message(
-			SPAN_NOTICE("\The [buckled] climbs into \the [src]."),
-			SPAN_NOTICE("You climb into \the [src]."),
-			SPAN_NOTICE("You hear a rustling sound.")
-		)
+		buckled.visible_action_message("climb", "into \the [src].", blind_message = SPAN_NOTICE("You hear a rustling sound."))
 	else
-		var/decl/pronouns/pronouns = buckled.get_pronouns()
-		visible_message(
-			SPAN_NOTICE("\The [buckled] [pronouns.is] bundled into \the [src] by \the [buckling]."),
-			SPAN_NOTICE("You are bundled into \the [src] by \the [buckling]."),
-			SPAN_NOTICE("You hear a rustling sound.")
-		)
+		buckling.targeted_visible_action_message("bundle", "\the [buckled] into \the [src].", blind_message = SPAN_NOTICE("You hear a rustling sound."))
 
 /obj/structure/bed/bedroll/show_unbuckle_message(var/mob/buckled, var/mob/buckling)
 	if(buckled == buckling)
-		visible_message(
-			SPAN_NOTICE("\The [buckled] climbs out of \the [src]."),
-			SPAN_NOTICE("You climb out of \the [src]."),
-			SPAN_NOTICE("You hear a rustling sound.")
-		)
+		buckled.visible_action_message("climb", "out of \the [src].", blind_message = SPAN_NOTICE("You hear a rustling sound."))
 	else
-		visible_message(
-			SPAN_NOTICE("\The [buckled] was pulled out of \the [src] by \the [buckling]."),
-			SPAN_NOTICE("You were pulled out of \the [src] by \the [buckling]."),
-			SPAN_NOTICE("You hear a rustling sound.")
-		)
+		buckling.targeted_visible_action_message("pull", "\the [buckled] out of \the [src].", blind_message = SPAN_NOTICE("You hear a rustling sound."))
 
 /obj/structure/bed/bedroll/on_update_icon()
 	. = ..()
@@ -112,7 +95,7 @@
 		return TRUE
 
 /obj/structure/bed/bedroll/proc/roll_bed(mob/user)
-	visible_message(SPAN_NOTICE("\The [user] rolls up \the [src]."))
+	user.visible_action_message("roll", "up \the [src].")
 	var/obj/item/bedroll/roll = new item_path(get_turf(src), material?.type)
 	roll.padding_material = reinf_material?.type
 	roll.matter = matter?.Copy()

--- a/code/game/objects/structures/beds/simple_bed.dm
+++ b/code/game/objects/structures/beds/simple_bed.dm
@@ -12,32 +12,15 @@
 
 /obj/structure/bed/simple/show_buckle_message(var/mob/buckled, var/mob/buckling)
 	if(buckled == buckling)
-		visible_message(
-			SPAN_NOTICE("\The [buckled] lies down on \the [src]."),
-			SPAN_NOTICE("You lie down on \the [src]."),
-			SPAN_NOTICE("You hear a rustling sound.")
-		)
+		buckling.visible_action_message("lie", "down on \the [src].", blind_message = SPAN_NOTICE("You hear a rustling sound."))
 	else
-		var/decl/pronouns/pronouns = buckled.get_pronouns()
-		visible_message(
-			SPAN_NOTICE("\The [buckled] [pronouns.is] laid down on \the [src] by \the [buckling]."),
-			SPAN_NOTICE("You are laid down on \the [src] by \the [buckling]."),
-			SPAN_NOTICE("You hear a rustling sound.")
-		)
+		buckling.targeted_visible_action_message(buckled, "lay", "\the [buckled] down on \the [src].", blind_message = SPAN_NOTICE("You hear a rustling sound."))
 
 /obj/structure/bed/simple/show_unbuckle_message(var/mob/buckled, var/mob/buckling)
 	if(buckled == buckling)
-		visible_message(
-			SPAN_NOTICE("\The [buckled] rises from \the [src]."),
-			SPAN_NOTICE("You rise from \the [src]."),
-			SPAN_NOTICE("You hear a rustling sound.")
-		)
+		buckling.visible_action_message("rise", "from \the [src].", blind_message = SPAN_NOTICE("You hear a rustling sound."))
 	else
-		visible_message(
-			SPAN_NOTICE("\The [buckled] was pulled off \the [src] by \the [buckling]."),
-			SPAN_NOTICE("You were pulled off \the [src] by \the [buckling]."),
-			SPAN_NOTICE("You hear a rustling sound.")
-		)
+		buckling.targeted_visible_action_message(buckled, "pull", "\the [buckling] off \the [src].", blind_message = SPAN_NOTICE("You hear a rustling sound."))
 
 /obj/structure/bed/simple/ebony
 	material = /decl/material/solid/organic/wood/ebony

--- a/code/game/objects/structures/coathanger.dm
+++ b/code/game/objects/structures/coathanger.dm
@@ -44,10 +44,7 @@
 	if(!length(contents) || !user.check_dexterity(DEXTERITY_HOLD_ITEM, TRUE))
 		return ..()
 	var/obj/item/removing = contents[contents.len]
-	user.visible_message( \
-		SPAN_NOTICE("\The [user] takes \the [removing] off \the [src]."),
-		SPAN_NOTICE("You take \the [removing] off \the [src].")
-	)
+	user.visible_action_message("take", "\the [removing] off \the [src].")
 	removing.dropInto(loc)
 	user.put_in_active_hand(removing)
 	update_icon()
@@ -77,10 +74,7 @@
 		to_chat(user, SPAN_NOTICE("There is no room on \the [src] to hang \the [used_item]."))
 		return TRUE
 	if(user.try_unequip(used_item, src))
-		user.visible_message( \
-			SPAN_NOTICE("\The [user] hangs \the [used_item] on \the [src]."), \
-			SPAN_NOTICE("You hang \the [used_item] on \the [src].") \
-		)
+		user.visible_action_message("hang", "\the [used_item] on \the [src].")
 		update_icon()
 	return TRUE
 

--- a/code/game/objects/structures/crates_lockers/closets/__closet.dm
+++ b/code/game/objects/structures/crates_lockers/closets/__closet.dm
@@ -344,7 +344,7 @@ var/global/list/closets = list()
 	if(!. && istype(AM) && opened && !istype(AM, /obj/structure/closet) && AM.simulated && !AM.anchored && (large || !ismob(AM)))
 		step_towards(AM, loc)
 		if(user != AM)
-			user.visible_message(SPAN_DANGER("\The [user] stuffs \the [AM] into \the [src]!"), SPAN_DANGER("You stuff \the [AM] into \the [src]!"))
+			user.visible_action_message("stuff", "\the [AM] into \the [src]!", dangerous = ACTION_DANGER_ALL)
 		return TRUE
 
 /obj/structure/closet/attack_ai(mob/living/silicon/ai/user)

--- a/code/game/objects/structures/curtains.dm
+++ b/code/game/objects/structures/curtains.dm
@@ -36,9 +36,7 @@
 			to_chat(user, SPAN_DANGER("You cannot install \the [src] in space."))
 			return TRUE
 
-		user.visible_message(
-			SPAN_NOTICE("\The [user] begins installing \the [src]."),
-			SPAN_NOTICE("You begin installing \the [src]."))
+		user.visible_action_message("begin", "installing \the [src].")
 		playsound(src, 'sound/items/Screwdriver.ogg', 100, 1)
 
 		if(!do_after(user, 4 SECONDS, src))
@@ -112,9 +110,7 @@
 
 /obj/structure/curtain/attackby(obj/item/used_item, mob/user)
 	if(IS_SCREWDRIVER(used_item) && curtain_kind_path)
-		user.visible_message(
-			SPAN_NOTICE("\The [user] begins uninstalling \the [src]."),
-			SPAN_NOTICE("You begin uninstalling \the [src]."))
+		user.visible_action_message("begin", "uninstalling \the [src].")
 		playsound(src, 'sound/items/Screwdriver.ogg', 100, 1)
 
 		if(!do_after(user, 4 SECONDS, src))

--- a/code/game/objects/structures/displaycase.dm
+++ b/code/game/objects/structures/displaycase.dm
@@ -134,7 +134,7 @@
 		return TRUE
 
 	else if(!destroyed && user.check_intent(I_FLAG_HARM))
-		visible_message(SPAN_WARNING("[user] kicks \the [src]."), SPAN_WARNING("You kick \the [src]."))
+		user.visible_action_message("kick", "\the [src].", dangerous = ACTION_DANGER_ALL)
 		take_damage(2)
 		return TRUE
 	return FALSE

--- a/code/game/objects/structures/door_assembly.dm
+++ b/code/game/objects/structures/door_assembly.dm
@@ -185,9 +185,9 @@
 	if(IS_WRENCH(used_item) && state == 0)
 		playsound(src.loc, 'sound/items/Ratchet.ogg', 100, 1)
 		if(anchored)
-			user.visible_message("[user] begins unsecuring the airlock assembly from the floor.", "You begin unsecuring the airlock assembly from the floor.")
+			user.visible_action_message("begin", "unsecuring the airlock assembly from the floor.")
 		else
-			user.visible_message("[user] begins securing the airlock assembly to the floor.", "You begin securing the airlock assembly to the floor.")
+			user.visible_action_message("begin", "securing the airlock assembly to the floor.")
 
 		if(do_after(user, 4 SECONDS, src))
 			if(QDELETED(src)) return TRUE
@@ -249,7 +249,7 @@
 			return TRUE
 
 		playsound(src.loc, 'sound/items/Crowbar.ogg', 100, 1)
-		user.visible_message("\The [user] starts removing the electronics from the airlock assembly.", "You start removing the electronics from the airlock assembly.")
+		user.visible_action_message("start", "removing the electronics from the airlock assembly.")
 
 		if(do_after(user, 4 SECONDS, src))
 			if(QDELETED(src)) return TRUE

--- a/code/game/objects/structures/door_assembly.dm
+++ b/code/game/objects/structures/door_assembly.dm
@@ -161,37 +161,33 @@
 			playsound(src.loc, 'sound/items/Welder2.ogg', 50, 1)
 			if(reinf_material)
 				var/mat_name = reinf_material.solid_name
-				user.visible_message("[user] welds the [mat_name] plating off the airlock assembly.", "You start to weld the [mat_name] plating off the airlock assembly.")
+				user.visible_action_message("start", "slicing the [mat_name] plating off \the [src]...")
 				if(do_after(user, 4 SECONDS, src))
 					if(!welder.isOn())
 						return TRUE
-					to_chat(user, "<span class='notice'>You welded the [mat_name] plating off!</span>")
+					user.visible_action_message("slice", "the [mat_name] plating off \the [src]!")
 					reinf_material.create_object(get_turf(src), 2)
 					reinf_material = null
 					update_icon()
 				return TRUE
 			if(!anchored)
-				user.visible_message("[user] dissassembles the airlock assembly.", "You start to dissassemble the airlock assembly.")
+				user.visible_action_message("start", "disassembling \the [src].")
 				if(do_after(user, 4 SECONDS, src))
 					if(!welder.isOn())
 						return TRUE
-					to_chat(user, "<span class='notice'>You dissasembled the airlock assembly!</span>")
+					user.visible_action_message("disassemble", "\the [src]!")
 					dismantle_structure(user)
 				return TRUE
 		else
-			to_chat(user, "<span class='notice'>You need more welding fuel.</span>")
+			to_chat(user, SPAN_NOTICE("You need more welding fuel."))
 			return TRUE
 
 	if(IS_WRENCH(used_item) && state == 0)
 		playsound(src.loc, 'sound/items/Ratchet.ogg', 100, 1)
-		if(anchored)
-			user.visible_action_message("begin", "unsecuring the airlock assembly from the floor.")
-		else
-			user.visible_action_message("begin", "securing the airlock assembly to the floor.")
-
+		user.visible_action_message("start", "[anchored ? "unsecuring" : "securing"] the airlock assembly [anchored ? "from" : "to"] the floor...")
 		if(do_after(user, 4 SECONDS, src))
 			if(QDELETED(src)) return TRUE
-			to_chat(user, "<span class='notice'>You [anchored? "un" : ""]secured the airlock assembly!</span>")
+			user.visible_action_message(anchored ? "unsecure" : "secure", "\the [src]!")
 			anchored = !anchored
 			update_icon()
 		return TRUE
@@ -200,23 +196,23 @@
 	else if(IS_COIL(used_item) && state == 0 && anchored)
 		var/obj/item/stack/cable_coil/C = used_item
 		if (C.get_amount() < 1)
-			to_chat(user, "<span class='warning'>You need one length of coil to wire the airlock assembly.</span>")
+			to_chat(user, SPAN_WARNING("You need one length of coil to wire the airlock assembly."))
 			return TRUE
-		user.visible_message("[user] wires the airlock assembly.", "You start to wire the airlock assembly.")
+		user.visible_action_message("start", "wiring \the [src]...")
 		if(do_after(user, 4 SECONDS, src) && state == 0 && anchored)
 			if (C.use(1))
 				src.state = 1
-				to_chat(user, "<span class='notice'>You wire the airlock.</span>")
+				user.visible_action_message("wire", "\the [src]!")
 				update_icon()
 		return TRUE
 
 	else if(IS_WIRECUTTER(used_item) && state == 1 )
 		playsound(src.loc, 'sound/items/Wirecutter.ogg', 100, 1)
-		user.visible_message("[user] cuts the wires from the airlock assembly.", "You start to cut the wires from airlock assembly.")
+		user.visible_action_message("start", "cutting the wires from \the [src]...")
 
-		if(do_after(user, 40,src))
+		if(do_after(user, 4 SECONDS, src))
 			if(QDELETED(src)) return TRUE
-			to_chat(user, "<span class='notice'>You cut the airlock wires!</span>")
+			user.visible_action_message("cut", "the wires from \the [src].")
 			new/obj/item/stack/cable_coil(src.loc, 1)
 			src.state = 0
 			update_icon()
@@ -227,15 +223,15 @@
 		if(!ispath(airlock_type, E.build_path))
 			return FALSE
 		playsound(src.loc, 'sound/items/Screwdriver.ogg', 100, 1)
-		user.visible_message("[user] installs the electronics into the airlock assembly.", "You start to install electronics into the airlock assembly.")
+		user.visible_action_message("start", "installing \the [used_item] into \the [src]...")
 
-		if(do_after(user, 40,src))
+		if(do_after(user, 4 SECONDS, src))
 			if(QDELETED(src)) return TRUE
 			if(!user.try_unequip(used_item, src))
 				return TRUE
-			to_chat(user, "<span class='notice'>You installed the airlock electronics!</span>")
+			user.visible_action_message("install", "\the [used_item] into \the [src]!")
 			src.state = 2
-			src.SetName("Near finished Airlock Assembly")
+			update_material_name()
 			src.electronics = used_item
 			update_icon()
 		return TRUE
@@ -243,19 +239,19 @@
 	else if(IS_CROWBAR(used_item) && state == 2 )
 		//This should never happen, but just in case I guess
 		if (!electronics)
-			to_chat(user, "<span class='notice'>There was nothing to remove.</span>")
+			to_chat(user, SPAN_NOTICE("There was nothing to remove."))
 			src.state = 1
 			update_icon()
 			return TRUE
 
 		playsound(src.loc, 'sound/items/Crowbar.ogg', 100, 1)
-		user.visible_action_message("start", "removing the electronics from the airlock assembly.")
+		user.visible_action_message("start", "removing the electronics from the airlock assembly...")
 
 		if(do_after(user, 4 SECONDS, src))
 			if(QDELETED(src)) return TRUE
-			to_chat(user, "<span class='notice'>You removed the airlock electronics!</span>")
+			user.visible_action_message("remove", "\the [electronics]!")
 			src.state = 1
-			src.SetName("Wired Airlock Assembly")
+			update_material_name()
 			electronics.dropInto(loc)
 			electronics = null
 			update_icon()
@@ -266,22 +262,23 @@
 		var/decl/material/sheet_material = S.get_material()
 		if (S.get_amount() >= 2)
 			playsound(src.loc, 'sound/items/Crowbar.ogg', 100, 1)
-			user.visible_message("[user] adds [S.name] to the airlock assembly.", "You start to install [S.name] into the airlock assembly.")
+			user.visible_action_message("start", "adding [S.get_string_for_amount(2)] to \the [src]...")
 			if(do_after(user, 4 SECONDS, src) && can_install_glass && !reinf_material)
 				if (S.use(2))
 					reinf_material = sheet_material
-					to_chat(user, "<span class='notice'>You installed [reinf_material.solid_name] windows into the airlock assembly.</span>")
+					update_material_name()
+					user.visible_action_message("install", "[reinf_material.solid_name] windows into \the [src]!")
 					update_icon()
 			return TRUE
 		return FALSE
 
 	else if(IS_SCREWDRIVER(used_item) && state == 2 )
 		playsound(src.loc, 'sound/items/Screwdriver.ogg', 100, 1)
-		to_chat(user, "<span class='notice'>Now finishing the airlock.</span>")
+		to_chat(user, SPAN_NOTICE("Now finishing the airlock."))
 
 		if(do_after(user, 4 SECONDS, src))
 			if(QDELETED(src)) return TRUE
-			to_chat(user, "<span class='notice'>You finish the airlock!</span>")
+			to_chat(user, SPAN_NOTICE("You finish the airlock!"))
 			var/obj/machinery/door/door = new airlock_type(get_turf(src), dir, FALSE, src)
 			door.construct_state.post_construct(door) // it eats the circuit inside Initialize
 			qdel(src)

--- a/code/game/objects/structures/fitness.dm
+++ b/code/game/objects/structures/fitness.dm
@@ -86,9 +86,7 @@
 				message = "; this does not look safe"
 		else
 			message = fail_message[min(1 + round(weight - skill), fail_message.len)]
-		H.visible_message( \
-			SPAN_NOTICE("\The [H] fails to lift the weights[message]."), \
-			SPAN_NOTICE("You fail to lift the weights[message]."))
+		H.visible_action_message("fail", "to lift the weights[message].")
 	else
 		if(!synth)
 			var/adj_weight = weight * 5

--- a/code/game/objects/structures/inflatable.dm
+++ b/code/game/objects/structures/inflatable.dm
@@ -14,11 +14,11 @@
 	if(!isturf(user.loc))
 		to_chat(user, SPAN_WARNING("\The [src] cannot be inflated here."))
 		return
-	user.visible_message("[user] starts inflating \the [src].", "You start inflating \the [src].")
+	user.visible_action_message("start", "inflating \the [src].")
 	if(!do_after(user, 1 SECOND, src))
 		return
 	playsound(loc, 'sound/items/zip.ogg', 75, 1)
-	user.visible_message(SPAN_NOTICE("[user] inflates \the [src]."), SPAN_NOTICE("You inflate \the [src]."))
+	user.visible_action_message("inflate", "\the [src].")
 	var/obj/structure/inflatable/debris = new deploy_path(user.loc)
 	transfer_fingerprints_to(debris)
 	debris.add_fingerprint(user)

--- a/code/game/objects/structures/pit.dm
+++ b/code/game/objects/structures/pit.dm
@@ -266,9 +266,9 @@
 		return FALSE
 	var/obj/structure/pit/grave = locate() in target_turf
 	var/where = grave ? "on \the [grave]" : "in \the [target_turf]"
-	user.visible_message(SPAN_NOTICE("\The [user] starts planting \a [src] [where]."), SPAN_NOTICE("You start planting \a [src] [where]."), SPAN_NOTICE("You hear soil shifting."))
+	user.visible_action_message("start", "planting \a [src] [where].", blind_message = "You hear soil shifting.")
 	if(!do_after(user, 5 SECONDS, grave || target_turf))
-		user.visible_message(SPAN_NOTICE("\The [user] stops planting \a [src] [where]."), SPAN_NOTICE("You stop planting \a [src] [where]."), SPAN_NOTICE("You hear the soil become still once more."))
+		user.visible_action_message("stop", "planting \a [src] [where].", blind_message = "You hear the soil become still once more.")
 		return TRUE
 	// check again after the delay, just in case
 	if(!can_bury(target_turf, user))
@@ -276,7 +276,7 @@
 	if(bury(target_turf, user))
 		grave = locate() in target_turf // could have been removed or created during the delay
 		where = grave ? "on \the [grave]" : "in \the [target_turf]"
-		user.visible_message(SPAN_NOTICE("\The [user] plants \a [src] [where]."), SPAN_NOTICE("You plant \a [src] [where]."), SPAN_NOTICE("You hear soil shifting."))
+		user.visible_action_message("plant", "\a [src] [where].", blind_message = "You hear soil shifting.")
 
 /obj/item/gravemarker/proc/can_bury(turf/target_turf, mob/user, silent = FALSE)
 	var/obj/structure/pit/grave = locate() in target_turf

--- a/code/game/objects/structures/railing.dm
+++ b/code/game/objects/structures/railing.dm
@@ -255,7 +255,7 @@ WOOD_RAILING_SUBTYPE(yew)
 			if(do_after(user, 2 SECONDS, src))
 				if(anchored)
 					return TRUE
-				user.visible_message("<span class='notice'>\The [user] dismantles \the [src].</span>", "<span class='notice'>You dismantle \the [src].</span>")
+				user.visible_action_message("dismantle", "\the [src].")
 				material.create_object(loc, 2)
 				qdel(src)
 			return TRUE
@@ -283,7 +283,7 @@ WOOD_RAILING_SUBTYPE(yew)
 			if(do_after(user, 20, src))
 				if(current_health >= current_max_health)
 					return TRUE
-				user.visible_message("<span class='notice'>\The [user] repairs some damage to \the [src].</span>", "<span class='notice'>You repair some damage to \the [src].</span>")
+				user.visible_action_message("repair", "some damage to \the [src].")
 				current_health = min(current_health+(current_max_health/5), current_max_health)
 			return TRUE
 

--- a/code/game/objects/structures/stasis_cage.dm
+++ b/code/game/objects/structures/stasis_cage.dm
@@ -80,9 +80,7 @@
 		if(!stat && !istype(buckled, /obj/effect/energy_net))
 			to_chat(user, SPAN_WARNING("It's going to be difficult to convince \the [src] to move into \the [cage] without capturing it in a net."))
 			return TRUE
-		user.visible_message( \
-			SPAN_NOTICE("\The [user] begins stuffing \the [src] into \the [cage]."), \
-			SPAN_NOTICE("You begin stuffing \the [src] into \the [cage]."))
+		user.visible_action_message("begin", "stuffing \the [src] into \the [cage].")
 		Bumped(user)
 		if(do_after(user, 20, cage))
 			cage.visible_message( \

--- a/code/game/objects/structures/tables.dm
+++ b/code/game/objects/structures/tables.dm
@@ -142,9 +142,7 @@
 		return ..()
 
 	if(felted)
-		user.visible_message(
-			SPAN_NOTICE("\The [user] removes the felting from \the [src]."),
-			SPAN_NOTICE("You remove the felting from \the [src]."))
+		user.visible_action_message("remove", "the felting from \the [src].")
 		new /obj/item/stack/tile/carpet(loc)
 		felted = FALSE
 		update_icon()
@@ -173,8 +171,7 @@
 			additional_reinf_material.create_object(src.loc)
 			additional_reinf_material = null
 
-		user.visible_message(SPAN_NOTICE("\The [user] removes the [remove_mat.solid_name] [remove_noun] from \the [src]."),
-			SPAN_NOTICE("You remove the [remove_mat.solid_name] [remove_noun] from \the [src]."))
+		user.visible_action_message("remove", "the [remove_mat.solid_name] [remove_noun] from \the [src].")
 		update_materials()
 	return TRUE
 
@@ -197,9 +194,7 @@
 	if(!felted && istype(used_item, /obj/item/stack/tile/carpet))
 		var/obj/item/stack/tile/carpet/C = used_item
 		if(C.use(1))
-			user.visible_message(
-				SPAN_NOTICE("\The [user] adds \the [C] to \the [src]."),
-				SPAN_NOTICE("You add \the [C] to \the [src]."))
+			user.visible_action_message("add", "\the [C] to \the [src].")
 			felted = TRUE
 			update_icon()
 		else

--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -134,16 +134,13 @@ var/global/list/hygiene_props = list()
 		return ..()
 
 	if(swirlie)
-		usr.visible_message(
-			SPAN_DANGER("\The [user] slams the toilet seat onto \the [swirlie]'s head!"),
-			SPAN_NOTICE("You slam the toilet seat onto \the [swirlie]'s head!"),
-			"You hear reverberating porcelain.")
+		user.visible_action_message("slam", "the toilet seat onto \the [swirlie]'s head!", dangerous = ACTION_DANGER_OTHERS, blind_message = "You hear reverberating porcelain.")
 		swirlie.take_damage(8)
 		return TRUE
 
 	// TODO: storage datum
 	if(cistern && !open)
-		if(!contents.len)
+		if(!length(contents))
 			to_chat(user, SPAN_NOTICE("The cistern is empty."))
 		else
 			var/obj/item/thing = pick(contents)
@@ -181,9 +178,7 @@ var/global/list/hygiene_props = list()
 				victim.take_damage(5, OXY)
 			swirlie = null
 		else
-			user.visible_message(
-			SPAN_DANGER("\The [user] slams \the [victim] into \the [src]!"),
-			SPAN_NOTICE("You slam \the [victim] into \the [src]!"))
+			user.visible_action_message("slam", "\the [victim] into \the [src]!", dangerous = ACTION_DANGER_OTHERS)
 			victim.take_damage(8)
 			playsound(src.loc, 'sound/effects/bang.ogg', 25, 1)
 		return TRUE
@@ -412,9 +407,7 @@ var/global/list/hygiene_props = list()
 
 	var/obj/item/chems/chem_container = used_item
 	if (istype(chem_container) && ATOM_IS_OPEN_CONTAINER(chem_container) && chem_container.reagents)
-		user.visible_message(
-			SPAN_NOTICE("\The [user] fills \the [chem_container] using \the [src]."),
-			SPAN_NOTICE("You fill \the [chem_container] using \the [src]."))
+		user.visible_action_message("fill", "\the [chem_container] using \the [src].")
 		playsound(loc, 'sound/effects/sink.ogg', 75, 1)
 		chem_container.add_to_reagents(/decl/material/liquid/water, min(REAGENTS_FREE_SPACE(chem_container.reagents), chem_container.amount_per_transfer_from_this))
 		return TRUE
@@ -518,7 +511,7 @@ var/global/list/hygiene_props = list()
 		return
 
 	if(can_use(1))
-		usr.visible_message(SPAN_NOTICE("\The [usr] tears a sheet from \the [src]."), SPAN_NOTICE("You tear a sheet from \the [src]."))
+		usr.visible_action_message("tear", "a sheet from \the [src].")
 		var/obj/item/paper/crumpled/bog/C =  new(loc)
 		usr.put_in_hands(C)
 

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -165,18 +165,10 @@
 
 		playsound(src.loc, 'sound/effects/glassknock.ogg', 80, 1)
 		user.do_attack_animation(src)
-		user.visible_message(
-			SPAN_DANGER("\The [user] bangs against \the [src]!"),
-			SPAN_DANGER("You bang against \the [src]!"),
-			"You hear a banging sound."
-		)
+		user.visible_action_message("bang", "against \the [src]!", ACTION_DANGER_ALL, SPAN_DANGER("You hear a banging sound."))
 	else
 		playsound(src.loc, 'sound/effects/glassknock.ogg', 80, 1)
-		user.visible_message(
-			SPAN_NOTICE("\The [user] knocks on \the [src]."),
-			SPAN_NOTICE("You knock on \the [src]."),
-			"You hear a knocking sound."
-		)
+		user.visible_action_message("knock", "on \the [src].", ACTION_DANGER_NONE, SPAN_NOTICE("You hear a knocking sound."))
 	return TRUE
 
 /obj/structure/window/do_simple_ranged_interaction(var/mob/user)

--- a/code/game/turfs/walls/wall_natural.dm
+++ b/code/game/turfs/walls/wall_natural.dm
@@ -79,7 +79,7 @@ var/global/_wall_chisel_skill = SKILL_CONSTRUCTION
 
 		if (istype(used_item, /obj/item/measuring_tape))
 			var/obj/item/measuring_tape/P = used_item
-			user.visible_message(SPAN_NOTICE("\The [user] extends [P] towards [src]."),SPAN_NOTICE("You extend [P] towards [src]."))
+			user.visible_action_message("extend", "\the [P] towards [src].")
 			if(do_after(user,10, src))
 				to_chat(user, SPAN_NOTICE("\The [src] has been excavated to a depth of [excavation_level]cm."))
 			return TRUE

--- a/code/modules/ZAS/Airflow.dm
+++ b/code/modules/ZAS/Airflow.dm
@@ -112,7 +112,7 @@ Contains helper procs for airflow, called by /connection_group.
 	airborne_acceleration = 0
 
 /mob/airflow_hit(atom/A)
-	visible_message(SPAN_DANGER("\The [src] slams into \the [A]!"), SPAN_DANGER("You slam into \the [A]!"), SPAN_DANGER("You hear a loud slam!"))
+	visible_action_message("slam", "into \the [A]!", ACTION_DANGER_ALL, SPAN_DANGER("You hear a loud slam!"))
 	playsound(src.loc, "smash.ogg", 25, 1, -1)
 	var/weak_amt = istype(A,/obj/item) ? A:w_class : rand(1,5) //Heheheh
 	SET_STATUS_MAX(src, STAT_WEAK, weak_amt)

--- a/code/modules/assembly/mousetrap.dm
+++ b/code/modules/assembly/mousetrap.dm
@@ -80,9 +80,7 @@
 	var/mob/living/M = AM
 	if(MOVING_DELIBERATELY(M))
 		return
-	M.visible_message(
-		SPAN_DANGER("\The [M] steps on \the [src]!"),
-		SPAN_DANGER("You step on \the [src]!"))
+	M.visible_action_message("step", "on \the [src]!", dangerous = ACTION_DANGER_ALL)
 	triggered(M)
 
 /obj/item/assembly/mousetrap/on_found(mob/finder)

--- a/code/modules/banners/_banner_frame.dm
+++ b/code/modules/banners/_banner_frame.dm
@@ -51,11 +51,7 @@
 		user.put_in_hands(banner)
 		var/old_banner = banner
 		set_banner(null)
-		user.visible_message(
-			SPAN_NOTICE("\The [user] removes \the [old_banner] from \the [src]."),
-			SPAN_NOTICE("You remove \the [old_banner] from \the [src]."),
-			SPAN_NOTICE("You hear the rustling of fabric.")
-		)
+		user.visible_action_message("remove", "\the [old_banner] from \the [src].", blind_message = SPAN_NOTICE("You hear the rustling of fabric."))
 		return TRUE
 	return ..()
 
@@ -71,7 +67,7 @@
 			return TRUE
 
 		if(user.try_unequip(used_item, src))
-			user.visible_message(SPAN_NOTICE("\The [user] hangs \the [used_item] from \the [src]."), SPAN_NOTICE("You hang \the [used_item] from \the [src]."), SPAN_NOTICE("You hear the rustling of fabric."))
+			user.visible_action_message("hang", "\the [used_item] from \the [src].", blind_message = SPAN_NOTICE("You hear the rustling of fabric."))
 			set_banner(used_item)
 		return TRUE
 	return ..()

--- a/code/modules/clothing/badges/_badge.dm
+++ b/code/modules/clothing/badges/_badge.dm
@@ -59,10 +59,7 @@
 
 /obj/item/clothing/badge/use_on_mob(mob/living/target, mob/living/user, animate = TRUE)
 	if(isliving(user) && user.check_intent(I_FLAG_HARM))
-		user.visible_message(
-			SPAN_DANGER("\The [user] invades \the [target]'s personal space, thrusting \the [src] into their face insistently."),
-			SPAN_DANGER("You invade \the [target]'s personal space, thrusting \the [src] into their face insistently.")
-		)
+		user.targeted_visible_action_message(target, "invade", "$TARGET'S$ personal space, thrusting \the [src] into $TARGET_THEIR$ face insistently.", dangerous = ACTION_DANGER_ALL)
 		if(stored_name)
 			to_chat(target, SPAN_NOTICE("It reads: [stored_name], [badge_string]."))
 		return TRUE

--- a/code/modules/clothing/badges/_badge.dm
+++ b/code/modules/clothing/badges/_badge.dm
@@ -52,10 +52,7 @@
 		return
 
 	if(isliving(user))
-		if(stored_name)
-			user.visible_message("<span class='notice'>[user] displays their [src.name].\nIt reads: [stored_name], [badge_string].</span>","<span class='notice'>You display your [src.name].\nIt reads: [stored_name], [badge_string].</span>")
-		else
-			user.visible_message("<span class='notice'>[user] displays their [src.name].\nIt reads: [badge_string].</span>","<span class='notice'>You display your [src.name]. It reads: [badge_string].</span>")
+		user.visible_action_message("display", "$USER_THEIR$ [src.name].\nIt reads: [stored_name ? "[stored_name], " : ""][badge_string].")
 
 /obj/item/clothing/badge/use_on_mob(mob/living/target, mob/living/user, animate = TRUE)
 	if(isliving(user) && user.check_intent(I_FLAG_HARM))

--- a/code/modules/clothing/gloves/jewelry/rings/ring_misc.dm
+++ b/code/modules/clothing/gloves/jewelry/rings/ring_misc.dm
@@ -7,7 +7,7 @@
 	decorations = list(/obj/item/gemstone/round)
 
 /obj/item/clothing/gloves/ring/engagement/attack_self(mob/user)
-	user.visible_message(SPAN_WARNING("\The [user] gets down on one knee, presenting \the [src]."), SPAN_WARNING("You get down on one knee, presenting \the [src]."))
+	user.visible_action_message("get", "down on one knee, presenting \the [src].", dangerous = ACTION_DANGER_OTHERS)
 
 /obj/item/clothing/gloves/ring/cti
 	name        = "\improper CTI ring"

--- a/code/modules/clothing/head/misc_special.dm
+++ b/code/modules/clothing/head/misc_special.dm
@@ -165,10 +165,7 @@
 			)
 			slice_amount = rand(1, max(1, round(slice_amount*0.5)))
 		else
-			user.visible_message(
-				SPAN_NOTICE("\The [user] slices \the [src]!"),
-				SPAN_NOTICE("You slice \the [src]!")
-			)
+			user.visible_action_message("slice", "\the [src]!")
 		for(var/i = 1 to slice_amount)
 			new /obj/item/food/processed_grown/chopped(loc, null, TRUE, plant)
 		qdel(src)

--- a/code/modules/clothing/masks/smokable.dm
+++ b/code/modules/clothing/masks/smokable.dm
@@ -527,7 +527,7 @@
 		extinguish_fire(user, no_message = TRUE)
 	else if (smoketime)
 		var/turf/location = get_turf(user)
-		user.visible_message(SPAN_NOTICE("[user] empties out [src]."), SPAN_NOTICE("You empty out [src]."))
+		user.visible_action_message("empty", "out \the [src].")
 		new /obj/effect/decal/cleanable/ash(location)
 		smoketime = 0
 		reagents.clear_reagents()

--- a/code/modules/clothing/masks/smokable.dm
+++ b/code/modules/clothing/masks/smokable.dm
@@ -368,11 +368,8 @@
 		if(blocked)
 			to_chat(target, SPAN_WARNING("\The [blocked] is in the way!"))
 			return TRUE
-		var/decl/pronouns/pronouns = user.get_pronouns()
 		var/puff_str = pick("drag","puff","pull")
-		user.visible_message(\
-			SPAN_NOTICE("\The [user] takes a [puff_str] on [pronouns.his] [name]."), \
-			SPAN_NOTICE("You take a [puff_str] on your [name]."))
+		user.visible_action_message("take", "a [puff_str] on $USER_THEIR$ [name].")
 		smoke(12, TRUE)
 		add_trace_DNA(target)
 		user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
@@ -526,7 +523,7 @@
 
 /obj/item/clothing/mask/smokable/pipe/attack_self(var/mob/user)
 	if(lit)
-		user.visible_message(SPAN_NOTICE("[user] puts out [src]."), SPAN_NOTICE("You put out [src]."))
+		user.visible_action_message("put", "out [src].")
 		extinguish_fire(user, no_message = TRUE)
 	else if (smoketime)
 		var/turf/location = get_turf(user)

--- a/code/modules/clothing/sensors/vitals_sensor.dm
+++ b/code/modules/clothing/sensors/vitals_sensor.dm
@@ -117,20 +117,11 @@
 		return
 	if(wearer)
 		if(sensor_mode == 0)
-			user.visible_message(
-				SPAN_DANGER("\The [user] disables \the [wearer]'s vitals sensor."),
-				SPAN_DANGER("You disable \the [wearer]'s vitals sensor.")
-			)
+			user.visible_action_message("disable", "\the [wearer]'s vitals sensor.", dangerous = ACTION_DANGER_ALL)
 		else
-			user.visible_message(
-				SPAN_NOTICE("\The [user] adjusts \the [wearer]'s vitals sensor."),
-				SPAN_NOTICE("You adjust \the [wearer]'s vitals sensor.")
-			)
+			user.visible_action_message("adjust", "\the [wearer]'s vitals sensor.")
 		return
-	user.visible_message(
-		SPAN_NOTICE("\The [user] adjusts \the [src]"),
-		SPAN_NOTICE("You adjust \the [src].")
-	)
+	user.visible_action_message("adjust", "\the [src].")
 
 /obj/item/clothing/sensor/vitals/emp_act(var/severity)
 	..()

--- a/code/modules/clothing/spacesuits/rig/modules/combat.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/combat.dm
@@ -156,7 +156,7 @@
 
 	charge.charges--
 	var/obj/item/grenade/new_grenade = new charge.product_type(get_turf(wearer))
-	wearer.visible_message(SPAN_DANGER("[wearer] launches \a [new_grenade]!"), SPAN_DANGER("You launch \a [new_grenade]!"))
+	wearer.visible_action_message("launch", "\a [new_grenade]!", dangerous = ACTION_DANGER_ALL)
 	log_and_message_admins("fired a grenade ([new_grenade.name]) from a rigsuit grenade launcher.")
 	new_grenade.activate(wearer)
 	new_grenade.throw_at(target,fire_force,fire_distance)

--- a/code/modules/clothing/spacesuits/rig/rig.dm
+++ b/code/modules/clothing/spacesuits/rig/rig.dm
@@ -254,7 +254,7 @@
 	sealing = 1
 
 	if(!seal_target && !suit_is_deployed())
-		wearer.visible_message("<span class='danger'>[wearer]'s suit flashes an error light.</span>","<span class='danger'>Your suit flashes an error light. It can't function properly without being fully deployed.</span>")
+		wearer.visible_message(SPAN_DANGER("[wearer]'s suit flashes an error light."), SPAN_DANGER("Your suit flashes an error light. It can't function properly without being fully deployed."))
 		failed_to_seal = 1
 
 	if(!failed_to_seal)

--- a/code/modules/clothing/spacesuits/rig/rig.dm
+++ b/code/modules/clothing/spacesuits/rig/rig.dm
@@ -671,9 +671,7 @@
 	..()
 
 	if(seal_delay > 0 && istype(M) && M.get_equipped_item(slot_back_str) == src)
-		M.visible_message(
-			SPAN_HARDSUIT("[M] starts putting on \the [src]..."),
-			SPAN_HARDSUIT("You start putting on \the [src]..."))
+		M.visible_action_message("start", "putting on \the [src].", "font_blue")
 
 		if(!do_after(M,seal_delay,src))
 			if(M && M.get_equipped_item(slot_back_str) == src)
@@ -683,9 +681,7 @@
 			return
 
 	if(istype(M) && M.get_equipped_item(slot_back_str) == src)
-		M.visible_message(
-			SPAN_HARDSUIT("<b>[M] struggles into \the [src].</b>"),
-			SPAN_HARDSUIT("<b>You struggle into \the [src].</b>"))
+		M.visible_action_message("struggle", "into \the [src].", "font_blue")
 		wearer = M
 		update_icon()
 

--- a/code/modules/detectivework/tools/evidencebag.dm
+++ b/code/modules/detectivework/tools/evidencebag.dm
@@ -79,8 +79,7 @@
 
 /obj/item/evidencebag/attack_self(mob/user)
 	if(stored_item)
-		user.visible_message("[user] takes [stored_item] out of [src]", "You take [stored_item] out of [src].",\
-		"You hear someone rustle around in a plastic bag, and remove something.")
+		user.visible_action_message("take", "\the [stored_item] out of [src].", blind_message = "You hear someone rustle around in a plastic bag and remove something.")
 		user.put_in_hands(stored_item)
 		empty()
 	else

--- a/code/modules/detectivework/tools/rag.dm
+++ b/code/modules/detectivework/tools/rag.dm
@@ -35,7 +35,7 @@
 
 /obj/item/chems/rag/attack_self(mob/user)
 	if(is_on_fire() && user.try_unequip(src))
-		user.visible_message(SPAN_NOTICE("\The [user] stamps out [src]."), SPAN_NOTICE("You stamp out [src]."))
+		user.visible_action_message("stamp", "out [src].")
 		extinguish_fire()
 		return TRUE
 
@@ -81,20 +81,14 @@
 	if(REAGENT_TOTAL_VOLUME(reagents) <= 0)
 		return
 	var/target_text = trans_dest? "\the [trans_dest]" : "\the [user.loc]"
-	user.visible_message(
-		SPAN_NOTICE("\The [user] begins to wring out [src] over [target_text]."),
-		SPAN_NOTICE("You begin to wring out \the [src] over [target_text].")
-	)
+	user.visible_action_message("begin", "to wring out \the [src] over [target_text].")
 	if(!do_after(user, REAGENT_TOTAL_VOLUME(reagents)*5, progress = 0) || !REAGENT_TOTAL_VOLUME(reagents)) //50 for a fully soaked rag
 		return
 	if(trans_dest)
 		reagents.trans_to(trans_dest, REAGENT_TOTAL_VOLUME(reagents))
 	else
 		reagents.splash(user.loc, REAGENT_TOTAL_VOLUME(reagents))
-	user.visible_message(
-		SPAN_NOTICE("\The [user] wrings out \the [src] over [target_text]."),
-		SPAN_NOTICE("You finish to wringing out \the [src].")
-	)
+	user.visible_action_message("wring", "out \the [src] over [target_text].")
 	update_name()
 
 /obj/item/chems/rag/proc/wipe_down(atom/target, mob/user)
@@ -111,10 +105,7 @@
 /obj/item/chems/rag/use_on_mob(mob/living/target, mob/living/user, animate = TRUE)
 
 	if(is_on_fire())
-		user.visible_message(
-			SPAN_DANGER("\The [user] hits \the [target] with \the [src]!"),
-			SPAN_DANGER("You hit \the [target] with \the [src]!")
-		)
+		user.visible_action_message("hit", "\the [target] with \the [src]!", dangerous = ACTION_DANGER_ALL)
 		user.do_attack_animation(target)
 		admin_attack_log(user, target, "used \the [src] (ignited) to attack", "was attacked using \the [src] (ignited)", "attacked with \the [src] (ignited)")
 		target.ignite_fire()
@@ -130,21 +121,14 @@
 			return TRUE
 
 		user.do_attack_animation(src)
-		user.visible_message(
-			SPAN_DANGER("\The [user] brings \the [src] up to \the [target]'s mouth!"),
-			SPAN_DANGER("You bring \the [src] up to \the [target]'s mouth!"),
-			SPAN_WARNING("You hear some struggling and muffled cries of surprise.")
-		)
+		user.targeted_visible_action_message(target, "bring", "\the [src] up to $TARGET'S$ mouth!", dangerous = ACTION_DANGER_ALL, blind_message = SPAN_WARNING("You hear some struggling and muffled cries of surprise."))
 
 		var/grab_time = 6 SECONDS
 		if (user.skill_check(SKILL_COMBAT, SKILL_ADEPT))
 			grab_time = 3 SECONDS
 
 		if (do_after(user, grab_time, target))
-			user.visible_message(
-				SPAN_DANGER("\The [user] smothers \the [target] with \the [src]!"),
-				SPAN_DANGER("You smother \the [target] with \the [src]!")
-			)
+			user.targeted_visible_action_message("smother", "$TARGET$ with \the [src]!", dangerous = ACTION_DANGER_ALL)
 			var/trans_amt = reagents.trans_to_mob(target, amount_per_transfer_from_this, CHEM_INHALE)
 			var/contained_reagents = reagents.get_reagents()
 			admin_inject_log(user, target, src, contained_reagents, trans_amt)

--- a/code/modules/food/utensils/_utensil.dm
+++ b/code/modules/food/utensils/_utensil.dm
@@ -77,10 +77,7 @@
 	return FALSE
 
 /obj/item/food/proc/show_slice_message(mob/user, obj/item/tool)
-	user.visible_message(
-		SPAN_NOTICE("\The [user] slices \the [src]!"),
-		SPAN_NOTICE("You slice \the [src]!")
-	)
+	user.visible_action_message("slice", "\the [src]!")
 
 /obj/item/food/proc/show_slice_message_poor(mob/user, obj/item/tool)
 	user.visible_message(

--- a/code/modules/interactions/interactions_reagents.dm
+++ b/code/modules/interactions/interactions_reagents.dm
@@ -145,9 +145,6 @@
 		var/turf/target_turf = target
 		fluid_name = "\the [target_turf.get_fluid_name()]"
 
-	user.visible_message(
-		SPAN_NOTICE("\The [user] drinks from [fluid_name]."),
-		SPAN_NOTICE("You drink from [fluid_name].")
-	)
+	user.visible_action_message("drink", "from [fluid_name].")
 	target.reagents.trans_to_mob(user, 5, CHEM_INGEST)
 	playsound(user.loc, 'sound/items/drink.ogg', rand(10, 50), 1)

--- a/code/modules/mechs/components/_components.dm
+++ b/code/modules/mechs/components/_components.dm
@@ -146,10 +146,7 @@
 		to_chat(user, SPAN_WARNING("Turn \the [welder] on, first."))
 		return
 	if(welder.weld((SKILL_MAX + 1) - user.get_skill_value(SKILL_CONSTRUCTION), user))
-		user.visible_message(
-			SPAN_NOTICE("\The [user] begins welding the damage on \the [src]..."),
-			SPAN_NOTICE("You begin welding the damage on \the [src]...")
-		)
+		user.visible_action_message("begin", "welding the damage on \the [src]...")
 		var/repair_value = 10 * max(user.get_skill_value(SKILL_CONSTRUCTION), user.get_skill_value(SKILL_DEVICES))
 		if(user.do_skilled(10, SKILL_DEVICES , src, 0.6) && brute_damage)
 			repair_brute_damage(repair_value)

--- a/code/modules/mechs/equipment/medical.dm
+++ b/code/modules/mechs/equipment/medical.dm
@@ -84,8 +84,8 @@
 			return TRUE
 		if(beaker)
 			user.put_in_hands(beaker)
-			user.visible_message("<span class='notice'>\The [user] removes \the [beaker] from \the [src].</span>", "<span class='notice'>You remove \the [beaker] from \the [src].</span>")
+			user.visible_action_message("remove", "\the [beaker] from \the [src].")
 		beaker = used_item
-		user.visible_message("<span class='notice'>\The [user] adds \a [used_item] to \the [src].</span>", "<span class='notice'>You add \a [used_item] to \the [src].</span>")
+		user.visible_action_message("add", "\a [used_item] to \the [src].")
 		return TRUE
 	return FALSE

--- a/code/modules/mechs/mech_construction.dm
+++ b/code/modules/mechs/mech_construction.dm
@@ -84,10 +84,7 @@
 	if(user)
 		var/delay = 3 SECONDS * user.skill_delay_mult(SKILL_DEVICES)
 		if(delay > 0)
-			user.visible_message(
-				SPAN_NOTICE("\The [user] begins trying to install \the [system] into \the [src]."),
-				SPAN_NOTICE("You begin trying to install \the [system] into \the [src].")
-			)
+			user.visible_action_message("begin", "trying to install \the [system] into \the [src].")
 			if(!do_after(user, delay, src) || user.get_active_held_item() != system)
 				return FALSE
 

--- a/code/modules/mining/drilling/drill.dm
+++ b/code/modules/mining/drilling/drill.dm
@@ -195,10 +195,6 @@
 		contained_ore.Cut()
 		playsound(src, 'sound/machines/vending_machine.ogg', 60, 1)
 		playsound(box, 'sound/effects/rockcrumble.ogg', 60, 1)
-		visible_message(
-			SPAN_NOTICE("\The [user] unloads \the [src]'s storage cache into \the [box]."),
-			SPAN_NOTICE("You unload \the [src]'s storage cache into \the [box]."),
-			SPAN_NOTICE("You hear rocks falling into a container.")
-		)
+		user.visible_action_message("unload", "\the [src]'s storage cache into \the [box].", blind_message = SPAN_NOTICE("You hear rocks falling into a container."))
 	else
 		to_chat(user, SPAN_NOTICE("You must move an ore box up to \the [src] before you can unload it."))

--- a/code/modules/mining/machinery/material_extractor.dm
+++ b/code/modules/mining/machinery/material_extractor.dm
@@ -171,7 +171,7 @@
 				return TRUE
 			output_container = used_item
 			events_repository.register(/decl/observ/destroyed, output_container, src, TYPE_PROC_REF(/obj/machinery/material_processing/extractor, remove_container))
-			user.visible_message(SPAN_NOTICE("\The [user] places \a [used_item] in \the [src]."), SPAN_NOTICE("You place \a [used_item] in \the [src]."))
+			user.visible_action_message("place", "\a [used_item] in \the [src].")
 			return TRUE
 
 		to_chat(user, SPAN_WARNING("\The [src] already has an output container!"))

--- a/code/modules/mob/living/bot/bot.dm
+++ b/code/modules/mob/living/bot/bot.dm
@@ -114,7 +114,7 @@
 		if(current_health < get_max_health())
 			if(open)
 				heal_overall_damage(10)
-				user.visible_message("<span class='notice'>\The [user] repairs \the [src].</span>","<span class='notice'>You repair \the [src].</span>")
+				user.visible_action_message("repair", "\the [src].")
 			else
 				to_chat(user, "<span class='notice'>Unable to repair with the maintenance panel closed.</span>")
 		else

--- a/code/modules/mob/living/bot/medibot.dm
+++ b/code/modules/mob/living/bot/medibot.dm
@@ -325,7 +325,7 @@
 
 /mob/living/bot/medbot/proc/tip_over(mob/user)
 	playsound(src, 'sound/machines/warning-buzzer.ogg', 50)
-	user.visible_message(SPAN_DANGER("[user] tips over [src]!"), SPAN_DANGER("You tip [src] over!"))
+	user.targeted_visible_action_message(src, "tip", "$TARGET$ over!", dangerous = ACTION_DANGER_ALL)
 	is_tipped = TRUE
 	tipper_name = user.name
 	var/matrix/mat = transform
@@ -334,13 +334,13 @@
 /mob/living/bot/medbot/proc/set_right(mob/user)
 	var/list/messagevoice
 	if(user)
-		user.visible_action_message("set", "\the [src] right-side up!")
+		user.targeted_visible_action_message(src, "set", "$TARGET$ right-side up!")
 		if(user.name == tipper_name)
 			messagevoice = list("I forgive you." = 'sound/voice/medbot/forgive.ogg')
 		else
 			messagevoice = list("Thank you!" = 'sound/voice/medbot/thank_you.ogg', "You are a good person." = 'sound/voice/medbot/youre_good.ogg')
 	else
-		visible_message(SPAN_NOTICE("[src] manages to [pick("writhe", "wriggle", "wiggle")] enough to right itself."))
+		user.visible_action_message("manage", "to [pick("writhe", "wriggle", "wiggle")] enough to right $USER_SELF$.")
 		messagevoice = list("Fuck you." = 'sound/voice/medbot/fuck_you.ogg', "Your behavior has been reported, have a nice day." = 'sound/voice/medbot/reported.ogg')
 
 	tipper_name = null

--- a/code/modules/mob/living/bot/medibot.dm
+++ b/code/modules/mob/living/bot/medibot.dm
@@ -185,7 +185,7 @@
 
 /mob/living/bot/medbot/default_help_interaction(mob/user)
 	if(is_tipped)
-		user.visible_message(SPAN_NOTICE("\The [user] begins righting [src]."), SPAN_NOTICE("You begin righting [src]..."))
+		user.visible_action_message("begin", "righting [src].")
 		if(do_after(user, 3 SECONDS, target=src))
 			set_right(user)
 		return TRUE
@@ -334,7 +334,7 @@
 /mob/living/bot/medbot/proc/set_right(mob/user)
 	var/list/messagevoice
 	if(user)
-		user.visible_message(SPAN_NOTICE("[user] sets [src] right-side up!"), SPAN_NOTICE("You set [src] right-side up!"))
+		user.visible_action_message("set", "\the [src] right-side up!")
 		if(user.name == tipper_name)
 			messagevoice = list("I forgive you." = 'sound/voice/medbot/forgive.ogg')
 		else

--- a/code/modules/mob/living/human/human.dm
+++ b/code/modules/mob/living/human/human.dm
@@ -323,7 +323,7 @@
 			if(species.gluttonous & GLUT_PROJECTILE_VOMIT)
 				M.throw_at(get_edge_target_turf(src,dir),7,7,src)
 
-	visible_message(SPAN_DANGER("\The [src] throws up!"),SPAN_DANGER("You throw up!"))
+	visible_action_message("throw", "up!", dangerous = ACTION_DANGER_ALL)
 	playsound(loc, 'sound/effects/splat.ogg', 50, 1)
 	var/turf/location = loc
 	if(istype(location) && location.simulated)

--- a/code/modules/mob/living/human/human_attackhand.dm
+++ b/code/modules/mob/living/human/human_attackhand.dm
@@ -3,6 +3,7 @@
 		hit_zone = get_target_zone()
 	var/list/available_attacks = get_mob_natural_attacks()
 	var/decl/natural_attack/use_attack = default_attack
+	var/decl/pronouns/self_pronouns = get_self_pronouns()
 	if(!use_attack || !use_attack.attack_is_usable(src, target, hit_zone) || !(use_attack in available_attacks))
 		var/alert_non_default_attack = use_attack?.name
 		use_attack = null
@@ -17,7 +18,7 @@
 		if(!use_attack && length(other_attacks))
 			use_attack = pick(other_attacks)
 		if(use_attack && alert_non_default_attack)
-			to_chat(src, SPAN_WARNING("You cannot [alert_non_default_attack] \the [target] currently, so you switch attacks."))
+			to_chat(src, SPAN_WARNING("[self_pronouns.He] cannot [alert_non_default_attack] \the [target] currently, so [self_pronouns.he] [verb_agree_with_pronouns("switch", self_pronouns)] attacks."))
 
 	. = use_attack?.resolve_to_soft_variant(src)
 
@@ -70,14 +71,15 @@
 		. += (!include_visible || owner?.is_blind()) ? "completely limp" : "dangling uselessly"
 
 /mob/living/human/proc/check_self_injuries(include_pain = TRUE, include_visible = TRUE)
+	var/decl/pronouns/self_pronouns = get_self_pronouns()
 	if(include_visible)
-		var/decl/pronouns/pronouns = get_pronouns()
+		// this is annoying: we use different verbs for self and other
 		visible_message(
-			SPAN_NOTICE("\The [src] examines [pronouns.self]."),
-			SPAN_NOTICE("You check yourself for injuries.")
+			SPAN_NOTICE(get_action_string(FALSE, "examine", "$USER_SELF$.")),
+			SPAN_NOTICE(get_action_string(TRUE, "check", "$USER_SELF$ for injuries."))
 		)
 	else if(include_pain)
-		to_chat(src, SPAN_NOTICE("You take note of how your body feels..."))
+		self_action_message("take", "note of how $USER_THEIR$ body feels...")
 	else
 		return // This should never happen, we should always check pain, visible status, or both.
 
@@ -85,13 +87,13 @@
 	for(var/obj/item/organ/external/org in get_external_organs())
 		var/list/status = org.get_injury_status(include_pain, include_visible)
 		if(length(status))
-			to_chat(src, "Your [org.name] is <span class='warning'>[english_list(status)].</span>")
+			to_chat(src, "[self_pronouns.His] [org.name] is <span class='warning'>[english_list(status)].</span>")
 		else if(is_blind() || !include_visible)
-			to_chat(src, "You <span class='notice'>can't feel anything wrong</span> with your [org.name].")
+			to_chat(src, "[self_pronouns.He] <span class='notice'>can't feel anything wrong</span> with [self_pronouns.his] [org.name].")
 		else if(!include_pain)
-			to_chat(src, "You <span class='notice'>can't see anything wrong</span> with your [org.name].")
+			to_chat(src, "[self_pronouns.He] <span class='notice'>can't see anything wrong</span> with [self_pronouns.his] [org.name].")
 		else
-			to_chat(src, "Your [org.name] is <span class='notice'>OK.</span>")
+			to_chat(src, "[self_pronouns.His] [org.name] is <span class='notice'>OK.</span>")
 
 /mob/living/human/default_help_interaction(mob/user)
 	if(apply_pressure(user, user.get_target_zone()))
@@ -122,7 +124,7 @@
 		return TRUE
 
 	if(user.incapacitated())
-		to_chat(user, SPAN_WARNING("You can't attack while incapacitated."))
+		self_action_message("can't", "attack while incapacitated.", ACTION_DANGER_OTHERS)
 		return TRUE
 
 	if(!ishuman(user))
@@ -142,14 +144,14 @@
 		return TRUE
 
 	if(world.time < H.last_attack + attack.delay)
-		to_chat(H, SPAN_NOTICE("You can't attack again so soon."))
+		self_action_message("can't", "attack again so soon.")
 		return TRUE
 
 	last_handled_by_mob = weakref(H)
 	H.last_attack = world.time
 
 	if(!affecting)
-		to_chat(user, SPAN_DANGER("They are missing that limb!"))
+		to_chat(user, SPAN_DANGER(user.get_targeted_action_string(src, TRUE, "are", "missing that limb!")))
 		return TRUE
 
 	// We didn't see this coming, so we get the full blow
@@ -195,15 +197,15 @@
 			hit_zone = ran_zone(hit_zone, target = src)
 		if(prob(15) && hit_zone != BP_CHEST) // Missed!
 			if(!src.current_posture.prone)
-				attack_message = "\The [H] attempted to strike \the [src], but missed!"
+				attack_message = "\The [H] attempts to strike \the [src], but misses!"
 			else
 				var/decl/pronouns/pronouns = get_pronouns()
-				attack_message = "\The [H] attempted to strike \the [src], but [pronouns.he] rolled out of the way!"
+				attack_message = "\The [H] attempts to strike \the [src], but [pronouns.he] rolls out of the way!"
 				src.set_dir(pick(global.cardinal))
 			miss_type = 1
 
 	if(!miss_type && block)
-		attack_message = "[H] went for [src]'s [affecting.name] but was blocked!"
+		attack_message = "[H] goes for [src]'s [affecting.name] but is blocked!"
 		miss_type = 2
 
 	H.do_attack_animation(src)
@@ -251,13 +253,13 @@
 /mob/living/human/proc/start_compressions(mob/living/human/H, starting = FALSE, cpr_mode)
 	if(length(H.get_held_items()))
 		performing_cpr = FALSE
-		to_chat(H, SPAN_WARNING("You cannot perform CPR with anything in your hands."))
+		to_chat(H, SPAN_WARNING(get_action_string(TRUE, "cannot", "perform CPR with anything in $USER_THEIR$ hands.")))
 		return
 
 	//Keeps doing CPR unless cancelled, or the target recovers
 	if(!(performing_cpr && H.Adjacent(src) && (is_asystole() || (status_flags & FAKEDEATH) || failed_last_breath)))
 		performing_cpr = FALSE
-		to_chat(H, SPAN_NOTICE("You stop performing CPR on \the [src]."))
+		to_chat(H, SPAN_NOTICE(get_targeted_action_string(src, TRUE, "stop", "performing CPR on $TARGET$.")))
 		return
 
 	else if (starting)
@@ -272,15 +274,15 @@
 
 		if(length(H.get_held_items()))
 			performing_cpr = FALSE
-			to_chat(H, SPAN_WARNING("You cannot perform CPR with anything in your hands."))
+			to_chat(H, SPAN_WARNING(get_action_string(TRUE, "cannot", "perform CPR with anything in $USER_THEIR$ hands.")))
 			return
 
-		H.visible_message(SPAN_NOTICE("\The [H] is trying to perform CPR on \the [src]."))
+		H.targeted_visible_action_message(src, "try", "to perform CPR on $TARGET$.")
 
 	var/pumping_skill = max(H.get_skill_value(SKILL_MEDICAL), H.get_skill_value(SKILL_ANATOMY))
 	var/cpr_delay = 15 * H.skill_delay_mult(SKILL_ANATOMY, 0.2)
 
-	H.visible_message(SPAN_NOTICE("\The [H] performs CPR on \the [src]!"))
+	H.targeted_visible_action_message(src, "perform", "CPR on $TARGET$.")
 
 	H.do_attack_animation(src, null)
 	var/starting_pixel_y = pixel_y
@@ -301,34 +303,37 @@
 			resuscitate()
 
 	if(!do_after(H, cpr_delay, FALSE)) //Chest compresssions are fast, need to wait for the loading bar to do mouth to mouth
+		to_chat(H, SPAN_NOTICE(get_targeted_action_string(src, TRUE, "stop", "performing CPR on $TARGET$.")))
 		to_chat(H, SPAN_NOTICE("You stop performing CPR on \the [src]."))
 		performing_cpr = FALSE //If it cancelled, cancel it. Simple.
 		return
 
 	if(cpr_mode == "Mouth-to-Mouth")
 		if(!H.check_has_mouth())
-			to_chat(H, SPAN_WARNING("You don't have a mouth, you cannot do mouth-to-mouth resuscitation!"))
+			to_chat(H, SPAN_WARNING(get_action_string(TRUE, "lack", "have a mouth, $USER_THEY$ cannot perform mouth-to-mouth resuscitation!")))
 			return TRUE
 
 		if(!check_has_mouth())
-			to_chat(H, SPAN_WARNING("They don't have a mouth, you cannot do mouth-to-mouth resuscitation!"))
+			var/decl/pronouns/victim_pronouns = get_visible_pronouns_for_viewer(H)
+			var/decl/pronouns/self_pronouns = H.get_self_pronouns()
+			to_chat(H, SPAN_WARNING("[victim_pronouns.He] [victim_pronouns.does]n't have a mouth, [self_pronouns.he] cannot do mouth-to-mouth resuscitation!"))
 			return TRUE
 
 		for(var/slot in global.airtight_slots)
 			var/obj/item/gear = H.get_equipped_item(slot)
 			if(gear && (gear.body_parts_covered & SLOT_FACE))
-				to_chat(H, SPAN_WARNING("You need to remove your mouth covering for mouth-to-mouth resuscitation!"))
+				to_chat(H, SPAN_WARNING(get_action_string(TRUE, "need", "to remove $USER_THEIR$ mouth covering for mouth-to-mouth resuscitation!")))
 				return TRUE
 
 		for(var/slot in global.airtight_slots)
 			var/obj/item/gear = get_equipped_item(slot)
 			if(gear && (gear.body_parts_covered & SLOT_FACE))
-				to_chat(H, SPAN_WARNING("You need to remove \the [src]'s mouth covering for mouth-to-mouth resuscitation!"))
+				to_chat(H, SPAN_WARNING(get_targeted_action_string(src, TRUE, "need", "to remove $TARGET'S$ mouth covering for mouth-to-mouth resuscitation!")))
 				return TRUE
 
 		var/decl/bodytype/root_bodytype = H.get_bodytype()
 		if(!GET_INTERNAL_ORGAN(H, root_bodytype.breathing_organ))
-			to_chat(H, SPAN_WARNING("You need lungs for mouth-to-mouth resuscitation!"))
+			to_chat(H, SPAN_WARNING(get_action_string(TRUE, "need", "lungs for mouth-to-mouth resuscitation!")))
 			return TRUE
 
 		if(!need_breathe())
@@ -341,7 +346,7 @@
 		if(!lungs.handle_owner_breath(H.get_breath_from_environment(), 1))
 			if(!lungs.is_bruised())
 				suffocation_counter = 0
-			to_chat(src, SPAN_NOTICE("You feel a breath of fresh air enter your lungs. It feels good."))
+			to_chat(src, SPAN_WARNING(get_targeted_action_string(src, TRUE, "feel", "a breath of fresh air enter $USER_THEIR$ lungs. It feels good.")))
 
 	// Again.
 	start_compressions(H, FALSE, cpr_mode)
@@ -351,7 +356,9 @@
 	. = FALSE
 	for(var/obj/item/grab/grab as anything in get_active_grabs())
 		if(grab.affecting)
-			visible_message(SPAN_DANGER("\The [user] has broken \the [src]'s grip on [grab.affecting]!"))
+			// todo: an even more niche language helper that can handle replacing a variable object (like grab.affecting) with pronouns
+			// if it's the same as the viewer or user
+			targeted_visible_action_message(src, "break", "$TARGET'S$ grip on [grab.affecting]!")
 			. = TRUE
 		drop_from_inventory(grab)
 
@@ -369,19 +376,12 @@
 		return 0
 
 	if(organ.applied_pressure)
-		var/message = "<span class='warning'>[ismob(organ.applied_pressure)? "Someone" : "\A [organ.applied_pressure]"] is already applying pressure to [user == src? "your [organ.name]" : "[src]'s [organ.name]"].</span>"
+		var/decl/pronouns/self_pronouns = get_self_pronouns()
+		var/message = "<span class='warning'>[ismob(organ.applied_pressure)? "Someone" : "\A [organ.applied_pressure]"] is already applying pressure to [user == src? "[self_pronouns.his] [organ.name]" : "[src]'s [organ.name]"].</span>"
 		to_chat(user, message)
 		return 0
 
-	if(user == src)
-		var/decl/pronouns/pronouns = user.get_pronouns()
-		user.visible_message( \
-			SPAN_NOTICE("\The [user] starts applying pressure to [pronouns.his] [organ.name]!"), \
-			SPAN_NOTICE("You start applying pressure to your [organ.name]!"))
-	else
-		user.visible_message( \
-			SPAN_NOTICE("\The [user] starts applying pressure to \the [src]'s [organ.name]!"), \
-			SPAN_NOTICE("You start applying pressure to \the [src]'s [organ.name]!"))
+	user.targeted_visible_action_message(src, "start", "applying pressure to $TARGET'S$ [organ.name]!")
 	// TODO: refactor applying pressure to use grabs instead? would probably require making grabs locked to the zone they were started on
 	spawn(0)
 		organ.applied_pressure = user
@@ -391,15 +391,7 @@
 
 		organ.applied_pressure = null
 
-		if(user == src)
-			var/decl/pronouns/pronouns = user.get_pronouns()
-			user.visible_message( \
-				SPAN_NOTICE("\The [user] stops applying pressure to [pronouns.his] [organ.name]!"), \
-				SPAN_NOTICE("You stop applying pressure to your [organ.name]!"))
-		else
-			user.visible_message( \
-				SPAN_NOTICE("\The [user] stops applying pressure to \the [src]'s [organ.name]!"), \
-				SPAN_NOTICE("You stop applying pressure to \the [src]'s [organ.name]!"))
+		user.targeted_visible_action_message(src, "stop", "applying pressure to $TARGET'S$ [organ.name]!")
 
 	return 1
 
@@ -418,7 +410,8 @@
 	if(QDELETED(src) || !istype(new_attack) || !(new_attack in get_mob_natural_attacks()))
 		return
 	default_attack = new_attack
-	to_chat(src, SPAN_NOTICE("Your default unarmed attack is now <b>[default_attack?.name || "cleared"]</b>."))
+	var/decl/pronouns/self_pronouns = get_self_pronouns()
+	to_chat(src, SPAN_NOTICE("[self_pronouns.His] default unarmed attack is now <b>[default_attack?.name || "cleared"]</b>."))
 	if(default_attack)
 		var/summary = default_attack.summarize()
 		if(summary)

--- a/code/modules/mob/living/human/human_verbs.dm
+++ b/code/modules/mob/living/human/human_verbs.dm
@@ -100,29 +100,26 @@
 		return
 
 	var/self = (usr == src)
-	var/decl/pronouns/pronouns = usr.get_pronouns()
 	if(!self)
-		var/decl/pronouns/target_gender = src.get_pronouns()
 		usr.visible_message( \
-			SPAN_NOTICE("\The [usr] kneels down, puts [pronouns.his] hand on \the [src]'s wrist, and begins counting [target_gender.his] pulse."), \
-			SPAN_NOTICE("You begin counting \the [src]'s pulse."))
+			SPAN_NOTICE(usr.get_targeted_action_string(src, FALSE, "kneel", "down, put$USER_S$ $USER_THEIR$ hand on $TARGET'S$ wrist, and begin$USER_S$ counting $TARGET_THEIR$ pulse.")), \
+			SPAN_NOTICE(usr.get_targeted_action_string(src, TRUE, "begin", "counting $TARGET'S$ pulse.")))
 	else
-		usr.visible_message(
-			SPAN_NOTICE("\The [usr] begins counting [pronouns.his] pulse."), \
-			SPAN_NOTICE("You begin counting your pulse."))
+		usr.targeted_visible_action_message(src, "begin", "counting $TARGET_THEIR$ pulse.")
 
 	if(get_pulse())
-		to_chat(usr, "<span class='notice'>[self ? "You have a" : "[src] has a"] pulse! Counting...</span>")
+		to_chat(usr, SPAN_NOTICE(src.get_action_string(self, "has", "a pulse! Counting...")))
 	else
-		to_chat(usr, "<span class='danger'>[src] has no pulse!</span>")//it is REALLY UNLIKELY that a dead person would check his own pulse
+		// someone with a robot heart could be checking their pulse
+		to_chat(usr, SPAN_DANGER(src.get_action_string(self, "has", "no pulse!")))
 		return
 
 	to_chat(usr, "You must[self ? "" : " both"] remain still until counting is finished.")
-	if(do_mob(usr, src, 60))
-		var/message = "<span class='notice'>[self ? "Your" : "[src]'s"] pulse is [src.get_pulse_as_string(GETPULSE_HAND)].</span>"
+	if(do_mob(usr, src, 6 SECONDS))
+		var/message = SPAN_NOTICE("[self ? "Your" : "[src]'s"] pulse is [src.get_pulse_as_string(GETPULSE_HAND)].")
 		to_chat(usr, message)
 	else
-		to_chat(usr, "<span class='warning'>You failed to check the pulse. Try again.</span>")
+		to_chat(usr, SPAN_WARNING("You failed to check the pulse. Try again."))
 
 /mob/living/human/proc/bloody_doodle()
 	set category = "IC"
@@ -204,12 +201,7 @@
 		to_chat(usr, "You are restrained and cannot do that!")
 		return
 
-	var/mob/S = src
-	var/mob/U = usr
-	var/self = null
-	if(S == U)
-		self = 1 // Removing object from yourself.
-
+	var/self = src == usr
 	var/list/limbs = list()
 	for(var/obj/item/organ/external/current_limb in get_external_organs())
 		if(current_limb && current_limb.is_dislocated() && !current_limb.is_parent_dislocated()) //if the parent is also dislocated you will have to relocate that first
@@ -219,30 +211,20 @@
 	if(!current_limb)
 		return
 
-	if(self)
-		to_chat(src, "<span class='warning'>You brace yourself to relocate your [current_limb.joint]...</span>")
-	else
-		to_chat(U, "<span class='warning'>You begin to relocate [S]'s [current_limb.joint]...</span>")
-	if(!do_after(U, 30, src))
+	usr.targeted_visible_action_message(src, "begin", "to relocate $TARGET'S$ [current_limb.joint].", dangerous = ACTION_DANGER_ALL)
+	if(!do_mob(usr, src, 3 SECONDS))
 		return
-	if(!current_limb || !S || !U)
+	if(!current_limb || QDELETED(src) || QDELETED(usr))
 		return
 
-	var/fail_prob = U.skill_fail_chance(SKILL_MEDICAL, 60, SKILL_ADEPT, 3)
+	var/fail_prob = usr.skill_fail_chance(SKILL_MEDICAL, 60, SKILL_ADEPT, 3)
 	if(self)
-		fail_prob += U.skill_fail_chance(SKILL_MEDICAL, 20, SKILL_EXPERT, 1)
-	var/decl/pronouns/pronouns = get_pronouns()
+		fail_prob += usr.skill_fail_chance(SKILL_MEDICAL, 20, SKILL_EXPERT, 1)
 	if(prob(fail_prob))
-		visible_message( \
-		"<span class='danger'>[U] pops [self ? "[pronouns.his]" : "[S]'s"] [current_limb.joint] in the WRONG place!</span>", \
-		"<span class='danger'>[self ? "You pop" : "[U] pops"] your [current_limb.joint] in the WRONG place!</span>" \
-		)
+		usr.targeted_visible_action_message(src, "pop", "$TARGET'S$ [current_limb.joint] in the WRONG place!", dangerous = ACTION_DANGER_ALL)
 		current_limb.add_pain(30)
 		current_limb.take_damage(5)
 		shock_stage += 20
 	else
-		visible_message( \
-		"<span class='danger'>[U] pops [self ? "[pronouns.his]" : "[S]'s"] [current_limb.joint] back in!</span>", \
-		"<span class='danger'>[self ? "You pop" : "[U] pops"] your [current_limb.joint] back in!</span>" \
-		)
+		usr.targeted_visible_action_message(src, "pop", "$TARGET'S$ [current_limb.joint] back in!", dangerous = ACTION_DANGER_ALL)
 		current_limb.undislocate()

--- a/code/modules/mob/living/human/life.dm
+++ b/code/modules/mob/living/human/life.dm
@@ -368,7 +368,9 @@
 		animate_tail_reset()
 		heal_damage(PAIN, 3)
 		if(prob(2) && is_asystole() && isSynthetic())
-			visible_message("<b>[src]</b> [pick("emits low pitched whirr","beeps urgently")].")
+			var/static/synth_asystole_options = list("emit" = "a low pitched whirr.", "beep" = "urgently.")
+			var/chosen_option = pick(synth_asystole_options)
+			visible_action_message(chosen_option, synth_asystole_options[chosen_option])
 	else
 		set_stat(CONSCIOUS)
 

--- a/code/modules/mob/living/human/unarmed_attack.dm
+++ b/code/modules/mob/living/human/unarmed_attack.dm
@@ -134,29 +134,28 @@
 	return TRUE
 
 /decl/natural_attack/proc/show_attack(var/mob/living/human/user, var/mob/living/human/target, var/zone, var/attack_damage)
-	var/msg = "\The [user] [pick(attack_verb)] \the [target]"
+	var/msg = "$TARGET$"
 	var/obj/item/organ/external/affecting = istype(target) && zone && GET_EXTERNAL_ORGAN(target, zone)
 	if(affecting)
 		msg = "[msg] in the [affecting.name]"
 	if(islist(attack_noun) && length(attack_noun))
-		msg = "[msg] with their [pick(attack_noun)]"
+		msg = "[msg] with $USER_THEIR$ [pick(attack_noun)]"
 	if(msg)
-		user.visible_message(SPAN_DANGER("[msg]!"))
+		user.targeted_visible_action_message(target, pick(attack_verb), "[msg]!")
 		playsound(user.loc, attack_sound, 25, 1, -1)
 
 /decl/natural_attack/proc/handle_eye_attack(var/mob/living/human/user, var/mob/living/human/target)
 	var/obj/item/organ/internal/eyes = GET_INTERNAL_ORGAN(target, BP_EYES)
-	var/decl/pronouns/pronouns = user.get_pronouns()
 	if(eyes)
 		eyes.take_damage(rand(3,4), 1)
-		user.visible_message(SPAN_DANGER("\The [user] jams [pronouns.his] [eye_attack_text] into \the [target]'s [eyes.name]!"))
 		if(eyes.can_feel_pain())
-			to_chat(target, SPAN_DANGER("You experience immense pain as [eye_attack_text_victim] are jammed into your [eyes.name]!"))
+			to_chat(target, SPAN_DANGER(target.get_action_string(TRUE, "experience", "immense pain as [eye_attack_text_victim] are jammed into $USER_THEIR$ [eyes.name]!")))
 		else
-			to_chat(target, SPAN_DANGER("You experience [eye_attack_text_victim] being jammed into your [eyes.name]."))
+			to_chat(target, SPAN_DANGER(target.get_action_string(TRUE, "experience", "[eye_attack_text_victim] being jammed into $USER_THEIR$ [eyes.name].")))
+
+		user.targeted_visible_action_message("jam", "$USER_THEIR$ [eye_attack_text] into $TARGET'S$ [eyes.name]!")
 	else
-		var/decl/pronouns/target_gender = target.get_pronouns()
-		user.visible_message(SPAN_DANGER("\The [user] attempts to press [pronouns.his] [eye_attack_text] into \the [target]'s eyes, but [target_gender.he] [target_gender.does]n't have any!"))
+		user.targeted_visible_action_message(target, "attempt", "to press $USER_THEIR$ [eye_attack_text] into $TARGET'S$ eyes, but $TARGET_THEY$ $TARGET_DOES$n't have any!")
 
 /decl/natural_attack/proc/damage_flags()
 	return (sharp ? DAM_SHARP : 0) | (edge ? DAM_EDGE : 0)
@@ -192,7 +191,7 @@
 /decl/natural_attack/punch
 	name = "punch"
 	selector_icon_state = "attack_punch"
-	attack_verb = list("punched")
+	attack_verb = list("punch")
 	attack_noun = list("fist")
 	eye_attack_text = "fingers"
 	eye_attack_text_victim = "digits"
@@ -209,54 +208,75 @@
 	attack_damage = clamp(attack_damage, 1, 5) // We expect damage input of 1 to 5 for this proc. But we leave this check juuust in case.
 
 	if(target == user)
-		var/decl/pronouns/pronouns = user.get_pronouns()
-		user.visible_message(SPAN_DANGER("\The [user] [pick(attack_verb)] [pronouns.self] in \the [affecting]!"))
+		user.visible_action_message(pick(attack_verb), "$USER_SELF$ in \the [affecting]!", dangerous = ACTION_DANGER_ALL)
 		return 0
 
 	target.update_personal_goal(/datum/goal/achievement/fistfight, TRUE)
 	user.update_personal_goal(/datum/goal/achievement/fistfight, TRUE)
 
-	var/decl/pronouns/user_gender =   user.get_pronouns()
-	var/decl/pronouns/target_gender = target.get_pronouns()
-	var/attack_string
+	var/attack_use_verb
+	var/attack_phrase
 	if(!target.current_posture.prone)
 		switch(zone)
 			if(BP_HEAD, BP_MOUTH, BP_EYES)
 				// ----- HEAD ----- //
 				switch(attack_damage)
 					if(1 to 2)
-						attack_string = "slapped \the [target] across [target_gender.his] cheek"
+						attack_use_verb = "slap"
+						attack_phrase = "$TARGET$ across $TARGET_THEIR$ cheek!"
 					if(3 to 4)
-						user.visible_message(pick(
-							80; attack_string = "[pick(attack_verb)] \the [target] in the head",
-							20; attack_string = "struck \the [target] in the head[pick("", " with a closed fist")]",
-							50; attack_string = "threw a hook against \the [target]'s head"
-							))
+						switch(rand(1, 15))
+							if(1 to 8)
+								attack_use_verb = pick(attack_verb)
+								attack_phrase = "$TARGET$ in the head!"
+							if(9 to 10)
+								attack_use_verb = "strike"
+								attack_phrase = "$TARGET$ in the head[prob(50) ? " with a closed fist" : null]!"
+							if(11 to 15)
+								attack_use_verb = "throw"
+								attack_phrase = "a hook against $TARGET'S$ head!"
 					if(5)
-						user.visible_message(pick(
-							10; attack_string = "gave \the [target] a solid slap across [target_gender.his] face",
-							90; attack_string = "smashed [user_gender.his] [pick(attack_noun)] into \the [target]'s [pick("[affecting.name]", "face", "jaw")]"
-							))
+						if(prob(10))
+							attack_use_verb = "give"
+							attack_phrase = "$TARGET$ a solid slap across $TARGET_THEIR$ face!"
+						else
+							attack_use_verb = "smash"
+							attack_phrase = "$USER_THEIR$ [pick(attack_noun)] into $TARGET'S$ [pick("[affecting.name]", "face", "jaw")]!"
 			else
 				// ----- BODY ----- //
 				switch(attack_damage)
 					if(1 to 2)
-						attack_string = "threw a glancing punch at [target]'s [affecting.name]"
+						attack_use_verb = "throw"
+						attack_phrase = "a glancing punch at $TARGET'S$ [affecting.name]!"
 					if(1 to 4)
-						attack_string = "[pick(attack_verb)] [target] in \the [affecting]"
+						attack_use_verb = pick(attack_verb)
+						attack_phrase = "$TARGET$ in \the [affecting]!"
 					if(5)
-						attack_string = "smashed [user_gender.his] [pick(attack_noun)] into [target]'s [affecting.name]"
+						attack_use_verb = "smash"
+						attack_phrase = "$USER_THEIR$ [pick(attack_noun)] into $TARGET'S$ [affecting.name]!"
 	else
 		//why do we have a separate set of verbs for lying targets?
-		attack_string = "[pick("punched", "threw a punch at", "struck", "slammed their [pick(attack_noun)] into")] \the [target]'s [affecting.name]"
+		switch(rand(1,4))
+			if(1)
+				attack_use_verb = "punch"
+				attack_phrase = "$TARGET'S$ [affecting.name]!"
+			if(2)
+				attack_use_verb = "throw"
+				attack_phrase = "a punch at $TARGET'S$ [affecting.name]!"
+			if(3)
+				attack_use_verb = "strike"
+				attack_phrase = "$TARGET'S$ [affecting.name]!"
+			if(4)
+				attack_use_verb = "slam"
+				attack_phrase = "$USER_THEIR$ [pick(attack_noun)] into $TARGET'S$ [affecting.name]!"
 
-	if(attack_string)
-		user.visible_message(SPAN_DANGER("\The [user] [attack_string]!"))
+	if(attack_use_verb && attack_phrase)
+		user.targeted_visible_action_message(target, attack_use_verb, attack_phrase, ACTION_DANGER_ALL)
 
 /decl/natural_attack/kick
 	name = "kick"
 	selector_icon_state = "attack_kick"
-	attack_verb = list("struck")
+	attack_verb = list("strike")
 	attack_noun = list("foot", "knee")
 	attack_sound = "swing_hit"
 	damage = 0
@@ -289,7 +309,7 @@
 /decl/natural_attack/stomp
 	name = "stomp"
 	selector_icon_state = "attack_stomp"
-	attack_verb = list("stomped on")
+	attack_verb = list("stomps on")
 	attack_noun = list("foot")
 	attack_sound = "swing_hit"
 	damage = 0
@@ -339,7 +359,7 @@
 	deal_halloss = 3
 	selector_icon_state = "attack_light_strike"
 	attack_noun = list("limb")
-	attack_verb = list("tapped", "lightly struck")
+	attack_verb = list("tap", "lightly struck")
 	shredding = 0
 	damage = 0
 	sharp = FALSE

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -564,10 +564,7 @@ default behaviour is:
 		)
 		sleep(3 SECONDS)
 		if(get_fire_intensity() <= 0)
-			visible_message(
-				SPAN_NOTICE("\The [src] successfully extinguishes [pronouns.him][pronouns.self]!"),
-				SPAN_NOTICE("You extinguish yourself.")
-			)
+			visible_action_message("successfully extinguish", "$USER_SELF$!")
 			extinguish_fire()
 		return TRUE
 
@@ -842,7 +839,7 @@ default behaviour is:
 	set waitfor = 0
 	sleep(rand(5,10))
 	if(!HAS_STATUS(src, STAT_PARA) && stat == CONSCIOUS)
-		visible_message(SPAN_DANGER("\The [src] starts having a seizure!"))
+		visible_action_message("start", "having a seizure!", dangerous = ACTION_DANGER_ALL)
 		SET_STATUS_MAX(src, STAT_PARA, rand(8,16))
 		set_status_condition(STAT_JITTER, rand(150,200))
 		take_damage(rand(50, 60), PAIN)
@@ -972,7 +969,9 @@ default behaviour is:
 			blood_splatter(loc, src, large = TRUE)
 		if(prob(25))
 			take_damage(1)
-			visible_message(SPAN_DANGER("\The [src]'s [isSynthetic() ? "state worsens": "wounds open more"] from being dragged!"))
+			var/decl/pronouns/self_pronouns = get_self_pronouns()
+			var/damage_string = "[isSynthetic() ? "state worsens": "wounds open more"] from being dragged!"
+			visible_message(SPAN_DANGER("\The [src]'s [damage_string]!"), SPAN_DANGER("[self_pronouns.His] [damage_string]"))
 
 /mob/living/CanUseTopicPhysical(mob/user)
 	. = CanUseTopic(user, global.physical_no_access_topic_state)

--- a/code/modules/mob/living/living_attackhand.dm
+++ b/code/modules/mob/living/living_attackhand.dm
@@ -77,18 +77,12 @@
 		user.adjust_fire_intensity(1)
 	user.ignite_fire()
 	if (user.is_on_fire())
-		user.visible_message(
-			SPAN_DANGER("The fire spreads from \the [src] to \the [user]!"),
-			SPAN_DANGER("The fire spreads to you as well!")
-		)
+		user.visible_action_message("catch", "fire", dangerous = ACTION_DANGER_ALL, self_postfix = "as well!", other_postfix = "spreading from \the [src]!")
 		return TRUE
 
 	adjust_fire_intensity(-0.5) //Less effective than stop, drop, and roll - also accounting for the fact that it takes half as long.
 	if (get_fire_intensity() <= 0)
-		user.visible_message(
-			SPAN_NOTICE("\The [user] successfully pats out \the [src]'s flames."),
-			SPAN_NOTICE("You successfully pat out \the [src]'s flames.")
-		)
+		user.visible_action_message("successfully pat", "out \the [src]'s flames.")
 		extinguish_fire()
 		set_fire_intensity(0)
 
@@ -97,17 +91,13 @@
 // Returns TRUE if further interactions should be halted, FALSE otherwise.
 /mob/living/proc/try_awaken(mob/user)
 
-	var/decl/pronouns/pronouns = get_pronouns()
 	var/obj/item/uniform = get_equipped_item(slot_w_uniform_str)
 	if(uniform)
 		uniform.add_fingerprint(user)
 
 	// They're SSD, so permanently asleep.
 	if(ssd_check() && get_species()?.get_ssd(src))
-		user.visible_message(
-			SPAN_NOTICE("\The [user] shakes \the [src] trying to wake [pronouns.him] up!"),
-			SPAN_NOTICE("You shake \the [src], but they do not respond...")
-		)
+		user.targeted_visible_action_message(src, "shake", "$TARGET$", self_postfix = "trying to wake $TARGET_THEM$ up!", other_postfix = "but $TARGET_THEY$ $TARGET_DOES$ not respond...")
 		playsound(src.loc, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
 		. = TRUE
 
@@ -117,10 +107,7 @@
 		ADJ_STATUS(src, STAT_ASLEEP, -5)
 		if(!HAS_STATUS(src, STAT_ASLEEP))
 			set_posture(/decl/posture/lying) // overrides 'delibrate' lying so you will stand up if possible.
-		user.visible_message(
-			SPAN_NOTICE("\The [user] shakes \the [src] trying to wake [pronouns.him] up!"),
-			SPAN_NOTICE("You shake \the [src] trying to wake [pronouns.him] up!")
-		)
+		user.targeted_visible_action_message(src, "shake", "$TARGET$ trying to wake $TARGET_THEM$ up!")
 		. = TRUE
 
 	if(.)

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -135,11 +135,8 @@
 /mob/living/proc/hit_with_weapon(obj/item/I, mob/living/user, var/effective_force, var/hit_zone)
 	var/weapon_mention
 	if(I.attack_message_name())
-		weapon_mention = " with [I.attack_message_name()]"
-	if(effective_force)
-		visible_message(SPAN_DANGER("\The [src] has been [I.pick_attack_verb()][weapon_mention] by \the [user]!"))
-	else
-		visible_message(SPAN_WARNING("\The [src] has been [I.pick_attack_verb()][weapon_mention] by \the [user]!"))
+		weapon_mention = "with [I.attack_message_name()]"
+	user.targeted_visible_action_message(src, I.pick_attack_verb(), "[weapon_mention] by $USER$!", dangerous = effective_force ? ACTION_DANGER_ALL : ACTION_DANGER_OTHERS)
 	. = standard_weapon_hit_effects(I, user, effective_force, hit_zone)
 	if(I.atom_damage_type == BRUTE && prob(33))
 		blood_splatter(get_turf(loc), src)
@@ -168,7 +165,8 @@
 				SET_STATUS_MAX(src, STAT_WEAK, rand(3,5))
 			if(M.skill_fail_prob(SKILL_HAULING, 100))
 				SET_STATUS_MAX(M, STAT_WEAK, rand(4,8))
-			M.visible_message(SPAN_DANGER("\The [M] collides with \the [src]!"))
+			// todo: i would love an 'exclude mob' parameter to visible_message to let us give the target their own self-message too
+			M.targeted_visible_action_message(src, "collide", "with \the [src]!", dangerous = ACTION_DANGER_ALL)
 
 		if(mob_modifiers_block_attack(MM_ATTACK_TYPE_THROWN, AM, TT.speed))
 			return FALSE

--- a/code/modules/mob/living/living_eating.dm
+++ b/code/modules/mob/living/living_eating.dm
@@ -2,15 +2,5 @@
 	user = user || src
 	if(get_food_satiation(consumption_method) < get_max_nutrition())
 		return TRUE
-	var/eat_verb = consumption_method == EATING_METHOD_EAT ? "eat" : "drink"
-	if(eating)
-		if(user == src)
-			to_chat(user, SPAN_WARNING("You cannot force yourself to [eat_verb] any more of \the [eating]."))
-		else
-			to_chat(user, SPAN_WARNING("You cannot force \the [src] to [eat_verb] any more of \the [eating]."))
-	else
-		if(user == src)
-			to_chat(user, SPAN_WARNING("You cannot force yourself to [eat_verb] any more."))
-		else
-			to_chat(user, SPAN_WARNING("You cannot force \the [src] to [eat_verb] any more."))
+	to_chat(user, SPAN_WARNING(user.get_targeted_action_string(src, TRUE, "cannot", "force $TARGET$ to [consumption_method == EATING_METHOD_EAT ? "eat" : "drink"] any more[eating ? " of \the [eating]" : null].")))
 	return FALSE

--- a/code/modules/mob/living/living_give.dm
+++ b/code/modules/mob/living/living_give.dm
@@ -15,30 +15,30 @@
 		if(length(inactive_hands))
 			I = inactive_hands[1]
 	if(!I)
-		to_chat(src, SPAN_WARNING("You don't have anything in your hands to give to \the [target]."))
+		self_action_message("don't", "have anything in $USER_THEIR$ hands to give to \the [target].", ACTION_DANGER_OTHERS)
 		return
 	if(istype(I, /obj/item/grab))
-		to_chat(usr, SPAN_WARNING("You can't give someone a grab."))
+		self_action_message("can't", "give someone a grab.", ACTION_DANGER_OTHERS)
 		return
-	usr.visible_message(SPAN_NOTICE("\The [usr] holds out \the [I] to \the [target]."), SPAN_NOTICE("You hold out \the [I] to \the [target], waiting for them to accept it."))
-	if(alert(target,"[src] wants to give you \a [I]. Will you accept it?",,"Yes","No") == "No")
-		target.visible_message(SPAN_NOTICE("\The [src] tried to hand \the [I] to \the [target], \
-		but \the [target] didn't want it."))
+	targeted_visible_action_message(target, "hold", "out \the [I] to $TARGET$", self_postfix = "and wait$USER_S$ for $TARGET_THEM$ to accept it.", other_postfix = ".")
+	var/decl/pronouns/target_self_pronouns = target.get_self_pronouns()
+	if(alert(target,"[src] wants to give [target_self_pronouns.him] \a [I]. Will [target_self_pronouns.he] accept it?",,"Yes","No") == "No")
+		target.targeted_visible_action_message(target, "try", "to hand \the [I] to $TARGET$, but $TARGET_THEY$ refuse$TARGET_S$ it.")
 		return
 	if(!I)
 		return
 	if(!Adjacent(target))
-		to_chat(src, SPAN_WARNING("You need to stay in reaching distance while giving an object"))
-		to_chat(target, SPAN_WARNING("\The [src] moved too far away."))
+		src.self_action_message("need", "to stay in reaching distance while giving an object.", ACTION_DANGER_OTHERS)
+		to_chat(target, SPAN_WARNING("\The [src] is too far away."))
 		return
 	if(I.loc != src || !(I in get_held_items()))
-		to_chat(src, SPAN_WARNING("You need to keep the item in your hands."))
-		to_chat(target, SPAN_WARNING("\The [src] seems to have given up on passing \the [I] to you."))
+		src.self_action_message("need", "to keep the item in $USER_THEIR$ hands.", ACTION_DANGER_OTHERS)
+		to_chat(target, SPAN_WARNING("\The [src] seems to have given up on passing \the [I] to [target_self_pronouns.him]."))
 		return
 	if(!target.get_empty_hand_slot())
-		to_chat(target, SPAN_WARNING("Your hands are full."))
-		to_chat(src, SPAN_WARNING("Their hands are full."))
+		to_chat(target, SPAN_WARNING("[target_self_pronouns.His] hands are full."))
+		to_chat(src, SPAN_WARNING("\The [target]'s hands are full."))
 		return
 	if(try_unequip(I))
 		target.put_in_hands(I) // If this fails it will just end up on the floor, but that's fitting for things like dionaea.
-		target.visible_message(SPAN_NOTICE("\The [src] handed \the [I] to \the [target]."))
+		target.visible_action_message("hand", "\the [I] to \the [target].")

--- a/code/modules/mob/living/living_grabs.dm
+++ b/code/modules/mob/living/living_grabs.dm
@@ -1,10 +1,11 @@
 /mob/living/proc/check_grab_hand(defer_hand)
+	var/decl/pronouns/self_pronouns = get_self_pronouns()
 	if(defer_hand)
 		if(!get_empty_hand_slot())
-			to_chat(src, SPAN_WARNING("Your hands are full!"))
+			to_chat(src, SPAN_WARNING("[self_pronouns.His] hands are full!"))
 			return FALSE
 	else if(get_active_held_item())
-		to_chat(src, SPAN_WARNING("Your [parse_zone(get_active_held_item_slot())] is full!"))
+		to_chat(src, SPAN_WARNING("[self_pronouns.His] [parse_zone(get_active_held_item_slot())] is full!"))
 		return FALSE
 	return TRUE
 
@@ -15,18 +16,18 @@
 	if(!check_grab_hand(defer_hand))
 		return FALSE
 	if(LAZYLEN(grabbed_by))
-		to_chat(src, SPAN_WARNING("You cannot start grappling while already being grappled!"))
+		to_chat(src, SPAN_WARNING(get_action_string(TRUE, "cannot", "start grappling while already being grappled!")))
 		return FALSE
 	for(var/obj/item/grab/grab as anything in target.grabbed_by)
 		if(grab.assailant != src)
 			continue
 		if(!target_zone || !ismob(target))
-			to_chat(src, SPAN_WARNING("You already have a grip on \the [target]!"))
+			to_chat(src, SPAN_WARNING(get_action_string(TRUE, "has", "a grip on \the [target]!", "already")))
 			return FALSE
 		if(grab.target_zone == target_zone)
 			var/obj/O = grab.get_targeted_organ()
 			if(O)
-				to_chat(src, SPAN_WARNING("You already have a grip on \the [target]'s [O.name]."))
+				to_chat(src, SPAN_WARNING(get_targeted_action_string(target, TRUE, "has", "a grip on $TARGET'S$ [O.name].", "already")))
 				return FALSE
 	return TRUE
 
@@ -39,7 +40,8 @@
 		grabbing_mob = grabbing_mob.buckled
 	if(grabbing_mob && grabbing_mob != original_target)
 		target = grabbing_mob
-		to_chat(src, SPAN_WARNING("As \the [original_target] is buckled to \the [target], you try to grab that instead!"))
+		var/decl/pronouns/self_pronouns = get_self_pronouns()
+		to_chat(src, SPAN_WARNING("As \the [original_target] is buckled to \the [target], [self_pronouns.he] [verb_agree_with_pronouns("try", self_pronouns)] to grab that instead!"))
 
 	if(!istype(target))
 		return
@@ -56,8 +58,8 @@
 
 	if(QDELETED(grab))
 		if(original_target != src && ismob(original_target))
-			to_chat(original_target, SPAN_WARNING("\The [src] tries to grab you, but fails!"))
-		to_chat(src, SPAN_WARNING("You try to grab \the [target], but fail!"))
+			to_chat(original_target, SPAN_WARNING(get_action_string(FALSE, "try", "to grab you, but fail$USER_S$!")))
+		to_chat(src, SPAN_WARNING(get_targeted_action_string(target, TRUE, "try", "to grab $TARGET$, but fail$USER_S$!")))
 	return grab
 
 /mob/living/add_grab(var/obj/item/grab/grab, var/defer_hand = FALSE)

--- a/code/modules/mob/living/living_powers.dm
+++ b/code/modules/mob/living/living_powers.dm
@@ -121,5 +121,5 @@
 	if(my_species && my_species.sniff_message_3p && my_species.sniff_message_1p)
 		visible_message(SPAN_NOTICE("\The [src] [my_species.sniff_message_3p]."), SPAN_NOTICE(my_species.sniff_message_1p))
 	else
-		visible_message(SPAN_NOTICE("\The [src] sniffs the air."), SPAN_NOTICE("You sniff the air."))
+		visible_action_message("sniff", "the air.")
 	LAZYCLEARLIST(smell_cooldown)

--- a/code/modules/mob/living/silicon/pai/paiwire.dm
+++ b/code/modules/mob/living/silicon/pai/paiwire.dm
@@ -11,7 +11,7 @@
 	if(istype(M, /obj/machinery/door) || istype(M, /obj/machinery/camera))
 		if(!user.try_unequip(src, M))
 			return
-		user.visible_message("[user] inserts [src] into a data port on [M].", "You insert [src] into a data port on [M].", "You hear the satisfying click of a wire jack fastening into place.")
+		user.visible_action_message("insert", "\the [src] into a data port on [M].", blind_message = "You hear the satisfying click of a wire jack fastening into place.")
 		machine = M
 		return TRUE
 	else

--- a/code/modules/mob/living/silicon/robot/drone/drone_items.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_items.dm
@@ -242,7 +242,7 @@
 				A.update_icon()
 				A.cell.forceMove(src)
 				A.cell = null
-				user.visible_message("<span class='danger'>[user] removes the power cell from [A]!</span>", "You remove the power cell.")
+				user.targeted_visible_action_message("remove", "\the [wrapped] from $TARGET$!", dangerous = A.has_power ? ACTION_DANGER_OTHERS : ACTION_DANGER_NONE)
 				A.power_down()
 
 /obj/item/gripper/proc/finish_using(var/atom/target, var/mob/living/user, params, force_holder, resolved)

--- a/code/modules/mob/living/silicon/robot/life.dm
+++ b/code/modules/mob/living/silicon/robot/life.dm
@@ -32,7 +32,7 @@
 
 /mob/living/silicon/robot/proc/power_down()
 	if (has_power)
-		visible_message("[src] beeps stridently as it begins to run on emergency backup power!", SPAN_WARNING("You beep stridently as you begin to run on emergency backup power!"))
+		visible_action_message("beep", "stridently as $USER_HE$ begin$USER_S$ to run on emergency backup power!", dangerous = ACTION_DANGER_WARNING)
 		has_power = 0
 		set_stat(UNCONSCIOUS)
 	if(lights_on) // Light is on but there is no power!

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -419,6 +419,7 @@
 	if(istype(used_item, /obj/item/inducer) || istype(used_item, /obj/item/handcuffs))
 		return TRUE
 
+	var/decl/pronouns/self_pronouns = user.get_self_pronouns()
 	if(opened) // Are they trying to insert something?
 		for(var/V in components)
 			var/datum/robot_component/C = components[V]
@@ -472,13 +473,11 @@
 	else if(IS_CROWBAR(used_item) && !user.check_intent(I_FLAG_HARM))	// crowbar means open or close the cover - we all know what a crowbar is by now
 		if(opened)
 			if(cell)
-				user.visible_message(
-					SPAN_NOTICE("\The [user] begins clasping shut \the [src]'s maintenance hatch."),
-					SPAN_NOTICE("You begin closing up \the [src]."))
+				user.visible_action_message("begin", "clasping shut \the [src]'s maintenance hatch.")
 
-				if(do_after(user, 50, src))
-					to_chat(user, SPAN_NOTICE("You close \the [src]'s maintenance hatch."))
-					opened = 0
+				if(do_after(user, 5 SECONDS, src))
+					to_chat(user, SPAN_NOTICE("[self_pronouns.He] [verb_agree_with_pronouns("close", self_pronouns)] \the [src]'s maintenance hatch."))
+					opened = FALSE
 					update_icon()
 
 			else if(wiresexposed && wires.IsAllCut())
@@ -487,10 +486,7 @@
 					to_chat(user, "\The [src] has no central processor to remove.")
 					return TRUE
 
-				user.visible_message(
-					SPAN_NOTICE("\The [user] begins ripping \the [central_processor] out of \the [src]."),
-					SPAN_NOTICE("You jam the crowbar into the robot and begin levering out \the [central_processor]."))
-
+				user.visible_action_message("jam", "\the [used_item] into \the [src] and begin$USER_S$ levering out \the [central_processor].", dangerous = ACTION_DANGER_OTHERS)
 				if(do_after(user, 5 SECONDS, src))
 					dismantle_robot(user)
 			else
@@ -502,7 +498,7 @@
 					if(C.installed == 1 || C.installed == -1)
 						removable_components += V
 				removable_components |= stock_parts
-				var/remove = input(user, "Which component do you want to pry out?", "Remove Component") as null|anything in removable_components
+				var/remove = input(user, "Which component [self_pronouns.does] [self_pronouns.he] want to pry out?", "Remove Component") as null|anything in removable_components
 				if(!remove || !opened || !(remove in (stock_parts|components)) || !Adjacent(user))
 					return TRUE
 				var/obj/item/removed_item
@@ -521,16 +517,16 @@
 					stock_parts -= remove
 					removed_item = remove
 				if(removed_item)
-					to_chat(user, SPAN_NOTICE("You remove \the [removed_item]."))
+					to_chat(user, SPAN_NOTICE(user.get_action_string(TRUE, "remove", "\the [removed_item].")))
 					removed_item.forceMove(loc)
 		else
 			if(locked)
 				to_chat(user, "The cover is locked and cannot be opened.")
 			else
-				user.visible_message("<span class='notice'>\The [user] begins prying open \the [src]'s maintenance hatch.</span>", "<span class='notice'>You start opening \the [src]'s maintenance hatch.</span>")
-				if(do_after(user, 50, src))
-					to_chat(user, "<span class='notice'>You open \the [src]'s maintenance hatch.</span>")
-					opened = 1
+				user.visible_action_message("begin", "prying open \the [src]'s maintenance hatch.")
+				if(do_after(user, 5 SECONDS, src))
+					to_chat(user, SPAN_NOTICE(user.get_action_string("open", "\the [src]'s maintenance hatch.")))
+					opened = TRUE
 					update_icon()
 		return TRUE
 	else if (istype(used_item, /obj/item/cell) && opened)	// trying to put a cell inside
@@ -544,8 +540,8 @@
 		else if(user.try_unequip(used_item, src))
 			cell = used_item
 			handle_selfinsert(used_item, user) //Just in case.
-			to_chat(user, "You insert the power cell.")
-			C.installed = 1
+			to_chat(user, SPAN_NOTICE(user.get_action_string(TRUE, "insert", "\the [used_item].")))
+			C.installed = TRUE
 			C.wrapped = used_item
 			C.install()
 			// This means that removing and replacing a power cell will repair the mount.
@@ -556,52 +552,52 @@
 		if (wiresexposed)
 			wires.Interact(user)
 		else
-			to_chat(user, "You can't reach the wiring.")
+			to_chat(user, SPAN_WARNING(user.get_action_string(TRUE, "can't", "reach the wiring.")))
 		return TRUE
 	else if(IS_SCREWDRIVER(used_item) && opened && !cell)	// haxing
 		wiresexposed = !wiresexposed
-		to_chat(user, "The wires have been [wiresexposed ? "exposed" : "unexposed"].")
+		to_chat(user, SPAN_NOTICE("The wires have been [wiresexposed ? "exposed" : "unexposed"]."))
 		update_icon()
 		return TRUE
 	else if(IS_SCREWDRIVER(used_item) && opened && cell)	// radio
 		if(silicon_radio)
 			silicon_radio.attackby(used_item,user)//Push it to the radio to let it handle everything
 		else
-			to_chat(user, "Unable to locate a radio.")
+			to_chat(user, SPAN_WARNING("Unable to locate a radio."))
 		update_icon()
 		return TRUE
-	else if(istype(used_item, /obj/item/encryptionkey/) && opened)
+	else if(istype(used_item, /obj/item/encryptionkey) && opened)
 		if(silicon_radio)//sanityyyyyy
 			silicon_radio.attackby(used_item,user)//GTFO, you have your own procs
 		else
-			to_chat(user, "Unable to locate a radio.")
+			to_chat(user, SPAN_WARNING("Unable to locate a radio."))
 		return TRUE
 	else if (istype(used_item, /obj/item/card/id)||istype(used_item, /obj/item/modular_computer)||istype(used_item, /obj/item/card/robot))			// trying to unlock the interface with an ID card
 		if(emagged)//still allow them to open the cover
-			to_chat(user, "The interface seems slightly damaged.")
+			to_chat(user, SPAN_WARNING("The interface seems slightly damaged."))
 		if(opened)
-			to_chat(user, "You must close the cover to swipe an ID card.")
+			to_chat(user, SPAN_WARNING("You must close the cover to swipe an ID card."))
 		else
 			if(allowed(user))
 				locked = !locked
-				to_chat(user, "You [ locked ? "lock" : "unlock"] [src]'s interface.")
+				user.self_action_message(locked ? "lock" : "unlock", "\the [src]'s interface.")
 				update_icon()
 			else
-				to_chat(user, "<span class='warning'>Access denied.</span>")
+				to_chat(user, SPAN_WARNING("Access denied."))
 		return TRUE
 	else if(istype(used_item, /obj/item/borg/upgrade))
 		var/obj/item/borg/upgrade/U = used_item
 		if(!opened)
-			to_chat(user, "You must access [src]'s internals!")
+			user.self_action_message("must", "access \the [src]'s internals!", dangerous = ACTION_DANGER_OTHERS)
 		else if(!src.module && U.require_module)
-			to_chat(user, "[src] must choose a module before they can be upgraded!")
+			to_chat(user, SPAN_WARNING(get_action_string(FALSE, "must", "choose a module before $USER_THEY$ can be upgraded!")))
 		else if(U.locked)
 			to_chat(user, "The upgrade is locked and cannot be used yet!")
 		else
 			if(U.action(src))
 				if(!user.try_unequip(U, src))
 					return TRUE
-				to_chat(user, "You apply the upgrade to [src]!")
+				user.self_action_message("apply", "\the [U] to \the [src]!")
 				handle_selfinsert(used_item, user)
 			else
 				to_chat(user, "Upgrade error!")
@@ -635,7 +631,7 @@
 			cell.update_icon()
 			cell.add_fingerprint(user)
 			user.put_in_active_hand(cell)
-			to_chat(user, "You remove \the [cell].")
+			user.self_action_message("remove", "\the [cell].")
 			cell = null
 			cell_component.wrapped = null
 			cell_component.installed = 0
@@ -643,7 +639,7 @@
 		else if(cell_component.installed == -1)
 			cell_component.installed = 0
 			var/obj/item/broken_device = cell_component.wrapped
-			to_chat(user, "You remove \the [broken_device].")
+			user.self_action_message("remove", "\the [broken_device].")
 			user.put_in_active_hand(broken_device)
 		return TRUE
 	. = ..()
@@ -781,7 +777,8 @@
 	icon = module_sprites[selected_icon]
 	icon_selected = TRUE
 	update_icon()
-	to_chat(src, "Your icon has been set. You now require a module reset to change it.")
+	var/decl/pronouns/self_pronouns = get_self_pronouns()
+	to_chat(src, "[self_pronouns.His] icon has been set. [self_pronouns.He] now require[self_pronouns.s] a module reset to change it.")
 
 /mob/living/silicon/robot/proc/sensor_mode() //Medical/Security HUD controller for borgs
 	set name = "Set Sensor Augmentation"
@@ -846,10 +843,10 @@
 	if(!opened)//Cover is closed
 		if(locked)
 			if(prob(90))
-				to_chat(user, "You emag the cover lock.")
+				user.self_action_message("emag", "the cover lock.")
 				locked = 0
 			else
-				to_chat(user, "You fail to emag the cover lock.")
+				user.self_action_message("fail", "to emag the cover lock.")
 				to_chat(src, "Hack attempt detected.")
 			return 1
 		else
@@ -860,7 +857,7 @@
 		if(emagged)
 			return //Prevents the X has hit Y with Z message also you cant emag them twice
 		if(wiresexposed)
-			to_chat(user, "You must close the panel first.")
+			user.self_action_message("must", "close the panel first.")
 			return
 		else
 			sleep(6)
@@ -868,7 +865,7 @@
 				emagged = 1
 				lawupdate = 0
 				disconnect_from_ai()
-				to_chat(user, "You emag [src]'s interface.")
+				user.self_action_message("emag", "\the [src]'s interface.")
 				log_and_message_admins("emagged cyborg [key_name_admin(src)].  Laws overridden.", src)
 				clear_supplied_laws()
 				clear_inherent_laws()
@@ -900,7 +897,7 @@
 						module.handle_emagged()
 					update_icon()
 			else
-				to_chat(user, "You fail to hack [src]'s interface.")
+				user.self_action_message("fail", "to hack \the [src]'s interface.", dangerous = ACTION_DANGER_OTHERS)
 				to_chat(src, "Hack attempt detected.")
 			return 1
 
@@ -922,7 +919,7 @@
 
 	if(central_processor)
 		if(user)
-			to_chat(user, SPAN_NOTICE("You damage some parts of the chassis, but eventually manage to rip out \the [central_processor]."))
+			user.self_action_message("damage", "some parts of the chassis, but eventually manage to rip out \the [central_processor].", dangerous = ACTION_DANGER_OTHERS)
 		central_processor.dropInto(loc)
 		var/mob/living/brainmob = central_processor.get_brainmob(create_if_missing = TRUE)
 		if(mind && brainmob)
@@ -1010,7 +1007,7 @@
 
 /mob/living/silicon/robot/check_grab_hand()
 	if(locate(/obj/item/grab) in contents)
-		to_chat(src, SPAN_WARNING("You have already grabbed something!"))
+		self_action_message("have", "already grabbed something!", dangerous = ACTION_DANGER_OTHERS)
 		return FALSE
 	return TRUE
 

--- a/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
+++ b/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
@@ -249,7 +249,7 @@ var/global/chicken_count = 0
 	var/obj/item/food/G = used_item //feedin' dem chickens
 	if(findtext(G.get_grown_tag(), "wheat")) // includes chopped, crushed, dried etc.
 		if(!stat && eggsleft < 4)
-			user.visible_message(SPAN_NOTICE("[user] feeds \the [used_item] to \the [src]! It clucks happily."), SPAN_NOTICE("You feed \the [used_item] to \the [src]! It clucks happily."), SPAN_NOTICE("You hear clucking."))
+			user.visible_action_message("feed", "\the [used_item] to \the [src]! It clucks happily.", blind_message = "You hear clucking.")
 			qdel(used_item)
 			eggsleft += rand(1, 2)
 		else

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/parrot.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/parrot.dm
@@ -184,7 +184,7 @@
 				if(!parrot.parrot_perch || parrot.parrot_interest.loc != parrot.parrot_perch.loc)
 					parrot.held_item = parrot.parrot_interest
 					parrot.parrot_interest.forceMove(parrot)
-					parrot.visible_message("[parrot] grabs the [parrot.held_item]!", "<span class='notice'>You grab the [parrot.held_item]!</span>", "You hear the sounds of wings flapping furiously.")
+					parrot.visible_action_message("grab", "\the [parrot.held_item]!", blind_message = "You hear the sounds of wings flapping furiously.")
 
 			parrot.parrot_interest = null
 			parrot.parrot_state = PARROT_SWOOP | PARROT_RETURN
@@ -432,7 +432,7 @@
 
 			held_item = I
 			I.forceMove(src)
-			visible_message("[src] grabs the [held_item]!", "<span class='notice'>You grab the [held_item]!</span>", "You hear the sounds of wings flapping furiously.")
+			visible_action_message("grab", "\the [held_item]!", blind_message = "You hear the sounds of wings flapping furiously.")
 			return held_item
 
 	to_chat(src, "<span class='warning'>There is nothing of interest to take.</span>")

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -161,10 +161,12 @@
 // Determines span styling used for visible_action_message.
 /// Uses SPAN_NOTICE for both self and other messages.
 var/global/const/ACTION_DANGER_NONE = 0
+/// Uses SPAN_WARNING for both self and others.
+var/global/const/ACTION_DANGER_WARNING = 1
 /// Uses SPAN_DANGER for others and SPAN_WARNING for self.
-var/global/const/ACTION_DANGER_OTHERS = 1
+var/global/const/ACTION_DANGER_OTHERS = 2
 /// Uses SPAN_DANGER for both self and others.
-var/global/const/ACTION_DANGER_ALL = 2
+var/global/const/ACTION_DANGER_ALL = 3
 /**
 	Show an action message to all mobs and objects in sight of this mob.
 
@@ -187,6 +189,9 @@ var/global/const/ACTION_DANGER_ALL = 2
 		if(ACTION_DANGER_NONE)
 			other_message = SPAN_NOTICE(other_message)
 			self_message = SPAN_NOTICE(self_message)
+		if(ACTION_DANGER_WARNING)
+			other_message = SPAN_WARNING(other_message)
+			self_message = SPAN_WARNING(self_message)
 		if(ACTION_DANGER_OTHERS)
 			other_message = SPAN_DANGER(other_message)
 			self_message = SPAN_WARNING(self_message)
@@ -210,6 +215,9 @@ var/global/const/ACTION_DANGER_ALL = 2
 		if(ACTION_DANGER_NONE)
 			other_message = SPAN_NOTICE(other_message)
 			self_message = SPAN_NOTICE(self_message)
+		if(ACTION_DANGER_WARNING)
+			other_message = SPAN_WARNING(other_message)
+			self_message = SPAN_WARNING(self_message)
 		if(ACTION_DANGER_OTHERS)
 			other_message = SPAN_DANGER(other_message)
 			self_message = SPAN_WARNING(self_message)
@@ -231,6 +239,8 @@ var/global/const/ACTION_DANGER_ALL = 2
 	switch(dangerous)
 		if(ACTION_DANGER_NONE)
 			the_message = SPAN_NOTICE(the_message)
+		if(ACTION_DANGER_WARNING)
+			the_message = SPAN_WARNING(the_message)
 		if(ACTION_DANGER_OTHERS)
 			the_message = SPAN_WARNING(the_message)
 		if(ACTION_DANGER_ALL)

--- a/code/modules/multiz/hoist.dm
+++ b/code/modules/multiz/hoist.dm
@@ -20,10 +20,7 @@
 
 	var/obj/structure/hoist/hoist = new (get_turf(user), user.dir)
 	transfer_fingerprints_to(hoist)
-	user.visible_message(
-		SPAN_NOTICE("[user] deploys the hoist kit!"),
-		SPAN_NOTICE("You deploy the hoist kit!"),
-		"You hear the sound of parts snapping into place.")
+	user.visible_action_message("deploy", "\the [src]!", blind_message = SPAN_NOTICE("You hear the sound of parts snapping into place."))
 	qdel(src)
 
 /obj/effect/hoist_hook
@@ -200,19 +197,13 @@
 		return TRUE
 
 	if (!hoistee)
-		user.visible_message(
-			SPAN_NOTICE("[user] begins to [movtext] the clamp."),
-			SPAN_NOTICE("You begin to [movtext] the clamp."),
-			SPAN_NOTICE("You hear the sound of a crank."))
+		user.visible_action_message("begin", "to [movtext] the clamp.", blind_message = SPAN_NOTICE("You hear the sound of a crank."))
 		move_dir(movedir, 0)
 		return TRUE
 
 	check_consistency()
 
-	user.visible_message(
-		SPAN_NOTICE("[user] begins to [movtext] \the [hoistee]!"),
-		SPAN_NOTICE("You begin to [movtext] \the [hoistee]!"),
-		SPAN_NOTICE("You hear the sound of a crank."))
+	user.visible_action_message("begin", "to [movtext] \the [hoistee]!", blind_message = SPAN_NOTICE("You hear the sound of a crank."))
 	if (do_after(user, (1 SECONDS) * get_object_size(hoistee) / 4, src))
 		move_dir(movedir, 1)
 	return TRUE

--- a/code/modules/multiz/hoist.dm
+++ b/code/modules/multiz/hoist.dm
@@ -39,7 +39,7 @@
 		return ..()
 	source_hoist.check_consistency()
 	source_hoist.hoistee.forceMove(get_turf(src))
-	user.visible_message(SPAN_NOTICE("[user] detaches \the [source_hoist.hoistee] from the hoist clamp."), SPAN_NOTICE("You detach \the [source_hoist.hoistee] from the hoist clamp."), SPAN_NOTICE("You hear something unclamp."))
+	user.visible_action_message("detach", "\the [source_hoist.hoistee] from \the [src].", blind_message = SPAN_NOTICE("You hear something unclamp."))
 	source_hoist.release_hoistee()
 	return TRUE
 
@@ -63,10 +63,7 @@
 		if (!user.check_dexterity(DEXTERITY_HOLD_ITEM))
 			return
 		source_hoist.attach_hoistee(dropped_movable)
-		user.visible_message(
-			SPAN_NOTICE("[user] attaches \the [dropped_movable] to \the [src]."),
-			SPAN_NOTICE("You attach \the [dropped_movable] to \the [src]."),
-			"You hear something clamp into place.")
+		user.visible_action_message("attach", "\the [dropped_movable] to \the [src].", blind_message = SPAN_NOTICE("You hear something clamp into place."))
 		return TRUE
 
 /obj/structure/hoist/proc/attach_hoistee(atom/movable/victim)

--- a/code/modules/multiz/mobile_ladder.dm
+++ b/code/modules/multiz/mobile_ladder.dm
@@ -41,15 +41,9 @@
 		return FALSE
 
 	if(above)
-		user.visible_message(
-			SPAN_NOTICE("\The [user] begins deploying \the [src] on \the [A]."),
-			SPAN_NOTICE("You begin to deploy \the [src] on \the [A].")
-		)
+		user.visible_action_message("begin", "deploying \the [src] on \the [A].")
 	else
-		user.visible_message(
-			SPAN_NOTICE("\The [user] begins to lower \the [src] into \the [A]."),
-			SPAN_WARNING("You begin to lower \the [src] into \the [A].")
-		)
+		user.visible_action_message("begin", "lowering \the [src] into \the [A].")
 
 	if (!handle_action(A, user))
 		return
@@ -100,9 +94,7 @@
 		if(!user.check_dexterity(DEXTERITY_HOLD_ITEM))
 			return
 
-		user.visible_message(
-			SPAN_NOTICE("[user] starts folding up \the [src]."),
-			SPAN_NOTICE("You start folding up \the [src]."))
+		user.visible_action_message("start", "folding up \the [src].")
 
 		if(!do_after(user, 30, src))
 			return
@@ -112,9 +104,7 @@
 		user.put_in_hands(R)
 		transfer_fingerprints_to(R)
 
-		user.visible_message(
-			SPAN_NOTICE("[user] folds \the [src]."),
-			SPAN_NOTICE("You fold \the [src]."))
+		user.visible_action_message("fold", "\the [src].")
 
 	if(target_down && istype(target_down, /obj/structure/ladder/mobile))
 		QDEL_NULL(target_down)

--- a/code/modules/multiz/movement.dm
+++ b/code/modules/multiz/movement.dm
@@ -290,7 +290,7 @@
 			visible_action_message("climb", "onto \the [A]!")
 			src.Move(T)
 		else
-			visible_message("<span class='warning'>[src] gives up on trying to climb onto \the [A]!</span>", "<span class='warning'>You give up on trying to climb onto \the [A]!</span>")
+			visible_action_message("give", "up on trying to climb onto \the [A]!", dangerous = ACTION_DANGER_WARNING)
 		return TRUE
 
 /mob/living/verb/lookup()

--- a/code/modules/multiz/movement.dm
+++ b/code/modules/multiz/movement.dm
@@ -285,9 +285,9 @@
 		if(loc.has_gravity() && !can_overcome_gravity())
 			return FALSE
 
-		visible_message("<span class='notice'>[src] starts climbing onto \the [A]!</span>", "<span class='notice'>You start climbing onto \the [A]!</span>")
+		visible_action_message("start", "climbing onto \the [A]!")
 		if(do_after(src, 50, A))
-			visible_message("<span class='notice'>[src] climbs onto \the [A]!</span>", "<span class='notice'>You climb onto \the [A]!</span>")
+			visible_action_message("climb", "onto \the [A]!")
 			src.Move(T)
 		else
 			visible_message("<span class='warning'>[src] gives up on trying to climb onto \the [A]!</span>", "<span class='warning'>You give up on trying to climb onto \the [A]!</span>")

--- a/code/modules/overmap/disperser/disperser.dm
+++ b/code/modules/overmap/disperser/disperser.dm
@@ -15,7 +15,7 @@
 /obj/machinery/disperser/attackby(obj/item/used_item, mob/user)
 	if(IS_WRENCH(used_item))
 		if(panel_open)
-			user.visible_message("<span class='notice'>\The [user] rotates \the [src] with \the [used_item].</span>", "<span class='notice'>You rotate \the [src] with \the [used_item].</span>")
+			user.visible_action_message("rotate", "\the [src] with \the [used_item].")
 			set_dir(turn(dir, 90))
 			playsound(src, 'sound/items/jaws_pry.ogg', 50, 1)
 		else

--- a/code/modules/overmap/ships/computers/helm.dm
+++ b/code/modules/overmap/ships/computers/helm.dm
@@ -331,25 +331,18 @@ var/global/list/overmap_helm_computers
  */
 /obj/machinery/computer/ship/helm/proc/display_operator_change_message(mob/old_operator, mob/new_operator, autopilot)
 	if (!old_operator)
-		new_operator.visible_message(
-			SPAN_NOTICE("\The [new_operator] takes \the [src]'s controls."),
-			SPAN_NOTICE("You take \the [src]'s controls.")
-		)
+		new_operator.visible_action_message("take", "\the [src]'s controls.")
+		new_operator.visible_action_message("take", "\the [src]'s controls.")
 	else if (!new_operator)
 		if (autopilot)
-			old_operator.visible_message(
-				SPAN_NOTICE("\The [old_operator] engages \the [src]'s autopilot and releases the controls."),
-				SPAN_NOTICE("You engage \the [src]'s autopilot and release the controls.")
-			)
+			old_operator.visible_action_message("engage", "\the [src]'s autopilot and release$USER_S$ the controls.")
 		else
-			old_operator.visible_message(
-				SPAN_WARNING("\The [old_operator] releases \the [src]'s controls."),
-				SPAN_WARNING("You release \the [src]'s controls.")
-			)
+			old_operator.visible_action_message("release", "\the [src]'s controls.", dangerous = ACTION_DANGER_NONE)
 	else
+		var/decl/pronouns/self_pronouns = old_operator.get_self_pronouns()
 		old_operator.visible_message(
 			SPAN_WARNING("\The [new_operator] takes \the [src]'s controls from \the [old_operator]."),
-			SPAN_DANGER("\The [new_operator] takes \the [src]'s controls from you!")
+			SPAN_DANGER("\The [new_operator] takes \the [src]'s controls from [self_pronouns.him]!")
 		)
 
 

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -169,18 +169,12 @@
 	target_zone = check_zone(target_zone)
 	if(target.get_organ_sprite_accessory_by_category(SAC_COSMETICS, target_zone))
 		if(target == user)
-			to_chat(user, SPAN_NOTICE("You wipe off the makeup with [src]."))
+			user.self_action_message("wipe", "off the makeup with \the [src].")
 			target.set_organ_sprite_accessory_by_category(null, SAC_COSMETICS, null, FALSE, FALSE, target_zone, FALSE)
 			return TRUE
-		user.visible_message(
-			SPAN_NOTICE("\The [user] begins to wipe \the [target]'s makeup off with \the [src]."),
-			SPAN_NOTICE("You begin to wipe off [target]'s makeup .")
-		)
-		if(do_after(user, 10, target) && do_after(target, 10, check_holding = 0))	//user needs to keep their active hand, H does not.
-			user.visible_message(
-				SPAN_NOTICE("\The [user] wipes \the [target]'s makeup off with \the [src]."),
-				SPAN_NOTICE("You wipe off \the [target]'s makeup .")
-			)
+		user.visible_action_message("begin", "to wipe off \the [target]'s makeup with \the [src].")
+		if(do_mob(user, target, 1 SECOND)) //user needs to keep their active hand, target does not.
+			user.visible_action_message("wipe", "off \the [target]'s makeup with \the [src].")
 		target.set_organ_sprite_accessory_by_category(null, SAC_COSMETICS, null, FALSE, FALSE, target_zone, FALSE)
 		return TRUE
 
@@ -285,30 +279,32 @@
 
 	return t
 
-/obj/item/paper/proc/burnpaper(obj/item/paper, mob/user)
+/obj/item/paper/proc/burnpaper(obj/item/lighter, mob/user)
 	var/class = "warning"
 
-	if(paper.isflamesource() && !user.restrained())
-		if(istype(paper, /obj/item/flame/fuelled/lighter/zippo))
+	if(lighter.isflamesource() && !user.restrained())
+		if(istype(lighter, /obj/item/flame/fuelled/lighter/zippo))
 			class = "rose"
 
 		var/decl/pronouns/pronouns = user.get_pronouns()
-		user.visible_message("<span class='[class]'>[user] holds \the [paper] up to \the [src], it looks like [pronouns.he] [pronouns.is] trying to burn it!</span>", \
-		"<span class='[class]'>You hold \the [paper] up to \the [src], burning it slowly.</span>")
+		user.visible_message("<span class='[class]'>[user] holds \the [lighter] up to \the [src], it looks like [pronouns.he] [pronouns.is] trying to burn it!</span>", \
+		"<span class='[class]'>You hold \the [lighter] up to \the [src], burning it slowly.</span>")
 
-		spawn(20)
-			if(get_dist(src, user) < 2 && user.get_active_held_item() == paper && paper.isflamesource())
-				user.visible_message("<span class='[class]'>[user] burns right through \the [src], turning it to ash. It flutters through the air before settling on the floor in a heap.</span>", \
-				"<span class='[class]'>You burn right through \the [src], turning it to ash. It flutters through the air before settling on the floor in a heap.</span>")
+		addtimer(CALLBACK(PROC_REF(_finishburnpaper), lighter, user, class), 2 SECONDS)
 
-				new /obj/effect/decal/cleanable/ash(get_turf(src))
-				qdel(src)
-
-			else
-				to_chat(user, SPAN_WARNING("You must hold \the [paper] steady to burn \the [src]."))
+/obj/item/paper/proc/_finishburnpaper(obj/item/lighter, mob/user, class)
+	if(user.restrained())
+		return
+	if(user.Adjacent(src) && user.get_active_held_item() == lighter && lighter.isflamesource())
+		var/obj_phrase = "right through \the [src], turning it to ash. It flutters through the air before settling on the floor in a heap."
+		user.visible_message(SPAN_CLASS(class, user.get_action_string(FALSE, "burn", obj_phrase)), SPAN_CLASS(class, user.get_action_string(TRUE, "burn", obj_phrase)))
+		new /obj/effect/decal/cleanable/ash(get_turf(src))
+		qdel(src)
+	else
+		to_chat(user, SPAN_WARNING("You must hold \the [lighter] steady to burn \the [src]."))
 
 /obj/item/paper/CouldNotUseTopic(mob/user)
-	to_chat(user, SPAN_WARNING("You can't reach!"))
+	user.self_action_message("can't", "reach!", dangerous = ACTION_DANGER_OTHERS)
 
 /obj/item/paper/OnTopic(mob/user, href_list, datum/topic_state/state)
 
@@ -321,14 +317,14 @@
 		//Try to find a usable pen on the user, if not abort
 		var/obj/item/I = user.get_accessible_pen()
 		if(!IS_PEN(I))
-			to_chat(user, SPAN_WARNING("You need something to write with!"))
+			user.self_action_message("need", "something to write with!", dangerous = ACTION_DANGER_OTHERS)
 			return TOPIC_NOACTION
 
 		//If we got a pen that's not in our hands, make sure to move it over
 		if(user.get_active_held_item() != I && user.get_empty_hand_slot() && user.put_in_hands(I))
-			to_chat(user, SPAN_NOTICE("You grab your trusty [I.name]!"))
+			user.self_action_message("grab", "$USER_THEIR$ trusty [I.name]!")
 		else if(user.get_active_held_item() != I)
-			to_chat(user, SPAN_WARNING("You'd use your trusty [I.name], but your hands are full!"))
+			user.self_action_message("would", "use $USER_THEIR$ trusty [I.name], but $USER_THEIR$ hands are full!", dangerous = ACTION_DANGER_OTHERS)
 			return TOPIC_NOACTION
 
 		var/pen_flags = I.get_tool_property(TOOL_PEN, TOOL_PROP_PEN_FLAG)
@@ -338,7 +334,8 @@
 		var/iscrayon = pen_flags & PEN_FLAG_CRAYON
 		var/isfancy  = pen_flags & PEN_FLAG_FANCY
 
-		var/t =  sanitize(input("Enter what you want to write:", "Write", null, null) as message, free_space, extra = 0, trim = 0)
+		var/decl/pronouns/self_pronouns = user.get_self_pronouns()
+		var/t =  sanitize(input("Enter what [self_pronouns.he] [verb_agree_with_pronouns("want", self_pronouns)] to write:", "Write", null, null) as message, free_space, extra = 0, trim = 0)
 		if(!t)
 			return TOPIC_NOACTION
 
@@ -346,7 +343,7 @@
 		t = parsepencode(t, I, user, iscrayon, isfancy) // Encode everything from pencode to html
 
 		if(fields > MAX_FIELDS)
-			to_chat(user, SPAN_WARNING("Too many fields. Sorry, you can't do this."))
+			to_chat(user, SPAN_WARNING("Too many fields. Sorry, [self_pronouns.he] can't do this."))
 			fields = last_fields_value
 			return TOPIC_NOACTION
 
@@ -406,7 +403,7 @@
 	else if(used_item.get_tool_quality(TOOL_STAMP))
 		apply_custom_stamp(used_item.icon, "with \the [used_item]")
 		playsound(src, 'sound/effects/stamp.ogg', 50, TRUE)
-		to_chat(user, SPAN_NOTICE("You stamp the paper with your [used_item.name]."))
+		user.visible_action_message("stamp", "\the [src] with $USER_THEIR$ [used_item.name].")
 		return TRUE
 
 	else if(used_item.isflamesource())
@@ -422,16 +419,16 @@
 /obj/item/paper/proc/try_bundle_with(var/obj/item/paper/other, var/mob/user)
 	if(!can_bundle_with(other))
 		if(user)
-			to_chat(user, SPAN_WARNING("You can't bundle those!"))
+			user.self_action_message("can't", "bundle those!", dangerous = ACTION_DANGER_OTHERS)
 		return
 
 	var/obj/item/paper_bundle/B = new(loc)
 	if(user)
 		if(!user.can_unequip_item(src))
-			to_chat(user, SPAN_WARNING("You can't unequip \the [src]!"))
+			user.self_action_message("can't", "unequip \the [src]!", dangerous = ACTION_DANGER_OTHERS)
 			return
 		if(!user.can_unequip_item(other))
-			to_chat(user, SPAN_WARNING("You can't unequip \the [other]!"))
+			user.self_action_message("can't", "unequip \the [other]!", dangerous = ACTION_DANGER_OTHERS)
 			return
 		user.try_unequip(src, B)
 		user.try_unequip(other, B)
@@ -517,13 +514,14 @@
 	set category = "Object"
 	set src in usr
 	if(usr.incapacitated())
-		to_chat(usr, SPAN_WARNING("You can't do that in your current state!"))
+		usr.self_action_message("can't", "do that in $USER_THEIR$ current state!", dangerous = ACTION_DANGER_OTHERS)
 		return
 
 	if(usr.has_genetic_condition(GENE_COND_CLUMSY) && prob(50))
-		to_chat(usr, SPAN_WARNING("You cut yourself on the paper."))
+		usr.self_action_message("cut", "$TARGET$ on \the [src].", dangerous = ACTION_DANGER_OTHERS)
 		return
-	var/n_name = sanitize_safe(input(usr, "What would you like to name the paper?", "Paper Naming", name) as text, MAX_NAME_LEN)
+	var/decl/pronouns/self_pronouns = usr.get_self_pronouns()
+	var/n_name = sanitize_safe(input(usr, "What would [self_pronouns.he] like to name the paper?", "Paper Naming", name) as text, MAX_NAME_LEN)
 
 	// We check loc one level up, so we can rename in clipboards and such. See also: /obj/item/photo/rename()
 	if(!n_name || !CanInteract(usr, global.deep_inventory_topic_state))
@@ -633,7 +631,7 @@ var/global/datum/topic_state/default/paper_state/paper_topic_state = new
 	var/obj/item/paper/scroll/scroll = target
 	// TODO: paper sound
 	scroll.furled = !scroll.furled
-	user.visible_message(SPAN_NOTICE("\The [user] [scroll.furled ? "furls" : "unfurls"] \the [target]."))
+	user.visible_action_message(scroll.furled ? "furls" : "unfurls", "\the [target].")
 	scroll.update_icon()
 
 /decl/interaction_handler/scroll/furl

--- a/code/modules/paperwork/paper_bundle.dm
+++ b/code/modules/paperwork/paper_bundle.dm
@@ -90,7 +90,7 @@
 	cur_page = clamp((index <= cur_page)? (cur_page + 1) : cur_page, 1, length(pages))
 
 	if(user)
-		to_chat(user, SPAN_NOTICE("You add \the [sheet] as the [get_ordinal_string(index)] page in \the [name]."))
+		user.self_action_message("add", "\the [sheet] as the [index]\th page in \the [src].")
 	updateUsrDialog()
 	update_icon()
 	return TRUE
@@ -133,7 +133,7 @@
 	LAZYREMOVE(pages, I)
 	if(user)
 		user.put_in_hands(I)
-		to_chat(user, SPAN_NOTICE("You remove the [I.name] from the bundle."))
+		user.self_action_message("remove", "\the [I] from \the [src].")
 	else
 		I.dropInto(loc)
 
@@ -168,11 +168,9 @@
 	if(QDELETED(P) || QDELETED(user))
 		return
 	if(!Adjacent(user) || user.get_active_held_item() != P || !P.lit)
-		to_chat(user, SPAN_WARNING("You must hold \the [P] steady to burn \the [src]."))
+		user.self_action_message("must", "hold \the [P] steady to burn \the [src].", dangerous = ACTION_DANGER_OTHERS)
 		return
-	user.visible_message( \
-		"<span class='[span_class]'>\The [user] burns right through \the [src], turning it to ash. It flutters through the air before settling on the floor in a heap.</span>", \
-		"<span class='[span_class]'>You burn right through \the [src], turning it to ash. It flutters through the air before settling on the floor in a heap.</span>")
+	user.visible_action_message("burn", "right through \the [src], turning it to ash. It flutters through the air before settling on the floor in a heap.", dangerous = span_class)
 	new /obj/effect/decal/cleanable/ash(loc)
 	qdel(src)
 
@@ -181,6 +179,7 @@
 		return
 	var/span_class = istype(P, /obj/item/flame/fuelled/lighter/zippo) ? "rose" : "warning"
 	var/decl/pronouns/pronouns = user.get_pronouns()
+	user.visible_action_message("hold", "\the [P] up to \the [src]", dangerous = span_class, self_postfix = "and burns it slowly.", other_postfix = "It looks like [pronouns.he] [pronouns.is] trying to burn it!")
 	user.visible_message( \
 		"<span class='[span_class]'>\The [user] holds \the [P] up to \the [src]. It looks like [pronouns.he] [pronouns.is] trying to burn it!</span>", \
 		"<span class='[span_class]'>You hold \the [P] up to \the [src], burning it slowly.</span>")

--- a/code/modules/paperwork/paper_plane.dm
+++ b/code/modules/paperwork/paper_plane.dm
@@ -31,7 +31,7 @@
 	if(user)
 		if(!user.try_unequip(src))
 			return
-		user.visible_message(SPAN_NOTICE("\The [user] unfolds \the [src]."), SPAN_NOTICE("You unfold \the [src]."))
+		user.visible_action_message("unfold", "\the [src].")
 		if(my_paper)
 			user.put_in_active_hand(my_paper)
 	else if(my_paper)
@@ -83,7 +83,7 @@
 	return ..() && !target.is_crumpled
 
 /decl/interaction_handler/make_paper_plane/invoked(atom/target, mob/user, obj/item/prop)
-	user.visible_message(SPAN_NOTICE("\The [user] folds \the [target] into a plane."), SPAN_NOTICE("You fold \the [target] into a plane."))
+	user.visible_action_message("fold", "\the [target] into a plane.")
 	var/obj/item/paper_plane/PP = new
 	user.try_unequip(target, PP)
 	PP.set_paper(target)

--- a/code/modules/paperwork/paperbin.dm
+++ b/code/modules/paperwork/paperbin.dm
@@ -66,7 +66,7 @@
 			P.set_content("<font face=\"[P.crayonfont]\" color=\"red\"><b>HONK HONK HONK HONK HONK HONK HONK<br>HOOOOOOOOOOOOOOOOOOOOOONK<br>APRIL FOOLS</b></font>")
 
 	user.put_in_hands(P)
-	to_chat(user, SPAN_NOTICE("You take \the [P] out of \the [src]."))
+	user.self_action_message("take", "\the [P] out of \the [src].")
 	amount--
 	update_icon()
 	add_fingerprint(user)
@@ -80,7 +80,7 @@
 		if(!user.try_unequip(used_item, src))
 			return TRUE
 		add_paper(used_item)
-		to_chat(user, SPAN_NOTICE("You put [used_item] in [src]."))
+		user.self_action_message("put", "\the [used_item] in \the [src].")
 		return TRUE
 	else if(istype(used_item, /obj/item/paper_bundle))
 		if(amount >= max_amount)
@@ -96,7 +96,7 @@
 				was_there_a_photo = TRUE
 				bundleitem.dropInto(user.loc)
 				bundleitem.reset_plane_and_layer()
-		to_chat(user, SPAN_NOTICE("You loosen \the [used_item] and add its papers into \the [src]."))
+		user.self_action_message("loosen", "\the [used_item] and add its papers into \the [src].")
 		B.reevaluate_existence()
 		if(was_there_a_photo)
 			to_chat(user, SPAN_NOTICE("The photo cannot go into \the [src]."))
@@ -162,7 +162,7 @@
 
 /decl/interaction_handler/paper_bin_dump_contents/invoked(atom/target, mob/user, obj/item/prop)
 	var/obj/item/paper_bin/bin = target
-	to_chat(user, SPAN_NOTICE("You start emptying \the [bin]..."))
+	user.self_action_message("start", "emptying \the [bin]...")
 	if(do_after(user, 2 SECONDS) && !QDELETED(bin))
 		bin.dump_contents()
-		to_chat(user, SPAN_NOTICE("You emptied \the [bin]."))
+	user.self_action_message("empty", "\the [bin].")

--- a/code/modules/paperwork/papershredder.dm
+++ b/code/modules/paperwork/papershredder.dm
@@ -246,9 +246,7 @@
 	if(!do_after(user,20, src))
 		to_chat(user, SPAN_WARNING("You must hold \the [P] steady to burn \the [src]."))
 		return
-	user.visible_message( \
-		SPAN_DANGER("\The [user] burns right through \the [src], turning it to ash. It flutters through the air before settling on the floor in a heap."), \
-		SPAN_DANGER("You burn right through \the [src], turning it to ash. It flutters through the air before settling on the floor in a heap."))
+	user.visible_action_message("burn", "right through \the [src], turning it to ash. It flutters through the air before settling on the floor in a heap.", dangerous = ACTION_DANGER_ALL)
 	fire_act(return_air(), P.get_heat(), 500)
 
 /obj/item/shreddedp/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume)

--- a/code/modules/paperwork/photocopier.dm
+++ b/code/modules/paperwork/photocopier.dm
@@ -228,7 +228,7 @@
 		if(!user.try_unequip(I, src))
 			return
 		scanner_item = I
-		to_chat(user, SPAN_NOTICE("You insert \the [I] into \the [src]."))
+		user.self_action_message("insert", "\the [I] into \the [src].")
 		SSnano.update_uis(src)
 		update_icon()
 		return TRUE
@@ -239,7 +239,7 @@
 	if(!scanner_item)
 		return
 	user.put_in_hands(scanner_item)
-	to_chat(user, SPAN_NOTICE("You take \the [scanner_item] out of \the [src]."))
+	user.self_action_message("take", "\the [scanner_item] out of \the [src].")
 	scanner_item = null
 	SSnano.update_uis(src)
 	update_icon()

--- a/code/modules/paperwork/photography.dm
+++ b/code/modules/paperwork/photography.dm
@@ -251,7 +251,7 @@
 
 /obj/item/camera/proc/eject_film(mob/user)
 	if(film)
-		user.visible_message(SPAN_NOTICE("[user] ejects \the [film] from \the [src]."), SPAN_NOTICE("You eject \the [film] from \the [src]."))
+		user.visible_action_message("eject", "\the [film] from \the [src].")
 		playsound(user, 'sound/machines/button1.ogg', 40, TRUE)
 		user.put_in_hands(film)
 		film = null
@@ -268,8 +268,8 @@
 			if(user.get_skill_value(SKILL_DEVICES) >= SKILL_EXPERT)
 				if(user.do_skilled(1 SECONDS, SKILL_DEVICES, src))
 					user.visible_message(
-						SPAN_NOTICE("In a swift flick of the finger, [user] ejects \the [film], and slides in \the [used_item]!"),
-						SPAN_NOTICE("From habit you instinctively pop the old [film] from \the [src] and insert a new [used_item] deftly!"))
+						SPAN_NOTICE("With a swift flick of the finger, [user] ejects \the [film] and slides in \the [used_item]!"),
+						SPAN_NOTICE("From habit you instinctively pop the old [film.name] from \the [src] and insert a new [used_item.name] deftly!"))
 					user.try_unequip(used_item, src)
 					user.put_in_active_hand(film)
 					film = used_item
@@ -281,13 +281,12 @@
 		else
 			if(user.do_skilled(1 SECONDS, SKILL_DEVICES, src))
 				if(user.get_skill_value(SKILL_DEVICES) >= SKILL_EXPERT)
+					user.visible_action_message("swiftly slide", "\the [used_item] into $USER_THEIR$ [name].")
 					user.visible_message(
 						SPAN_NOTICE("[user] swiftly slides \the [used_item] into \the [src]!"),
 						SPAN_NOTICE("You insert \a [used_item] swiftly into \the [src]!"))
 				else
-					user.visible_message(
-						SPAN_NOTICE("[user] inserts \a [used_item] into his [src]."),
-						SPAN_NOTICE("You insert \the [used_item] into \the [src]."))
+					user.visible_action_message("insert", "\the [used_item] into $USER_THEIR$ [name].")
 				user.try_unequip(used_item, src)
 				film = used_item
 				return TRUE

--- a/code/modules/paperwork/printer.dm
+++ b/code/modules/paperwork/printer.dm
@@ -140,17 +140,17 @@
 	QDEL_NULL_LIST(print_queue)
 
 /**Allow inserting a toner cartridge into the printer */
-/obj/item/stock_parts/printer/proc/insert_toner(var/obj/item/chems/toner_cartridge/T, var/mob/user)
+/obj/item/stock_parts/printer/proc/insert_toner(var/obj/item/chems/toner_cartridge/new_toner, var/mob/user)
 	if(toner)
 		if(user)
 			to_chat(user, SPAN_WARNING("There's already a cartridge in \the [src]."))
 		return TRUE
 
-	if(!user.try_unequip(T, src))
+	if(!user.try_unequip(new_toner, src))
 		return TRUE
-	toner = T
+	toner = new_toner
 	if(user)
-		to_chat(user, SPAN_NOTICE("You install \a [T] in \the [src]."))
+		user.self_action_message("install", "\a [new_toner] in \the [src].")
 	if(call_on_status_changed)
 		call_on_status_changed.InvokeAsync()
 	return TRUE
@@ -164,7 +164,7 @@
 
 	if(user)
 		user.put_in_hands(toner)
-		to_chat(user, SPAN_NOTICE("You remove \the [toner] from \the [src]."))
+		user.self_action_message("remove", "\the [toner] from \the [src].")
 	else
 		toner.dropInto(get_turf(loc))
 	toner = null
@@ -188,7 +188,7 @@
 		if(!user?.try_unequip(paper_refill))
 			return TRUE
 		if(user)
-			to_chat(user, SPAN_NOTICE("You insert \a [paper_refill] in \the [src]."))
+			user.self_action_message("insert", "\a [paper_refill] in \the [src].")
 		qdel(paper_refill)
 		paper_left++
 
@@ -205,7 +205,7 @@
 			if(!user.try_unequip(B))
 				return TRUE
 			if(user)
-				to_chat(user, SPAN_NOTICE("You insert \a [paper_refill] in \the [src]."))
+				user.self_action_message("insert", "\a [paper_refill] in \the [src].")
 			qdel(B)
 		else
 			B.remove_sheets(to_insert, user)
@@ -228,7 +228,7 @@
 
 	if(user)
 		user.put_in_hands(B)
-		to_chat(user, SPAN_NOTICE("You grab all the paper sheets from \the [src]."))
+		user.self_action_message("grab", "all the paper sheets in \the [src].")
 	else
 		B.dropInto(get_turf(loc))
 	if(call_on_status_changed)

--- a/code/modules/posters/_poster.dm
+++ b/code/modules/posters/_poster.dm
@@ -156,44 +156,40 @@
 		return
 
 	//must place on a wall and user must not be inside a closet/exosuit/whatever
-	var/turf/used_item = get_turf(A)
-	if(!istype(used_item) || !used_item.is_wall() || !isturf(user.loc))
+	var/turf/target_turf = get_turf(A)
+	if(!istype(target_turf) || !target_turf.is_wall() || !isturf(user.loc))
 		to_chat(user, SPAN_WARNING("You can't place this here!"))
 		return
 
-	var/placement_dir = get_dir(user, used_item)
+	var/placement_dir = get_dir(user, target_turf)
 	if (!(placement_dir in global.cardinal))
 		to_chat(user, SPAN_WARNING("You must stand directly in front of the wall you wish to place that on."))
 		return
 
-	if (ArePostersOnWall(used_item))
+	if (ArePostersOnWall(target_turf))
 		to_chat(user, SPAN_WARNING("There is already a poster there!"))
 		return
 
-	user.visible_message(
-		SPAN_NOTICE("\The [user] starts placing a poster on \the [used_item]."),
-		SPAN_NOTICE("You start placing the poster on \the [used_item]."))
+	user.visible_action_message("start", "placing \the [src] on \the [target_turf].")
 
 	var/obj/structure/sign/poster/P = new (user.loc, null, null, placement_dir, poster_design)
 	qdel(src)
 	flick("poster_being_set", P)
 	// Time to place is equal to the time needed to play the flick animation
-	if(do_after(user, 28, used_item) && used_item.is_wall() && !ArePostersOnWall(used_item, P))
-		user.visible_message(
-			SPAN_NOTICE("\The [user] has placed a poster on \the [used_item]."),
-			SPAN_NOTICE("You have placed the poster on \the [used_item]."))
+	if(do_after(user, 28, target_turf) && target_turf.is_wall() && !ArePostersOnWall(target_turf, P))
+		user.visible_action_message("place", "\the [src] on \the [target_turf].")
 	else
 		// We cannot rely on user being on the appropriate turf when placement fails
 		P.dismantle_structure(user)
 
-/obj/item/poster/proc/ArePostersOnWall(var/turf/used_item, var/placed_poster)
+/obj/item/poster/proc/ArePostersOnWall(var/turf/target_turf, var/placed_poster)
 	//just check if there is a poster on or adjacent to the wall
-	if (locate(/obj/structure/sign/poster) in used_item)
+	if (locate(/obj/structure/sign/poster) in target_turf)
 		return TRUE
 
 	//crude, but will cover most cases. We could do stuff like check pixel_x/y but it's not really worth it.
 	for (var/dir in global.cardinal)
-		var/turf/T = get_step(used_item, dir)
+		var/turf/T = get_step(target_turf, dir)
 		var/poster = locate(/obj/structure/sign/poster) in T
 		if (poster && placed_poster != poster)
 			return TRUE

--- a/code/modules/power/fission/core.dm
+++ b/code/modules/power/fission/core.dm
@@ -216,7 +216,7 @@
 		if(!user.try_unequip(used_item, src))
 			return TRUE
 		fuel_rods[used_item] = FALSE // Rod is not exposed to begin with.
-		user.visible_message(SPAN_NOTICE("\The [user] inserts \a [used_item] into \the [src]."), SPAN_NOTICE("You insert \a [used_item] into \the [src]."))
+		user.visible_action_message("insert", "\a [used_item] into \the [src].")
 		return TRUE
 	. = ..()
 

--- a/code/modules/power/fusion/core/_core.dm
+++ b/code/modules/power/fusion/core/_core.dm
@@ -84,7 +84,7 @@
 		owned_field.ChangeFieldStrength(value)
 
 /obj/machinery/fusion_core/physical_attack_hand(var/mob/user)
-	visible_message(SPAN_NOTICE("\The [user] hugs \the [src] to make it feel better!"))
+	user.visible_action_message("hug", "\the [src] to make it feel better!")
 	Shutdown()
 	return TRUE
 
@@ -103,15 +103,7 @@
 		anchored = !anchored
 		playsound(src.loc, 'sound/items/Ratchet.ogg', 75, 1)
 		if(anchored)
-			user.visible_message("\The [user] secures \the [src] to the floor.", 
-				"You secure \the [src] to the floor.", 
-				"You hear a ratchet."
-			)
-		else
-			user.visible_message("\The [user] unsecures \the [src] from the floor.", 
-				"You unsecure \the [src] from the floor.", 
-				"You hear a ratchet."
-			)
+			user.visible_action_message(anchored ? "secure" : "unsecure", "\the [src] to the floor.", blind_message = "You hear a ratchet.")
 		return TRUE
 
 	return ..()

--- a/code/modules/power/stirling.dm
+++ b/code/modules/power/stirling.dm
@@ -180,7 +180,7 @@
 		return TRUE
 	to_chat(user, "You start trying to manually rev up \the [src].")
 	if(do_after(user, 2 SECONDS, src) && !active && inserted_cylinder && !(stat & BROKEN))
-		visible_message("[user] pulls on the starting cord of \the [src], revving it up!", "You pull on the starting cord of \the [src], revving it up!")
+		user.visible_action_message("pull", "on the starting cord of \the [src], revving it up!")
 		playsound(src.loc, 'sound/machines/engine.ogg', 35, 1)
 		active = TRUE
 	return TRUE

--- a/code/modules/projectiles/ammunition.dm
+++ b/code/modules/projectiles/ammunition.dm
@@ -247,10 +247,7 @@
 	var/obj/item/ammo_casing/C = stored_ammo[stored_ammo.len]
 	stored_ammo -= C
 	user.put_in_hands(C)
-	user.visible_message(
-		"\The [user] removes \a [C] from [src].",
-		SPAN_NOTICE("You remove \a [C] from [src].")
-	)
+	user.visible_action_message("remove", "\a [C] from \the [src].")
 	update_icon()
 	return TRUE
 

--- a/code/modules/projectiles/ammunition/boxes.dm
+++ b/code/modules/projectiles/ammunition/boxes.dm
@@ -69,10 +69,7 @@
 	var/obj/item/ammo_casing/C = stored_ammo[stored_ammo.len]
 	stored_ammo -= C
 	user.put_in_hands(C)
-	user.visible_message(
-		"\The [user] removes \a [C] from [src].",
-		SPAN_NOTICE("You remove \a [C] from [src].")
-	)
+	user.visible_action_message("remove", "\a [C] from \the [src].")
 	update_icon()
 	return TRUE
 

--- a/code/modules/projectiles/guns/launcher/bows/bow_messages.dm
+++ b/code/modules/projectiles/guns/launcher/bows/bow_messages.dm
@@ -1,52 +1,35 @@
 /obj/item/gun/launcher/bow/proc/show_string_relax_message(mob/user)
 	if(user)
-		user.visible_message(
-			"\The [user] relaxes the tension on \the [src]'s string.",
-			"You relax the tension on \the [src]'s string."
-		)
+		user.visible_action_message("relax", "the tension on \the [src]'s string.")
 
 /obj/item/gun/launcher/bow/proc/show_unload_message(mob/user)
 	if(user)
-		user.visible_message(
-			"\The [user] removes \the [_loaded] from \the [src].",
-			"You remove \the [_loaded] from \the [src]."
-		)
+		user.visible_action_message("remove", "\the [_loaded] from \the [src].")
 
 /obj/item/gun/launcher/bow/proc/show_draw_message(mob/user)
 	if(user)
-		user.visible_message(
-			SPAN_NOTICE("\The [user] begins to draw back the string of \the [src]."),
-			SPAN_NOTICE("You begin to draw back the string of \the [src].")
-		)
+		user.visible_action_message("begin", "to draw back the string of \the [src].")
 
 /obj/item/gun/launcher/bow/proc/show_max_draw_message(mob/user)
-	to_chat(user, SPAN_NOTICE("\The [src] strains as you draw the string to its maximum tension!"))
+	var/decl/pronouns/self_pronouns = user.get_self_pronouns()
+	to_chat(user, SPAN_NOTICE("\The [src] strains as [self_pronouns.he] [verb_agree_with_pronouns("draw", self_pronouns)] the string to its maximum tension!"))
 
 /obj/item/gun/launcher/bow/proc/show_cancel_draw_message(mob/user)
 	if(user)
-		user.visible_message(
-			SPAN_NOTICE("\The [user] stops drawing and relaxes the string of \the [src]."),
-			SPAN_NOTICE("You stop drawing back and relax the string of \the [src].")
-		)
+		user.visible_action_message("stop", "drawing back and relax$USER_ES$ the string of \the [src].")
 
 /obj/item/gun/launcher/bow/proc/show_working_draw_message(mob/user)
 	if(user)
-		user.visible_message(
-			SPAN_NOTICE("\The [user] draws back the string of \the [src]!"),
-			SPAN_NOTICE("You continue drawing back the string of \the [src]!")
-		)
+		user.visible_action_message("continue", "drawing back the string of \the [src]!")
 
 /obj/item/gun/launcher/bow/proc/show_load_message(mob/user)
 	if(user)
-		user.visible_message(
-			SPAN_NOTICE("\The [user] nocks \the [_loaded] on \the [src]."),
-			SPAN_NOTICE("You nock \the [_loaded] on \the [src].")
-		)
+		user.visible_action_message("nock", "\the [_loaded] on \the [src].")
 
 /obj/item/gun/launcher/bow/proc/show_string_remove_message(mob/user)
 	if(user)
-		user.visible_message("\The [user] unstrings \the [src].")
+		user.visible_action_message("unstring", "\the [src].")
 
 /obj/item/gun/launcher/bow/proc/show_string_message(mob/user)
 	if(user)
-		user.visible_message("\The [user] strings \the [src] with \the [string].")
+		user.visible_action_message("string", "\the [src] with \the [string].")

--- a/code/modules/projectiles/guns/launcher/bows/crossbow.dm
+++ b/code/modules/projectiles/guns/launcher/bows/crossbow.dm
@@ -16,7 +16,4 @@
 
 /obj/item/gun/launcher/bow/crossbow/show_load_message(mob/user)
 	if(user)
-		user.visible_message(
-			SPAN_NOTICE("\The [user] slides \the [_loaded] into \the [src]."),
-			SPAN_NOTICE("You slide \the [_loaded] into \the [src].")
-		)
+		user.visible_action_message("slide", "\the [_loaded] into \the [src].")

--- a/code/modules/projectiles/guns/launcher/bows/sling.dm
+++ b/code/modules/projectiles/guns/launcher/bows/sling.dm
@@ -24,31 +24,19 @@
 
 /obj/item/gun/launcher/bow/sling/show_load_message(mob/user)
 	if(user)
-		user.visible_message(
-			SPAN_NOTICE("\The [user] drops \the [_loaded] into \the cup of \the [src]."),
-			SPAN_NOTICE("You drop \the [_loaded] into \the cup of \the [src].")
-		)
+		user.visible_action_message("drop", "\the [_loaded] into \the cup of \the [src].")
 
 /obj/item/gun/launcher/bow/sling/show_string_relax_message(mob/user)
 	if(user)
-		user.visible_message(
-			"\The [user] ceases swinging \the [src].",
-			"You cease swinging \the [src]."
-		)
+		user.visible_action_message("cease", "swinging \the [src].")
 
 /obj/item/gun/launcher/bow/sling/show_cancel_draw_message(mob/user)
 	if(user)
-		user.visible_message(
-			"\The [user] ceases swinging \the [src].",
-			"You cease swinging \the [src]."
-		)
+		user.visible_action_message("cease", "swinging \the [src].")
 
 /obj/item/gun/launcher/bow/sling/show_draw_message(mob/user)
 	if(user)
-		user.visible_message(
-			SPAN_NOTICE("\The [user] starts swinging \the [src]"),
-			SPAN_NOTICE("You start swinging \the [src].")
-		)
+		user.visible_action_message("start", "swinging \the [src].")
 
 /obj/item/gun/launcher/bow/sling/show_max_draw_message(mob/user)
 	return

--- a/code/modules/projectiles/guns/launcher/grenade_launcher.dm
+++ b/code/modules/projectiles/guns/launcher/grenade_launcher.dm
@@ -64,7 +64,7 @@
 	if(!user.try_unequip(G, src))
 		return
 	grenades.Insert(1, G) //add to the head of the list, so that it is loaded on the next pump
-	user.visible_message("\The [user] inserts \a [G] into \the [src].", "<span class='notice'>You insert \a [G] into \the [src].</span>")
+	user.visible_action_message("insert", "\a [G] into \the [src].")
 
 /obj/item/gun/launcher/grenade/proc/unload(mob/user)
 	if(grenades.len)

--- a/code/modules/projectiles/guns/launcher/syringe_gun.dm
+++ b/code/modules/projectiles/guns/launcher/syringe_gun.dm
@@ -122,10 +122,7 @@
 	var/obj/item/syringe_cartridge/C = darts[1]
 	darts -= C
 	user.put_in_hands(C)
-	user.visible_message(
-		SPAN_NOTICE("\The [user] removes \a [C] from \the [src]."),
-		SPAN_NOTICE("You remove \a [C] from \the [src].")
-	)
+	user.visible_action_message("remove", "\a [C] from \the [src].")
 	return TRUE
 
 /obj/item/gun/launcher/syringe/attackby(var/obj/item/used_item, mob/user)
@@ -137,7 +134,7 @@
 		if(!user.try_unequip(C, src))
 			return TRUE
 		darts += C //add to the end
-		user.visible_message("[user] inserts \a [C] into [src].", "<span class='notice'>You insert \a [C] into [src].</span>")
+		user.visible_action_message("insert", "\a [C] into [src].")
 		return TRUE
 	else
 		return ..()

--- a/code/modules/projectiles/guns/launcher/syringe_gun.dm
+++ b/code/modules/projectiles/guns/launcher/syringe_gun.dm
@@ -102,11 +102,11 @@
 
 /obj/item/gun/launcher/syringe/attack_self(mob/user)
 	if(next)
-		user.visible_message("[user] unlatches and carefully relaxes the bolt on [src].", "<span class='warning'>You unlatch and carefully relax the bolt on [src], unloading the spring.</span>")
+		user.visible_action_message("unlatch", "and carefully relax$USER_ES$", dangerous = ACTION_DANGER_WARNING, self_postfix = "the bolt on \the [src], unloading the spring.", other_postfix = "the bolt on \the [src].")
 		next = null
 	else if(darts.len)
 		playsound(src.loc, 'sound/weapons/flipblade.ogg', 50, 1)
-		user.visible_message("[user] draws back the bolt on [src], clicking it into place.", "<span class='warning'>You draw back the bolt on \the [src], loading the spring!</span>")
+		user.visible_action_message("draw", "back the bolt on \the [src],", dangerous = ACTION_DANGER_WARNING, self_postfix = "clicking it into place.", other_postfix = "loading the spring!")
 		next = darts[1]
 	add_fingerprint(user)
 

--- a/code/modules/projectiles/guns/projectile.dm
+++ b/code/modules/projectiles/guns/projectile.dm
@@ -158,7 +158,7 @@
 				if(!user.try_unequip(AM, src))
 					return
 				ammo_magazine = AM
-				user.visible_message("[user] inserts [AM] into [src].", "<span class='notice'>You insert [AM] into [src].</span>")
+				user.visible_action_message("insert", "\the [AM] into [src].")
 				playsound(loc, mag_insert_sound, 50, 1)
 			if(SPEEDLOADER)
 				if(loaded.len >= max_shells)
@@ -188,7 +188,7 @@
 		if(!user.try_unequip(C, src))
 			return
 		loaded.Insert(1, C) //add to the head of the list
-		user.visible_message("[user] inserts \a [C] into [src].", "<span class='notice'>You insert \a [C] into [src].</span>")
+		user.visible_action_message("insert", "\a [C] into [src].")
 		playsound(loc, load_sound, 50, 1)
 
 	update_icon()
@@ -206,7 +206,7 @@
 
 	if(ammo_magazine)
 		user.put_in_hands(ammo_magazine)
-		user.visible_message("[user] removes [ammo_magazine] from [src].", "<span class='notice'>You remove [ammo_magazine] from [src].</span>")
+		user.visible_action_message("remove", "\the [ammo_magazine] from [src].")
 		playsound(loc, mag_remove_sound, 50, 1)
 		ammo_magazine.update_icon()
 		ammo_magazine = null
@@ -231,7 +231,7 @@
 			var/obj/item/ammo_casing/C = loaded[loaded.len]
 			loaded.len--
 			user.put_in_hands(C)
-			user.visible_message("[user] removes \a [C] from [src].", "<span class='notice'>You remove \a [C] from [src].</span>")
+			user.visible_action_message("remove", "\a [C] from [src].")
 			. = TRUE
 	if(.)
 		update_icon()

--- a/code/modules/reagents/reagent_containers/drinks/cocktailshaker.dm
+++ b/code/modules/reagents/reagent_containers/drinks/cocktailshaker.dm
@@ -10,17 +10,17 @@
 
 /obj/item/chems/drinks/shaker/attack_self(mob/user)
 	if(user.skill_check(SKILL_COOKING, SKILL_PROF))
-		user.visible_message("<span class='rose'>\The [user] shakes \the [src] briskly in one hand, with supreme confidence and competence.</span>", "<span class='rose'>You shake \the [src] briskly with one hand.</span>")
+		user.visible_action_message("shake", "\the [src] briskly in one hand", dangerous = "rose", self_postfix = ".", other_postfix = ", with supreme confidence and competence.")
 		mix()
 		return
 	if(user.skill_check(SKILL_COOKING, SKILL_ADEPT))
-		user.visible_message(SPAN_NOTICE("\The [user] shakes \the [src] briskly, with some skill."), SPAN_NOTICE("You shake \the [src] briskly, with some skill."))
+		user.visible_action_message("shake", "\the [src] briskly, with some skill.")
 		mix()
 		return
 	else
-		user.visible_message(SPAN_NOTICE("\The [user] shakes \the [src] gingerly."), SPAN_NOTICE("You shake \the [src] gingerly."))
+		user.visible_action_message("shake", "\the [src] gingerly.")
 		if(prob(15) && (reagents && REAGENT_TOTAL_VOLUME(reagents)))
-			user.visible_message(SPAN_WARNING("\The [user] spills the contents of \the [src] over themselves!"), SPAN_WARNING("You spill the contents of \the [src] over yourself!"))
+			user.visible_action_message("spill", "the contents of \the [src] over $USER_SELF$!", dangerous = ACTION_DANGER_WARNING)
 			reagents.splash(user, REAGENT_TOTAL_VOLUME(reagents))
 		else
 			mix()

--- a/code/modules/reagents/reagent_containers/dropper.dm
+++ b/code/modules/reagents/reagent_containers/dropper.dm
@@ -33,7 +33,7 @@
 			if(user.check_intent(I_FLAG_HELP))
 				return
 
-			var/time = 20 //2/3rds the time of a syringe
+			var/time = 2 SECONDS //2/3rds the time of a syringe
 			user.visible_message(SPAN_DANGER("\The [user] is trying to squirt something into \the [target]'s eyes!"))
 
 			if(!do_mob(user, target, time))
@@ -45,10 +45,7 @@
 					var/obj/item/safe_thing = victim.get_equipped_item(slot)
 					if(safe_thing && (safe_thing.body_parts_covered & SLOT_EYES))
 						trans = reagents.splash(safe_thing, amount_per_transfer_from_this, max_spill=30)
-						user.visible_message(
-							SPAN_DANGER("\The [user] tries to squirt something into [target]'s eyes, but fails!"),
-							SPAN_DANGER("You squirt [trans] unit\s at \the [target]'s eyes, but fail!")
-						)
+						user.targeted_visible_action_message(target, "try to squirt", "into $TARGET'S$ eyes, but fail$USER_S$!", dangerous = ACTION_DANGER_ALL, self_infix = "[trans] unit\s", other_infix = "something")
 						return
 
 			var/mob/living/M = target
@@ -58,7 +55,7 @@
 			var/spill_amt = M.incapacitated()? 0 : 30
 			trans += reagents.splash(M, REAGENT_TOTAL_VOLUME(reagents)/2, max_spill = spill_amt)
 			trans += reagents.trans_to_mob(M, REAGENT_TOTAL_VOLUME(reagents)/2, CHEM_INJECT) //I guess it gets into the bloodstream through the eyes or something
-			user.visible_message(SPAN_DANGER("[user] squirts something into \the [target]'s eyes!"), SPAN_DANGER("You squirt [trans] unit\s into \the [target]'s eyes!"))
+			user.targeted_visible_action_message(target, "squirt", "into $TARGET'S$ eyes!", dangerous = ACTION_DANGER_ALL, self_infix = "[trans] unit\s", other_infix = "something")
 			return
 		else
 			trans = reagents.splash(target, amount_per_transfer_from_this, max_spill=0) //sprinkling reagents on generic non-mobs. Droppers are very precise

--- a/code/modules/reagents/reagent_containers/food/canned/_canned.dm
+++ b/code/modules/reagents/reagent_containers/food/canned/_canned.dm
@@ -37,19 +37,16 @@
 /obj/item/food/can/attackby(obj/item/used_item, mob/user)
 	if(!ATOM_IS_OPEN_CONTAINER(src))
 		if(istype(used_item, /obj/item/knife))
-			user.visible_message(
-				SPAN_NOTICE("\The [user] starts trying to open \the [src] with \the [used_item]."),
-				SPAN_NOTICE("You start to open \the [src].")
-			)
+			user.visible_action_message("start", "trying to open \the [src] with \the [used_item].")
 			var/open_timer = istype(used_item, /obj/item/knife/opener) ? 5 SECONDS : 15 SECONDS
 			if(!do_after(user, open_timer, src))
-				to_chat(user, SPAN_WARNING("You must remain uninterrupted to open \the [src]."))
+				user.self_action_message("must", "remain uninterrupted to open \the [src].", ACTION_DANGER_OTHERS)
 				return TRUE
-			to_chat(user, SPAN_NOTICE("You unseal \the [src] with a crack of metal."))
+			user.self_action_message("unseal", "\the [src] with a crack of metal.")
 			unseal()
 			return TRUE
 		else if(istype(used_item,/obj/item/utensil))
-			to_chat(user, SPAN_WARNING("You need a can opener to open this!"))
+			user.self_action_message("need", "a can opener to open \the [src]!", ACTION_DANGER_OTHERS)
 			return TRUE
 	return ..()
 

--- a/code/modules/reagents/reagent_containers/food/donkpocket.dm
+++ b/code/modules/reagents/reagent_containers/food/donkpocket.dm
@@ -66,7 +66,7 @@
 		to_chat(user, "<span class='notice'>The heating chemicals have already been spent.</span>")
 		return
 	has_been_heated = 1
-	user.visible_message("<span class='notice'>[user] crushes \the [src] package.</span>", "You crush \the [src] package and feel a comfortable heat build up.")
+	user.visible_action_message("crush", "\the [src]", self_postfix = "package and feel a comfortable heat build up.", other_postfix = "package.")
 	addtimer(CALLBACK(src, PROC_REF(heat), weakref(user)), 20 SECONDS)
 
 /obj/item/food/donkpocket/sinpocket/heat(weakref/message_to)

--- a/code/modules/reagents/reagent_containers/inhaler.dm
+++ b/code/modules/reagents/reagent_containers/inhaler.dm
@@ -46,7 +46,7 @@
 		return ..()
 
 	if(ATOM_IS_OPEN_CONTAINER(src))
-		to_chat(user, SPAN_NOTICE("You must secure the reagents inside \the [src] before using it!"))
+		to_chat(user, SPAN_NOTICE(user.get_action_string(TRUE, "must", "secure the reagents inside \the [src] before using it!")))
 		return FALSE
 
 	if(!REAGENT_TOTAL_VOLUME(reagents))
@@ -61,21 +61,19 @@
 
 	if(user == target)
 		user.visible_message(
-			SPAN_NOTICE("\The [user] inhales from \the [src]."),
-			SPAN_NOTICE("You stick \the [src] in your mouth and press the injection button.")
+			SPAN_NOTICE(user.get_targeted_action_string(target, FALSE, "inhale", "from \the [src].")),
+			SPAN_NOTICE(user.get_targeted_action_string(target, TRUE, "stick", "\the [src] in $TARGET'S$ mouth and press$USER_ES$ the dispenser button."))
 		)
 	else
-		user.visible_message(
-			SPAN_WARNING("\The [user] attempts to administer \the [src] to \the [target]..."),
-			SPAN_NOTICE("You attempt to administer \the [src] to \the [target]...")
-		)
+		user.targeted_visible_action_message(target, "attempt", "to administer \the [src] to $TARGET$...")
 		if (!do_after(user, 1 SECONDS, target))
-			to_chat(user, SPAN_NOTICE("You and the target need to be standing still in order to inject \the [src]."))
+			var/decl/pronouns/self_pronouns = user.get_self_pronouns()
+			to_chat(user, SPAN_NOTICE("[self_pronouns.He] and the target need to be standing still in order to administer \the [src]."))
 			return TRUE
 
 		user.visible_message(
-			SPAN_NOTICE("\The [user] administers \the [src] to \the [target]."),
-			SPAN_NOTICE("You stick \the [src] in \the [target]'s mouth and press the injection button.")
+			SPAN_NOTICE(user.get_targeted_action_string(target, FALSE, "administer", "\the [src] to $TARGET$.")),
+			SPAN_NOTICE(user.get_targeted_action_string(target, TRUE, "stick", "\the [src] in $TARGET'S$ mouth and press$USER_ES$ the dispenser button."))
 		)
 
 	var/contained = REAGENT_LIST(reagents)
@@ -90,20 +88,22 @@
 	return TRUE
 
 /obj/item/chems/inhaler/attack_self(mob/user)
+	var/decl/pronouns/self_pronouns = user.get_self_pronouns()
 	if(ATOM_IS_OPEN_CONTAINER(src))
 		if(REAGENT_TOTAL_VOLUME(reagents) > 0)
-			to_chat(user, SPAN_NOTICE("With a quick twist of \the [src]'s lid, you secure the reagents inside."))
+			to_chat(user, SPAN_NOTICE("With a quick twist of \the [src]'s lid, [self_pronouns.he] [verb_agree_with_pronouns("secure", self_pronouns)] the reagents inside."))
 			atom_flags &= ~ATOM_FLAG_OPEN_CONTAINER
 			update_icon()
 		else
-			to_chat(user, SPAN_NOTICE("You can't secure \the [src] without putting reagents in!"))
+			to_chat(user, SPAN_NOTICE("[self_pronouns.He] can't secure \the [src] without putting reagents in!"))
 	else
 		to_chat(user, SPAN_NOTICE("The reagents inside \the [src] are already secured."))
 	return TRUE
 
 /obj/item/chems/inhaler/attackby(obj/item/used_item, mob/user)
 	if(IS_SCREWDRIVER(used_item) && !ATOM_IS_OPEN_CONTAINER(src))
-		to_chat(user, SPAN_NOTICE("Using \the [used_item], you unsecure the inhaler's lid.")) // it locks shut after being secured
+		var/decl/pronouns/self_pronouns = user.get_self_pronouns()
+		to_chat(user, SPAN_NOTICE("Using \the [used_item], [self_pronouns.he] [verb_agree_with_pronouns("unsecure", self_pronouns)] the inhaler's lid.")) // it locks shut after being secured
 		atom_flags |= ATOM_FLAG_OPEN_CONTAINER
 		update_icon()
 		return TRUE

--- a/code/modules/reagents/reagent_dispenser.dm
+++ b/code/modules/reagents/reagent_dispenser.dm
@@ -228,7 +228,7 @@
 		user.put_in_active_hand(cup)
 		cups--
 		if(!skip_text)
-			visible_message("\The [user] grabs a paper cup from \the [src].", "You grab a paper cup from \the [src]'s cup compartment.")
+			user.visible_action_message("grab", "a paper cup from \the [src]'s cup compartment.")
 		return TRUE
 
 	if(!skip_text)

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -147,13 +147,11 @@ var/global/list/diversion_junctions = list()
 		src.add_fingerprint(user)
 		var/old_loc = AM.loc
 		if(AM == user)
-			user.visible_message("<span class='warning'>[user] starts climbing into [src].</span>", \
-								"<span class='notice'>You start climbing into [src].</span>")
+			user.visible_action_message("start", "climbing into \the [src].", dangerous = ACTION_DANGER_WARNING)
 		else
 			if(istype(M) && isliving(user))
 				M.last_handled_by_mob = weakref(user)
-			user.visible_message("<span class='[is_dangerous ? "warning" : "notice"]'>[user] starts stuffing [AM] into [src].</span>", \
-								"<span class='notice'>You start stuffing [AM] into [src].</span>")
+			user.visible_action_message("start", "stuffing \the [AM] into \the [src].", dangerous = is_dangerous ? ACTION_DANGER_WARNING : ACTION_DANGER_NONE)
 
 		if(!do_after(user, 2 SECONDS, src))
 			return FALSE

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -106,7 +106,7 @@ var/global/list/diversion_junctions = list()
 	if(!user.try_unequip(used_item, src) || QDELETED(used_item))
 		return
 
-	user.visible_message("\The [user] places \the [used_item] into \the [src].", "You place \the [used_item] into \the [src].")
+	user.visible_action_message("place", "\the [used_item] into \the [src].")
 
 	update_icon()
 
@@ -168,12 +168,10 @@ var/global/list/diversion_junctions = list()
 
 		// Messages and logging
 		if(AM == user)
-			user.visible_message("<span class='danger'>[user] climbs into [src].</span>", \
-								"<span class='notice'>You climb into [src].</span>")
+			user.visible_action_message("climb", "into \the [src].", dangerous = ACTION_DANGER_OTHERS)
 			admin_attack_log(user, null, "Stuffed themselves into \the [src].", null, "stuffed themselves into \the [src].")
 		else
-			user.visible_message("<span class='[is_dangerous ? "danger" : "notice"]'>[user] stuffs [AM] into [src][is_dangerous ? "!" : "."]</span>", \
-								"<span class='notice'>You stuff [AM] into [src].</span>")
+			user.visible_action_message("stuff", "\the [AM] into \the [src][is_dangerous ? "!" : "."]", dangerous = is_dangerous ? ACTION_DANGER_OTHERS : ACTION_DANGER_NONE)
 			if(ismob(M))
 				admin_attack_log(user, M, "Placed the victim into \the [src].", "Was placed into \the [src] by the attacker.", "stuffed \the [src] with")
 				if (M.client)

--- a/code/modules/recycling/wrapped_package.dm
+++ b/code/modules/recycling/wrapped_package.dm
@@ -154,10 +154,10 @@
 	return TRUE
 
 /obj/item/parcel/proc/unwrap(var/mob/user)
-	visible_message(SPAN_NOTICE("\The [user] starts tearing the wrapping off \the [src]."), SPAN_NOTICE("You start tearing the wrapping off \the [src]."))
+	user.visible_action_message("start", "tearing the wrapping off \the [src].")
 	//I guess cargo techs would definitely be faster at opening packages.
 	if(user.do_skilled(3 SECONDS, SKILL_HAULING, src))
-		visible_message(SPAN_NOTICE("\The [user] unwrapped \the [src]!"), SPAN_NOTICE("You unwrapped \the [src]!"))
+		user.visible_action_message("unwrap", "\the [src]!")
 		if(!length(contents))
 			to_chat(user, SPAN_WARNING("\The [src] was empty!"))
 		playsound(src, 'sound/items/poster_ripped.ogg', 50, TRUE)

--- a/code/modules/species/species.dm
+++ b/code/modules/species/species.dm
@@ -596,9 +596,9 @@ var/global/const/DEFAULT_SPECIES_HEALTH = 200
 		target.apply_effect(push_mod, WEAKEN, armor_check)
 		playsound(target.loc, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
 		if(armor_check < 100)
-			target.visible_message("<span class='danger'>[attacker] has pushed [target]!</span>")
+			attacker.targeted_visible_action_message(target, "push", "$TARGET$!", ACTION_DANGER_ALL)
 		else
-			target.visible_message("<span class='warning'>[attacker] attempted to push [target]!</span>")
+			attacker.targeted_visible_action_message(target, "attempt", "to push $TARGET$!", ACTION_DANGER_ALL)
 		return
 
 	if(randn <= 60)
@@ -610,12 +610,12 @@ var/global/const/DEFAULT_SPECIES_HEALTH = 200
 		//Actually disarm them
 		for(var/obj/item/I in holding)
 			if(I && target.try_unequip(I))
-				target.visible_message("<span class='danger'>[attacker] has disarmed [target]!</span>")
+				attacker.targeted_visible_action_message(target, "disarm", "$TARGET$!", ACTION_DANGER_ALL)
 				playsound(target.loc, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
 				return
 
 	playsound(target.loc, 'sound/weapons/punchmiss.ogg', 25, 1, -1)
-	target.visible_message("<span class='danger'>[attacker] attempted to disarm \the [target]!</span>")
+	attacker.targeted_visible_action_message(target, "attempt", "to disarm $TARGET$!", ACTION_DANGER_ALL)
 
 /decl/species/proc/disfigure_msg(var/mob/living/human/H) //Used for determining the message a disfigured face has on examine. To add a unique message, just add this onto a specific species and change the "return" message.
 	var/decl/pronouns/pronouns = H.get_pronouns()

--- a/code/modules/surgery/bones.dm
+++ b/code/modules/surgery/bones.dm
@@ -90,22 +90,20 @@
 	var/bone = affected.encased ? "\the [target]'s [affected.encased]" : "bones in \the [target]'s [affected.name]"
 	if (affected.status & ORGAN_BROKEN)
 		if(affected.encased == "skull")
-			user.visible_message("<span class='notice'>\The [user] pieces [bone] back together with \the [tool].</span>", \
-				"<span class='notice'>You piece [bone] back together with \the [tool].</span>")
+			user.visible_action_message("piece", "[bone] back together with \the [tool].")
 		else
-			user.visible_message("<span class='notice'>\The [user] sets [bone] in place with \the [tool].</span>", \
-				"<span class='notice'>You set [bone] in place with \the [tool].</span>")
+			user.visible_action_message("set", "[bone] in place with \the [tool].")
 		affected.stage = 2
 		..() // The pseudo-fail condition below plays a fracture sound anyway.
 	else
-		user.visible_message("<span class='notice'>\The [user] sets [bone]</span> <span class='warning'>in the WRONG place with \the [tool].</span>", \
-			"<span class='notice'>You set [bone]</span> <span class='warning'>in the WRONG place with \the [tool].</span>")
+		user.visible_action_message("set", "[bone]</span> <span class='warning'>in the WRONG place with \the [tool].")
 		affected.fracture()
 
 /decl/surgery_step/bone/set_bone/fail_step(mob/living/user, mob/living/target, target_zone, obj/item/tool)
+	var/decl/pronouns/self_pronouns = user.get_self_pronouns()
 	var/obj/item/organ/external/affected = GET_EXTERNAL_ORGAN(target, target_zone)
-	user.visible_message("<span class='warning'>\The [user]'s hand slips, damaging the [affected.encased ? affected.encased : "bones"] in \the [target]'s [affected.name] with \the [tool]!</span>" , \
-		"<span class='warning'>Your hand slips, damaging the [affected.encased ? affected.encased : "bones"] in \the [target]'s [affected.name] with \the [tool]!</span>")
+	user.visible_message(SPAN_WARNING("\The [user]'s hand slips, damaging the [affected.encased ? affected.encased : "bones"] in \the [target]'s [affected.name] with \the [tool]!"), \
+		SPAN_WARNING("[self_pronouns.His] hand slips, damaging the [affected.encased ? affected.encased : "bones"] in \the [target]'s [affected.name] with \the [tool]!"))
 	affected.fracture()
 	affected.take_damage(5, inflicter = tool)
 	..()
@@ -131,8 +129,7 @@
 /decl/surgery_step/bone/finish/begin_step(mob/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = GET_EXTERNAL_ORGAN(target, target_zone)
 	var/bone = affected.encased ? "\the [target]'s damaged [affected.encased]" : "damaged bones in \the [target]'s [affected.name]"
-	user.visible_message("[user] starts to finish mending [bone] with \the [tool].", \
-	"You start to finish mending [bone] with \the [tool].")
+	user.visible_action_message("start", "to finish mending [bone] with \the [tool].")
 	..()
 
 /decl/surgery_step/bone/finish/end_step(mob/living/user, mob/living/target, target_zone, obj/item/tool)
@@ -140,12 +137,12 @@
 	var/bone = affected.encased ? "\the [target]'s damaged [affected.encased]" : "damaged bones in [target]'s [affected.name]"
 	// if it's too damaged to mend/will just re-break, warn them and don't lower our stage
 	if(affected.mend_fracture())
-		user.visible_message(SPAN_NOTICE("[user] has mended [bone] with \the [tool].")  , \
-			SPAN_NOTICE("You have mended [bone] with \the [tool]."))
+		user.visible_action_message("mend", "[bone] with \the [tool].")
 		affected.stage = 0
 	else
+		var/decl/pronouns/self_pronouns = user.get_self_pronouns()
 		user.visible_message(SPAN_WARNING("[user] attempted to mend [bone] with \the [tool], but it was too damaged!"),
-			SPAN_WARNING("You failed to mend [bone] with \the [tool], as it is too damaged."))
+			SPAN_WARNING("[self_pronouns.He] failed to mend [bone] with \the [tool], as it is too damaged."))
 	affected.update_wounds()
 	..()
 

--- a/code/modules/surgery/bones.dm
+++ b/code/modules/surgery/bones.dm
@@ -32,18 +32,16 @@
 
 /decl/surgery_step/bone/glue/begin_step(mob/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = GET_EXTERNAL_ORGAN(target, target_zone)
-	var/bone = affected.encased ? "\the [target]'s [affected.encased]" : "bones in \the [target]'s [affected.name]"
+	var/bone = affected.encased ? "$TARGET'S$ [affected.encased]" : "bones in $TARGET'S$ [affected.name]"
 	if (affected.stage == 0)
-		user.visible_message("\The [user] starts applying \the [tool] to [bone]." , \
-		"You start applying \the [tool] to [bone].")
+		user.targeted_visible_action_message(target, "start", "applying some [tool.name] to [bone].")
 	target.custom_pain("Something in your [affected.name] is causing you a lot of pain!",50, affecting = affected)
 	..()
 
 /decl/surgery_step/bone/glue/end_step(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = GET_EXTERNAL_ORGAN(target, target_zone)
-	var/bone = affected.encased ? "\the [target]'s [affected.encased]" : "bones in \the [target]'s [affected.name]"
-	user.visible_message("<span class='notice'>[user] applies some [tool.name] to [bone]</span>", \
-		"<span class='notice'>You apply some [tool.name] to [bone].</span>")
+	var/bone = affected.encased ? "$TARGET'S$ [affected.encased]" : "bones in $TARGET'S$ [affected.name]"
+	user.targeted_visible_action_message(target, "apply", "some [tool.name] to [bone].")
 	if(affected.stage == 0)
 		affected.stage = 1
 	affected.status &= ~ORGAN_BRITTLE
@@ -75,28 +73,26 @@
 
 /decl/surgery_step/bone/set_bone/begin_step(mob/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = GET_EXTERNAL_ORGAN(target, target_zone)
-	var/bone = affected.encased ? "\the [target]'s [affected.encased]" : "bones in \the [target]'s [affected.name]"
+	var/bone = affected.encased ? "$TARGET'S$ [affected.encased]" : "bones in $TARGET'S$ [affected.name]"
 	if(affected.encased == "skull")
-		user.visible_message("[user] is beginning to piece [bone] back together with \the [tool]." , \
-			"You are beginning to piece [bone] back together with \the [tool].")
+		user.targeted_visible_action_message(target, "begin", "piecing [bone] back together with \the [tool].")
 	else
-		user.visible_message("[user] is beginning to set [bone] in place with \the [tool]." , \
-			"You are beginning to set [bone] in place with \the [tool].")
+		user.targeted_visible_action_message(target, "begin", "setting [bone] in place with \the [tool].")
 	target.custom_pain("The pain in your [affected.name] is going to make you pass out!",50, affecting = affected)
 	..()
 
 /decl/surgery_step/bone/set_bone/end_step(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = GET_EXTERNAL_ORGAN(target, target_zone)
-	var/bone = affected.encased ? "\the [target]'s [affected.encased]" : "bones in \the [target]'s [affected.name]"
+	var/bone = affected.encased ? "$TARGET'S$ [affected.encased]" : "bones in $TARGET'S$ [affected.name]"
 	if (affected.status & ORGAN_BROKEN)
 		if(affected.encased == "skull")
-			user.visible_action_message("piece", "[bone] back together with \the [tool].")
+			user.targeted_visible_action_message(target, "piece", "[bone] back together with \the [tool].")
 		else
-			user.visible_action_message("set", "[bone] in place with \the [tool].")
+			user.targeted_visible_action_message(target, "set", "[bone] in place with \the [tool].")
 		affected.stage = 2
 		..() // The pseudo-fail condition below plays a fracture sound anyway.
 	else
-		user.visible_action_message("set", "[bone]</span> <span class='warning'>in the WRONG place with \the [tool].")
+		user.targeted_visible_action_message(target, "set", "[bone]</span> <span class='warning'>in the WRONG place with \the [tool].")
 		affected.fracture()
 
 /decl/surgery_step/bone/set_bone/fail_step(mob/living/user, mob/living/target, target_zone, obj/item/tool)
@@ -128,21 +124,19 @@
 
 /decl/surgery_step/bone/finish/begin_step(mob/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = GET_EXTERNAL_ORGAN(target, target_zone)
-	var/bone = affected.encased ? "\the [target]'s damaged [affected.encased]" : "damaged bones in \the [target]'s [affected.name]"
-	user.visible_action_message("start", "to finish mending [bone] with \the [tool].")
+	var/bone = affected.encased ? "$TARGET'S$ [affected.encased]" : "bones in $TARGET'S$ [affected.name]"
+	user.targeted_visible_action_message(target, "start", "to finish mending [bone] with \the [tool].")
 	..()
 
 /decl/surgery_step/bone/finish/end_step(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = GET_EXTERNAL_ORGAN(target, target_zone)
-	var/bone = affected.encased ? "\the [target]'s damaged [affected.encased]" : "damaged bones in [target]'s [affected.name]"
+	var/bone = affected.encased ? "$TARGET'S$ [affected.encased]" : "bones in $TARGET'S$ [affected.name]"
 	// if it's too damaged to mend/will just re-break, warn them and don't lower our stage
 	if(affected.mend_fracture())
-		user.visible_action_message("mend", "[bone] with \the [tool].")
+		user.targeted_visible_action_message(target, "mend", "[bone] with \the [tool].")
 		affected.stage = 0
 	else
-		var/decl/pronouns/self_pronouns = user.get_self_pronouns()
-		user.visible_message(SPAN_WARNING("[user] attempted to mend [bone] with \the [tool], but it was too damaged!"),
-			SPAN_WARNING("[self_pronouns.He] failed to mend [bone] with \the [tool], as it is too damaged."))
+		user.targeted_visible_action_message(target, "fail", "to mend [bone] with \the [tool], as it is too damaged!", dangerous = ACTION_DANGER_WARNING)
 	affected.update_wounds()
 	..()
 

--- a/code/modules/surgery/encased.dm
+++ b/code/modules/surgery/encased.dm
@@ -29,8 +29,7 @@
 
 /decl/surgery_step/open_encased/begin_step(mob/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = GET_EXTERNAL_ORGAN(target, target_zone)
-	user.visible_message("[user] begins to cut through [target]'s [affected.encased] with \the [tool].", \
-	"You begin to cut through [target]'s [affected.encased] with \the [tool].")
+	user.visible_action_message("begin", "to cut through [target]'s [affected.encased] with \the [tool].")
 	target.custom_pain("Something hurts horribly in your [affected.name]!",60, affecting = affected)
 	..()
 

--- a/code/modules/surgery/face.dm
+++ b/code/modules/surgery/face.dm
@@ -20,13 +20,11 @@
 			return affected
 
 /decl/surgery_step/fix_face/begin_step(mob/user, mob/living/target, target_zone, obj/item/tool)
-	user.visible_message("[user] starts repairing damage to \the [target]'s face with \the [tool].", \
-	"You start repairing damage to \the [target]'s face with \the [tool].")
+	user.visible_action_message("start", "repairing damage to \the [target]'s face with \the [tool].")
 	..()
 
 /decl/surgery_step/fix_face/end_step(mob/living/user, mob/living/target, target_zone, obj/item/tool)
-	user.visible_message("<span class='notice'>[user] repairs \the [target]'s face with \the [tool].</span>",	\
-	"<span class='notice'>You repair \the [target]'s face with \the [tool].</span>")
+	user.visible_action_message("repair", "\the [target]'s face with \the [tool].")
 	var/obj/item/organ/external/h = GET_EXTERNAL_ORGAN(target, target_zone)
 	if(h)
 		h.status &= ~ORGAN_DISFIGURED

--- a/code/modules/surgery/generic.dm
+++ b/code/modules/surgery/generic.dm
@@ -41,8 +41,7 @@
 
 /decl/surgery_step/generic/cut_open/begin_step(mob/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = GET_EXTERNAL_ORGAN(target, target_zone)
-	user.visible_message("[user] starts [access_string] on [target]'s [affected.name] with \the [tool].", \
-	"You start [access_string] on [target]'s [affected.name] with \the [tool].")
+	user.visible_action_message("start", "[access_string] on [target]'s [affected.name] with \the [tool].")
 	target.custom_pain("You feel a horrible pain as if from a sharp knife in your [affected.name]!",40, affecting = affected)
 	..()
 
@@ -94,15 +93,13 @@
 
 /decl/surgery_step/generic/clamp_bleeders/begin_step(mob/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = GET_EXTERNAL_ORGAN(target, target_zone)
-	user.visible_message("[user] starts clamping bleeders in [target]'s [affected.name] with \the [tool].", \
-	"You start clamping bleeders in [target]'s [affected.name] with \the [tool].")
+	user.visible_action_message("start", "clamping bleeders in [target]'s [affected.name] with \the [tool].")
 	target.custom_pain("The pain in your [affected.name] is maddening!",40, affecting = affected)
 	..()
 
 /decl/surgery_step/generic/clamp_bleeders/end_step(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = GET_EXTERNAL_ORGAN(target, target_zone)
-	user.visible_message("<span class='notice'>[user] clamps bleeders in [target]'s [affected.name] with \the [tool].</span>",	\
-	"<span class='notice'>You clamp bleeders in [target]'s [affected.name] with \the [tool].</span>")
+	user.visible_action_message("clamp", "bleeders in [target]'s [affected.name] with \the [tool].")
 	affected.clamp_organ()
 	spread_germs_to_organ(affected, user)
 	..()
@@ -141,15 +138,13 @@
 
 /decl/surgery_step/generic/retract_skin/begin_step(mob/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = GET_EXTERNAL_ORGAN(target, target_zone)
-	user.visible_message("[user] starts to pry open the incision on [target]'s [affected.name] with \the [tool].",	\
-	"You start to pry open the incision on [target]'s [affected.name] with \the [tool].")
+	user.visible_action_message("start", "to pry open the incision on [target]'s [affected.name] with \the [tool].")
 	target.custom_pain("It feels like the skin on your [affected.name] is on fire!",40,affecting = affected)
 	..()
 
 /decl/surgery_step/generic/retract_skin/end_step(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = GET_EXTERNAL_ORGAN(target, target_zone)
-	user.visible_message("<span class='notice'>[user] keeps the incision open on [target]'s [affected.name] with \the [tool].</span>",	\
-	"<span class='notice'>You keep the incision open on [target]'s [affected.name] with \the [tool].</span>")
+	user.visible_action_message("keep", "the incision open on [target]'s [affected.name] with \the [tool].")
 	affected.open_incision()
 	..()
 
@@ -282,9 +277,7 @@
 /decl/surgery_step/generic/amputate/fail_step(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = GET_EXTERNAL_ORGAN(target, target_zone)
 	if(user.try_unequip(tool, affected))
-		user.visible_message(
-			SPAN_DANGER("\The [user] manages to get \the [tool] stuck in \the [target]'s [affected.name]!"), \
-			SPAN_DANGER("You manage to get \the [tool] stuck in \the [target]'s [affected.name]!"))
+		user.visible_action_message("manage", "to get \the [tool] stuck in \the [target]'s [affected.name]!", dangerous = ACTION_DANGER_ALL)
 		affected.embed_in_organ(tool, affected.take_damage(30, damage_flags = (DAM_SHARP|DAM_EDGE), inflicter = tool))
 	else
 		user.visible_message(

--- a/code/modules/surgery/implant.dm
+++ b/code/modules/surgery/implant.dm
@@ -213,8 +213,7 @@
 			SPAN_NOTICE("There's something inside [target]'s [affected.name], but you just missed it this time.") )
 			playsound(target.loc, "rustle", 15, TRUE)
 	else
-		user.visible_message(SPAN_NOTICE("[user] could not find anything inside [target]'s [affected.name], and pulls \the [tool] out."), \
-		SPAN_NOTICE("You could not find anything inside [target]'s [affected.name].") )
+		user.targeted_visible_action_message(target, "could not find", "anything inside", self_postfix = "$TARGET'S$ [affected.name].", other_postfix = "$TARGET'S$ [affected.name], and pulls \the [tool] out.")
 		playsound(target.loc, "rustle", 15, TRUE)
 
 

--- a/code/modules/surgery/implant.dm
+++ b/code/modules/surgery/implant.dm
@@ -44,16 +44,14 @@
 
 /decl/surgery_step/cavity/make_space/begin_step(mob/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = GET_EXTERNAL_ORGAN(target, target_zone)
-	user.visible_message("[user] starts making some space inside [target]'s [affected.cavity_name] with \the [tool].", \
-	"You start making some space inside [target]'s [affected.cavity_name] with \the [tool]." )
+	user.targeted_visible_action_message(target, "start", "making some space inside $TARGET'S$ [affected.cavity_name] with \the [tool].")
 	target.custom_pain("The pain in your chest is living hell!",1,affecting = affected)
 	affected.cavity = TRUE
 	..()
 
 /decl/surgery_step/cavity/make_space/end_step(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = GET_EXTERNAL_ORGAN(target, target_zone)
-	user.visible_message(SPAN_NOTICE("[user] makes some space inside [target]'s \the [affected.cavity_name] with \the [tool]."), \
-	SPAN_NOTICE("You make some space inside [target]'s \the [affected.cavity_name] with \the [tool].") )
+	user.targeted_visible_action_message(target, "make", "some space inside $TARGET'S$ \the [affected.cavity_name] with \the [tool].")
 	..()
 
 //////////////////////////////////////////////////////////////////
@@ -76,15 +74,13 @@
 
 /decl/surgery_step/cavity/close_space/begin_step(mob/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = GET_EXTERNAL_ORGAN(target, target_zone)
-	user.visible_message("[user] starts mending [target]'s \the [affected.cavity_name] wall with \the [tool].", \
-	"You start mending [target]'s \the [affected.cavity_name] wall with \the [tool]." )
+	user.targeted_visible_action_message(target, "start", "mending $TARGET'S$ [affected.cavity_name] wall with \the [tool].")
 	target.custom_pain("The pain in your chest is living hell!",1,affecting = affected)
 	..()
 
 /decl/surgery_step/cavity/close_space/end_step(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = GET_EXTERNAL_ORGAN(target, target_zone)
-	user.visible_message(SPAN_NOTICE("[user] mends [target]'s \the [affected.cavity_name] walls with \the [tool]."), \
-	SPAN_NOTICE("You mend [target]'s \the [affected.cavity_name] walls with \the [tool].") )
+	user.targeted_visible_action_message(target, "mend", "$TARGET'S$ [affected.cavity_name] walls with \the [tool].")
 	affected.cavity = FALSE
 	..()
 
@@ -131,8 +127,7 @@
 
 /decl/surgery_step/cavity/place_item/begin_step(mob/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = GET_EXTERNAL_ORGAN(target, target_zone)
-	user.visible_message("[user] starts putting \the [tool] inside [target]'s \the [affected.cavity_name].", \
-	"You start putting \the [tool] inside [target]'s \the [affected.cavity_name]." )
+	user.targeted_visible_action_message(target, "start", "putting \the [tool] inside $TARGET'S$ [affected.cavity_name].")
 	target.custom_pain("The pain in your chest is living hell!",1,affecting = affected)
 	..()
 
@@ -140,8 +135,7 @@
 	var/obj/item/organ/external/affected = GET_EXTERNAL_ORGAN(target, target_zone)
 	if(!user.try_unequip(tool, affected))
 		return
-	user.visible_message(SPAN_NOTICE("[user] puts \the [tool] inside [target]'s \the [affected.cavity_name]."), \
-	SPAN_NOTICE("You put \the [tool] inside [target]'s \the [affected.cavity_name].") )
+	user.visible_action_message("put", "\the [tool] inside [target]'s \the [affected.cavity_name].")
 	if (tool.w_class > affected.cavity_max_w_class/2 && prob(50) && !BP_IS_PROSTHETIC(affected) && affected.sever_artery())
 		to_chat(user, SPAN_WARNING("You tear some blood vessels trying to fit such a big object in this cavity."))
 		affected.owner.custom_pain("You feel something rip in your [affected.name]!", 1,affecting = affected)
@@ -173,8 +167,7 @@
 
 /decl/surgery_step/cavity/implant_removal/begin_step(mob/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = GET_EXTERNAL_ORGAN(target, target_zone)
-	user.visible_message("[user] starts poking around inside [target]'s [affected.name] with \the [tool].", \
-	"You start poking around inside [target]'s [affected.name] with \the [tool]." )
+	user.targeted_visible_action_message(target, "start", "poking around inside $TARGET'S$ [affected.name] with \the [tool].")
 	target.custom_pain("The pain in your [affected.name] is living hell!",1,affecting = affected)
 	..()
 
@@ -211,8 +204,7 @@
 			find_prob += 50
 
 		if (prob(find_prob))
-			user.visible_message(SPAN_NOTICE("[user] takes something out of the incision on [target]'s [affected.name] with \the [tool]."), \
-			SPAN_NOTICE("You take \the [obj] out of the incision on \the [target]'s [affected.name] with \the [tool].") )
+			user.targeted_visible_action_message(target, "take", "out of the incision on $TARGET'S$ [affected.name] with \the [tool].", self_infix = "\the [obj]", other_infix = "something")
 			target.remove_implant(obj, TRUE, affected)
 			BITSET(target.hud_updateflag, IMPLOYAL_HUD)
 			..()

--- a/code/modules/surgery/limb_reattach.dm
+++ b/code/modules/surgery/limb_reattach.dm
@@ -103,8 +103,7 @@
 		return
 	var/obj/item/organ/external/P = GET_EXTERNAL_ORGAN(target, target_zone)
 	var/obj/item/organ/external/E = tool
-	user.visible_message("<span class='notice'>[user] has attached [target]'s [E.name] to the [E.amputation_point].</span>",	\
-	"<span class='notice'>You have attached [target]'s [E.name] to the [E.amputation_point].</span>")
+	user.targeted_visible_action_message(target, "attach", "[target]'s [E.name] to the [E.amputation_point].")
 
 	//Add the organ but in a detached state
 	target.add_organ(E, P, FALSE, TRUE, TRUE)
@@ -115,8 +114,8 @@
 
 /decl/surgery_step/limb/attach/fail_step(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/E = tool
-	user.visible_message("<span class='warning'> [user]'s hand slips, damaging [target]'s [E.amputation_point]!</span>", \
-	"<span class='warning'> Your hand slips, damaging [target]'s [E.amputation_point]!</span>")
+	user.visible_message("<span class='warning'>[user]'s hand slips, damaging [target]'s [E.amputation_point]!</span>", \
+	"<span class='warning'>Your hand slips, damaging [target]'s [E.amputation_point]!</span>")
 	target.apply_damage(10, BRUTE, null, damage_flags=DAM_SHARP)
 	..()
 
@@ -144,15 +143,13 @@
 
 /decl/surgery_step/limb/connect/begin_step(mob/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/E = GET_EXTERNAL_ORGAN(target, target_zone)
-	user.visible_message("[user] starts reattaching tendons and muscles in [target]'s [E.amputation_point] with [tool].", \
-	"You start reattaching tendons and muscle in [target]'s [E.amputation_point].")
+	user.targeted_visible_action_message(target, "start", "reattaching tendons and muscle in $TARGET'S$ [E.amputation_point] with \the [tool].")
 	..()
 
 /decl/surgery_step/limb/connect/end_step(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/E = GET_EXTERNAL_ORGAN(target, target_zone)
 	var/obj/item/organ/external/P = GET_EXTERNAL_ORGAN(target, E.parent_organ)
-	user.visible_message("<span class='notice'>[user] has reattached tendons and muscles in [target]'s [E.amputation_point] with [tool].</span>",	\
-	"<span class='notice'>You have reattached tendons and muscles in [target]'s [E.amputation_point] with [tool].</span>")
+	user.targeted_visible_action_message(target, "reattach", "tendons and muscles in $TARGET'S$ [E.amputation_point] with [tool].")
 
 	//This time we call add_organ but we want it to install in a non detached state
 	target.add_organ(E, P, FALSE, TRUE, FALSE)
@@ -160,7 +157,7 @@
 
 /decl/surgery_step/limb/connect/fail_step(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/E = GET_EXTERNAL_ORGAN(target, target_zone)
-	user.visible_message("<span class='warning'> [user]'s hand slips, damaging [target]'s [E.amputation_point]!</span>", \
-	"<span class='warning'> Your hand slips, damaging [target]'s [E.amputation_point]!</span>")
+	user.visible_message("<span class='warning'>[user]'s hand slips, damaging [target]'s [E.amputation_point]!</span>", \
+	"<span class='warning'>Your hand slips, damaging [target]'s [E.amputation_point]!</span>")
 	target.apply_damage(10, BRUTE, null, damage_flags=DAM_SHARP)
 	..()

--- a/code/modules/surgery/limb_reattach.dm
+++ b/code/modules/surgery/limb_reattach.dm
@@ -95,8 +95,7 @@
 
 /decl/surgery_step/limb/attach/begin_step(mob/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/E = tool
-	user.visible_message("[user] starts attaching [E.name] to [target]'s [E.amputation_point].", \
-	"You start attaching [E.name] to [target]'s [E.amputation_point].")
+	user.visible_action_message("start", "attaching [E.name] to [target]'s [E.amputation_point].")
 	..()
 
 /decl/surgery_step/limb/attach/end_step(mob/living/user, mob/living/target, target_zone, obj/item/tool)

--- a/code/modules/surgery/organs_internal.dm
+++ b/code/modules/surgery/organs_internal.dm
@@ -44,12 +44,10 @@
 	else if (istype(tool, /obj/item/stack/medical/bandage))
 		tool_name = "the bandaid"
 	var/obj/item/organ/external/affected = GET_EXTERNAL_ORGAN(target, target_zone)
-	user.visible_message("[user] starts treating damage within \the [target]'s [affected.name] with [tool_name].", \
-	"You start treating damage within \the [target]'s [affected.name] with [tool_name]." )
+	user.targeted_visible_action_message(target, "start", "treating damage within $TARGET'S$ [affected.name] with [tool_name].")
 	for(var/obj/item/organ/internal/organ in affected.internal_organs)
 		if(organ && organ.get_organ_damage() > 0 && !BP_IS_PROSTHETIC(organ) && !(organ.status & ORGAN_DEAD) && (organ.surface_accessible || affected.how_open() >= (affected.encased ? SURGERY_ENCASED : SURGERY_RETRACTED)))
-			user.visible_message("[user] starts treating damage to [target]'s [organ] with [tool_name].", \
-			"You start treating damage to [target]'s [organ] with [tool_name]." )
+			user.targeted_visible_action_message(target, "start", "treating damage to $TARGET'S$ [organ] with [tool_name].")
 	target.custom_pain("The pain in your [affected.name] is living hell!",100,affecting = affected)
 	..()
 
@@ -65,17 +63,21 @@
 			if(organ.status & ORGAN_DEAD)
 				to_chat(user, SPAN_NOTICE("You were unable to treat \the [organ] due to its necrotic state."))
 			else
-				user.visible_message("<span class='notice'>[user] treats damage to [target]'s [organ] with [tool_name].</span>", \
-				"<span class='notice'>You treat damage to [target]'s [organ] with [tool_name].</span>" )
+				user.targeted_visible_action_message(target, "treat", "damage to $TARGET'S$ [organ] with [tool_name].")
 				organ.surgical_fix(user)
-	user.visible_message("\The [user] finishes treating damage within \the [target]'s [affected.name] with [tool_name].", \
-	"You finish treating damage within \the [target]'s [affected.name] with [tool_name]." )
+	user.targeted_visible_action_message(target, "finish", "treating damage within $TARGET'S$ [affected.name] with [tool_name].")
 	..()
 
 /decl/surgery_step/internal/fix_organ/fail_step(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = GET_EXTERNAL_ORGAN(target, target_zone)
-	user.visible_message("<span class='warning'>[user]'s hand slips, getting mess and tearing the inside of [target]'s [affected.name] with \the [tool]!</span>", \
-	"<span class='warning'>Your hand slips, getting mess and tearing the inside of [target]'s [affected.name] with \the [tool]!</span>")
+	var/decl/pronouns/target_pronouns = target.get_visible_pronouns()
+	var/target_their = (user == target) ? target_pronouns.his : "\the [target]'s"
+	var/decl/pronouns/self_pronouns = user.get_self_pronouns()
+	var/target_their_self = (user == target) ? self_pronouns.his : "\the [target]'s"
+	user.visible_message(
+		SPAN_WARNING("\The [user]'s hand slips, getting mess all over the torn insides of [target_their] [affected.name] with \the [tool]!"),
+		SPAN_WARNING("[self_pronouns.His] hand slips, getting mess all over the torn insides of [target_their_self] [affected.name] with \the [tool]!")
+	)
 	var/dam_amt = 2
 	if(istype(tool, /obj/item/stack/medical/bandage/advanced))
 		target.take_damage(5, TOX)

--- a/code/modules/surgery/other.dm
+++ b/code/modules/surgery/other.dm
@@ -28,15 +28,13 @@
 
 /decl/surgery_step/fix_tendon/begin_step(mob/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = GET_EXTERNAL_ORGAN(target, target_zone)
-	user.visible_message("[user] starts reattaching the damaged [affected.tendon_name] in [target]'s [affected.name] with \the [tool]." , \
-	"You start reattaching the damaged [affected.tendon_name] in [target]'s [affected.name] with \the [tool].")
+	user.visible_action_message("start", "reattaching the damaged [affected.tendon_name] in $TARGET'S$ [affected.name] with \the [tool].")
 	target.custom_pain("The pain in your [affected.name] is unbearable!",100,affecting = affected)
 	..()
 
 /decl/surgery_step/fix_tendon/end_step(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = GET_EXTERNAL_ORGAN(target, target_zone)
-	user.visible_message("<span class='notice'>[user] has reattached the [affected.tendon_name] in [target]'s [affected.name] with \the [tool].</span>", \
-		"<span class='notice'>You have reattached the [affected.tendon_name] in [target]'s [affected.name] with \the [tool].</span>")
+	user.targeted_visible_action_message(target, "reattach", "the [affected.tendon_name] in $TARGET'S$ [affected.name] with \the [tool].")
 	affected.status &= ~ORGAN_TENDON_CUT
 	affected.update_damages()
 	..()
@@ -74,15 +72,13 @@
 
 /decl/surgery_step/fix_vein/begin_step(mob/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = GET_EXTERNAL_ORGAN(target, target_zone)
-	user.visible_message("[user] starts patching the damaged [affected.artery_name] in [target]'s [affected.name] with \the [tool]." , \
-	"You start patching the damaged [affected.artery_name] in [target]'s [affected.name] with \the [tool].")
+	user.visible_action_message("start", "patching the damaged [affected.artery_name] in $TARGET'S$ [affected.name] with \the [tool].")
 	target.custom_pain("The pain in your [affected.name] is unbearable!",100,affecting = affected)
 	..()
 
 /decl/surgery_step/fix_vein/end_step(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = GET_EXTERNAL_ORGAN(target, target_zone)
-	user.visible_message("<span class='notice'>[user] has patched the [affected.artery_name] in [target]'s [affected.name] with \the [tool].</span>", \
-		"<span class='notice'>You have patched the [affected.artery_name] in [target]'s [affected.name] with \the [tool].</span>")
+	user.targeted_visible_action_message(target, "patch", "the [affected.artery_name] in $TARGET'S$ [affected.name] with \the [tool].")
 	affected.status &= ~ORGAN_ARTERY_CUT
 	affected.update_damages()
 	..()
@@ -130,8 +126,7 @@
 
 /decl/surgery_step/hardsuit/begin_step(mob/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/rig/rig = target.get_rig()
-	user.visible_message("[user] starts cutting through the support systems of [target]'s [rig] with \the [tool]." , \
-	"You start cutting through the support systems of [target]'s [rig] with \the [tool].")
+	user.visible_action_message("start", "cutting through the support systems of [target]'s [rig] with \the [tool].")
 	..()
 
 /decl/surgery_step/hardsuit/end_step(mob/living/user, mob/living/target, target_zone, obj/item/tool)
@@ -139,13 +134,12 @@
 	var/obj/item/rig/rig = target.get_rig()
 	if(rig)
 		rig.reset()
-	user.visible_message("<span class='notice'>[user] has cut through the support systems of [target]'s [rig] with \the [tool].</span>", \
-		"<span class='notice'>You have cut through the support systems of [target]'s [rig] with \the [tool].</span>")
+	user.targeted_visible_action_message(target, "cut", "through the support systems of $TARGET'S$ [rig] with \the [tool].")
 	..()
 
 /decl/surgery_step/hardsuit/fail_step(mob/living/user, mob/living/target, target_zone, obj/item/tool)
-	user.visible_message("<span class='danger'>[user]'s [tool] can't quite seem to get through the metal...</span>", \
-	"<span class='danger'>Your [tool] can't quite seem to get through the metal. It's weakening, though - try again.</span>")
+	user.visible_message(SPAN_DANGER("[user]'s [tool] can't quite seem to get through the metal..."), \
+	SPAN_DANGER("Your [tool] can't quite seem to get through the metal. It's weakening, though - try again."))
 	..()
 
 
@@ -195,8 +189,7 @@
 
 /decl/surgery_step/sterilize/begin_step(mob/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = GET_EXTERNAL_ORGAN(target, target_zone)
-	user.visible_message("[user] starts pouring [tool]'s contents on \the [target]'s [affected.name]." , \
-	"You start pouring [tool]'s contents on \the [target]'s [affected.name].")
+	user.targeted_visible_action_message(target, "start", "pouring [tool]'s contents on $TARGET'S$ [affected.name].")
 	target.custom_pain("Your [affected.name] is on fire!",50,affecting = affected)
 	..()
 
@@ -209,8 +202,7 @@
 	container.reagents.trans_to_holder(temp_reagents, amount)
 	var/trans = temp_reagents.trans_to_mob(target, REAGENT_TOTAL_VOLUME(temp_reagents), CHEM_INJECT) //technically it's contact, but the reagents are being applied to internal tissue
 	if (trans > 0)
-		user.visible_message("<span class='notice'>[user] rubs [target]'s [affected.name] down with \the [tool]'s contents</span>.", \
-			"<span class='notice'>You rub [target]'s [affected.name] down with \the [tool]'s contents.</span>")
+		user.targeted_visible_action_message(target, "rub", "$TARGET'S$ [affected.name] down with \the [tool]'s contents.")
 	affected.disinfect()
 	qdel(temp_reagents)
 	qdel(temp_holder)
@@ -220,8 +212,8 @@
 	var/obj/item/organ/external/affected = GET_EXTERNAL_ORGAN(target, target_zone)
 	var/obj/item/chems/container = tool
 	container.reagents.trans_to_mob(target, container.amount_per_transfer_from_this, CHEM_INJECT)
-	user.visible_message("<span class='warning'>[user]'s hand slips, spilling \the [tool]'s contents over the [target]'s [affected.name]!</span>" , \
-	"<span class='warning'>Your hand slips, spilling \the [tool]'s contents over the [target]'s [affected.name]!</span>")
+	user.visible_message(SPAN_WARNING("[user]'s hand slips, spilling \the [tool]'s contents over \the [target]'s [affected.name]!"), \
+	SPAN_WARNING("Your hand slips, spilling \the [tool]'s contents over \the [target]'s [affected.name]!"))
 	affected.disinfect()
 	..()
 

--- a/code/modules/surgery/robotics.dm
+++ b/code/modules/surgery/robotics.dm
@@ -48,8 +48,7 @@
 
 /decl/surgery_step/robotics/unscrew_hatch/begin_step(mob/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = GET_EXTERNAL_ORGAN(target, target_zone)
-	user.visible_message("[user] starts to unscrew the maintenance hatch on [target]'s [affected.name] with \the [tool].", \
-	"You start to unscrew the maintenance hatch on [target]'s [affected.name] with \the [tool].")
+	user.visible_action_message("start", "to unscrew the maintenance hatch on [target]'s [affected.name] with \the [tool].")
 	..()
 
 /decl/surgery_step/robotics/unscrew_hatch/end_step(mob/living/user, mob/living/target, target_zone, obj/item/tool)
@@ -82,8 +81,7 @@
 
 /decl/surgery_step/robotics/screw_hatch/begin_step(mob/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = GET_EXTERNAL_ORGAN(target, target_zone)
-	user.visible_message("[user] starts to screw down the maintenance hatch on [target]'s [affected.name] with \the [tool].", \
-	"You start to screw down the maintenance hatch on [target]'s [affected.name] with \the [tool].")
+	user.visible_action_message("start", "to screw down the maintenance hatch on [target]'s [affected.name] with \the [tool].")
 	..()
 
 /decl/surgery_step/robotics/screw_hatch/end_step(mob/living/user, mob/living/target, target_zone, obj/item/tool)
@@ -119,14 +117,12 @@
 
 /decl/surgery_step/robotics/open_hatch/begin_step(mob/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = GET_EXTERNAL_ORGAN(target, target_zone)
-	user.visible_message("[user] starts to pry open the maintenance hatch on [target]'s [affected.name] with \the [tool].",
-	"You start to pry open the maintenance hatch on [target]'s [affected.name] with \the [tool].")
+	user.visible_action_message("start", "to pry open the maintenance hatch on [target]'s [affected.name] with \the [tool].")
 	..()
 
 /decl/surgery_step/robotics/open_hatch/end_step(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = GET_EXTERNAL_ORGAN(target, target_zone)
-	user.visible_message("<span class='notice'>[user] opens the maintenance hatch on [target]'s [affected.name] with \the [tool].</span>", \
-	 "<span class='notice'>You open the maintenance hatch on [target]'s [affected.name] with \the [tool].</span>")
+	user.visible_action_message("open", "the maintenance hatch on [target]'s [affected.name] with \the [tool].")
 	affected.hatch_state = HATCH_OPENED
 	..()
 
@@ -163,8 +159,7 @@
 
 /decl/surgery_step/robotics/close_hatch/end_step(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = GET_EXTERNAL_ORGAN(target, target_zone)
-	user.visible_message("<span class='notice'>[user] closes the hatch on [target]'s [affected.name] with \the [tool].</span>", \
-	"<span class='notice'>You close the hatch on [target]'s [affected.name] with \the [tool].</span>")
+	user.visible_action_message("close", "the hatch on [target]'s [affected.name] with \the [tool].")
 	affected.hatch_state = HATCH_UNSCREWED
 	affected.germ_level = 0
 	..()
@@ -372,8 +367,7 @@
 	for(var/obj/item/organ/internal/organ in affected.internal_organs)
 		if(organ.get_organ_damage() > 0)
 			if(BP_IS_PROSTHETIC(organ))
-				user.visible_message("[user] starts mending the damage to [target]'s [organ.name]'s mechanisms.", \
-				"You start mending the damage to [target]'s [organ.name]'s mechanisms." )
+				user.targeted_visible_action_message(target, "start", "mending the damage to $TARGET'S$ [organ.name]'s mechanisms.")
 	..()
 
 /decl/surgery_step/robotics/fix_organ_robotic/end_step(mob/living/user, mob/living/target, target_zone, obj/item/tool)
@@ -381,15 +375,14 @@
 	for(var/obj/item/organ/internal/organ in affected.internal_organs)
 		if(organ.get_organ_damage() > 0)
 			if(BP_IS_PROSTHETIC(organ))
-				user.visible_message("<span class='notice'>[user] repairs [target]'s [organ.name] with [tool].</span>", \
-				"<span class='notice'>You repair [target]'s [organ.name] with [tool].</span>" )
+				user.targeted_visible_action_message(target, "repair", "$TARGET'S$ [organ.name] with [tool].")
 				organ.set_organ_damage(0)
 	..()
 
 /decl/surgery_step/robotics/fix_organ_robotic/fail_step(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = GET_EXTERNAL_ORGAN(target, target_zone)
-	user.visible_message("<span class='warning'>[user]'s hand slips, gumming up the mechanisms inside of [target]'s [affected.name] with \the [tool]!</span>", \
-	"<span class='warning'>Your hand slips, gumming up the mechanisms inside of [target]'s [affected.name] with \the [tool]!</span>")
+	user.visible_message(SPAN_WARNING("[user]'s hand slips, gumming up the mechanisms inside of [target]'s [affected.name] with \the [tool]!"), \
+	SPAN_WARNING("Your hand slips, gumming up the mechanisms inside of [target]'s [affected.name] with \the [tool]!"))
 	target.take_damage(5, TOX)
 	affected.createwound(CUT, 5)
 	for(var/internal in affected.internal_organs)
@@ -473,8 +466,7 @@
 	return organ_to_replace
 
 /decl/surgery_step/robotics/attach_organ_robotic/begin_step(mob/user, mob/living/target, target_zone, obj/item/tool)
-	user.visible_message("[user] begins reattaching [target]'s [LAZYACCESS(global.surgeries_in_progress["\ref[target]"], target_zone)] with \the [tool].", \
-	"You start reattaching [target]'s [LAZYACCESS(global.surgeries_in_progress["\ref[target]"], target_zone)] with \the [tool].")
+	user.targeted_visible_action_message(target, "begin", "reattaching $TARGET'S$ [LAZYACCESS(global.surgeries_in_progress["\ref[target]"], target_zone)] with \the [tool].")
 	..()
 
 /decl/surgery_step/robotics/attach_organ_robotic/end_step(mob/living/user, mob/living/target, target_zone, obj/item/tool)

--- a/code/modules/surgery/robotics.dm
+++ b/code/modules/surgery/robotics.dm
@@ -60,7 +60,7 @@
 
 /decl/surgery_step/robotics/unscrew_hatch/fail_step(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = GET_EXTERNAL_ORGAN(target, target_zone)
-	user.visible_message("<span class='warning'>\The [user]'s [tool.name] slips, failing to unscrew \the [target]'s [affected.name].</span>", \
+	user.visible_message("<span class='warning'>\The [user]'s [tool.name] slips, failing to unscrew $TARGET'S$ [affected.name].</span>", \
 	"<span class='warning'>Your [tool.name] slips, failing to unscrew [target]'s [affected.name].</span>")
 	..()
 
@@ -153,8 +153,7 @@
 
 /decl/surgery_step/robotics/close_hatch/begin_step(mob/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = GET_EXTERNAL_ORGAN(target, target_zone)
-	user.visible_message("[user] begins to close the hatch on [target]'s [affected.name] with \the [tool]." , \
-	"You begin to close the hatch on [target]'s [affected.name] with \the [tool].")
+	user.targeted_visible_action_message(target, "begin", "to close the hatch on [target]'s [affected.name] with \the [tool].")
 	..()
 
 /decl/surgery_step/robotics/close_hatch/end_step(mob/living/user, mob/living/target, target_zone, obj/item/tool)
@@ -213,14 +212,12 @@
 
 /decl/surgery_step/robotics/repair_brute/begin_step(mob/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = GET_EXTERNAL_ORGAN(target, target_zone)
-	user.visible_message("[user] begins to patch damage to [target]'s [affected.name]'s support structure with \the [tool]." , \
-	"You begin to patch damage to [target]'s [affected.name]'s support structure with \the [tool].")
+	user.targeted_visible_action_message(target, "begin", "to patch damage to [target]'s [affected.name]'s support structure with \the [tool].")
 	..()
 
 /decl/surgery_step/robotics/repair_brute/end_step(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = GET_EXTERNAL_ORGAN(target, target_zone)
-	user.visible_message("<span class='notice'>[user] finishes patching damage to [target]'s [affected.name] with \the [tool].</span>", \
-	"<span class='notice'>You finish patching damage to [target]'s [affected.name] with \the [tool].</span>")
+	user.targeted_visible_action_message(target, "finish", "patching damage to [target]'s [affected.name] with \the [tool].")
 	affected.heal_damage(rand(30,50),0,1,1)
 	affected.status &= ~ORGAN_DISFIGURED
 	..()
@@ -254,21 +251,18 @@
 
 /decl/surgery_step/robotics/repair_brittle/begin_step(mob/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = GET_EXTERNAL_ORGAN(target, target_zone)
-	user.visible_message("[user] begins to repair the brittle metal inside \the [target]'s [affected.name]." , \
-	"You begin to repair the brittle metal inside \the [target]'s [affected.name].")
+	user.targeted_visible_action_message(target, "begin", "to repair the brittle metal inside $TARGET'S$ [affected.name].")
 	..()
 
 /decl/surgery_step/robotics/repair_brittle/end_step(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = GET_EXTERNAL_ORGAN(target, target_zone)
-	user.visible_message("<span class='notice'>[user] finishes repairing the brittle interior of \the [target]'s [affected.name].</span>", \
-	"<span class='notice'>You finish repairing the brittle interior of \the [target]'s [affected.name].</span>")
+	user.targeted_visible_action_message(target, "finish", "repairing the brittle interior of $TARGET'S$ [affected.name].")
 	affected.status &= ~ORGAN_BRITTLE
 	..()
 
 /decl/surgery_step/robotics/repair_brittle/fail_step(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = GET_EXTERNAL_ORGAN(target, target_zone)
-	user.visible_message("<span class='warning'>[user] causes some of \the [target]'s [affected.name] to crumble!</span>",
-	"<span class='warning'>You cause some of \the [target]'s [affected.name] to crumble!</span>")
+	user.targeted_visible_action_message(target, "cause", "some of $TARGET'S$ [affected.name] to crumble!", dangerous = ACTION_DANGER_WARNING)
 	target.apply_damage(rand(5,10), BRUTE, affected)
 	..()
 
@@ -312,22 +306,19 @@
 
 /decl/surgery_step/robotics/repair_burn/begin_step(mob/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = GET_EXTERNAL_ORGAN(target, target_zone)
-	user.visible_message("[user] begins to splice new cabling into [target]'s [affected.name]." , \
-	"You begin to splice new cabling into [target]'s [affected.name].")
+	user.targeted_visible_action_message(target, "begin", "to splice new cabling into [target]'s [affected.name].")
 	..()
 
 /decl/surgery_step/robotics/repair_burn/end_step(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = GET_EXTERNAL_ORGAN(target, target_zone)
-	user.visible_message("<span class='notice'>[user] finishes splicing cable into [target]'s [affected.name].</span>", \
-	"<span class='notice'>You finishes splicing new cable into [target]'s [affected.name].</span>")
+	user.targeted_visible_action_message("finish", "splicing cable into $TARGET'S$ [affected.name].")
 	affected.heal_damage(0,rand(30,50),1,1)
 	affected.status &= ~ORGAN_DISFIGURED
 	..()
 
 /decl/surgery_step/robotics/repair_burn/fail_step(mob/living/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = GET_EXTERNAL_ORGAN(target, target_zone)
-	user.visible_message("<span class='warning'>[user] causes a short circuit in [target]'s [affected.name]!</span>",
-	"<span class='warning'>You cause a short circuit in [target]'s [affected.name]!</span>")
+	user.targeted_visible_action_message(target, "cause", "a short circuit in $TARGET'S$ [affected.name]!", dangerous = ACTION_DANGER_WARNING)
 	target.apply_damage(rand(5,10), BURN, affected)
 	..()
 

--- a/code/modules/surgery/suture_wounds.dm
+++ b/code/modules/surgery/suture_wounds.dm
@@ -20,8 +20,7 @@
 
 /decl/surgery_step/suture_wounds/begin_step(mob/user, mob/living/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = GET_EXTERNAL_ORGAN(target, target_zone)
-	user.visible_message("[user] is beginning to close a wound on [target]'s [affected.name] with \the [tool]." , \
-		"You are beginning to close a wound on [target]'s [affected.name] with \the [tool].")
+	user.targeted_visible_action_message(target, "begin", "to close a wound on $TARGET'S$ [affected.name] with \the [tool].")
 	target.custom_pain("Your [affected.name] is being stabbed!",1)
 	..()
 
@@ -32,10 +31,9 @@
 			// Close it up to a point that it can be bandaged and heal naturally!
 			wound.heal_damage(rand(10,20)+10)
 			if(wound.damage >= wound.autoheal_cutoff)
-				user.visible_message(SPAN_NOTICE("\The [user] partially closes a wound on [target]'s [affected.name] with \the [tool]."), \
-				SPAN_NOTICE("You partially close a wound on [target]'s [affected.name] with \the [tool]."))
+				user.targeted_visible_action_message(target, "partially close", "a wound on $TARGET'S$ [affected.name] with \the [tool].")
 			else
-				user.visible_action_message("close", "a wound on [target]'s [affected.name] with \the [tool].")
+				user.targeted_visible_action_message(target, "close", "a wound on $TARGET'S$ [affected.name] with \the [tool].")
 				if(!wound.damage)
 					affected.wounds -= wound
 					qdel(wound)

--- a/code/modules/surgery/suture_wounds.dm
+++ b/code/modules/surgery/suture_wounds.dm
@@ -35,8 +35,7 @@
 				user.visible_message(SPAN_NOTICE("\The [user] partially closes a wound on [target]'s [affected.name] with \the [tool]."), \
 				SPAN_NOTICE("You partially close a wound on [target]'s [affected.name] with \the [tool]."))
 			else
-				user.visible_message(SPAN_NOTICE("\The [user] closes a wound on [target]'s [affected.name] with \the [tool]."), \
-				SPAN_NOTICE("You close a wound on [target]'s [affected.name] with \the [tool]."))
+				user.visible_action_message("close", "a wound on [target]'s [affected.name] with \the [tool].")
 				if(!wound.damage)
 					affected.wounds -= wound
 					qdel(wound)

--- a/code/modules/tools/archetypes/tool_extension.dm
+++ b/code/modules/tools/archetypes/tool_extension.dm
@@ -84,10 +84,7 @@
 	if(check_result != TOOL_USE_SUCCESS)
 		return check_result
 
-	user.visible_message(
-		SPAN_NOTICE("\The [user] begins [start_message || tool_archetype.tool_message] \the [target] with \the [tool]."),
-		SPAN_NOTICE("You begin [start_message || tool_archetype.tool_message] \the [target] with \the [tool].")
-	)
+	user.visible_action_message("begin", "[start_message || tool_archetype.tool_message] \the [target] with \the [tool].")
 
 	var/datum/extension/tool/tool_data = get_extension(tool, /datum/extension/tool)
 	var/use_sound = istype(tool_data) ? tool_data.get_tool_sound(archetype) : null

--- a/code/modules/xenoarcheaology/artifacts/standalone/replicator.dm
+++ b/code/modules/xenoarcheaology/artifacts/standalone/replicator.dm
@@ -129,7 +129,7 @@
 	if(!user.try_unequip(used_item, src))
 		return FALSE
 	stored_materials.Add(used_item)
-	user.visible_message(SPAN_NOTICE("\The [user] inserts \the [used_item] into \the [src]."), SPAN_NOTICE("You insert \the [used_item] into \the [src]."))
+	user.visible_action_message("insert", "\the [used_item] into \the [src].")
 	return TRUE
 
 /obj/machinery/replicator/OnTopic(user, href_list)

--- a/code/modules/xenoarcheaology/boulder.dm
+++ b/code/modules/xenoarcheaology/boulder.dm
@@ -48,10 +48,7 @@
 
 	if(istype(used_item, /obj/item/measuring_tape))
 		var/obj/item/measuring_tape/P = used_item
-		user.visible_message(
-			SPAN_NOTICE("\The [user] extends \the [P] towards \the [src]."),
-			SPAN_NOTICE("You extend \the [P] towards \the [src].")
-		)
+		user.visible_action_message("extend", "\the [P] towards \the [src].")
 		if(do_after(user, 15))
 			to_chat(user, SPAN_NOTICE("\The [src] has been excavated to a depth of [src.excavation_level]cm."))
 		return TRUE

--- a/mods/content/beekeeping/hives/_hive.dm
+++ b/mods/content/beekeeping/hives/_hive.dm
@@ -59,7 +59,7 @@
 		if(closed)
 			to_chat(user, "<span class='notice'>You need to open \the [src] with a crowbar before smoking the bees.</span>")
 			return TRUE
-		user.visible_message("<span class='notice'>\The [user] smokes the bees in \the [src].</span>", "<span class='notice'>You smoke the bees in \the [src].</span>")
+		user.visible_action_message("smoke", "the bees in \the [src].")
 		smoked = 30
 		update_icon()
 		return TRUE
@@ -75,7 +75,7 @@
 			to_chat(user, "<span class='notice'>\The [used_item] is full with beeswax and honey, empty it in the extractor first.</span>")
 			return TRUE
 		++frames
-		user.visible_message("<span class='notice'>\The [user] loads \the [used_item] into \the [src].</span>", "<span class='notice'>You load \the [used_item] into \the [src].</span>")
+		user.visible_action_message("load", "\the [used_item] into \the [src].")
 		update_icon()
 		qdel(used_item)
 		return TRUE
@@ -94,11 +94,11 @@
 			to_chat(user, "<span class='notice'>You need to open \the [src] with a crowbar before moving the bees.</span>")
 			return TRUE
 		if(B.full)
-			user.visible_message("<span class='notice'>\The [user] puts the queen and the bees from \the [used_item] into \the [src].</span>", "<span class='notice'>You put the queen and the bees from \the [used_item] into \the [src].</span>")
+			user.visible_action_message("put", "the queen and the bees from \the [used_item] into \the [src].")
 			bee_count = 20
 			B.empty()
 		else
-			user.visible_message("<span class='notice'>\The [user] puts bees and larvae from \the [src] into \the [used_item].</span>", "<span class='notice'>You put bees and larvae from \the [src] into \the [used_item].</span>")
+			user.visible_action_message("put", "bees and larvae from \the [src] into \the [used_item].")
 			bee_count /= 2
 			B.fill()
 		update_icon()
@@ -122,7 +122,7 @@
 		to_chat(user, "<span class='notice'>You start dismantling \the [src]...</span>")
 		playsound(loc, 'sound/items/Screwdriver.ogg', 50, 1)
 		if(do_after(user, 30, src))
-			user.visible_message("<span class='notice'>\The [user] dismantles \the [src].</span>", "<span class='notice'>You dismantle \the [src].</span>")
+			user.visible_action_message("dismantle", "\the [src].")
 			new /obj/item/beehive_assembly(loc)
 			qdel(src)
 		return TRUE

--- a/mods/content/beekeeping/hives/_hive.dm
+++ b/mods/content/beekeeping/hives/_hive.dm
@@ -138,8 +138,8 @@
 	if(!smoked && bee_count)
 		to_chat(user, "<span class='notice'>The bees won't let you take the honeycombs out like this, smoke them first.</span>")
 		return
-	user.visible_message("<span class='notice'>\The [user] starts taking the honeycombs out of \the [src].</span>", "<span class='notice'>You start taking the honeycombs out of \the [src]...</span>")
-	while(honeycombs >= 100 && do_after(user, 30, src))
+	user.visible_action_message("start", "taking the honeycombs out of \the [src]...")
+	while(honeycombs >= 100 && do_after(user, 3 SECONDS, src))
 		new /obj/item/hive_frame/crafted/filled(loc)
 		honeycombs -= 100
 		--frames

--- a/mods/content/beekeeping/items.dm
+++ b/mods/content/beekeeping/items.dm
@@ -8,7 +8,7 @@
 /obj/item/beehive_assembly/attack_self(var/mob/user)
 	to_chat(user, "<span class='notice'>You start assembling \the [src]...</span>")
 	if(do_after(user, 30, src))
-		user.visible_message("<span class='notice'>\The [user] constructs a beehive.</span>", "<span class='notice'>You construct a beehive.</span>")
+		user.visible_action_message("construct", "a beehive.")
 		new /obj/machinery/beehive(get_turf(user))
 		qdel(src)
 

--- a/mods/content/xenobiology/slime/slime_surgery.dm
+++ b/mods/content/xenobiology/slime/slime_surgery.dm
@@ -39,12 +39,11 @@
 	return ..() && istype(target) && target.core_removal_stage == 0
 
 /decl/surgery_step/slime/cut_flesh/begin_step(mob/user, mob/living/slime/target, target_zone, obj/item/tool)
-	user.visible_action_message("start", "cutting through [target]'s flesh with \the [tool].")
+	user.targeted_visible_action_message(target, "start", "cutting through $TARGET'S$ flesh with \the [tool].")
 	..()
 
 /decl/surgery_step/slime/cut_flesh/end_step(mob/living/user, mob/living/slime/target, target_zone, obj/item/tool)
-	user.visible_message("<span class='notice'>[user] cuts through [target]'s flesh with \the [tool].</span>",	\
-	"<span class='notice'>You cut through [target]'s flesh with \the [tool], revealing its silky innards.</span>")
+	user.targeted_visible_action_message(target, "cut", "through $TARGET'S$ flesh", self_postfix = "with \the [tool], revealing its silky innards.", other_postfix = "with \the [tool].")
 	target.core_removal_stage = 1
 	..()
 
@@ -67,7 +66,7 @@
 	return ..() && istype(target) && target.core_removal_stage == 1
 
 /decl/surgery_step/slime/cut_innards/begin_step(mob/user, mob/living/slime/target, target_zone, obj/item/tool)
-	user.visible_action_message("start", "cutting [target]'s silky innards apart with \the [tool].")
+	user.targeted_visible_action_message(target, "start", "cutting $TARGET'S$ silky innards apart with \the [tool].")
 	..()
 
 /decl/surgery_step/slime/cut_innards/end_step(mob/living/user, mob/living/slime/target, target_zone, obj/item/tool)

--- a/mods/content/xenobiology/slime/slime_surgery.dm
+++ b/mods/content/xenobiology/slime/slime_surgery.dm
@@ -39,8 +39,7 @@
 	return ..() && istype(target) && target.core_removal_stage == 0
 
 /decl/surgery_step/slime/cut_flesh/begin_step(mob/user, mob/living/slime/target, target_zone, obj/item/tool)
-	user.visible_message("[user] starts cutting through [target]'s flesh with \the [tool].", \
-	"You start cutting through [target]'s flesh with \the [tool].")
+	user.visible_action_message("start", "cutting through [target]'s flesh with \the [tool].")
 	..()
 
 /decl/surgery_step/slime/cut_flesh/end_step(mob/living/user, mob/living/slime/target, target_zone, obj/item/tool)
@@ -68,19 +67,17 @@
 	return ..() && istype(target) && target.core_removal_stage == 1
 
 /decl/surgery_step/slime/cut_innards/begin_step(mob/user, mob/living/slime/target, target_zone, obj/item/tool)
-	user.visible_message("[user] starts cutting [target]'s silky innards apart with \the [tool].", \
-	"You start cutting [target]'s silky innards apart with \the [tool].")
+	user.visible_action_message("start", "cutting [target]'s silky innards apart with \the [tool].")
 	..()
 
 /decl/surgery_step/slime/cut_innards/end_step(mob/living/user, mob/living/slime/target, target_zone, obj/item/tool)
-	user.visible_message("<span class='notice'>[user] cuts [target]'s innards apart with \the [tool], exposing the cores.</span>",	\
-	"<span class='notice'>You cut [target]'s innards apart with \the [tool], exposing the cores.</span>")
+	user.visible_action_message("cut", "\the [target]'s innards apart with \the [tool], exposing the cores.")
 	target.core_removal_stage = 2
 	..()
 
 /decl/surgery_step/slime/cut_innards/fail_step(mob/living/user, mob/living/slime/target, target_zone, obj/item/tool)
-	user.visible_message("<span class='warning'>[user]'s hand slips, tearing [target]'s innards with \the [tool]!</span>", \
-	"<span class='warning'>Your hand slips, tearing [target]'s innards with \the [tool]!</span>")
+	user.visible_message(SPAN_WARNING("[user]'s hand slips, tearing \the [target]'s innards with \the [tool]!"), \
+	SPAN_WARNING("Your hand slips, tearing \the [target]'s innards with \the [tool]!"))
 	..()
 
 //////////////////////////////////////////////////////////////////
@@ -100,25 +97,23 @@
 	return ..() && (istype(target) && target.core_removal_stage == 2 && target.cores > 0) //This is being passed a human as target, unsure why.
 
 /decl/surgery_step/slime/saw_core/begin_step(mob/user, mob/living/slime/target, target_zone, obj/item/tool)
-	user.visible_message(
-		SPAN_NOTICE("\The [user] starts cutting out one of \the [target]'s cores with \the [tool]."), \
-		SPAN_NOTICE("You start cutting out one of \the [target]'s cores with \the [tool]."))
+	user.visible_action_message("start", "cutting out one of \the [target]'s cores with \the [tool].")
 	..()
 
 /decl/surgery_step/slime/saw_core/end_step(mob/living/user, mob/living/slime/target, target_zone, obj/item/tool)
+	var/decl/pronouns/self_pronouns = user.get_self_pronouns()
 	if(target.cores <= 0)
-		to_chat(user, SPAN_WARNING("You cannot find any cores within \the [target]."))
+		to_chat(user, SPAN_WARNING("[self_pronouns.He] cannot find any cores within \the [target]."))
 		return
 	var/atom/core = new /obj/item/slime_extract(target.loc, /decl/material/liquid/slimejelly, target.slime_type)
 	target.cores--
-	user.visible_message(
-		SPAN_NOTICE("\The [user] cuts \the [core] out of \the [target] with \the [tool]."),	\
-		SPAN_NOTICE("You cut \the [core] out of \the [target] with \the [tool]. It looks like there are [target.cores] core\s left."))
+	user.visible_action_message("cut", "\the [core] out of \the [target] with \the [tool].", self_postfix = "It looks like there are [target.cores] core\s left.")
 	target.update_icon()
 	..()
 
 /decl/surgery_step/slime/saw_core/fail_step(mob/living/user, mob/living/slime/target, target_zone, obj/item/tool)
+	var/decl/pronouns/self_pronouns = user.get_self_pronouns()
 	user.visible_message(
 		SPAN_DANGER("\The [user]'s hand slips, failing to extract the slime core."), \
-		SPAN_DANGER("Your hand slips, causing you to miss the core!"))
+		SPAN_DANGER("[self_pronouns.His] hand slips, causing [self_pronouns.him] to miss the core!"))
 	..()

--- a/mods/gamemodes/cult/runes.dm
+++ b/mods/gamemodes/cult/runes.dm
@@ -324,7 +324,7 @@
 		return TRUE
 	var/force = used_item.expend_attack_force(user)
 	if(force)
-		user.visible_message(SPAN_NOTICE("\The [user] hits \the [src] with \the [used_item]."), SPAN_NOTICE("You hit \the [src] with \the [used_item]."))
+		user.visible_action_message("hit", "\the [src] with \the [used_item].")
 		take_damage(force, used_item.atom_damage_type)
 		user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
 		user.do_attack_animation(src)

--- a/mods/gamemodes/cult/talisman.dm
+++ b/mods/gamemodes/cult/talisman.dm
@@ -28,13 +28,10 @@
 	user.say("Dream Sign: Evil Sealing Talisman!") //TODO: never change this shit
 	var/obj/item/nullrod/nrod = locate() in target
 	if(nrod)
-		user.visible_message(
-			SPAN_DANGER("\The [user] invokes \the [src] at [target], but they are unaffected."),
-			SPAN_DANGER("You invoke \the [src] at [target], but they are unaffected.")
-		)
+		user.visible_action_message("invoke", "\the [src] at [target], but they are unaffected.", dangerous = ACTION_DANGER_ALL)
 		return TRUE
 
-	user.visible_message(SPAN_DANGER("\The [user] invokes \the [src] at [target]."), SPAN_DANGER("You invoke \the [src] at [target]."))
+	user.visible_action_message("invoke", "\the [src] at [target].", dangerous = ACTION_DANGER_ALL)
 	if(isliving(target))
 		if(issilicon(target))
 			SET_STATUS_MAX(target, STAT_WEAK, 15)
@@ -59,7 +56,7 @@
 	if(!proximity)
 		return
 	user.say("Ta'gh fara[pick("'","`")]qha fel d'amar det!")
-	user.visible_message(SPAN_DANGER("\The [user] invokes \the [src] at [target]."), SPAN_DANGER("You invoke \the [src] at [target]."))
+	user.visible_action_message("invoke", "\the [src] at [target].", dangerous = ACTION_DANGER_ALL)
 	target.emp_act(1)
 	user.try_unequip(src)
 	qdel(src)

--- a/mods/mobs/dionaea/mob/nymph_attacks.dm
+++ b/mods/mobs/dionaea/mob/nymph_attacks.dm
@@ -69,7 +69,7 @@
 		add_to_reagents(/decl/material/liquid/nutriment/glucose, (tray.weedlevel + tray.pestlevel))
 		tray.weedlevel = 0
 		tray.pestlevel = 0
-		visible_message(SPAN_NOTICE("<b>\The [src]</b> begins rooting through \the [tray], ripping out pests and weeds, and eating them noisily."),SPAN_NOTICE("You begin rooting through \the [tray], ripping out pests and weeds, and eating them noisily."))
+		visible_action_message("begin", "rooting through \the [tray], ripping out pests and weeds, and eating them noisily.")
 		return TRUE
 
 	if(tray.nutrilevel < 10)
@@ -91,5 +91,5 @@
 			to_chat(src, SPAN_NOTICE("You haven't eaten enough to refill \the [tray]'s water."))
 		return TRUE
 
-	visible_message(SPAN_NOTICE("<b>\The [src]</b> rolls around in \the [tray] for a bit."),SPAN_NOTICE("You roll around in \the [tray] for a bit."))
+	visible_action_message("roll", "around in \the [tray] for a bit.")
 	return TRUE

--- a/mods/species/ascent/structures/ship_furniture.dm
+++ b/mods/species/ascent/structures/ship_furniture.dm
@@ -46,6 +46,6 @@ MANTIDIFY(/obj/structure/chair/padded/purple, "mantid nest", "resting place") //
 	. = ..(user, TRUE)
 	if(!skip_text)
 		if(.)
-			user.visible_message("\The [user] grabs a hydration ration orb from \the [src].", "You grab a hydration ration orb from \the [src].")
+			user.visible_action_message("grab", "a hydration ration orb from \the [src].")
 		else
 			to_chat(user, "\The [src]'s orb supply is empty. Notify a control mind.")


### PR DESCRIPTION
Based on #5205. Uses the grammar helpers introduced in that PR. Extensive changes, some handling is a little clunky and needs to be redone. Has not been tested yet.

Also, as a note to myself for later: Bedroll and possibly bed visible_messages are broken because a self_message is passed despite it being called on an `/obj`.