### PR TITLE
Replacing direct access to /datum/reagents vars with macros.

### DIFF
--- a/code/__defines/chemistry.dm
+++ b/code/__defines/chemistry.dm
@@ -78,13 +78,30 @@
 #define HANDLE_REACTIONS(_reagents)  if(!QDELETED(_reagents)) { SSmaterials.active_holders[_reagents] = TRUE; }
 #define UNQUEUE_REACTIONS(_reagents) SSmaterials.active_holders -= _reagents
 
-#define REAGENT_LIST(R) (R.reagents?.get_reagents() || "No reagent holder")
+#define REAGENT_LIST(R) ((istype(R, /datum/reagents) && R:get_reagents()) || "No reagent holder")
 
-#define REAGENTS_FREE_SPACE(R) (R?.maximum_volume - R?.total_volume)
-#define REAGENT_VOLUME(REAGENT_HOLDER, REAGENT_TYPE) (REAGENT_HOLDER?.reagent_volumes && REAGENT_HOLDER.reagent_volumes[RESOLVE_TO_DECL(REAGENT_TYPE)])
-#define LIQUID_VOLUME(REAGENT_HOLDER,  REAGENT_TYPE) (REAGENT_HOLDER?.liquid_volumes  && REAGENT_HOLDER.liquid_volumes[RESOLVE_TO_DECL(REAGENT_TYPE)])
-#define SOLID_VOLUME(REAGENT_HOLDER,   REAGENT_TYPE) (REAGENT_HOLDER?.solid_volumes   && REAGENT_HOLDER.solid_volumes[RESOLVE_TO_DECL(REAGENT_TYPE)])
-#define REAGENT_DATA(REAGENT_HOLDER,   REAGENT_TYPE) (REAGENT_HOLDER?.reagent_data    && REAGENT_HOLDER.reagent_data[RESOLVE_TO_DECL(REAGENT_TYPE)])
+#define REAGENT_TOTAL_VOLUME(R) (UNLINT((istype(R, /datum/reagents) && R:total_volume) || 0))
+#define REAGENT_TOTAL_LIQUID_VOLUME(R) (UNLINT((istype(R, /datum/reagents) && R:total_liquid_volume) || 0))
+
+#define REAGENT_MAXIMUM_VOLUME(R) (UNLINT((istype(R, /datum/reagents) && R:maximum_volume) || 0))
+#define REAGENTS_FREE_SPACE(R) (UNLINT(istype(R, /datum/reagents) ? (R.maximum_volume - R.total_volume) : 0))
+
+#define REAGENT_VOLUMES(R)        ( (istype(R, /datum/reagents) && UNLINT(R:reagent_volumes)) || null )
+#define REAGENT_SOLID_VOLUMES(R)  ( (istype(R, /datum/reagents) && UNLINT(R:solid_volumes))   || null )
+#define REAGENT_LIQUID_VOLUMES(R) ( (istype(R, /datum/reagents) && UNLINT(R:liquid_volumes))  || null )
+#define REAGENT_GET_MAX_VOL(R)    ( (istype(R, /datum/reagents) && UNLINT(R:maximum_volume))  || 0 )
+#define REAGENT_GET_ATOM(R)       ( (istype(R, /datum/reagents) && UNLINT(R:my_atom))         || null )
+
+#define REAGENT_VOLUME(R, M)      ( istype(R, /datum/reagents) && UNLINT(R:reagent_volumes && R:reagent_volumes[RESOLVE_TO_DECL(M)]) )
+#define LIQUID_VOLUME(R, M)       ( istype(R, /datum/reagents) && UNLINT(R:liquid_volumes  && R:liquid_volumes[RESOLVE_TO_DECL(M)]) )
+#define SOLID_VOLUME(R, M)        ( istype(R, /datum/reagents) && UNLINT(R:solid_volumes   && R:solid_volumes[RESOLVE_TO_DECL(M)]) )
+#define REAGENT_DATA(R, M)        ( istype(R, /datum/reagents) && UNLINT(R:reagent_data    && R:reagent_data[RESOLVE_TO_DECL(M)]) )
+
+#define REAGENT_SET_MAX_VOL(R, V) if(istype(R, /datum/reagents)) { UNLINT(R:maximum_volume = V) }
+#define REAGENT_ADD_MAX_VOL(R, V) if(istype(R, /datum/reagents)) { UNLINT(R:maximum_volume += V) }
+#define REAGENT_SET_ATOM(R, A)    if(istype(R, /datum/reagents)) { UNLINT(R:my_atom = A) }
+#define REAGENT_SET_DATA(R, M, D) if(istype(R, /datum/reagents)) { LAZYSET(UNLINT(R:reagent_data), M, D) }
+
 
 #define CHEM_DOSE(M, R) LAZYACCESS(M._chem_doses, RESOLVE_TO_DECL(R))
 

--- a/code/_helpers/medical_scans.dm
+++ b/code/_helpers/medical_scans.dm
@@ -42,15 +42,14 @@
 	.["immune_system"] =    get_immunity()
 	.["reagents"] = list()
 
-	if(reagents?.total_volume)
-		for(var/decl/material/reagent as anything in reagents.liquid_volumes)
+	if(REAGENT_TOTAL_VOLUME(reagents))
+		for(var/decl/material/reagent as anything in REAGENT_LIQUID_VOLUMES(reagents))
 			var/list/reagent_data = list()
 			reagent_data["name"]      = reagent.get_reagent_name(reagents, MAT_PHASE_LIQUID)
 			reagent_data["quantity"]  = round(REAGENT_VOLUME(reagents, reagent),1)
 			reagent_data["scannable"] = reagent.scannable
 			.["reagents"] += list(reagent_data)
-
-		for(var/decl/material/reagent as anything in reagents.solid_volumes)
+		for(var/decl/material/reagent as anything in REAGENT_SOLID_VOLUMES(reagents))
 			var/list/reagent_data = list()
 			reagent_data["name"]      = reagent.get_reagent_name(reagents, MAT_PHASE_SOLID)
 			reagent_data["quantity"]  = round(REAGENT_VOLUME(reagents, reagent),1)
@@ -98,8 +97,8 @@
 	.["blood_pressure"] =   get_blood_pressure()
 	.["blood_o2"] =         get_blood_oxygenation()
 	if(vessel)
-		.["blood_volume"] =     vessel.total_volume
-		.["blood_volume_max"] = vessel.maximum_volume
+		.["blood_volume"] =     REAGENT_TOTAL_VOLUME(vessel)
+		.["blood_volume_max"] = REAGENT_MAXIMUM_VOLUME(vessel)
 
 /proc/display_medical_data_header(var/list/scan, skill_level = SKILL_DEFAULT)
 	//In case of problems, abort.

--- a/code/controllers/subsystems/fluids.dm
+++ b/code/controllers/subsystems/fluids.dm
@@ -100,7 +100,7 @@ SUBSYSTEM_DEF(fluids)
 		i++
 		current_fluid_holder = processing_fluids[i]
 
-		if(QDELETED(current_fluid_holder) || !current_fluid_holder.reagents?.total_volume)
+		if(QDELETED(current_fluid_holder) || !REAGENT_TOTAL_VOLUME(current_fluid_holder.reagents))
 			REMOVE_ACTIVE_FLUID(current_fluid_holder)
 			continue
 
@@ -110,7 +110,7 @@ SUBSYSTEM_DEF(fluids)
 
 		reagent_holder = current_fluid_holder.reagents
 		UPDATE_FLUID_BLOCKED_DIRS(current_fluid_holder)
-		current_depth = reagent_holder?.total_volume || 0
+		current_depth = REAGENT_TOTAL_VOLUME(reagent_holder)
 
 		// How is this happening
 		if(QDELETED(reagent_holder) || current_depth == -1.#IND || current_depth == 1.#IND)
@@ -123,7 +123,7 @@ SUBSYSTEM_DEF(fluids)
 			current_depth = current_fluid_holder.get_fluid_depth()
 
 		// Mimimum liquid depth for creation of slurries. Do this after evaporation since it may change the total depth.
-		if(reagent_holder?.total_liquid_volume < FLUID_SLURRY)
+		if(REAGENT_TOTAL_LIQUID_VOLUME(reagent_holder) < FLUID_SLURRY)
 			current_fluid_holder.dump_solid_reagents()
 			current_depth = current_fluid_holder.get_fluid_depth()
 
@@ -135,7 +135,7 @@ SUBSYSTEM_DEF(fluids)
 		// Wash our turf.
 		current_fluid_holder.fluid_act(reagent_holder)
 
-		if(isspaceturf(current_fluid_holder) || (istype(current_fluid_holder, /turf/floor) && (current_fluid_holder.turf_flags & TURF_FLAG_ABSORB_LIQUID) && (current_fluid_holder.reagents?.total_volume + current_fluid_holder.get_physical_height()) > 0))
+		if(isspaceturf(current_fluid_holder) || (istype(current_fluid_holder, /turf/floor) && (current_fluid_holder.turf_flags & TURF_FLAG_ABSORB_LIQUID) && (REAGENT_TOTAL_VOLUME(current_fluid_holder.reagents) + current_fluid_holder.get_physical_height()) > 0))
 			removing = round(current_depth * 0.5)
 			if(removing > 0)
 				current_fluid_holder.remove_fluids(removing, defer_update = TRUE)
@@ -154,8 +154,9 @@ SUBSYSTEM_DEF(fluids)
 			if(other_fluid_holder)
 				UPDATE_FLUID_BLOCKED_DIRS(other_fluid_holder)
 				if(!(other_fluid_holder.fluid_blocked_dirs & UP) && other_fluid_holder.CanFluidPass(UP))
-					if(!QDELETED(other_fluid_holder) && other_fluid_holder.reagents?.total_volume < FLUID_MAX_DEPTH)
-						current_fluid_holder.transfer_fluids_to(other_fluid_holder, min(floor(current_depth*0.5), FLUID_MAX_DEPTH - other_fluid_holder.reagents?.total_volume))
+					var/other_volume = REAGENT_TOTAL_VOLUME(other_fluid_holder.reagents)
+					if(!QDELETED(other_fluid_holder) && other_volume < FLUID_MAX_DEPTH)
+						current_fluid_holder.transfer_fluids_to(other_fluid_holder, min(floor(current_depth*0.5), FLUID_MAX_DEPTH - other_volume))
 						current_depth = current_fluid_holder.get_fluid_depth()
 
 		// Flow into the lowest level neighbor.
@@ -173,7 +174,7 @@ SUBSYSTEM_DEF(fluids)
 			if((neighbor.fluid_blocked_dirs & coming_from) || !neighbor.CanFluidPass(coming_from) || neighbor.is_flooded(absolute = TRUE) || !neighbor.CanFluidPass(global.reverse_dir[spread_dir]))
 				continue
 			other_fluid_holder = neighbor
-			neighbor_depth = (other_fluid_holder?.reagents?.total_volume || 0) + neighbor.get_physical_height()
+			neighbor_depth = (REAGENT_TOTAL_VOLUME(other_fluid_holder.reagents)) + neighbor.get_physical_height()
 			flow_amount = round((current_turf_depth - neighbor_depth)*0.5)
 			// TODO: multiply flow amount or minimum transfer amount by some
 			// viscosity calculation to allow for piles of jelly vs piles of water.
@@ -235,7 +236,7 @@ SUBSYSTEM_DEF(fluids)
 		if(current_fluid_holder.last_flow_strength >= 10)
 			// Catwalks mean items will be above the turf; subtract the turf height from our volume.
 			// TODO: somehow handle stuff that is on a catwalk or on the turf within the same turf.
-			var/effective_volume = current_fluid_holder.reagents?.total_volume
+			var/effective_volume = REAGENT_TOTAL_VOLUME(current_fluid_holder.reagents)
 			if(current_fluid_holder.get_supporting_platform())
 				// Depth is negative height, hence +=. TODO: positive heights? No idea how to handle that.
 				effective_volume += current_fluid_holder.get_physical_height()

--- a/code/datums/extensions/milkable/milkable.dm
+++ b/code/datums/extensions/milkable/milkable.dm
@@ -73,7 +73,7 @@
 	if(critter.stat == DEAD)
 		return FALSE
 
-	if(udder?.total_volume <= 0)
+	if(REAGENT_TOTAL_VOLUME(udder) <= 0)
 		to_chat(user, SPAN_WARNING("\The [critter]'s udder is dry. Wait a little longer."))
 		return TRUE
 
@@ -108,7 +108,7 @@
 	if(critter.stat == DEAD)
 		return FALSE
 
-	if(udder?.total_volume <= 0)
+	if(REAGENT_TOTAL_VOLUME(udder) <= 0)
 		to_chat(user, SPAN_WARNING("\The [critter]'s udder is dry. Wait a little longer."))
 		return TRUE
 

--- a/code/datums/inventory_slots/inventory_gripper_subtypes.dm
+++ b/code/datums/inventory_slots/inventory_gripper_subtypes.dm
@@ -23,8 +23,9 @@
 
 		// This means critters can hoover up beakers as a kind of impromptu chem disposal
 		// technique, so long as they're okay with the reagents reacting inside them.
-		if(prop.reagents?.total_volume)
-			prop.reagents.trans_to_mob(src, prop.reagents.total_volume, CHEM_INGEST)
+		var/prop_reagents = REAGENT_TOTAL_VOLUME(prop.reagents)
+		if(prop_reagents)
+			prop.reagents.trans_to_mob(src, prop_reagents, CHEM_INGEST)
 
 		// It also means they can do the old school cartoon schtick of eating
 		// an entire sandwich and spitting up an empty plate. Ptooie.

--- a/code/datums/inventory_slots/slots/slot_shoes.dm
+++ b/code/datums/inventory_slots/slots/slot_shoes.dm
@@ -23,7 +23,7 @@
 		var/blood_color
 		for(var/foot_tag in list(BP_L_FOOT, BP_R_FOOT))
 			var/obj/item/organ/external/stomper = GET_EXTERNAL_ORGAN(user, foot_tag)
-			if(stomper && stomper.coating?.total_volume)
+			if(REAGENT_TOTAL_VOLUME(stomper?.coating))
 				blood_color = stomper.coating.get_color()
 				break
 		if(blood_color)
@@ -39,7 +39,7 @@
 		return "[pronouns.He] [pronouns.is] wearing [_holding.get_examine_line()] on [pronouns.his] feet."
 	for(var/bp in list(BP_L_FOOT, BP_R_FOOT))
 		var/obj/item/organ/external/E = GET_EXTERNAL_ORGAN(owner, bp)
-		if(E && E.coating?.total_volume)
+		if(REAGENT_TOTAL_VOLUME(E?.coating))
 			if(user == owner)
 				return "There's <font color='[E.coating.get_color()]'>something on your feet</font>!"
 			return "There's <font color='[E.coating.get_color()]'>something on [pronouns.his] feet</font>!"

--- a/code/datums/storage/_storage.dm
+++ b/code/datums/storage/_storage.dm
@@ -193,7 +193,7 @@ var/global/list/_test_storage_items = list()
 		if(!M.try_unequip(inserting))
 			return FALSE
 
-	if(holder.reagents?.total_volume)
+	if(REAGENT_TOTAL_VOLUME(holder.reagents))
 		inserting.fluid_act(holder.reagents)
 		if(QDELETED(inserting))
 			return FALSE

--- a/code/datums/storage/subtypes_box.dm
+++ b/code/datums/storage/subtypes_box.dm
@@ -51,7 +51,7 @@
 	if(istype(removing, /obj/item/clothing/mask/smokable/cigarette/cigar) && isatom(holder))
 		var/atom/atom_holder = holder
 		if(atom_holder.reagents)
-			atom_holder.reagents.trans_to_obj(removing, (atom_holder.reagents.total_volume/max(1, length(get_contents()))))
+			atom_holder.reagents.trans_to_obj(removing, (REAGENT_TOTAL_VOLUME(atom_holder.reagents)/max(1, length(get_contents()))))
 	return ..()
 
 /datum/storage/box/cigarettes
@@ -63,7 +63,7 @@
 	if(istype(removing, /obj/item/clothing/mask/smokable/cigarette) && isatom(holder))
 		var/atom/atom_holder = holder
 		if(atom_holder.reagents)
-			atom_holder.reagents.trans_to_obj(removing, (atom_holder.reagents.total_volume/max(1, length(get_contents()))))
+			atom_holder.reagents.trans_to_obj(removing, (REAGENT_TOTAL_VOLUME(atom_holder.reagents)/max(1, length(get_contents()))))
 	return ..()
 
 /datum/storage/box/cigarettes/cigarello

--- a/code/datums/storage/subtypes_misc.dm
+++ b/code/datums/storage/subtypes_misc.dm
@@ -124,7 +124,7 @@
 	. = ..()
 	if(!.)
 		return
-	return inserting_item.reagents?.total_volume > 0
+	return REAGENT_TOTAL_VOLUME(inserting_item.reagents) > 0
 
 /datum/storage/photo_album
 	storage_slots = DEFAULT_BOX_STORAGE //yes, that's storage_slots. Photos are w_class 1 so this has as many slots equal to the number of photos you could put in a box

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -164,7 +164,7 @@
 
 /atom/proc/on_reagent_change()
 	SHOULD_CALL_PARENT(TRUE)
-	if(storage && reagents?.total_volume)
+	if(storage && REAGENT_TOTAL_VOLUME(reagents))
 		for(var/obj/item/thing in get_stored_inventory())
 			thing.fluid_act(reagents)
 	return TRUE
@@ -445,9 +445,10 @@
  * Most useful for calculating worth or deconstructing something along with its contents.
  */
 /atom/proc/get_contained_matter(include_reagents = TRUE)
-	if(include_reagents && length(reagents?.reagent_volumes))
+	var/list/reagent_volumes = REAGENT_VOLUMES(reagents)
+	if(include_reagents && length(reagent_volumes))
 		LAZYINITLIST(.)
-		for(var/decl/material/reagent as anything in reagents.reagent_volumes)
+		for(var/decl/material/reagent as anything in reagent_volumes)
 			.[reagent.type] += floor(REAGENT_VOLUME(reagents, reagent) / REAGENT_UNITS_PER_MATERIAL_UNIT)
 	for(var/atom/contained_obj as anything in get_contained_external_atoms()) // machines handle component parts separately
 		. = MERGE_ASSOCS_WITH_NUM_VALUES(., contained_obj.get_contained_matter(include_reagents))
@@ -504,7 +505,7 @@
 */
 /atom/proc/try_detonate_reagents(var/severity = 3)
 	if(reagents)
-		for(var/decl/material/reagent as anything in reagents.reagent_volumes)
+		for(var/decl/material/reagent as anything in REAGENT_VOLUMES(reagents))
 			reagent.explosion_act(src, severity)
 
 /**
@@ -1026,13 +1027,13 @@
 	return istype(turf) ? turf.is_outside() : OUTSIDE_UNCERTAIN
 
 /atom/proc/can_be_poured_into(atom/source)
-	return (reagents?.maximum_volume > 0) && ATOM_IS_OPEN_CONTAINER(src)
+	return (REAGENT_MAXIMUM_VOLUME(reagents) > 0) && ATOM_IS_OPEN_CONTAINER(src)
 
 /// This is whether it's physically possible to pour from this atom to the target atom, based on context like user intent and src being open, etc.
 /// This should not check things like whether there is actually anything in src to pour.
 /// It should also not check anything controlled by the target atom, because can_be_poured_into() already exists.
 /atom/proc/can_be_poured_from(mob/user, atom/target)
-	return (reagents?.maximum_volume > 0) && ATOM_IS_OPEN_CONTAINER(src)
+	return (REAGENT_MAXIMUM_VOLUME(reagents) > 0) && ATOM_IS_OPEN_CONTAINER(src)
 
 /atom/proc/take_vaporized_reagent(reagent, amount)
 	return
@@ -1041,7 +1042,7 @@
 	return !ATOM_IS_OPEN_CONTAINER(src)
 
 /atom/proc/can_drink_from(mob/user)
-	return ATOM_IS_OPEN_CONTAINER(src) && reagents?.total_volume && user.check_has_mouth()
+	return ATOM_IS_OPEN_CONTAINER(src) && REAGENT_TOTAL_VOLUME(reagents) && user.check_has_mouth()
 
 /atom/proc/adjust_required_attack_dexterity(mob/user, required_dexterity)
 	if(storage) // TODO: possibly check can_be_inserted() to avoid being able to shoot mirrors as a drake.

--- a/code/game/atoms_fluids.dm
+++ b/code/game/atoms_fluids.dm
@@ -3,9 +3,12 @@
 
 /atom/proc/fluid_act(var/datum/reagents/fluids)
 	SHOULD_CALL_PARENT(TRUE)
-	if(reagents && reagents != fluids && fluids?.total_volume >= FLUID_SHALLOW && !is_watertight())
-		reagents.trans_to_holder(fluids, reagents.total_volume)
-		fluids.trans_to_holder(reagents, min(fluids.total_volume, reagents.maximum_volume))
+	if(reagents && reagents != fluids && !is_watertight())
+		var/fluid_volume = REAGENT_TOTAL_VOLUME(fluids)
+		if(fluid_volume >= FLUID_SHALLOW)
+			var/reagent_volume = REAGENT_MAXIMUM_VOLUME(reagents)
+			reagents.trans_to_holder(fluids, reagent_volume)
+			fluids.trans_to_holder(reagents, fluid_volume, reagent_volume)
 
 /atom/proc/check_fluid_depth(var/min = 1)
 	return 0

--- a/code/game/atoms_interactions.dm
+++ b/code/game/atoms_interactions.dm
@@ -40,5 +40,5 @@ var/global/list/_reagent_interactions = list(
 	RETURN_TYPE(/list)
 	if(storage)
 		LAZYADD(., /decl/interaction_handler/storage_open)
-	if(reagents?.maximum_volume)
+	if(REAGENT_MAXIMUM_VOLUME(reagents))
 		LAZYADD(., global._reagent_interactions)

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -285,7 +285,7 @@
 
 		if(isturf(loc))
 			var/turf/T = loc
-			if(T.reagents?.total_volume && submerged())
+			if(REAGENT_TOTAL_VOLUME(T.reagents) && submerged())
 				fluid_act(T.reagents)
 
 		for(var/mob/viewer in storage?.storage_ui?.is_seeing)

--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -59,7 +59,7 @@
 		to_chat(user, SPAN_WARNING("\The [src] cannot accept any more chemical canisters."))
 		return FALSE
 	if(!emagged)
-		for(var/decl/material/reagent as anything in canister.reagents?.reagent_volumes)
+		for(var/decl/material/reagent as anything in REAGENT_VOLUMES(canister.reagents))
 			for(var/banned_type in banned_chem_types)
 				if(istype(reagent, banned_type))
 					to_chat(user, SPAN_WARNING("Automatic safety checking indicates the presence of a prohibited substance in this canister."))
@@ -125,7 +125,7 @@
 			. += SPAN_NOTICE("There are no chemical canisters loaded.")
 
 /obj/machinery/sleeper/proc/has_room_in_beaker()
-	return beaker && beaker.reagents.total_volume < beaker.reagents.maximum_volume
+	return beaker && REAGENT_TOTAL_VOLUME(beaker.reagents) < REAGENT_MAXIMUM_VOLUME(beaker.reagents)
 
 /obj/machinery/sleeper/Process()
 	if(stat & (NOPOWER|BROKEN))
@@ -142,7 +142,8 @@
 
 	if(filtering)
 		if(has_room_in_beaker())
-			var/trans_volume = LAZYLEN(occupant.reagents?.reagent_volumes)
+			var/trans_volumes = REAGENT_VOLUMES(occupant.reagents)
+			var/trans_volume = LAZYLEN(trans_volumes)
 			if(trans_volume)
 				occupant.reagents.trans_to_obj(beaker, pump_speed * trans_volume)
 				occupant.vessel.trans_to_obj(beaker, trans_volume + 1)
@@ -153,7 +154,8 @@
 		if(has_room_in_beaker())
 			var/datum/reagents/ingested = occupant.get_ingested_reagents()
 			if(ingested)
-				var/trans_volume = LAZYLEN(ingested.reagent_volumes)
+				var/trans_volumes = REAGENT_VOLUMES(ingested)
+				var/trans_volume = LAZYLEN(trans_volumes)
 				if(trans_volume)
 					ingested.trans_to_obj(beaker, pump_speed * trans_volume)
 		else
@@ -163,7 +165,8 @@
 		if(has_room_in_beaker())
 			var/datum/reagents/inhaled = occupant.get_inhaled_reagents()
 			if(inhaled)
-				var/trans_volume = LAZYLEN(inhaled?.reagent_volumes)
+				var/trans_volumes = REAGENT_VOLUMES(inhaled)
+				var/trans_volume = LAZYLEN(trans_volumes)
 				if(trans_volume)
 					inhaled.trans_to_obj(beaker, pump_speed * trans_volume)
 		else
@@ -208,7 +211,7 @@
 	var/empties = 0
 	var/list/loaded_reagents = list()
 	for(var/obj/item/chems/chem_disp_cartridge/canister in loaded_canisters)
-		if(!canister.reagents || !canister.reagents.total_volume)
+		if(!canister.reagents || !REAGENT_TOTAL_VOLUME(canister.reagents))
 			empties++
 			continue
 		var/list/reagent = list()
@@ -218,7 +221,7 @@
 		else
 			reagent	["name"] = "unlabeled"
 		reagent["id"] =     "\ref[canister]"
-		reagent["amount"] = canister.reagents.total_volume
+		reagent["amount"] = REAGENT_TOTAL_VOLUME(canister.reagents)
 		loaded_reagents += list(reagent)
 	data["reagents"] = loaded_reagents
 	data["empty_canisters"] = empties
@@ -258,7 +261,7 @@
 	if(href_list["eject_empties"])
 		. = TOPIC_NOACTION
 		for(var/obj/item/canister in loaded_canisters)
-			if(!canister.reagents || !canister.reagents.total_volume)
+			if(!canister.reagents || !REAGENT_TOTAL_VOLUME(canister.reagents))
 				eject_reagent_canister(null, canister)
 				. = TOPIC_REFRESH
 	if(href_list["eject"])
@@ -435,17 +438,16 @@
 	if(!istype(canister) || canister.loc != src)
 		to_chat(user, SPAN_WARNING("\The [src] cannot locate that canister."))
 		return
-	if(canister.reagents?.total_volume < amount)
+	if(REAGENT_TOTAL_VOLUME(canister.reagents) < amount)
 		to_chat(user, SPAN_WARNING("\The [canister] has less than [amount] unit\s left."))
 		return
 	if(!occupant || !occupant.reagents)
 		to_chat(user, SPAN_WARNING("There's no suitable occupant in \the [src]."))
 		return
-	if(!emagged && canister.reagents?.primary_reagent)
-		var/decl/material/chem = canister.reagents.primary_reagent
-		if(chem.overdose && REAGENT_VOLUME(occupant.reagents, canister.reagents.primary_reagent) + amount >= chem.overdose)
-			to_chat(user, SPAN_WARNING("Injecting more [chem.name] presents an overdose risk to the subject."))
-			return
+	var/decl/material/chem = canister.reagents?.get_primary_reagent_decl()
+	if(!emagged && chem?.overdose && REAGENT_VOLUME(occupant.reagents, chem) + amount >= chem.overdose)
+		to_chat(user, SPAN_WARNING("Injecting more [chem.name] presents an overdose risk to the subject."))
+		return
 	canister.reagents.trans_to_mob(occupant, amount, target_transfer_type)
 	to_chat(user, SPAN_NOTICE("You use \the [src] to [target_transfer_type == CHEM_INJECT ? "inject" : "infuse"] [amount] unit\s from \the [canister] into \the [occupant]."))
 

--- a/code/game/machinery/_machines_base/machinery.dm
+++ b/code/game/machinery/_machines_base/machinery.dm
@@ -472,7 +472,7 @@ Class Procs:
 // This is really pretty crap and should be overridden for specific machines.
 /obj/machinery/fluid_act(var/datum/reagents/fluids)
 	..()
-	if(!QDELETED(src) && !(stat & (NOPOWER|BROKEN)) && !waterproof && (fluids?.total_volume > FLUID_DEEP))
+	if(!QDELETED(src) && !(stat & (NOPOWER|BROKEN)) && !waterproof && (REAGENT_TOTAL_VOLUME(fluids) > FLUID_DEEP))
 		explosion_act(3)
 
 /obj/machinery/Move()

--- a/code/game/machinery/_machines_base/machinery_public_vars_common.dm
+++ b/code/game/machinery/_machines_base/machinery_public_vars_common.dm
@@ -104,7 +104,7 @@ Public vars at /obj/machinery level. Just because they are here does not mean th
 	var_type = VAR_FORMAT_LIST
 
 /decl/public_access/public_variable/reagents/access_var(obj/machinery/machine)
-	return machine?.reagents?.reagent_data
+	return istype(machine?.reagents) ? UNLINT(machine.reagents.reagent_data) : null
 
 /decl/public_access/public_variable/reagents/volumes
 	name = "reagents volumes"
@@ -112,7 +112,7 @@ Public vars at /obj/machinery level. Just because they are here does not mean th
 	var_type = VAR_FORMAT_LIST
 
 /decl/public_access/public_variable/reagents/volumes/access_var(obj/machinery/machine)
-	return machine?.reagents?.reagent_volumes
+	return istype(machine?.reagents) ? UNLINT(REAGENT_VOLUMES(machine.reagents)) : null
 
 /decl/public_access/public_variable/reagents/free_space
 	name = "reagents free space"
@@ -128,7 +128,7 @@ Public vars at /obj/machinery level. Just because they are here does not mean th
 	var_type = VAR_FORMAT_NUMBER
 
 /decl/public_access/public_variable/reagents/total_volume/access_var(obj/machinery/machine)
-	return machine?.reagents?.total_volume
+	return REAGENT_TOTAL_VOLUME(machine?.reagents)
 
 /decl/public_access/public_variable/reagents/maximum_volume
 	name = "reagents maximum volume"
@@ -136,7 +136,7 @@ Public vars at /obj/machinery level. Just because they are here does not mean th
 	var_type = VAR_FORMAT_NUMBER
 
 /decl/public_access/public_variable/reagents/maximum_volume/access_var(obj/machinery/machine)
-	return machine?.reagents?.maximum_volume
+	return REAGENT_MAXIMUM_VOLUME(machine?.reagents)
 
 /decl/public_access/public_method/toggle_power
 	name = "toggle power"

--- a/code/game/machinery/centrifuge.dm
+++ b/code/game/machinery/centrifuge.dm
@@ -5,7 +5,7 @@
 	expected_type = /obj/machinery/centrifuge
 
 /datum/storage/hopper/industrial/centrifuge/proc/should_ingest(mob/user, obj/item/thing)
-	if(thing.reagents?.total_volume <= 0)
+	if(REAGENT_TOTAL_VOLUME(thing.reagents) <= 0)
 		if(user)
 			to_chat(user, SPAN_WARNING("\The [thing] is empty."))
 		return FALSE

--- a/code/game/machinery/computer/prisoner.dm
+++ b/code/game/machinery/computer/prisoner.dm
@@ -26,7 +26,7 @@
 				continue // Out of range
 			if(!chem_implant.implanted)
 				continue
-			dat += "[chem_implant.imp_in.name] | Remaining Units: [chem_implant.reagents.total_volume] | Inject: "
+			dat += "[chem_implant.imp_in.name] | Remaining Units: [REAGENT_TOTAL_VOLUME(chem_implant.reagents)] | Inject: "
 			dat += "<A href='byond://?src=\ref[src];inject=\ref[chem_implant];amount=1'>(<font color=red>(1)</font>)</A>"
 			dat += "<A href='byond://?src=\ref[src];inject=\ref[chem_implant];amount=5'>(<font color=red>(5)</font>)</A>"
 			dat += "<A href='byond://?src=\ref[src];inject=\ref[chem_implant];amount=10'>(<font color=red>(10)</font>)</A><BR>"

--- a/code/game/machinery/cracker.dm
+++ b/code/game/machinery/cracker.dm
@@ -40,19 +40,21 @@
 	if(use_power == POWER_USE_IDLE)
 		return
 
-	// Produce materials.
 	var/turf/T = get_turf(src)
-	if(istype(T) && T.reagents?.total_volume)
+	if(!istype(T))
+		return
 
-		// Drink more water!
-		var/consuming = min(T.reagents.total_volume, fluid_consumption_per_tick)
-		T.remove_any_reagents(consuming)
-		T.show_bubbles()
+	var/local_fluid = REAGENT_VOLUME(T.reagents, /decl/material/liquid/water) // TODO: make this some list on the material?
+	if(local_fluid <= 0)
+		return
 
-		// Gas production.
-		var/datum/gas_mixture/produced = new
-		var/gen_amt = min(1, (gas_generated_per_tick * (consuming/fluid_consumption_per_tick)))
-		produced.adjust_gas(/decl/material/gas/oxygen,  gen_amt)
-		produced.adjust_gas(/decl/material/gas/hydrogen, gen_amt * 2)
-		produced.temperature = T20C //todo water temperature
-		air_contents.merge(produced)
+	var/consuming = min(REAGENT_TOTAL_VOLUME(T.reagents), fluid_consumption_per_tick)
+	T.remove_any_reagents(consuming)
+	T.show_bubbles()
+
+	var/datum/gas_mixture/produced = new
+	var/gen_amt = min(1, (gas_generated_per_tick * (consuming/fluid_consumption_per_tick)))
+	produced.adjust_gas(/decl/material/gas/oxygen,  gen_amt)
+	produced.adjust_gas(/decl/material/gas/hydrogen, gen_amt * 2)
+	produced.temperature = T20C //todo water temperature
+	air_contents.merge(produced)

--- a/code/game/machinery/kitchen/cooking_machines/_cooker.dm
+++ b/code/game/machinery/kitchen/cooking_machines/_cooker.dm
@@ -131,8 +131,9 @@
 		cook_path = /obj/item/food/variable
 	var/obj/item/food/result = new cook_path(src) //Holy typepaths, Batman.
 
-	if(cooking_obj.reagents && cooking_obj.reagents.total_volume)
-		cooking_obj.reagents.trans_to(result, cooking_obj.reagents.total_volume)
+	var/cooking_reagents = REAGENT_TOTAL_VOLUME(cooking_obj.reagents)
+	if(cooking_reagents > 0)
+		cooking_obj.reagents.trans_to(result, cooking_reagents)
 
 	// Set icon and appearance.
 	change_product_appearance(result)

--- a/code/game/machinery/kitchen/icecream.dm
+++ b/code/game/machinery/kitchen/icecream.dm
@@ -96,11 +96,11 @@
 	dat += "<b>Chocolate cones:</b> <a href='byond://?src=\ref[src];cone=[CONE_CHOC]'><b>Dispense</b></a> <a href='byond://?src=\ref[src];make=[CONE_CHOC];amount=1'><b>Make</b></a> <a href='byond://?src=\ref[src];make=[CONE_CHOC];amount=5'><b>x5</b></a> [product_types[CONE_CHOC]] cones left. (Ingredients: flour, sugar, coco powder)<br></div>"
 	dat += "<br>"
 	dat += "<b>VAT CONTENT</b><br>"
-	for(var/decl/material/reagent as anything in reagents?.liquid_volumes)
+	for(var/decl/material/reagent as anything in REAGENT_LIQUID_VOLUMES(reagents))
 		dat += "[reagent.get_reagent_name(reagents, MAT_PHASE_LIQUID)]: [LIQUID_VOLUME(reagents, reagent)]"
 		dat += "<A href='byond://?src=\ref[src];disposeI=\ref[reagent]'>Purge</A><BR>"
 
-	for(var/decl/material/reagent as anything in reagents?.solid_volumes)
+	for(var/decl/material/reagent as anything in REAGENT_SOLID_VOLUMES(reagents))
 		dat += "[reagent.get_reagent_name(reagents, MAT_PHASE_SOLID)]: [SOLID_VOLUME(reagents, reagent)]"
 		dat += "<A href='byond://?src=\ref[src];disposeI=\ref[reagent]'>Purge</A><BR>"
 
@@ -120,8 +120,9 @@
 				icecream.add_ice_cream(flavour_name)
 			//	if(beaker)
 			//		beaker.reagents.trans_to(icecream, 10)
-				if(icecream.reagents.total_volume < 10)
-					icecream.add_to_reagents(/decl/material/liquid/nutriment/sugar, 10 - icecream.reagents.total_volume)
+				var/icecream_volume = REAGENT_TOTAL_VOLUME(icecream.reagents)
+				if(icecream_volume < 10)
+					icecream.add_to_reagents(/decl/material/liquid/nutriment/sugar, 10 - icecream_volume)
 			else
 				to_chat(user, "<span class='warning'>There is not enough icecream left!</span>")
 		else

--- a/code/game/machinery/kitchen/microwave.dm
+++ b/code/game/machinery/kitchen/microwave.dm
@@ -180,8 +180,9 @@
 	for(var/obj/used_item in get_contained_external_atoms())
 		data["cooking_items"][used_item.name]++
 	data["cooking_reagents"] = list()
-	for(var/decl/material/reagent as anything in reagents.reagent_volumes)
-		data["cooking_reagents"][reagent.name] = reagents.reagent_volumes[reagent]
+	var/reagent_volumes = REAGENT_VOLUMES(reagents)
+	for(var/decl/material/reagent as anything in reagent_volumes)
+		data["cooking_reagents"][reagent.name] = reagent_volumes[reagent]
 	data["on"] = !!operating
 	data["broken"] = broken > 0
 	data["dirty"] = dirty >= 100
@@ -209,12 +210,13 @@
 	if(stat & (NOPOWER|BROKEN))
 		return
 
-	if (!reagents.total_volume && !length(get_contained_external_atoms())) //dry run
+	var/reagent_volume = REAGENT_TOTAL_VOLUME(reagents)
+	if (!reagent_volume && !length(get_contained_external_atoms())) //dry run
 		start()
 		return
 
-	if (reagents.total_volume && prob(50)) // 50% chance a liquid recipe gets messy
-		dirty += ceil(reagents.total_volume / 10)
+	if (reagent_volume && prob(50)) // 50% chance a liquid recipe gets messy
+		dirty += ceil(reagent_volume / 10)
 
 	var/decl/recipe/recipe = select_recipe(RECIPE_CATEGORY_MICROWAVE, src, cooking_temperature)
 	if (!recipe)
@@ -253,7 +255,7 @@
 			break
 
 	//Any leftover reagents are divided amongst the foods
-	var/total = reagents.total_volume
+	var/total = REAGENT_TOTAL_VOLUME(reagents)
 	for (var/obj/item/I in cooked_items)
 		reagents.trans_to_holder(I.reagents, total/cooked_items.len)
 		I.dropInto(loc) // since eject only ejects ingredients!
@@ -347,11 +349,12 @@
 
 /obj/machinery/microwave/proc/dispose(var/mob/user, var/message = TRUE)
 	var/list/ingredients = get_contained_external_atoms()
-	if (!LAZYLEN(ingredients) && !reagents.total_volume)
+	var/reagent_volume = REAGENT_TOTAL_VOLUME(reagents)
+	if (!LAZYLEN(ingredients) && !reagent_volume)
 		return
 	for (var/obj/thing in ingredients)
 		thing.dropInto(loc)
-	if (reagents.total_volume)
+	if (reagent_volume)
 		dirty++
 	reagents.clear_reagents()
 	if(user && message)
@@ -367,7 +370,7 @@
 	SSnano.update_uis(src)
 
 /obj/machinery/microwave/proc/eject_reagent(var/mob/user, var/decl/material/reagent)
-	if(!reagents.reagent_volumes[reagent])
+	if(!REAGENT_VOLUME(reagents, reagent))
 		SSnano.update_uis(src)
 		return // should not happen, must be a UI glitch or href hacking
 	var/obj/item/chems/held_container = user.get_active_held_item()
@@ -404,8 +407,9 @@
 
 	for (var/obj/thing in ingredients)
 		amount++
-		if (thing.reagents && thing.reagents.primary_reagent)
-			amount += REAGENT_VOLUME(thing.reagents, thing.reagents.primary_reagent)
+		var/thing_reagent = istype(thing.reagents) && thing.reagents.get_primary_reagent_decl()
+		if (thing_reagent)
+			amount += REAGENT_VOLUME(thing.reagents, thing_reagent)
 		qdel(thing)
 	reagents.clear_reagents()
 	SSnano.update_uis(src)
@@ -432,7 +436,7 @@
 			return TOPIC_REFRESH
 
 		if ("ejectreagent")
-			for(var/decl/material/reagent as anything in reagents.reagent_volumes)
+			for(var/decl/material/reagent as anything in REAGENT_VOLUMES(reagents))
 				if(reagent.name == href_list["target"])
 					eject_reagent(user, reagent)
 					break

--- a/code/game/machinery/smartfridge/foods.dm
+++ b/code/game/machinery/smartfridge/foods.dm
@@ -11,4 +11,4 @@
 		/obj/item/chems/glass/bowl,
 		/obj/item/chems/glass/handmade/bowl
 	)
-	return istype(O) && O.reagents?.total_volume && is_type_in_list(O, _food_types)
+	return istype(O) && REAGENT_TOTAL_VOLUME(O.reagents) && is_type_in_list(O, _food_types)

--- a/code/game/machinery/washing_machine.dm
+++ b/code/game/machinery/washing_machine.dm
@@ -65,7 +65,7 @@
 /obj/machinery/washing_machine/proc/wash()
 	if(operable())
 		var/list/washing_atoms = get_contained_external_atoms()
-		var/amount_per_atom = floor(reagents.total_volume / length(washing_atoms))
+		var/amount_per_atom = floor(REAGENT_TOTAL_VOLUME(reagents) / length(washing_atoms))
 
 		if(amount_per_atom > 0)
 			var/decl/material/smelliest = get_smelliest_reagent(reagents)
@@ -94,13 +94,13 @@
 		if(!(atom_flags & ATOM_FLAG_OPEN_CONTAINER))
 			to_chat(user, SPAN_WARNING("Open the detergent port first!"))
 			return TRUE
-		if(reagents.total_volume >= reagents.maximum_volume)
+		if(REAGENT_TOTAL_VOLUME(reagents) >= REAGENT_MAXIMUM_VOLUME(reagents))
 			to_chat(user, SPAN_WARNING("The detergent port is full!"))
 			return TRUE
 		if(!user.try_unequip(used_item))
 			return TRUE
 		// Directly transfer to the holder to avoid touch reactions.
-		used_item.reagents?.trans_to_holder(reagents, used_item.reagents.total_volume)
+		used_item.reagents?.trans_to_holder(reagents, REAGENT_TOTAL_VOLUME(used_item.reagents))
 		to_chat(user, SPAN_NOTICE("You dissolve \the [used_item] in the detergent port."))
 		qdel(used_item)
 		return TRUE
@@ -200,7 +200,7 @@
 		to_chat(user, SPAN_WARNING("\The [src] isn't functioning!"))
 		return
 
-	if(!reagents.total_volume)
+	if(!REAGENT_TOTAL_VOLUME(reagents))
 		to_chat(user, SPAN_WARNING("There are no cleaning products loaded in \the [src]!"))
 		return
 

--- a/code/game/objects/__objs.dm
+++ b/code/game/objects/__objs.dm
@@ -269,7 +269,7 @@
  */
 /obj/proc/initialize_reagents(var/populate = TRUE)
 	SHOULD_CALL_PARENT(TRUE)
-	if(reagents?.total_volume > 0)
+	if(REAGENT_TOTAL_VOLUME(reagents) > 0)
 		log_warning("\The [src] possibly is initializing its reagents more than once!")
 	create_or_update_reagents(chem_volume)
 	if(populate)
@@ -331,7 +331,7 @@
 
 /obj/fluid_act(var/datum/reagents/fluids)
 	..()
-	if(!QDELETED(src) && fluids?.total_volume)
+	if(!QDELETED(src) && REAGENT_TOTAL_VOLUME(fluids))
 		fluids.touch_obj(src)
 
 // TODO: maybe iterate the entire matter list or do some partial damage handling
@@ -345,8 +345,9 @@
 	. = ..()
 	if(QDELETED(src))
 		return
-	if(reagents?.total_volume)
-		reagents.trans_to(loc, reagents.total_volume)
+	var/reagent_volume = REAGENT_TOTAL_VOLUME(reagents)
+	if(reagent_volume)
+		reagents.trans_to(loc, reagent_volume)
 	dump_contents()
 	return place_melted_product(meltable_materials)
 
@@ -424,12 +425,12 @@
 /obj/physically_destroyed(skip_qdel)
 	var/dumped_reagents = FALSE
 	var/atom/last_loc = loc
-	if(last_loc && reagents?.total_volume)
-		reagents.trans_to(loc, reagents.total_volume, defer_update = TRUE)
+	if(last_loc && REAGENT_TOTAL_VOLUME(reagents))
+		reagents.trans_to(loc, REAGENT_TOTAL_VOLUME(reagents), defer_update = TRUE)
 		dumped_reagents = TRUE
 		reagents.clear_reagents() // We are qdeling, don't bother with a more nuanced update.
 	. = ..()
-	if(dumped_reagents && last_loc && !QDELETED(last_loc) && last_loc.reagents?.total_volume)
+	if(dumped_reagents && last_loc && !QDELETED(last_loc) && REAGENT_TOTAL_VOLUME(last_loc.reagents))
 		last_loc.reagents.handle_update()
 		HANDLE_REACTIONS(last_loc.reagents)
 

--- a/code/game/objects/_objs_edibility.dm
+++ b/code/game/objects/_objs_edibility.dm
@@ -151,12 +151,12 @@
 		show_feed_message_start(user, target, consumption_method)
 		if(!do_mob(user, target))
 			return EATEN_UNABLE
-		var/contained = json_encode(REAGENT_LIST(src))
+		var/contained = json_encode(REAGENT_LIST(reagents))
 		admin_attack_log(user, target, "Fed the victim with [name] (Reagents: [contained])", "Was fed [src] (Reagents: [contained])", "used [src] (Reagents: [contained]) to feed")
 
 	show_feed_message_end(user, target, consumption_method)
 	if(consumption_method == EATING_METHOD_DRINK && target?.has_personal_goal(/datum/goal/achievement/specific_object/drink))
-		for(var/decl/material/reagent as anything in reagents.reagent_volumes)
+		for(var/decl/material/reagent as anything in REAGENT_VOLUMES(reagents))
 			target.update_personal_goal(/datum/goal/achievement/specific_object/drink, reagent)
 	handle_consumed(user, target, consumption_method)
 

--- a/code/game/objects/effects/chem/chemsmoke.dm
+++ b/code/game/objects/effects/chem/chemsmoke.dm
@@ -106,7 +106,7 @@
 /datum/effect/effect/system/smoke_spread/chem/set_up(var/datum/reagents/carry = null, n = 10, c = 0, loca, direct)
 	range = n * 0.3
 	cardinals = c
-	carry.trans_to_obj(chemholder, carry.total_volume, copy = 1)
+	carry.trans_to_obj(chemholder, REAGENT_TOTAL_VOLUME(carry), copy = 1)
 
 	if(istype(loca, /turf/))
 		location = loca
@@ -157,7 +157,8 @@
 	if(!location)
 		return
 
-	if(LAZYLEN(chemholder.reagents.reagent_volumes))
+	var/trans_volumes = REAGENT_VOLUMES(chemholder.reagents)
+	if(LAZYLEN(trans_volumes))
 		for(var/turf/T in (wallList|targetTurfs))
 			chemholder.reagents.touch_turf(T)
 
@@ -216,8 +217,9 @@
 	else
 		smoke = new /obj/effect/effect/smoke/chem(location, smoke_duration + rand(0, 20), T, I)
 
-	if(LAZYLEN(chemholder.reagents.reagent_volumes))
-		chemholder.reagents.trans_to_obj(smoke, chemholder.reagents.total_volume / dist, copy = 1) //copy reagents to the smoke so mob/breathe() can handle inhaling the reagents
+	var/trans_volumes = REAGENT_VOLUMES(chemholder.reagents)
+	if(LAZYLEN(trans_volumes))
+		chemholder.reagents.trans_to_obj(smoke, REAGENT_TOTAL_VOLUME(chemholder.reagents) / dist, copy = 1) //copy reagents to the smoke so mob/breathe() can handle inhaling the reagents
 
 	//Kinda ugly, but needed unless the system is reworked
 	if(splash_initial)

--- a/code/game/objects/effects/chem/foam.dm
+++ b/code/game/objects/effects/chem/foam.dm
@@ -57,8 +57,8 @@
 
 		F = new(T, metal)
 		F.amount = amount
-		if(!metal && reagents?.total_volume)
-			for(var/decl/material/reagent as anything in reagents.reagent_volumes)
+		if(!metal && REAGENT_TOTAL_VOLUME(reagents))
+			for(var/decl/material/reagent as anything in REAGENT_VOLUMES(reagents))
 				F.add_to_reagents(reagent, 1, safety = 1) //added safety check since reagents in the foam have already had a chance to react
 
 /obj/effect/effect/foam/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume) // foam disolves when heated, except metal foams
@@ -92,7 +92,7 @@
 	// bit of a hack here. Foam carries along any reagent also present in the glass it is mixed with (defaults to water if none is present). Rather than actually transfer the reagents, this makes a list of the reagent ids and spawns 1 unit of that reagent when the foam disolves.
 
 	if(carry && !metal)
-		for(var/decl/material/reagent as anything in carry.reagent_volumes)
+		for(var/decl/material/reagent as anything in REAGENT_VOLUMES(carry))
 			carried_reagents += reagent
 
 /datum/effect/effect/system/foam_spread/start()

--- a/code/game/objects/effects/chem/water.dm
+++ b/code/game/objects/effects/chem/water.dm
@@ -34,15 +34,16 @@
 
 			//each step splash 1/5 of the reagents on non-mobs
 			//could determine the # of steps until target, but that would be complicated
+			// TODO: fix this logic so it isn't using an increasingly smaller amount each iteration.
 			for(var/atom/A in splash_others)
-				reagents.splash(A, (reagents.total_volume/step_count)/splash_others.len)
+				reagents.splash(A, (REAGENT_TOTAL_VOLUME(reagents)/step_count)/splash_others.len)
 			for(var/mob/living/M in splash_mobs)
-				reagents.splash(M, reagents.total_volume/splash_mobs.len)
-			if(reagents.total_volume < 1)
+				reagents.splash(M, REAGENT_TOTAL_VOLUME(reagents)/splash_mobs.len)
+			if(REAGENT_TOTAL_VOLUME(reagents) < 1)
 				break
 			if(T == get_turf(target))
 				for(var/atom/A in splash_others)
-					reagents.splash(A, reagents.total_volume/splash_others.len) //splash anything left
+					reagents.splash(A, REAGENT_TOTAL_VOLUME(reagents)/splash_others.len) //splash anything left
 				break
 
 		sleep(delay)

--- a/code/game/objects/effects/decals/Cleanable/misc.dm
+++ b/code/game/objects/effects/decals/Cleanable/misc.dm
@@ -101,7 +101,7 @@
 
 /obj/effect/decal/cleanable/vomit/Crossed(atom/movable/AM)
 	. = ..()
-	if(!QDELETED(src) && reagents?.total_volume >= 1 && isliving(AM))
+	if(!QDELETED(src) && REAGENT_TOTAL_VOLUME(reagents) >= 1 && isliving(AM))
 		var/mob/living/walker = AM
 		walker.add_walking_contaminant(reagents, rand(2, 3))
 

--- a/code/game/objects/effects/decals/cleanable.dm
+++ b/code/game/objects/effects/decals/cleanable.dm
@@ -72,7 +72,7 @@
 
 /obj/effect/decal/cleanable/fluid_act(var/datum/reagents/fluid)
 	SHOULD_CALL_PARENT(FALSE)
-	if(fluid?.total_liquid_volume && !QDELETED(src))
-		if(reagents?.total_volume)
-			reagents.trans_to(fluid, reagents.total_volume)
+	if(REAGENT_TOTAL_LIQUID_VOLUME(fluid) && !QDELETED(src))
+		if(REAGENT_TOTAL_VOLUME(reagents))
+			reagents.trans_to(fluid, REAGENT_TOTAL_VOLUME(reagents))
 		qdel(src)

--- a/code/game/objects/items/__item.dm
+++ b/code/game/objects/items/__item.dm
@@ -414,7 +414,7 @@
 	if(drying_wetness > 0 && drying_wetness != initial(drying_wetness))
 		desc_comp += "\The [src] is [get_dryness_text()]."
 
-	if(coating?.total_volume)
+	if(REAGENT_TOTAL_VOLUME(coating))
 		desc_comp += "It is covered in [coating.get_coated_name()]." // It is covered in dilute oily slimy bloody mud.
 
 	if(check_rights(R_DEBUG, 0, user))
@@ -1057,14 +1057,14 @@ modules/mob/living/human/life.dm if you die, you will be zoomed out.
 	if(!coating)
 		return
 	coating.remove_any(amount)
-	if(coating.total_volume <= MINIMUM_CHEMICAL_VOLUME)
+	if(REAGENT_TOTAL_VOLUME(coating) <= MINIMUM_CHEMICAL_VOLUME)
 		clean(FALSE)
 
 /obj/item/proc/transfer_coating_to(atom/target, amount = 1, multiplier = 1, copy = 0, defer_update = FALSE, transferred_phases = (MAT_PHASE_LIQUID | MAT_PHASE_SOLID))
 	if(!coating)
 		return
 	coating.trans_to(target, amount, multiplier)
-	if(coating.total_volume <= MINIMUM_CHEMICAL_VOLUME)
+	if(REAGENT_TOTAL_VOLUME(coating) <= MINIMUM_CHEMICAL_VOLUME)
 		clean(FALSE)
 
 /obj/item/clean(clean_forensics=TRUE)
@@ -1211,9 +1211,9 @@ modules/mob/living/human/life.dm if you die, you will be zoomed out.
 		var/decl/material/bait_mat = GET_DECL(mat)
 		if(bait_mat.fishing_bait_value)
 			. += MATERIAL_UNITS_TO_REAGENTS_UNITS(matter[mat]) * bait_mat.fishing_bait_value * BAIT_VALUE_CONSTANT
-	for(var/decl/material/reagent as anything in reagents?.reagent_volumes)
+	for(var/decl/material/reagent as anything in REAGENT_VOLUMES(reagents))
 		if(reagent.fishing_bait_value)
-			. += reagents.reagent_volumes[reagent] * reagent.fishing_bait_value * BAIT_VALUE_CONSTANT
+			. += REAGENT_VOLUME(reagents, reagent) * reagent.fishing_bait_value * BAIT_VALUE_CONSTANT
 #undef BAIT_VALUE_CONSTANT
 
 /obj/item/proc/get_storage_cost()
@@ -1277,7 +1277,7 @@ modules/mob/living/human/life.dm if you die, you will be zoomed out.
 /// @returns:
 /// - reagent_overlay as /image|null - the overlay image representing the reagents in this object
 /obj/item/proc/get_reagents_overlay(state_prefix)
-	if(reagents?.total_volume <= 0)
+	if(REAGENT_TOTAL_VOLUME(reagents) <= 0)
 		return
 	var/decl/material/primary_reagent = reagents.get_primary_reagent_decl()
 	if(!primary_reagent)
@@ -1292,7 +1292,7 @@ modules/mob/living/human/life.dm if you die, you will be zoomed out.
 	if(!reagents_state || !check_state_in_icon(reagents_state, icon))
 		return
 	var/image/reagent_overlay = overlay_image(icon, reagents_state, reagents.get_color(), RESET_COLOR | RESET_ALPHA)
-	for(var/decl/material/reagent as anything in reagents.reagent_volumes)
+	for(var/decl/material/reagent as anything in REAGENT_VOLUMES(reagents))
 		if(!reagent.reagent_overlay)
 			continue
 		var/modified_reagent_overlay = state_prefix ? "[state_prefix]_[reagent.reagent_overlay]" : reagent.reagent_overlay
@@ -1304,7 +1304,7 @@ modules/mob/living/human/life.dm if you die, you will be zoomed out.
 /obj/item/on_reagent_change()
 	. = ..()
 	// You can't put liquids in clay/sand/dirt vessels, sorry.
-	if(reagents?.total_liquid_volume > 0 && material && material.hardness <= MAT_VALUE_MALLEABLE && !QDELETED(src))
+	if(REAGENT_TOTAL_LIQUID_VOLUME(reagents) > 0 && material && material.hardness <= MAT_VALUE_MALLEABLE && !QDELETED(src))
 		visible_message(SPAN_DANGER("\The [src] falls apart!"))
 		squash_item()
 		if(!QDELETED(src))
@@ -1314,7 +1314,7 @@ modules/mob/living/human/life.dm if you die, you will be zoomed out.
 	return null
 
 /obj/item/get_examine_prefix()
-	if(coating?.total_volume)
+	if(REAGENT_TOTAL_VOLUME(coating))
 		var/coating_string = coating.get_coated_adjectives() // component coloring is handled in here
 		if(get_config_value(/decl/config/enum/colored_coating_names) == CONFIG_COATING_COLOR_MIXTURE)
 			coating_string = FONT_COLORED(coating.get_color(), coating_string)

--- a/code/game/objects/items/_item_edibility.dm
+++ b/code/game/objects/items/_item_edibility.dm
@@ -8,7 +8,7 @@
 	var/utensil_food_type = get_utensil_food_type()
 	if(!istype(utensil) || !utensil_food_type)
 		return
-	var/remove_amt = min(reagents?.total_volume, get_food_default_transfer_amount(user))
+	var/remove_amt = min(REAGENT_TOTAL_VOLUME(reagents), get_food_default_transfer_amount(user))
 	if(remove_amt)
 
 		// Create a dummy copy of the target food item.
@@ -28,7 +28,7 @@
 		utensil.loaded_food.reagents.clear_reagents()
 		reagents.trans_to(utensil.loaded_food, remove_amt)
 		handle_chunk_separated()
-		if(!reagents.total_volume)
+		if(!REAGENT_TOTAL_VOLUME(reagents))
 			handle_consumed(user) // it's not actually being consumed, so i'm not sure this is correct
 		utensil.update_icon()
 

--- a/code/game/objects/items/_item_reagents.dm
+++ b/code/game/objects/items/_item_reagents.dm
@@ -2,7 +2,7 @@
 	if(!istype(target) || isnull(target.get_reagent_amount_dispensed()) || (!skip_container_check && (target.atom_flags & ATOM_FLAG_OPEN_CONTAINER)))
 		return FALSE
 
-	if(!target.reagents || !target.reagents.total_volume)
+	if(!target.reagents || !REAGENT_TOTAL_VOLUME(target.reagents))
 		to_chat(user, SPAN_NOTICE("[target] is empty of reagents."))
 		return TRUE
 
@@ -22,7 +22,7 @@
 		to_chat(user, SPAN_NOTICE("You can't splash people on help intent."))
 		return TRUE
 
-	if(!reagents || !reagents.total_volume)
+	if(!reagents || !REAGENT_TOTAL_VOLUME(reagents))
 		to_chat(user, SPAN_NOTICE("[src] is empty of reagents."))
 		return TRUE
 
@@ -30,14 +30,14 @@
 		to_chat(user, SPAN_NOTICE("[target] is full of reagents."))
 		return TRUE
 
-	var/contained = REAGENT_LIST(src)
+	var/contained = REAGENT_LIST(reagents)
 
 	admin_attack_log(user, target, "Used \the [name] containing [contained] to splash the victim.", "Was splashed by \the [name] containing [contained].", "used \the [name] containing [contained] to splash")
 	user.visible_message( \
 		SPAN_DANGER("\The [target] has been splashed with the contents of \the [src] by \the [user]!"), \
 		SPAN_DANGER("You splash \the [target] with the contents of \the [src]."))
 
-	reagents.splash(target, reagents.total_volume)
+	reagents.splash(target, REAGENT_TOTAL_VOLUME(reagents))
 	return TRUE
 
 /obj/item/proc/standard_pour_into(mob/user, atom/target, amount = 5) // This goes into afterattack and yes, it's atom-level
@@ -55,7 +55,7 @@
 	if(!can_be_poured_from(user, target))
 		return TRUE // don't splash if we can't pour
 
-	if(!reagents || !reagents.total_volume)
+	if(!reagents || !REAGENT_TOTAL_VOLUME(reagents))
 		to_chat(user, SPAN_NOTICE("[src] is empty of reagents."))
 		return TRUE
 
@@ -63,7 +63,8 @@
 		to_chat(user, SPAN_NOTICE("[target] is full of reagents."))
 		return TRUE
 
-	var/had_liquids = length(reagents.liquid_volumes)
+	var/liquid_volumes = REAGENT_LIQUID_VOLUMES(reagents)
+	var/had_liquids = length(liquid_volumes)
 	var/transferred_amount = reagents.trans_to(target, amount)
 
 	if(had_liquids)
@@ -71,5 +72,5 @@
 	else
 		// Sounds more like pouring small pellets or dust.
 		playsound(src, 'sound/effects/refill.ogg', 25, 1)
-	to_chat(user, SPAN_NOTICE("You transfer [transferred_amount] unit\s of the solution to \the [target]. \The [src] now contains [reagents.total_volume] unit\s."))
+	to_chat(user, SPAN_NOTICE("You transfer [transferred_amount] unit\s of the solution to \the [target]. \The [src] now contains [REAGENT_TOTAL_VOLUME(reagents)] unit\s."))
 	return TRUE

--- a/code/game/objects/items/contraband.dm
+++ b/code/game/objects/items/contraband.dm
@@ -48,10 +48,10 @@
 		add_to_reagents(reagent, picked_reagents[reagent])
 
 	var/list/names = new
-	for(var/decl/material/reagent as anything in reagents.liquid_volumes)
+	for(var/decl/material/reagent as anything in REAGENT_LIQUID_VOLUMES(reagents))
 		names += reagent.get_reagent_name(reagents, MAT_PHASE_LIQUID)
 
-	for(var/decl/material/reagent as anything in reagents.solid_volumes)
+	for(var/decl/material/reagent as anything in REAGENT_SOLID_VOLUMES(reagents))
 		names += reagent.get_reagent_name(reagents, MAT_PHASE_SOLID)
 
 	desc = "Contains [english_list(names)]."

--- a/code/game/objects/items/flame/_flame.dm
+++ b/code/game/objects/items/flame/_flame.dm
@@ -158,19 +158,19 @@
 /obj/item/flame/fluid_act(var/datum/reagents/fluids)
 	..()
 
-	if(QDELETED(src) || !fluids?.total_volume || !lit)
+	if(QDELETED(src) || !REAGENT_TOTAL_VOLUME(fluids) || !lit)
 		return
 
 	var/turf/location = get_turf(src)
 	if(location)
 		location.hotspot_expose(700, 5) // Potentially set fire to fuel etc.
-		if(QDELETED(src) || !fluids?.total_volume)
+		if(QDELETED(src) || !REAGENT_TOTAL_VOLUME(fluids))
 			return
 
 	if(waterproof)
 		return
 
-	if(fluids.total_volume >= FLUID_PUDDLE)
+	if(REAGENT_TOTAL_VOLUME(fluids) >= FLUID_PUDDLE)
 		snuff_out(no_message = TRUE)
 
 /obj/item/flame/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume)

--- a/code/game/objects/items/flame/flame_fuelled.dm
+++ b/code/game/objects/items/flame/flame_fuelled.dm
@@ -22,9 +22,9 @@
 /obj/item/flame/fuelled/use_on_mob(mob/living/target, mob/living/user, animate = TRUE)
 	if(get_attack_force() && !(item_flags & ITEM_FLAG_NO_BLUDGEON) && user.check_intent(I_FLAG_HARM))
 		. = ..()
-		if(reagents?.total_volume && !QDELETED(target))
+		if(REAGENT_TOTAL_VOLUME(reagents) && !QDELETED(target))
 			target.visible_message(SPAN_DANGER("Some of the contents of \the [src] splash onto \the [target]."))
-			reagents.splash(target, reagents.total_volume)
+			reagents.splash(target, REAGENT_TOTAL_VOLUME(reagents))
 		return TRUE
 	return FALSE
 
@@ -40,9 +40,9 @@
 		return TRUE
 	if(handle_eaten_by_mob(user, target) != EATEN_INVALID)
 		return TRUE
-	if(reagents?.total_volume)
+	if(REAGENT_TOTAL_VOLUME(reagents))
 		to_chat(user, SPAN_NOTICE("You splash a small amount of the contents of \the [src] onto \the [target]."))
-		reagents.splash(target, min(reagents.total_volume, 5))
+		reagents.splash(target, min(REAGENT_TOTAL_VOLUME(reagents), 5))
 		return TRUE
 	. = ..()
 
@@ -56,8 +56,9 @@
 		if(fuel_reagent)
 			. += SPAN_NOTICE("\The [src] is designed to burn [fuel_reagent.liquid_name].")
 
-		if(reagents?.maximum_volume)
-			switch(reagents.total_volume / reagents.maximum_volume)
+		var/max_vol = REAGENT_MAXIMUM_VOLUME(reagents)
+		if(max_vol)
+			switch(REAGENT_TOTAL_VOLUME(reagents) / max_vol)
 				if(0 to 0.1)
 					. += SPAN_WARNING("\The [src] is nearly empty.")
 				if(0.1 to 0.25)
@@ -84,8 +85,10 @@
 	return FALSE
 
 /obj/item/flame/fuelled/populate_reagents()
-	if(start_fuelled && fuel_type && reagents?.maximum_volume)
-		add_to_reagents(fuel_type, reagents.maximum_volume)
+	if(start_fuelled && fuel_type)
+		var/max_vol = REAGENT_MAXIMUM_VOLUME(reagents)
+		if(max_vol)
+			add_to_reagents(fuel_type, max_vol)
 
 /obj/item/flame/fuelled/Process()
 	. = ..()

--- a/code/game/objects/items/flame/flame_torch.dm
+++ b/code/game/objects/items/flame/flame_torch.dm
@@ -20,7 +20,7 @@
 	return available_scents
 
 /obj/item/flame/torch/light(mob/user, no_message)
-	if(coating?.total_volume && coating.get_accelerant_value() < FUEL_VALUE_NONE)
+	if(REAGENT_TOTAL_VOLUME(coating) && coating.get_accelerant_value() < FUEL_VALUE_NONE)
 		to_chat(user, SPAN_WARNING("You cannot light \the [src] while it is wet!"))
 		return FALSE
 	if(burnt)

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -52,42 +52,43 @@
 	_base_attack_force            = 0
 
 /obj/item/chems/water_balloon/adjust_mob_overlay(mob/living/user_mob, bodytype, image/overlay, slot, bodypart, use_fallback_if_icon_missing = TRUE)
-	if(overlay && reagents?.total_volume <= 0)
+	if(overlay && REAGENT_TOTAL_VOLUME(reagents) <= 0)
 		overlay.icon_state = "[overlay.icon_state]_empty"
 	. = ..()
 
 /obj/item/chems/water_balloon/get_examine_strings(mob/user, distance, infix, suffix)
 	. = ..()
 	if(distance <= 1)
-		. += "It's [reagents?.total_volume > 0? "filled with liquid sloshing around" : "empty"]."
+		. += "It's [REAGENT_TOTAL_VOLUME(reagents) > 0? "filled with liquid sloshing around" : "empty"]."
 
 /obj/item/chems/water_balloon/on_reagent_change()
 	if(!(. = ..()))
 		return
-	w_class = (reagents?.total_volume > 0)? ITEM_SIZE_SMALL : ITEM_SIZE_TINY
+	w_class = (REAGENT_TOTAL_VOLUME(reagents) > 0)? ITEM_SIZE_SMALL : ITEM_SIZE_TINY
 	//#TODO: Maybe acids should handle eating their own containers themselves?
-	for(var/decl/material/reagent as anything in reagents?.reagent_volumes)
+	for(var/decl/material/reagent as anything in REAGENT_VOLUMES(reagents))
 		if(reagent.solvent_power >= MAT_SOLVENT_STRONG)
 			visible_message(SPAN_DANGER("\The [reagent] chews through \the [src]!"))
 			physically_destroyed()
 
 /obj/item/chems/water_balloon/throw_impact(atom/hit_atom, datum/thrownthing/TT)
 	..()
-	if(reagents?.total_volume > 0)
+	if(REAGENT_TOTAL_VOLUME(reagents) > 0)
 		visible_message(SPAN_WARNING("\The [src] bursts!"))
 		physically_destroyed()
 
 /obj/item/chems/water_balloon/physically_destroyed(skip_qdel)
-	if(reagents?.total_volume > 0)
+	var/reagent_volume = REAGENT_TOTAL_VOLUME(reagents)
+	if(reagent_volume > 0)
 		new /obj/effect/temporary(src, 5, icon, "[get_world_inventory_state()]_burst")
-		reagents.splash_turf(get_turf(src), reagents.total_volume)
+		reagents.splash_turf(get_turf(src), reagent_volume)
 		playsound(src, 'sound/effects/balloon-pop.ogg', 75, TRUE, 3)
 	. = ..()
 
 /obj/item/chems/water_balloon/on_update_icon()
 	. = ..()
 	icon_state = get_world_inventory_state()
-	if(reagents?.total_volume <= 0)
+	if(REAGENT_TOTAL_VOLUME(reagents) <= 0)
 		icon_state = "[icon_state]_empty"
 
 /obj/item/chems/water_balloon/afterattack(obj/target, mob/user, proximity)

--- a/code/game/objects/items/waterskin.dm
+++ b/code/game/objects/items/waterskin.dm
@@ -65,4 +65,4 @@
 
 /obj/item/chems/glass/waterskin/crafted/wine/populate_reagents()
 	. = ..()
-	add_to_reagents(/decl/material/liquid/alcohol/wine, reagents?.maximum_volume)
+	add_to_reagents(/decl/material/liquid/alcohol/wine, REAGENT_MAXIMUM_VOLUME(reagents))

--- a/code/game/objects/items/weapons/ecigs.dm
+++ b/code/game/objects/items/weapons/ecigs.dm
@@ -39,7 +39,7 @@
 /obj/item/clothing/mask/smokable/ecig/simple/get_examine_strings(mob/user, distance, infix, suffix)
 	. = ..()
 	if(ec_cartridge)
-		. += SPAN_NOTICE("There are [round(ec_cartridge.reagents.total_volume, 1)] units of liquid remaining.")
+		. += SPAN_NOTICE("There are [round(REAGENT_TOTAL_VOLUME(ec_cartridge.reagents), 1)] units of liquid remaining.")
 	else
 		. += SPAN_NOTICE("There's no cartridge connected.")
 
@@ -58,7 +58,7 @@
 /obj/item/clothing/mask/smokable/ecig/util/get_examine_strings(mob/user, distance, infix, suffix)
 	. = ..()
 	if(ec_cartridge)
-		. += SPAN_NOTICE("There are [round(ec_cartridge.reagents.total_volume, 1)] units of liquid remaining.")
+		. += SPAN_NOTICE("There are [round(REAGENT_TOTAL_VOLUME(ec_cartridge.reagents), 1)] units of liquid remaining.")
 	else
 		. += SPAN_NOTICE("There's no cartridge connected.")
 
@@ -74,7 +74,7 @@
 /obj/item/clothing/mask/smokable/ecig/deluxe/get_examine_strings(mob/user, distance, infix, suffix)
 	. = ..()
 	if(ec_cartridge)
-		. += SPAN_NOTICE("There are [round(ec_cartridge.reagents.total_volume, 1)] units of liquid remaining.")
+		. += SPAN_NOTICE("There are [round(REAGENT_TOTAL_VOLUME(ec_cartridge.reagents), 1)] units of liquid remaining.")
 	else
 		. += SPAN_NOTICE("There's no cartridge connected.")
 
@@ -102,8 +102,9 @@
 	if(ishuman(loc))
 		var/mob/living/human/user = loc
 
-		if (!lit || !ec_cartridge || !ec_cartridge.reagents.total_volume)//no cartridge
-			if(!ec_cartridge.reagents.total_volume)
+		var/cart_vol = REAGENT_TOTAL_VOLUME(ec_cartridge.reagents)
+		if (!lit || !ec_cartridge || !cart_vol)//no cartridge
+			if(!cart_vol)
 				to_chat(user, SPAN_NOTICE("There's no liquid left in \the [src], so you shut it down."))
 			Deactivate()
 			return
@@ -152,7 +153,7 @@
 			if (!ec_cartridge)
 				to_chat(user, SPAN_NOTICE("You can't use \the [src] with no cartridge installed!"))
 				return
-			else if(!ec_cartridge.reagents.total_volume)
+			else if(!REAGENT_TOTAL_VOLUME(ec_cartridge.reagents))
 				to_chat(user, SPAN_NOTICE("You can't use \the [src] with no liquid left!"))
 				return
 			else if(!cell.check_charge(power_usage * CELLRATE))
@@ -189,7 +190,7 @@
 
 /obj/item/chems/ecig_cartridge/get_examine_strings(mob/user, distance, infix, suffix)
 	. = ..()
-	. += "The cartridge has [reagents.total_volume] units of liquid remaining."
+	. += "The cartridge has [REAGENT_TOTAL_VOLUME(reagents)] units of liquid remaining."
 
 //flavours
 /obj/item/chems/ecig_cartridge/blank

--- a/code/game/objects/items/weapons/extinguisher.dm
+++ b/code/game/objects/items/weapons/extinguisher.dm
@@ -45,7 +45,7 @@
 	_base_attack_force            = 3
 
 /obj/item/chems/spray/extinguisher/populate_reagents()
-	add_to_reagents(/decl/material/liquid/water, reagents.maximum_volume)
+	add_to_reagents(/decl/material/liquid/water, REAGENT_MAXIMUM_VOLUME(reagents))
 
 /obj/item/chems/spray/extinguisher/has_safety()
 	return TRUE

--- a/code/game/objects/items/weapons/grenades/chem_grenade.dm
+++ b/code/game/objects/items/weapons/grenades/chem_grenade.dm
@@ -101,7 +101,7 @@
 			to_chat(user, "<span class='warning'>The grenade can not hold more containers.</span>")
 			return TRUE
 		else
-			if(used_item.reagents.total_volume)
+			if(REAGENT_TOTAL_VOLUME(used_item.reagents))
 				if(!user.try_unequip(used_item, src))
 					return TRUE
 				to_chat(user, "<span class='notice'>You add \the [used_item] to the assembly.</span>")
@@ -138,7 +138,7 @@
 
 	var/has_reagents = 0
 	for(var/obj/item/chems/glass/G in beakers)
-		if(G.reagents.total_volume)
+		if(REAGENT_TOTAL_VOLUME(G.reagents))
 			has_reagents = TRUE
 			break
 
@@ -162,13 +162,13 @@
 		M.toggle_throw_mode(FALSE)
 
 	for(var/obj/item/chems/glass/G in beakers)
-		G.reagents.trans_to_obj(src, G.reagents.total_volume)
+		G.reagents.trans_to_obj(src, REAGENT_TOTAL_VOLUME(G.reagents))
 
 	anchored = TRUE
 	set_invisibility(INVISIBILITY_MAXIMUM)
 
 	// Visual effect to show the grenade going off.
-	if(reagents.total_volume)
+	if(REAGENT_TOTAL_VOLUME(reagents))
 		var/datum/effect/effect/system/steam_spread/steam = new
 		steam.set_up(10, 0, get_turf(src))
 		steam.attach(src)
@@ -177,13 +177,14 @@
  	// Allow time for reactions to proc.
 	var/max_delays = 5
 	var/delays = 0
-	while(reagents.total_volume && delays <= max_delays)
+	while(REAGENT_TOTAL_VOLUME(reagents) && delays <= max_delays)
 		delays++
 		sleep(SSmaterials.wait)
 
 	// The reactions didn't use up all reagents, dump them as a fluid.
-	if(reagents.total_volume)
-		reagents.trans_to(loc, reagents.total_volume)
+	var/reagent_volume = REAGENT_TOTAL_VOLUME(reagents)
+	if(reagent_volume)
+		reagents.trans_to(loc, reagent_volume)
 
 	qdel(src)
 

--- a/code/game/objects/items/weapons/mop.dm
+++ b/code/game/objects/items/weapons/mop.dm
@@ -35,13 +35,14 @@
 	if(!istype(moppable_turf))
 		return ..()
 
-	if(moppable_turf?.reagents?.total_volume > 0)
-		if(moppable_turf.reagents.total_volume > FLUID_SHALLOW)
+	var/mop_reagents = REAGENT_TOTAL_VOLUME(moppable_turf?.reagents)
+	if(mop_reagents > 0)
+		if(mop_reagents > FLUID_SHALLOW)
 			to_chat(user, SPAN_WARNING("There is too much water here to be mopped up."))
 			return TRUE
 		user.visible_message(SPAN_NOTICE("\The [user] begins to mop up \the [moppable_turf]."))
 		if(do_after(user, 40, moppable_turf) && !QDELETED(moppable_turf))
-			if(moppable_turf.reagents?.total_volume > FLUID_SHALLOW)
+			if(REAGENT_TOTAL_VOLUME(moppable_turf.reagents) > FLUID_SHALLOW)
 				to_chat(user, SPAN_WARNING("There is too much water here to be mopped up."))
 			else
 				to_chat(user, SPAN_NOTICE("You have finished mopping!"))
@@ -51,7 +52,7 @@
 	if(!is_type_in_list(A, moppable_types))
 		return ..()
 
-	if(reagents?.total_volume < 1)
+	if(REAGENT_TOTAL_VOLUME(reagents) < 1)
 		to_chat(user, SPAN_WARNING("\The [src] is dry!"))
 		return TRUE
 
@@ -59,7 +60,7 @@
 		user.visible_message(SPAN_DANGER("\The [user] begins to aggressively mop \the [moppable_turf]!"))
 	else
 		user.visible_message(SPAN_NOTICE("\The [user] begins to clean \the [moppable_turf]."))
-	if(do_after(user, mopspeed, moppable_turf) && reagents?.total_volume)
+	if(do_after(user, mopspeed, moppable_turf) && REAGENT_TOTAL_VOLUME(reagents))
 		reagents.touch_turf(moppable_turf)
 		reagents.remove_any(1)
 		to_chat(user, SPAN_NOTICE("You have finished mopping!"))
@@ -103,7 +104,7 @@
 	playsound(user, 'sound/machines/click.ogg', 30, 1)
 
 /obj/item/mop/advanced/Process()
-	if(reagents.total_volume < reagents.maximum_volume)
+	if(REAGENT_TOTAL_VOLUME(reagents) < REAGENT_MAXIMUM_VOLUME(reagents))
 		add_to_reagents(refill_reagent, refill_rate)
 
 /obj/item/mop/advanced/get_examine_strings(mob/user, distance, infix, suffix)

--- a/code/game/objects/items/weapons/paint.dm
+++ b/code/game/objects/items/weapons/paint.dm
@@ -10,7 +10,7 @@
 	var/pigment
 
 /obj/item/chems/glass/bucket/paint/populate_reagents()
-	var/amt = reagents.maximum_volume
+	var/amt = REAGENT_MAXIMUM_VOLUME(reagents)
 	if(pigment)
 		amt = round(amt/2)
 		add_to_reagents(pigment, amt)

--- a/code/game/objects/items/weapons/soap.dm
+++ b/code/game/objects/items/weapons/soap.dm
@@ -68,7 +68,7 @@
 		wet()
 		return TRUE
 
-	if(reagents?.total_volume < 1)
+	if(REAGENT_TOTAL_VOLUME(reagents) < 1)
 		to_chat(user, SPAN_WARNING("\The [src] is too dry to clean \the [target]."))
 		return TRUE
 
@@ -77,7 +77,7 @@
 		if(!isturf(target))
 			return ..()
 		user.visible_message(SPAN_NOTICE("\The [user] starts scrubbing \the [target]."))
-		if(!do_after(user, 8 SECONDS, target) && reagents?.total_volume)
+		if(!do_after(user, 8 SECONDS, target) && REAGENT_TOTAL_VOLUME(reagents))
 			return TRUE
 		to_chat(user, SPAN_NOTICE("You scrub \the [target] clean."))
 	else if(istype(target,/obj/effect/decal/cleanable))
@@ -97,11 +97,11 @@
 		if(user.get_target_zone() == BP_MOUTH && victim.check_has_mouth())
 			user.visible_message(SPAN_DANGER("\The [user] washes \the [target]'s mouth out with soap!"))
 			if(reagents)
-				reagents.trans_to_mob(target, reagents.total_volume / 2, CHEM_INGEST)
+				reagents.trans_to_mob(target, REAGENT_TOTAL_VOLUME(reagents) / 2, CHEM_INGEST)
 		else
 			user.visible_message(SPAN_NOTICE("\The [user] cleans \the [target]."))
 			if(reagents)
-				reagents.trans_to(target, reagents.total_volume / 8)
+				reagents.trans_to(target, REAGENT_TOTAL_VOLUME(reagents) / 8)
 			target.clean()
 		user.setClickCooldown(DEFAULT_QUICK_COOLDOWN) //prevent spam
 		return TRUE

--- a/code/game/objects/items/weapons/storage/bible.dm
+++ b/code/game/objects/items/weapons/storage/bible.dm
@@ -89,7 +89,7 @@
 	if(proximity && user?.mind?.assigned_job?.is_holy)
 		if(A.reagents && A.reagents.has_reagent(/decl/material/liquid/water)) //blesses all the water in the holder
 			to_chat(user, SPAN_NOTICE("You bless \the [A].")) // I wish it was this easy in nethack
-			LAZYSET(A.reagents.reagent_data, /decl/material/liquid/water, list(DATA_WATER_HOLINESS = TRUE))
+			REAGENT_SET_DATA(A.reagents, /decl/material/liquid/water, list(DATA_WATER_HOLINESS = TRUE))
 
 /obj/item/bible/attackby(obj/item/used_item, mob/user)
 	if(storage?.use_sound)

--- a/code/game/objects/items/weapons/storage/fancy/cigarettes.dm
+++ b/code/game/objects/items/weapons/storage/fancy/cigarettes.dm
@@ -42,7 +42,7 @@
 
 		storage?.remove_from_storage(user, cig, null)
 		user.equip_to_slot(cig, slot_wear_mask_str)
-		reagents.maximum_volume = 5 * contents.len
+		create_or_update_reagents(5 * contents.len)
 		to_chat(user, SPAN_NOTICE("You take a cigarette out of the pack."))
 		update_icon()
 		return TRUE

--- a/code/game/objects/items/weapons/storage/med_pouch.dm
+++ b/code/game/objects/items/weapons/storage/med_pouch.dm
@@ -198,36 +198,36 @@ Single Use Emergency Pouches
 
 /obj/item/chems/pill/pouch_pill/Initialize(ml, material_key)
 	. = ..()
-	if(!reagents?.total_volume)
+	if(!REAGENT_TOTAL_VOLUME(reagents))
 		log_warning("[log_info_line(src)] was deleted for containing no reagents during init!")
 		return INITIALIZE_HINT_QDEL
 	if(reagents?.get_primary_reagent_name() && !_reagent_name)
-		_reagent_name = "emergency [reagents.get_primary_reagent_name()] pill ([reagents.total_volume]u)"
+		_reagent_name = "emergency [reagents.get_primary_reagent_name()] pill ([REAGENT_TOTAL_VOLUME(reagents)]u)"
 	if(_reagent_name)
 		SetName(_reagent_name)
 
 /obj/item/chems/pill/pouch_pill/stabilizer/populate_reagents()
-	add_to_reagents(/decl/material/liquid/stabilizer, reagents.maximum_volume)
+	add_to_reagents(/decl/material/liquid/stabilizer, REAGENT_MAXIMUM_VOLUME(reagents))
 	. = ..()
 
 /obj/item/chems/pill/pouch_pill/antitoxins/populate_reagents()
-	add_to_reagents(/decl/material/liquid/antitoxins, reagents.maximum_volume)
+	add_to_reagents(/decl/material/liquid/antitoxins, REAGENT_MAXIMUM_VOLUME(reagents))
 	. = ..()
 
 /obj/item/chems/pill/pouch_pill/oxy_meds/populate_reagents()
-	add_to_reagents(/decl/material/liquid/oxy_meds, reagents.maximum_volume)
+	add_to_reagents(/decl/material/liquid/oxy_meds, REAGENT_MAXIMUM_VOLUME(reagents))
 	. = ..()
 
 /obj/item/chems/pill/pouch_pill/painkillers/populate_reagents()
-	add_to_reagents(/decl/material/liquid/painkillers, reagents.maximum_volume)
+	add_to_reagents(/decl/material/liquid/painkillers, REAGENT_MAXIMUM_VOLUME(reagents))
 	. = ..()
 
 /obj/item/chems/pill/pouch_pill/brute_meds/populate_reagents()
-	add_to_reagents(/decl/material/liquid/brute_meds, reagents.maximum_volume)
+	add_to_reagents(/decl/material/liquid/brute_meds, REAGENT_MAXIMUM_VOLUME(reagents))
 	. = ..()
 
 /obj/item/chems/pill/pouch_pill/burn_meds/populate_reagents()
-	add_to_reagents(/decl/material/liquid/burn_meds, reagents.maximum_volume)
+	add_to_reagents(/decl/material/liquid/burn_meds, REAGENT_MAXIMUM_VOLUME(reagents))
 	. = ..()
 
 // Injectors

--- a/code/game/objects/items/weapons/swords_axes_etc.dm
+++ b/code/game/objects/items/weapons/swords_axes_etc.dm
@@ -66,7 +66,7 @@
 	update_held_icon()
 
 /obj/item/telebaton/on_update_icon()
-	if(coating?.total_volume || blood_DNA)
+	if(REAGENT_TOTAL_VOLUME(coating) || blood_DNA)
 		generate_coating_overlay(TRUE) // Force recheck.
 	. = ..()
 	if(on)

--- a/code/game/objects/items/weapons/towels.dm
+++ b/code/game/objects/items/weapons/towels.dm
@@ -27,7 +27,7 @@
 
 // Does not rely on ATOM_IS_OPEN_CONTAINER because we want to be able to pour in but not out.
 /obj/item/towel/can_be_poured_into(atom/source)
-	return (reagents?.maximum_volume > 0)
+	return (REAGENT_MAXIMUM_VOLUME(reagents) > 0)
 
 /obj/item/towel/proc/update_material_description()
 	if(!istype(material) || !(material_alteration & MAT_FLAG_ALTERATION_DESC))
@@ -39,9 +39,11 @@
 
 /obj/item/towel/get_examine_strings(mob/user, distance, infix, suffix)
 	. = ..()
-	if(reagents?.total_volume && distance <= 1)
+	var/total_vol = REAGENT_TOTAL_VOLUME(reagents)
+	if(total_vol && distance <= 1)
+		var/max_vol = REAGENT_MAXIMUM_VOLUME(reagents)
 		var/liquid_adjective = "damp"
-		switch(reagents.total_volume / reagents.maximum_volume)
+		switch(total_vol / max_vol)
 			if(0 to 0.1)
 				return // not enough to even bother worrying about
 			if(0.4 to 0.6)
@@ -61,13 +63,14 @@
 
 // Slowly dry out.
 /obj/item/towel/Process()
-	if(reagents?.total_volume)
-		reagents.remove_any(max(MINIMUM_CHEMICAL_VOLUME, CHEMS_QUANTIZE(reagents.total_volume * 0.05)))
-	if(!reagents?.total_volume)
+	var/total_volume = REAGENT_TOTAL_VOLUME(reagents)
+	if(total_volume)
+		reagents.remove_any(max(MINIMUM_CHEMICAL_VOLUME, CHEMS_QUANTIZE(total_volume * 0.05)))
+	if(!REAGENT_TOTAL_VOLUME(reagents))
 		return PROCESS_KILL
 
 /obj/item/towel/update_name()
-	if(reagents?.total_volume)
+	if(REAGENT_TOTAL_VOLUME(reagents))
 		if(!REAGENTS_FREE_SPACE(reagents))
 			name_prefix = "waterlogged"
 		else
@@ -80,7 +83,7 @@
 	if(!(. = ..()))
 		return
 	update_name()
-	if(reagents?.total_volume)
+	if(REAGENT_TOTAL_VOLUME(reagents))
 		if(!is_processing)
 			START_PROCESSING(SSobj, src)
 	else if(is_processing)
@@ -93,17 +96,17 @@
 
 /obj/item/towel/proc/dry_mob(mob/living/target, mob/living/user)
 	user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
-	var/reagent_space = reagents.maximum_volume - reagents.total_volume
+	var/reagent_space = REAGENT_MAXIMUM_VOLUME(reagents) - REAGENT_TOTAL_VOLUME(reagents)
 	if(reagent_space <= 0)
 		to_chat(user, SPAN_WARNING("\The [src] is too saturated to dry [user == target ? "yourself" : "\the [target]"] off effectively."))
 	else
 		var/decl/pronouns/pronouns = target.get_pronouns()
 		var/datum/reagents/touching_reagents = target.get_contact_reagents()
-		if(!touching_reagents?.total_volume)
+		if(!REAGENT_TOTAL_VOLUME(touching_reagents))
 			to_chat(user, SPAN_WARNING("[user == target ? "You are" : "\The [target] [pronouns.is]"] already dry."))
 		else
 			user.visible_message(SPAN_NOTICE("\The [user] uses \the [src] to towel [user == target ? pronouns.self : "\the [target]"] dry."))
-			touching_reagents.trans_to(src, min(touching_reagents.total_volume, reagent_space))
+			touching_reagents.trans_to(src, min(REAGENT_TOTAL_VOLUME(touching_reagents), reagent_space))
 			playsound(user, 'sound/weapons/towelwipe.ogg', 25, 1)
 	return TRUE
 
@@ -142,10 +145,11 @@
 		variability = 70 // 30-170%, clamped to be 30-100%
 	for(var/obj/item/target in targets)
 		var/datum/reagents/target_coating = target.coating
-		if(!target_coating?.total_volume)
+		var/coating_volume = REAGENT_TOTAL_VOLUME(target_coating)
+		if(!coating_volume)
 			continue
 		var/fraction_cleaned = clamp(CHEMS_QUANTIZE(rand(100 - variability, 100 + variability) / 100), 0, 100)
-		target.transfer_coating_to(src, fraction_cleaned * target_coating.total_volume)
+		target.transfer_coating_to(src, fraction_cleaned * coating_volume)
 		if(!REAGENTS_FREE_SPACE(reagents))
 			break
 

--- a/code/game/objects/items/welding/weldbackpack.dm
+++ b/code/game/objects/items/welding/weldbackpack.dm
@@ -85,14 +85,15 @@
 	if(user.check_intent(I_FLAG_HARM))
 		if(standard_splash_mob(user, O))
 			return TRUE
-		if(reagents && reagents.total_volume)
+		var/total_vol = REAGENT_TOTAL_VOLUME(reagents)
+		if(reagents && total_vol)
 			to_chat(user, SPAN_DANGER("You splash the contents of \the [src] onto \the [O]."))
-			reagents.splash(O, reagents.total_volume)
+			reagents.splash(O, total_vol)
 			return TRUE
 	return ..()
 
 /obj/item/chems/weldpack/populate_reagents()
-	add_to_reagents(/decl/material/liquid/fuel, reagents.maximum_volume)
+	add_to_reagents(/decl/material/liquid/fuel, REAGENT_MAXIMUM_VOLUME(reagents))
 
 /obj/item/chems/weldpack/Initialize(ml, material_key)
 	if(ispath(welder))
@@ -127,20 +128,20 @@
 		if(!tool.tank)
 			to_chat(user, SPAN_WARNING("\The [tool] has no tank attached!"))
 			return TRUE
-		if(!reagents?.total_volume)
+		if(!REAGENT_TOTAL_VOLUME(reagents))
 			to_chat(user, SPAN_WARNING("\The [src] is empty!"))
 			return TRUE
-		reagents.trans_to_obj(tool.tank, tool.tank.reagents.maximum_volume)
+		reagents.trans_to_obj(tool.tank, REAGENT_MAXIMUM_VOLUME(tool.tank.reagents))
 		to_chat(user, SPAN_NOTICE("You refuel \the [used_item]."))
 		playsound(src, 'sound/effects/refill.ogg', 50, TRUE, -6)
 		return TRUE
 
 	else if(istype(used_item, /obj/item/chems/welder_tank))
-		if(!reagents?.total_volume)
+		if(!REAGENT_TOTAL_VOLUME(reagents))
 			to_chat(user, SPAN_WARNING("\The [src] is empty!"))
 			return TRUE
 		var/obj/item/chems/welder_tank/tank = used_item
-		reagents.trans_to_obj(tank, tank.reagents.maximum_volume)
+		reagents.trans_to_obj(tank, REAGENT_MAXIMUM_VOLUME(tank.reagents))
 		to_chat(user, SPAN_NOTICE("You refuel \the [used_item]."))
 		playsound(src, 'sound/effects/refill.ogg', 50, TRUE, -6)
 		return TRUE
@@ -180,7 +181,7 @@
 
 /obj/item/chems/weldpack/get_examine_strings(mob/user, distance, infix, suffix)
 	. = ..()
-	. += "[html_icon(src)] [reagents.total_volume] unit\s of fuel left!"
+	. += "[html_icon(src)] [REAGENT_TOTAL_VOLUME(reagents)] unit\s of fuel left!"
 
 /obj/item/chems/weldpack/dropped(mob/user)
 	. = ..()

--- a/code/game/objects/items/welding/weldingtool.dm
+++ b/code/game/objects/items/welding/weldingtool.dm
@@ -169,7 +169,7 @@
 
 /obj/item/weldingtool/fluid_act(var/datum/reagents/fluids)
 	..()
-	if(!QDELETED(src) && fluids?.total_volume && welding && !waterproof)
+	if(!QDELETED(src) && REAGENT_TOTAL_VOLUME(fluids) && welding && !waterproof)
 		var/turf/location = get_turf(src)
 		if(location)
 			location.hotspot_expose(WELDING_TOOL_HOTSPOT_TEMP_ACTIVE, 50, 1)

--- a/code/game/objects/items/welding/weldingtool_tank.dm
+++ b/code/game/objects/items/welding/weldingtool_tank.dm
@@ -20,17 +20,18 @@
 	var/lit_force      = 11
 
 /obj/item/chems/welder_tank/populate_reagents()
-	add_to_reagents(/decl/material/liquid/fuel, reagents.maximum_volume)
+	add_to_reagents(/decl/material/liquid/fuel, REAGENT_MAXIMUM_VOLUME(reagents))
 
 /obj/item/chems/welder_tank/get_examine_strings(mob/user, distance, infix, suffix)
 	. = ..()
 	if(distance > 1)
 		return
-	if(reagents.total_volume <= 0)
+	var/total_vol = REAGENT_TOTAL_VOLUME(reagents)
+	if(total_vol <= 0)
 		. += SPAN_WARNING("It is empty.")
 	else
-		. += "It contains [reagents.total_volume] units of liquid."
-	. += "It can hold up to [reagents.maximum_volume] units."
+		. += "It contains [total_vol] units of liquid."
+	. += "It can hold up to [REAGENT_MAXIMUM_VOLUME(reagents)] units."
 
 /obj/item/chems/welder_tank/afterattack(obj/O, mob/user, proximity, click_parameters)
 	if (!ATOM_IS_OPEN_CONTAINER(src) || !proximity)
@@ -44,9 +45,10 @@
 	if(user.check_intent(I_FLAG_HARM))
 		if(standard_splash_mob(user, O))
 			return TRUE
-		if(reagents && reagents.total_volume)
+		var/total_vol = REAGENT_TOTAL_VOLUME(reagents)
+		if(reagents && total_vol)
 			to_chat(user, SPAN_DANGER("You splash the contents of \the [src] onto \the [O]."))
-			reagents.splash(O, reagents.total_volume)
+			reagents.splash(O, total_vol)
 			return TRUE
 	return ..()
 
@@ -136,7 +138,7 @@
 	return ..()
 
 /obj/item/chems/welder_tank/experimental/Process()
-	if(REAGENT_VOLUME(reagents, /decl/material/liquid/fuel) < reagents.maximum_volume)
+	if(REAGENT_VOLUME(reagents, /decl/material/liquid/fuel) < REAGENT_MAXIMUM_VOLUME(reagents))
 		var/gen_amount = ((world.time-last_gen)/25)
 		add_to_reagents(/decl/material/liquid/fuel, gen_amount)
 		last_gen = world.time

--- a/code/game/objects/structures/__structure.dm
+++ b/code/game/objects/structures/__structure.dm
@@ -86,15 +86,16 @@
 		. += "\The [src] [structure_pronouns.has] been <font color='[paint_color]'>[paint_verb]</font>."
 	if(distance <= 2 && !isnull(get_possible_reagent_transfer_amounts()) && reagents)
 		. += SPAN_NOTICE("It contains:")
-		if(LAZYLEN(reagents.reagent_volumes))
-			for(var/decl/material/reagent as anything in reagents.liquid_volumes)
+		var/reagent_volumes = REAGENT_VOLUMES(reagents)
+		if(LAZYLEN(reagent_volumes))
+			for(var/decl/material/reagent as anything in REAGENT_LIQUID_VOLUMES(reagents))
 				. += SPAN_NOTICE("[LIQUID_VOLUME(reagents, reagent)] unit\s of [reagent.get_reagent_name(reagents, MAT_PHASE_LIQUID)].")
-			for(var/decl/material/reagent as anything in reagents.solid_volumes)
+			for(var/decl/material/reagent as anything in REAGENT_SOLID_VOLUMES(reagents))
 				. += SPAN_NOTICE("[SOLID_VOLUME(reagents, reagent)] unit\s of [reagent.get_reagent_name(reagents, MAT_PHASE_SOLID)].")
 		else
 			. += SPAN_NOTICE("Nothing.")
-		if(reagents.maximum_volume)
-			. += "It may contain up to [reagents.maximum_volume] unit\s."
+		if(REAGENT_MAXIMUM_VOLUME(reagents))
+			. += "It may contain up to [REAGENT_MAXIMUM_VOLUME(reagents)] unit\s."
 
 /obj/structure/get_examine_hints(mob/user, distance, infix, suffix)
 	. = ..()

--- a/code/game/objects/structures/barrels/barrel.dm
+++ b/code/game/objects/structures/barrels/barrel.dm
@@ -26,13 +26,13 @@
 
 // Overrides due to wonky reagent_dispeners opencontainer flag handling.
 /obj/structure/reagent_dispensers/barrel/can_be_poured_from(mob/user, atom/target)
-	return (reagents?.maximum_volume > 0)
+	return (REAGENT_MAXIMUM_VOLUME(reagents) > 0)
 /obj/structure/reagent_dispensers/barrel/can_be_poured_into(mob/user, atom/target)
-	return (reagents?.maximum_volume > 0)
+	return (REAGENT_MAXIMUM_VOLUME(reagents) > 0)
 
 // Override to skip open container check.
 /obj/structure/reagent_dispensers/barrel/can_drink_from(mob/user)
-	return reagents?.total_volume && user.check_has_mouth()
+	return REAGENT_TOTAL_VOLUME(reagents) && user.check_has_mouth()
 
 /obj/structure/reagent_dispensers/barrel/Initialize()
 	if(ispath(metal_material))
@@ -73,7 +73,7 @@
 	// Add lid/reagents overlay/lid metal.
 	if(show_liquid_contents && ATOM_IS_OPEN_CONTAINER(src))
 		if(reagents)
-			var/overlay_amount = NONUNIT_CEILING(reagents.total_liquid_volume / reagents.maximum_volume * 100, 10)
+			var/overlay_amount = NONUNIT_CEILING(REAGENT_TOTAL_LIQUID_VOLUME(reagents) / REAGENT_MAXIMUM_VOLUME(reagents) * 100, 10)
 			var/image/filling_overlay = overlay_image(icon, "[icon_state]-[overlay_amount]", reagents.get_color(), RESET_COLOR | RESET_ALPHA)
 			add_overlay(filling_overlay)
 		add_overlay(overlay_image(icon, "[icon_state]-lidopen", material?.color, RESET_COLOR))
@@ -89,7 +89,7 @@
 
 /obj/structure/reagent_dispensers/barrel/get_standard_interactions(var/mob/user)
 	. = ..()
-	if(reagents?.maximum_volume)
+	if(REAGENT_MAXIMUM_VOLUME(reagents))
 		LAZYADD(., global._reagent_interactions)
 
 	// Disambiguation actions, since barrels can have several different potential interactions for
@@ -120,16 +120,16 @@
 
 /obj/structure/reagent_dispensers/barrel/ebony/water/populate_reagents()
 	. = ..()
-	add_to_reagents(/decl/material/liquid/water, reagents.maximum_volume)
+	add_to_reagents(/decl/material/liquid/water, REAGENT_MAXIMUM_VOLUME(reagents))
 
 /obj/structure/reagent_dispensers/barrel/ebony/beer/populate_reagents()
 	. = ..()
-	add_to_reagents(/decl/material/liquid/alcohol/beer, reagents.maximum_volume)
+	add_to_reagents(/decl/material/liquid/alcohol/beer, REAGENT_MAXIMUM_VOLUME(reagents))
 
 /obj/structure/reagent_dispensers/barrel/ebony/wine/populate_reagents()
 	. = ..()
-	add_to_reagents(/decl/material/liquid/alcohol/wine, reagents.maximum_volume)
+	add_to_reagents(/decl/material/liquid/alcohol/wine, REAGENT_MAXIMUM_VOLUME(reagents))
 
 /obj/structure/reagent_dispensers/barrel/ebony/oil/populate_reagents()
 	. = ..()
-	add_to_reagents(/decl/material/liquid/oil, reagents.maximum_volume)
+	add_to_reagents(/decl/material/liquid/oil, REAGENT_MAXIMUM_VOLUME(reagents))

--- a/code/game/objects/structures/barrels/cask.dm
+++ b/code/game/objects/structures/barrels/cask.dm
@@ -30,16 +30,16 @@
 
 /obj/structure/reagent_dispensers/barrel/cask/ebony/water/populate_reagents()
 	. = ..()
-	add_to_reagents(/decl/material/liquid/water, reagents.maximum_volume)
+	add_to_reagents(/decl/material/liquid/water, REAGENT_MAXIMUM_VOLUME(reagents))
 
 /obj/structure/reagent_dispensers/barrel/cask/ebony/beer/populate_reagents()
 	. = ..()
-	add_to_reagents(/decl/material/liquid/alcohol/beer, reagents.maximum_volume)
+	add_to_reagents(/decl/material/liquid/alcohol/beer, REAGENT_MAXIMUM_VOLUME(reagents))
 
 /obj/structure/reagent_dispensers/barrel/cask/ebony/wine/populate_reagents()
 	. = ..()
-	add_to_reagents(/decl/material/liquid/alcohol/wine, reagents.maximum_volume)
+	add_to_reagents(/decl/material/liquid/alcohol/wine, REAGENT_MAXIMUM_VOLUME(reagents))
 
 /obj/structure/reagent_dispensers/barrel/cask/ebony/oil/populate_reagents()
 	. = ..()
-	add_to_reagents(/decl/material/liquid/oil, reagents.maximum_volume)
+	add_to_reagents(/decl/material/liquid/oil, REAGENT_MAXIMUM_VOLUME(reagents))

--- a/code/game/objects/structures/beds/rollerbed.dm
+++ b/code/game/objects/structures/beds/rollerbed.dm
@@ -24,7 +24,7 @@
 		icon_state = "down"
 	if(beaker?.reagents)
 		var/image/iv = image(icon, "iv[iv_attached]")
-		var/percentage = round((beaker.reagents.total_volume / max(beaker.reagents.maximum_volume, 1)) * 100, 25)
+		var/percentage = round((REAGENT_TOTAL_VOLUME(beaker.reagents) / max(REAGENT_MAXIMUM_VOLUME(beaker.reagents), 1)) * 100, 25)
 		var/image/filling = image(icon, "iv_filling[percentage]")
 		filling.color = beaker.reagents.get_color()
 		iv.overlays += filling
@@ -74,7 +74,7 @@
 	if(SSobj.times_fired % 2)
 		return
 
-	if(beaker.reagents?.total_volume > 0)
+	if(REAGENT_TOTAL_VOLUME(beaker.reagents) > 0)
 		beaker.reagents.trans_to_mob(buckled_mob, beaker.amount_per_transfer_from_this, CHEM_INJECT)
 		queue_icon_update()
 

--- a/code/game/objects/structures/chemistry/filter_stand.dm
+++ b/code/game/objects/structures/chemistry/filter_stand.dm
@@ -84,17 +84,17 @@
 // Pouring directly into the filter via attackby() is not working, so we just dump our reagents into our filter or the turf.
 /obj/structure/filter_stand/on_reagent_change()
 	. = ..()
-	if(reagents?.total_volume <= 0)
+	if(REAGENT_TOTAL_VOLUME(reagents) <= 0)
 		return
-	if(filter?.reagents?.maximum_volume)
-		var/taking = min(reagents?.total_volume, REAGENTS_FREE_SPACE(filter.reagents))
+	if(REAGENT_MAXIMUM_VOLUME(filter?.reagents))
+		var/taking = min(REAGENT_TOTAL_VOLUME(reagents), REAGENTS_FREE_SPACE(filter.reagents))
 		if(taking > 0)
 			reagents.trans_to_holder(filter.reagents, taking)
-			if(reagents?.total_volume <= 0)
+			if(REAGENT_TOTAL_VOLUME(reagents) <= 0)
 				return
 	var/turf/my_turf = get_turf(src)
 	if(istype(my_turf))
-		reagents.trans_to_turf(my_turf, reagents.total_volume)
+		reagents.trans_to_turf(my_turf, REAGENT_TOTAL_VOLUME(reagents))
 
 /obj/item/chems/filter
 	name = "filter"
@@ -109,7 +109,7 @@
 
 /obj/item/chems/filter/on_reagent_change()
 	. = ..()
-	if(reagents?.total_liquid_volume)
+	if(REAGENT_TOTAL_LIQUID_VOLUME(reagents))
 		if(!is_processing)
 			START_PROCESSING(SSobj, src)
 	else
@@ -117,11 +117,11 @@
 			STOP_PROCESSING(SSobj, src)
 
 /obj/item/chems/filter/Process()
-	if(!reagents?.total_liquid_volume)
+	if(!REAGENT_TOTAL_LIQUID_VOLUME(reagents))
 		return PROCESS_KILL
 
 	var/dumping = 0
-	var/dripping = min(reagents.total_liquid_volume, rand(3,5))
+	var/dripping = min(REAGENT_TOTAL_LIQUID_VOLUME(reagents), rand(3,5))
 	var/obj/structure/filter_stand/stand = loc
 	if(!istype(stand) || stand.filter != src || !stand.loaded?.reagents)
 		dumping = dripping

--- a/code/game/objects/structures/compost.dm
+++ b/code/game/objects/structures/compost.dm
@@ -84,8 +84,9 @@ var/global/const/COMPOST_WORM_HUNGER_FACTOR = MINIMUM_CHEMICAL_VOLUME
 
 /obj/structure/reagent_dispensers/compost_bin/physically_destroyed()
 	dump_contents()
-	if(reagents)
-		reagents.trans_to(loc, reagents.total_volume)
+	var/reagent_volume = REAGENT_TOTAL_VOLUME(reagents)
+	if(reagent_volume)
+		reagents.trans_to(loc, reagent_volume)
 	return ..()
 
 /obj/structure/reagent_dispensers/compost_bin/attackby(obj/item/used_item, mob/user)
@@ -158,8 +159,8 @@ var/global/const/COMPOST_WORM_HUNGER_FACTOR = MINIMUM_CHEMICAL_VOLUME
 				for(var/obj/item/thing in composting.get_contained_external_atoms())
 					thing.forceMove(src)
 
-				if(composting.reagents?.total_volume)
-					composting.reagents.trans_to_holder(reagents, composting.reagents.total_volume)
+				if(REAGENT_TOTAL_VOLUME(composting.reagents))
+					composting.reagents.trans_to_holder(reagents, REAGENT_TOTAL_VOLUME(composting.reagents))
 					composting.reagents.clear_reagents()
 
 				composting.clear_matter()
@@ -174,12 +175,12 @@ var/global/const/COMPOST_WORM_HUNGER_FACTOR = MINIMUM_CHEMICAL_VOLUME
 				remains.update_primary_material()
 
 	// Digest reagents.
-	for(var/decl/material/reagent as anything in reagents.reagent_volumes)
+	for(var/decl/material/reagent as anything in REAGENT_VOLUMES(reagents))
 		if(istype(reagent, /decl/material/liquid/fertilizer))
 			continue
 		if(!reagent.compost_value)
 			continue
-		var/clamped_worm_drink_amount = min(round(worm_eat_amount * REAGENT_UNITS_PER_MATERIAL_UNIT), reagents.reagent_volumes[reagent])
+		var/clamped_worm_drink_amount = min(round(worm_eat_amount * REAGENT_UNITS_PER_MATERIAL_UNIT), REAGENT_VOLUME(reagents, reagent))
 		reagents.add_reagent(/decl/material/liquid/fertilizer/compost, max(1, round(clamped_worm_drink_amount * reagent.compost_value)))
 		reagents.remove_reagent(reagent, clamped_worm_drink_amount)
 		break

--- a/code/game/objects/structures/fires.dm
+++ b/code/game/objects/structures/fires.dm
@@ -126,8 +126,8 @@
 
 /obj/structure/fire_source/fluid_act(datum/reagents/fluids)
 	. = ..()
-	if(!QDELETED(src) && fluids?.total_volume && reagents)
-		var/transfer = min(reagents.maximum_volume - reagents.total_volume, max(max(1, round(fluids.total_volume * 0.25))))
+	if(!QDELETED(src) && REAGENT_TOTAL_VOLUME(fluids) && reagents)
+		var/transfer = min(REAGENT_MAXIMUM_VOLUME(reagents) - REAGENT_TOTAL_VOLUME(reagents), max(max(1, round(REAGENT_TOTAL_VOLUME(fluids) * 0.25))))
 		if(transfer > 0)
 			fluids.trans_to_obj(src, transfer)
 
@@ -363,13 +363,13 @@
 /obj/structure/fire_source/on_reagent_change()
 	if(!(. = ..()))
 		return
-	if(reagents?.total_volume)
+	if(REAGENT_TOTAL_VOLUME(reagents))
 		var/do_steam = FALSE
 		var/datum/gas_mixture/our_air = return_air()
 		var/ambient_pressure = our_air ? our_air.return_pressure() : ONE_ATMOSPHERE
 		var/list/waste = list()
 
-		for(var/decl/material/reagent as anything in reagents?.reagent_volumes)
+		for(var/decl/material/reagent as anything in REAGENT_VOLUMES(reagents))
 
 			if(reagent.accelerant_value <= FUEL_VALUE_SUPPRESSANT && reagent.phase_at_temperature(get_effective_burn_temperature(), ambient_pressure) == MAT_PHASE_GAS)
 				do_steam = TRUE

--- a/code/game/objects/structures/fishtanks.dm
+++ b/code/game/objects/structures/fishtanks.dm
@@ -53,7 +53,7 @@ var/global/list/fishtank_cache = list()
 
 /obj/structure/glass_tank/populate_reagents()
 	if(fill_type)
-		add_to_reagents(fill_type, reagents.maximum_volume)
+		add_to_reagents(fill_type, REAGENT_MAXIMUM_VOLUME(reagents))
 
 /obj/structure/glass_tank/attack_hand(var/mob/user)
 	if(user.check_intent(I_FLAG_HARM))
@@ -77,7 +77,7 @@ var/global/list/fishtank_cache = list()
 	if(paint_color)
 		shard.set_color(paint_color)
 	if(!silent)
-		if(contents.len || reagents.total_volume)
+		if(contents.len || REAGENT_TOTAL_VOLUME(reagents))
 			visible_message(SPAN_DANGER("\The [src] shatters, spilling its contents everywhere!"))
 		else
 			visible_message(SPAN_DANGER("\The [src] shatters!"))
@@ -90,8 +90,8 @@ var/global/list/fishtank_cache = list()
 /obj/structure/glass_tank/dump_contents(atom/forced_loc = loc, mob/user)
 	. = ..()
 	var/turf/T = get_turf(forced_loc)
-	if(reagents?.total_volume && T)
-		reagents.trans_to_turf(T, reagents.total_volume)
+	if(REAGENT_TOTAL_VOLUME(reagents) && T)
+		reagents.trans_to_turf(T, REAGENT_TOTAL_VOLUME(reagents))
 
 var/global/list/global/aquarium_states_and_layers = list(
 	"b" = FLY_LAYER - 0.02,
@@ -119,7 +119,7 @@ var/global/list/global/aquarium_states_and_layers = list(
 		tank_overlay.cut_overlays()
 		for(var/i = 1 to 4)
 			for(var/key_mod in global.aquarium_states_and_layers)
-				if(key_mod == "w" && (!reagents || !reagents.total_volume))
+				if(key_mod == "w" && (!reagents || !REAGENT_TOTAL_VOLUME(reagents)))
 					continue
 				var/cache_key = "[c_states[i]][key_mod]-[i]"
 				if(!global.fishtank_cache[cache_key])

--- a/code/game/objects/structures/fountain.dm
+++ b/code/game/objects/structures/fountain.dm
@@ -117,7 +117,7 @@
 	light_power            = null
 
 /obj/structure/fountain/mundane/populate_reagents()
-	add_to_reagents(/decl/material/liquid/water, reagents.maximum_volume) //Don't give free water when building one
+	add_to_reagents(/decl/material/liquid/water, REAGENT_MAXIMUM_VOLUME(reagents)) //Don't give free water when building one
 
 /obj/structure/fountain/mundane/attack_hand(mob/user)
 	if(user.check_intent(I_FLAG_HARM))

--- a/code/game/objects/structures/iv_drip.dm
+++ b/code/game/objects/structures/iv_drip.dm
@@ -38,8 +38,8 @@
 	add_overlay(base)
 
 	if(beaker?.reagents)
-		var/percent = round((beaker.reagents.total_volume / beaker.reagents.maximum_volume) * 100)
-		if(beaker.reagents.total_volume)
+		var/percent = round((REAGENT_TOTAL_VOLUME(beaker.reagents) / REAGENT_MAXIMUM_VOLUME(beaker.reagents)) * 100)
+		if(REAGENT_TOTAL_VOLUME(beaker.reagents))
 			var/mutable_appearance/filling = mutable_appearance(icon, "reagent")
 			switch(percent)
 				if(0)
@@ -119,11 +119,11 @@
 		return
 
 	if(mode) // Give blood
-		if(beaker.reagents?.total_volume > 0)
+		if(REAGENT_TOTAL_VOLUME(beaker.reagents) > 0)
 			beaker.reagents.trans_to_mob(attached, transfer_amount, CHEM_INJECT)
 			queue_icon_update()
 	else // Take blood
-		var/amount = beaker.reagents.maximum_volume - beaker.reagents.total_volume
+		var/amount = REAGENT_MAXIMUM_VOLUME(beaker.reagents) - REAGENT_TOTAL_VOLUME(beaker.reagents)
 		amount = min(amount, 4)
 
 		if(amount == 0) // If the beaker is full, ping
@@ -192,8 +192,8 @@
 	. += "The IV drip is [mode ? "injecting" : "taking blood"]."
 	. += "It is set to transfer [transfer_amount]u of chemicals per cycle."
 	if(beaker)
-		if(beaker.reagents?.total_volume)
-			. += SPAN_NOTICE("Attached is \a [beaker] with [beaker.reagents.total_volume] units of liquid.")
+		if(REAGENT_TOTAL_VOLUME(beaker.reagents))
+			. += SPAN_NOTICE("Attached is \a [beaker] with [REAGENT_TOTAL_VOLUME(beaker.reagents)] units of liquid.")
 		else
 			. += SPAN_NOTICE("Attached is an empty [beaker].")
 	else

--- a/code/game/objects/structures/janicart.dm
+++ b/code/game/objects/structures/janicart.dm
@@ -18,7 +18,7 @@
 /obj/structure/janitorialcart/get_examine_strings(mob/user, distance, infix, suffix)
 	. = ..()
 	if(distance <= 1)
-		. += "\The [src] [html_icon(src)] contains [reagents.total_volume] unit\s of liquid!"
+		. += "\The [src] [html_icon(src)] contains [REAGENT_TOTAL_VOLUME(reagents)] unit\s of liquid!"
 
 /obj/structure/janitorialcart/attackby(obj/item/used_item, mob/user)
 	if(istype(used_item, /obj/item/bag/trash) && !mybag)
@@ -31,11 +31,11 @@
 		return TRUE
 
 	else if(istype(used_item, /obj/item/mop))
-		if(used_item.reagents.total_volume < used_item.reagents.maximum_volume)	//if it's not completely soaked we assume they want to wet it, otherwise store it
-			if(reagents.total_volume < 1)
+		if(REAGENT_TOTAL_VOLUME(used_item.reagents) < REAGENT_MAXIMUM_VOLUME(used_item.reagents))	//if it's not completely soaked we assume they want to wet it, otherwise store it
+			if(REAGENT_TOTAL_VOLUME(reagents) < 1)
 				to_chat(user, "<span class='warning'>[src] is out of water!</span>")
 			else
-				reagents.trans_to_obj(used_item, used_item.reagents.maximum_volume)
+				reagents.trans_to_obj(used_item, REAGENT_MAXIMUM_VOLUME(used_item.reagents))
 				to_chat(user, "<span class='notice'>You wet [used_item] in [src].</span>")
 				playsound(loc, 'sound/effects/slosh.ogg', 25, 1)
 			return TRUE
@@ -209,14 +209,14 @@
 /obj/structure/janicart/get_examine_strings(mob/user, distance, infix, suffix)
 	. = ..()
 	if(distance <= 1)
-		. += "[html_icon(src)] This [callme] contains [reagents.total_volume] unit\s of water!"
+		. += "[html_icon(src)] This [callme] contains [REAGENT_TOTAL_VOLUME(reagents)] unit\s of water!"
 		if(mybag)
 			. += "\A [mybag] is hanging on the [callme]."
 
 /obj/structure/janicart/attackby(obj/item/used_item, mob/user)
 
 	if(istype(used_item, /obj/item/mop))
-		if(reagents.total_volume > 1)
+		if(REAGENT_TOTAL_VOLUME(reagents) > 1)
 			reagents.trans_to_obj(used_item, 2)
 			to_chat(user, SPAN_NOTICE("You wet [used_item] in the [callme]."))
 			playsound(loc, 'sound/effects/slosh.ogg', 25, 1)

--- a/code/game/objects/structures/mop_bucket.dm
+++ b/code/game/objects/structures/mop_bucket.dm
@@ -11,11 +11,11 @@
 /obj/structure/mopbucket/get_examine_strings(mob/user, distance, infix, suffix)
 	. = ..()
 	if(distance <= 1)
-		. += "\The [src] [html_icon(src)] contains [reagents.total_volume] unit\s of water!"
+		. += "\The [src] [html_icon(src)] contains [REAGENT_TOTAL_VOLUME(reagents)] unit\s of water!"
 
 /obj/structure/mopbucket/attackby(obj/item/used_item, mob/user)
 	if(istype(used_item, /obj/item/mop))
-		if(reagents.total_volume < 1)
+		if(REAGENT_TOTAL_VOLUME(reagents) < 1)
 			to_chat(user, SPAN_WARNING("\The [src] is out of water!"))
 		else if(REAGENTS_FREE_SPACE(used_item.reagents) >= 5)
 			reagents.trans_to_obj(used_item, 5)

--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -92,7 +92,7 @@ var/global/list/hygiene_props = list()
 				visible_message("\The [src] gurgles and overflows!")
 				next_gurgle = world.time + 80
 				playsound(T, pick(SSfluids.gurgles), 50, 1)
-			var/adding = min(flood_amt-T?.reagents?.total_volume, rand(30,50)*clogged)
+			var/adding = min(flood_amt - REAGENT_TOTAL_VOLUME(T?.reagents), rand(30,50)*clogged)
 			if(adding > 0)
 				T.add_to_reagents(/decl/material/liquid/water, adding)
 
@@ -336,7 +336,7 @@ var/global/list/hygiene_props = list()
 		add_to_reagents(/decl/material/liquid/water, REAGENTS_FREE_SPACE(reagents))
 		if(world.time >= next_wash)
 			next_wash = world.time + (10 SECONDS)
-			reagents.splash(get_turf(src), reagents.total_volume, max_spill = 0)
+			reagents.splash(get_turf(src), REAGENT_TOTAL_VOLUME(reagents), max_spill = 0)
 
 /obj/structure/hygiene/shower/proc/process_heat(mob/living/M)
 	if(!on || !istype(M))
@@ -370,7 +370,7 @@ var/global/list/hygiene_props = list()
 	. = ..()
 	if(!. && isitem(dropping) && ATOM_IS_OPEN_CONTAINER(dropping))
 		var/obj/item/thing = dropping
-		if(thing.reagents?.total_volume <= 0)
+		if(REAGENT_TOTAL_VOLUME(thing.reagents) <= 0)
 			to_chat(usr, SPAN_WARNING("\The [thing] is empty."))
 		else
 			visible_message(SPAN_NOTICE("\The [user] tips the contents of \the [thing] into \the [src]."))

--- a/code/game/objects/structures/well.dm
+++ b/code/game/objects/structures/well.dm
@@ -20,12 +20,12 @@
 
 // Override to skip open container check.
 /obj/structure/reagent_dispensers/well/can_drink_from(mob/user)
-	return reagents?.total_volume && user.check_has_mouth()
+	return REAGENT_TOTAL_VOLUME(reagents) && user.check_has_mouth()
 
 /obj/structure/reagent_dispensers/well/populate_reagents()
 	. = ..()
 	if(auto_refill)
-		add_to_reagents(auto_refill, reagents.maximum_volume)
+		add_to_reagents(auto_refill, REAGENT_MAXIMUM_VOLUME(reagents))
 
 /obj/structure/reagent_dispensers/well/Destroy()
 	if(is_processing)
@@ -34,7 +34,7 @@
 
 /obj/structure/reagent_dispensers/well/on_update_icon()
 	. = ..()
-	if(reagents?.total_volume)
+	if(REAGENT_TOTAL_VOLUME(reagents))
 		add_overlay(overlay_image(icon, "[icon_state]-fluid", reagents.get_color(), (RESET_COLOR | RESET_ALPHA)))
 	if(istype(reinf_material)) // reinf_material -> roof and posts, at this point in time
 		var/image/roof_image = overlay_image(icon, "[icon_state]-roof", reinf_material.color, RESET_COLOR | RESET_ALPHA | KEEP_APART)
@@ -50,25 +50,25 @@
 
 // Overrides due to wonky reagent_dispeners opencontainer flag handling.
 /obj/structure/reagent_dispensers/well/can_be_poured_from(mob/user, atom/target)
-	return (reagents?.maximum_volume > 0)
+	return (REAGENT_MAXIMUM_VOLUME(reagents) > 0)
 /obj/structure/reagent_dispensers/well/can_be_poured_into(mob/user, atom/target)
-	return (reagents?.maximum_volume > 0)
+	return (REAGENT_MAXIMUM_VOLUME(reagents) > 0)
 
 /obj/structure/reagent_dispensers/well/get_standard_interactions(var/mob/user)
 	. = ..()
-	if(reagents?.maximum_volume)
+	if(REAGENT_MAXIMUM_VOLUME(reagents))
 		LAZYADD(., global._reagent_interactions)
 
 /obj/structure/reagent_dispensers/well/Process()
 	if(!reagents || !auto_refill) // if we're full, we only stop at the end of the proc; we need to check for contaminants first
 		return PROCESS_KILL
 	var/amount_to_add = rand(5, 10)
-	if(length(reagents.reagent_volumes) > 1) // we have impurities!
+	if(length(REAGENT_VOLUMES(reagents)) > 1) // we have impurities!
 		reagents.remove_any(amount_to_add, defer_update = TRUE, skip_reagents = list(auto_refill)) // defer update until the add_reagent call below
-	if(reagents.total_volume < reagents.maximum_volume)
+	if(REAGENT_TOTAL_VOLUME(reagents) < REAGENT_MAXIMUM_VOLUME(reagents))
 		reagents.add_reagent(auto_refill, amount_to_add)
 		return // don't stop processing
-	else if(length(reagents.reagent_volumes) == 1 && reagents.get_primary_reagent_type() == auto_refill)
+	else if(length(REAGENT_VOLUMES(reagents)) == 1 && reagents.get_primary_reagent_type() == auto_refill)
 		// only one reagent and it's our auto_refill, our work is done here
 		return PROCESS_KILL
 	// if we get here, it means we have a full well with contaminants, so we keep processing

--- a/code/game/turfs/flooring/flooring_mud.dm
+++ b/code/game/turfs/flooring/flooring_mud.dm
@@ -14,7 +14,7 @@
 	uid             = "floor_mud"
 
 /decl/flooring/mud/fire_act(turf/floor/target, datum/gas_mixture/air, exposed_temperature, exposed_volume)
-	if(!target.reagents?.total_volume)
+	if(!REAGENT_TOTAL_VOLUME(target.reagents))
 		if(target.get_topmost_flooring() == src)
 			target.set_flooring(/decl/flooring/dry_mud)
 		else if(target.get_base_flooring() == src)

--- a/code/game/turfs/flooring/flooring_snow.dm
+++ b/code/game/turfs/flooring/flooring_snow.dm
@@ -25,7 +25,7 @@
 		. = max(., 0)
 
 /decl/flooring/snow/fire_act(turf/floor/target, datum/gas_mixture/air, exposed_temperature, exposed_volume)
-	if(!target.reagents?.total_volume)
+	if(!REAGENT_TOTAL_VOLUME(target.reagents))
 		if(target.get_topmost_flooring() == src)
 			target.remove_flooring(src)
 		else if(target.get_base_flooring() == src)

--- a/code/game/turfs/floors/_floor.dm
+++ b/code/game/turfs/floors/_floor.dm
@@ -67,8 +67,8 @@
 
 /turf/floor/proc/fill_to_zero_height()
 	var/my_height = get_physical_height()
-	if(fill_reagent_type && my_height < 0 && (!reagents || !QDELING(reagents)) && reagents?.total_volume < abs(my_height))
-		var/reagents_to_add = abs(my_height) - reagents?.total_volume
+	if(fill_reagent_type && my_height < 0 && (!reagents || !QDELING(reagents)) && REAGENT_TOTAL_VOLUME(reagents) < abs(my_height))
+		var/reagents_to_add = abs(my_height) - REAGENT_TOTAL_VOLUME(reagents)
 		add_to_reagents(fill_reagent_type, reagents_to_add, phase = MAT_PHASE_LIQUID)
 
 /turf/floor/can_climb_from_below(var/mob/climber)

--- a/code/game/turfs/floors/floor_acts.dm
+++ b/code/game/turfs/floors/floor_acts.dm
@@ -27,7 +27,7 @@
 
 /turf/floor/fluid_act(var/datum/reagents/fluids)
 	. = ..()
-	if(!QDELETED(fluids) && fluids.total_volume)
+	if(!QDELETED(fluids) && REAGENT_TOTAL_VOLUME(fluids))
 		for(var/decl/flooring/flooring in get_all_flooring())
 			if(flooring.fluid_act(src, fluids))
 				return

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -211,8 +211,8 @@
 	if(weather)
 		. += weather.get_movement_delay(return_air(), travel_dir)
 	// TODO: check user species webbed feet, wearing swimming gear
-	if(!get_supporting_platform() && reagents?.total_volume > FLUID_PUDDLE)
-		. += (reagents.total_volume > FLUID_SHALLOW) ? 6 : 3
+	if(!get_supporting_platform() && REAGENT_TOTAL_VOLUME(reagents) > FLUID_PUDDLE)
+		. += (REAGENT_TOTAL_VOLUME(reagents) > FLUID_SHALLOW) ? 6 : 3
 
 /turf/attack_hand(mob/user)
 
@@ -354,8 +354,8 @@
 		var/mob/mover_mob = mover
 		if(!istype(mover_mob) || (!mover_mob.throwing && !mover_mob.can_overcome_gravity()))
 			var/turf/old_turf  = mover.loc
-			var/old_height     = old_turf.get_physical_height() + old_turf.reagents?.total_volume
-			var/current_height = get_physical_height() + reagents?.total_volume
+			var/old_height     = old_turf.get_physical_height() + REAGENT_TOTAL_VOLUME(old_turf.reagents)
+			var/current_height = get_physical_height() + REAGENT_TOTAL_VOLUME(reagents)
 			if(abs(current_height - old_height) > FLUID_SHALLOW)
 				if(current_height > old_height)
 					return 0

--- a/code/game/turfs/turf_enter.dm
+++ b/code/game/turfs/turf_enter.dm
@@ -33,8 +33,8 @@
 	if(isturf(old_loc) && has_gravity() && A.can_fall() && !isnull(platform) && !(weakref(A) in skip_height_fall_for))
 
 		var/turf/old_turf  = old_loc
-		var/old_height     = old_turf.get_physical_height() + old_turf.reagents?.total_volume
-		var/current_height = get_physical_height() + reagents?.total_volume
+		var/old_height     = old_turf.get_physical_height() + REAGENT_TOTAL_VOLUME(old_turf.reagents)
+		var/current_height = get_physical_height() + REAGENT_TOTAL_VOLUME(reagents)
 		var/height_difference = abs(current_height - old_height)
 
 		if(current_height < old_height && height_difference > FLUID_SHALLOW)

--- a/code/game/turfs/turf_fluids.dm
+++ b/code/game/turfs/turf_fluids.dm
@@ -30,7 +30,7 @@
 			continue
 		LAZYDISTINCTADD(spread_into_neighbors, neighbor)
 	if(length(spread_into_neighbors))
-		var/spreading = round(reagents.total_volume / length(spread_into_neighbors))
+		var/spreading = round(REAGENT_TOTAL_VOLUME(reagents) / length(spread_into_neighbors))
 		if(spreading > 0)
 			for(var/turf/spread_into_turf as anything in spread_into_neighbors)
 				reagents.trans_to_turf(spread_into_turf, spreading)
@@ -83,8 +83,8 @@
 		return FLUID_MAX_DEPTH
 	var/obj/structure/glass_tank/aquarium = locate() in contents
 	if(aquarium)
-		return aquarium.reagents?.total_volume * TANK_WATER_MULTIPLIER
-	return reagents?.total_volume || 0
+		return REAGENT_TOTAL_VOLUME(aquarium.reagents) * TANK_WATER_MULTIPLIER
+	return REAGENT_TOTAL_VOLUME(reagents)
 
 /turf/proc/show_bubbles()
 	set waitfor = FALSE
@@ -102,7 +102,7 @@
 				T.fluid_update(TRUE)
 	if(flooded)
 		ADD_ACTIVE_FLUID_SOURCE(src)
-	else if(reagents?.total_volume > FLUID_QDEL_POINT)
+	else if(REAGENT_TOTAL_VOLUME(reagents) > FLUID_QDEL_POINT)
 		ADD_ACTIVE_FLUID(src)
 
 /turf/get_reagents()
@@ -119,10 +119,10 @@
 
 /turf/fluid_act(var/datum/reagents/fluids)
 	..()
-	if(!QDELETED(src) && fluids?.total_volume)
+	if(!QDELETED(src) && REAGENT_TOTAL_VOLUME(fluids))
 		fluids.touch_turf(src, touch_atoms = FALSE) // Handled in fluid_act() below.
 		// Wet items that are not supported on a platform or such.
-		var/effective_volume = fluids?.total_volume
+		var/effective_volume = REAGENT_TOTAL_VOLUME(fluids)
 		if(get_supporting_platform())
 			// Depth is negative height, hence +=. TODO: positive heights? No idea how to handle that.
 			effective_volume += get_physical_height()
@@ -133,7 +133,7 @@
 				AM.fluid_act(fluids)
 
 /turf/proc/remove_fluids(var/amount, var/defer_update)
-	if(!reagents?.total_liquid_volume)
+	if(!REAGENT_TOTAL_LIQUID_VOLUME(reagents))
 		return
 	remove_any_reagents(amount, defer_update = defer_update, removed_phases = MAT_PHASE_LIQUID)
 	if(defer_update && !QDELETED(reagents))
@@ -141,12 +141,12 @@
 
 /turf/proc/transfer_fluids_to(var/turf/target, var/amount, var/defer_update = TRUE)
 	// No flowing of reagents without liquids, but this proc should not be called if liquids are not present regardless.
-	if(!reagents?.total_liquid_volume)
+	if(!REAGENT_TOTAL_LIQUID_VOLUME(reagents))
 		return
 	target.create_or_update_reagents(FLUID_MAX_DEPTH)
 
 	// We reference total_volume instead of total_liquid_volume here because the maximum volume limits of the turfs still respect solid volumes, and depth is still determined by total volume.
-	reagents.trans_to_turf(target, min(reagents.total_volume, min(target.reagents.maximum_volume - target.reagents.total_volume, amount)), defer_update = defer_update)
+	reagents.trans_to_turf(target, min(REAGENT_TOTAL_VOLUME(reagents), min(REAGENT_MAXIMUM_VOLUME(target.reagents) - REAGENT_TOTAL_VOLUME(target.reagents), amount)), defer_update = defer_update)
 	if(defer_update)
 		if(!QDELETED(reagents))
 			SSfluids.holders_to_update[reagents] = TRUE
@@ -159,12 +159,12 @@
 		vaporize_fuel(air)
 
 /turf/proc/vaporize_fuel(datum/gas_mixture/air)
-	if(!length(reagents?.reagent_volumes) || !istype(air))
+	if(!length(REAGENT_VOLUMES(reagents)) || !istype(air))
 		return
 	var/update_air = FALSE
-	for(var/decl/material/reagent as anything in reagents.reagent_volumes)
+	for(var/decl/material/reagent as anything in REAGENT_VOLUMES(reagents))
 		if(reagent.gas_flags & XGM_GAS_FUEL)
-			var/moles = round(reagents.reagent_volumes[reagent] / REAGENT_UNITS_PER_GAS_MOLE)
+			var/moles = round(REAGENT_VOLUME(reagents, reagent) / REAGENT_UNITS_PER_GAS_MOLE)
 			if(moles > 0)
 				air.adjust_gas(reagent.type, moles, FALSE)
 				remove_from_reagents(reagent, round(moles * REAGENT_UNITS_PER_GAS_MOLE))
@@ -179,10 +179,10 @@
 	if(!(. = ..()))
 		return
 
-	if(reagents?.total_liquid_volume < FLUID_SLURRY)
+	if(REAGENT_TOTAL_LIQUID_VOLUME(reagents) < FLUID_SLURRY)
 		dump_solid_reagents()
 
-	if(reagents?.total_volume > FLUID_QDEL_POINT)
+	if(REAGENT_TOTAL_VOLUME(reagents) > FLUID_QDEL_POINT)
 		ADD_ACTIVE_FLUID(src)
 		var/decl/material/primary_reagent = reagents.get_primary_reagent_decl()
 		if(primary_reagent && (REAGENT_VOLUME(reagents, primary_reagent) >= primary_reagent.slippery_amount))
@@ -204,16 +204,17 @@
 
 	for(var/checkdir in global.cardinal)
 		var/turf/neighbor = get_step_resolving_mimic(src, checkdir)
-		if(neighbor?.reagents?.total_volume > FLUID_QDEL_POINT)
+		if(REAGENT_TOTAL_VOLUME(neighbor?.reagents) > FLUID_QDEL_POINT)
 			ADD_ACTIVE_FLUID(neighbor)
 
 /turf/proc/dump_solid_reagents(datum/reagents/solids)
 	if(!istype(solids))
 		solids = reagents
-	if(LAZYLEN(solids?.solid_volumes))
+	var/solid_volumes = REAGENT_SOLID_VOLUMES(solids)
+	if(LAZYLEN(solid_volumes))
 		var/list/matter_list = list()
-		for(var/decl/material/reagent as anything in solids.solid_volumes)
-			var/reagent_amount = solids.solid_volumes[reagent]
+		for(var/decl/material/reagent as anything in REAGENT_SOLID_VOLUMES(solid_volumes))
+			var/reagent_amount = SOLID_VOLUME(solids, reagent)
 			matter_list[reagent.type] = round(reagent_amount/REAGENT_UNITS_PER_MATERIAL_UNIT)
 			solids.remove_reagent(reagent, reagent_amount, defer_update = TRUE, removed_phases = MAT_PHASE_SOLID)
 

--- a/code/modules/atmospherics/datum_pipeline.dm
+++ b/code/modules/atmospherics/datum_pipeline.dm
@@ -30,7 +30,7 @@
 	STOP_PROCESSING(SSprocessing, src)
 	QDEL_NULL(network)
 
-	if(air?.total_volume || liquid?.total_volume)
+	if(air?.total_volume || REAGENT_TOTAL_VOLUME(liquid))
 		temporarily_store_fluids()
 
 	QDEL_NULL(air)
@@ -61,7 +61,7 @@
 /datum/pipeline/proc/temporarily_store_fluids()
 	//Update individual gas_mixtures by volume ratio
 
-	var/liquid_transfer_per_pipe = min(REAGENT_UNITS_PER_PIPE, (liquid && length(members)) ? (liquid.total_volume / length(members)) : 0)
+	var/liquid_transfer_per_pipe = min(REAGENT_UNITS_PER_PIPE, (liquid && length(members)) ? (REAGENT_TOTAL_VOLUME(liquid) / length(members)) : 0)
 	if(!air?.total_volume && !liquid_transfer_per_pipe)
 		return
 
@@ -119,9 +119,9 @@
 							air.merge(item.air_temporary)
 							item.air_temporary = null
 
-						liquid.maximum_volume += REAGENT_UNITS_PER_PIPE
+						REAGENT_ADD_MAX_VOL(liquid, REAGENT_UNITS_PER_PIPE)
 						if(item.liquid_temporary)
-							item.liquid_temporary.trans_to_holder(liquid, item.liquid_temporary.total_volume)
+							item.liquid_temporary.trans_to_holder(liquid, REAGENT_TOTAL_VOLUME(item.liquid_temporary))
 							item.liquid_temporary = null
 
 						if(item.leaking)
@@ -135,7 +135,7 @@
 			possible_expansions -= borderline
 
 	air.total_volume = temp_volume
-	liquid.maximum_volume = length(members) * REAGENT_UNITS_PER_PIPE
+	REAGENT_SET_MAX_VOL(liquid, (length(members) * REAGENT_UNITS_PER_PIPE))
 
 /datum/pipeline/proc/network_expand(datum/pipe_network/new_network, obj/machinery/atmospherics/pipe/reference)
 	if(new_network.line_members.Find(src))
@@ -186,7 +186,7 @@
 		air.merge(air_sample)
 		//turf_air already modified by equalize_gases()
 
-	if(liquid?.total_volume)
+	if(REAGENT_TOTAL_VOLUME(liquid))
 		liquid.trans_to_turf(target, FLUID_PUDDLE)
 
 	if(network)

--- a/code/modules/atmospherics/pipes.dm
+++ b/code/modules/atmospherics/pipes.dm
@@ -128,7 +128,7 @@
 			loc.assume_air(air_temporary)
 			air_temporary = null
 		if(liquid_temporary)
-			liquid_temporary.trans_to(loc, liquid_temporary.total_volume)
+			liquid_temporary.trans_to(loc, REAGENT_TOTAL_VOLUME(liquid_temporary))
 			liquid_temporary = null
 	if(leaking)
 		STOP_PROCESSING_MACHINE(src, MACHINERY_PROCESS_SELF)

--- a/code/modules/butchery/butchery_data.dm
+++ b/code/modules/butchery/butchery_data.dm
@@ -85,7 +85,7 @@
 		for(var/obj/item/food/slab in .)
 			LAZYADD(meat, slab)
 		if(length(meat))
-			var/reagent_split = round(donor.reagents.total_volume/length(meat), 1)
+			var/reagent_split = round(REAGENT_TOTAL_VOLUME(donor.reagents)/length(meat), 1)
 			for(var/obj/item/food/slab as anything in meat)
 				donor.reagents.trans_to_obj(slab, reagent_split)
 

--- a/code/modules/butchery/butchery_products.dm
+++ b/code/modules/butchery/butchery_products.dm
@@ -171,7 +171,7 @@
 
 /obj/item/food/butchery/offal/fluid_act(var/datum/reagents/fluids)
 	. = ..()
-	if(!QDELETED(src) && fluids?.total_volume && material?.tans_to)
+	if(!QDELETED(src) && REAGENT_TOTAL_VOLUME(fluids) && material?.tans_to)
 		if(!dried_type)
 			dried_type = type
 		drying_wetness = get_max_drying_wetness()
@@ -264,8 +264,8 @@
 
 /obj/item/food/butchery/stomach/get_dried_product()
 	var/obj/item/chems/glass/waterskin/result = ..()
-	if(istype(result) && reagents?.total_volume)
-		reagents.trans_to_holder(result.reagents, reagents.total_volume)
+	if(istype(result) && REAGENT_TOTAL_VOLUME(reagents))
+		reagents.trans_to_holder(result.reagents, REAGENT_TOTAL_VOLUME(reagents))
 	return result
 
 /obj/item/food/butchery/stomach/get_max_drying_wetness()

--- a/code/modules/clothing/gloves/jewelry/rings/ring_reagent.dm
+++ b/code/modules/clothing/gloves/jewelry/rings/ring_reagent.dm
@@ -10,10 +10,10 @@
 	if(istype(H) && H.get_equipped_item(slot_gloves_str) == src)
 		to_chat(H, SPAN_DANGER("You feel a prick as you slip on the ring."))
 
-		if(reagents.total_volume)
+		if(REAGENT_TOTAL_VOLUME(reagents))
 			if(H.reagents)
 				var/contained_reagents = reagents.get_reagents()
-				var/trans = reagents.trans_to_mob(H, reagents.total_volume, CHEM_INJECT)
+				var/trans = reagents.trans_to_mob(H, REAGENT_TOTAL_VOLUME(reagents), CHEM_INJECT)
 				admin_inject_log(usr, H, src, contained_reagents, trans)
 	return
 

--- a/code/modules/clothing/masks/chewable.dm
+++ b/code/modules/clothing/masks/chewable.dm
@@ -33,7 +33,7 @@
 
 /obj/item/clothing/mask/chewable/proc/chew(amount)
 	chewtime -= amount
-	if(reagents && reagents.total_volume)
+	if(reagents && REAGENT_TOTAL_VOLUME(reagents))
 		if(ishuman(loc))
 			var/mob/living/human/user = loc
 			if (src == user.get_equipped_item(slot_wear_mask_str) && user.check_has_mouth())
@@ -133,7 +133,7 @@
 
 /obj/item/clothing/mask/chewable/candy/Initialize()
 	. = ..()
-	if(reagents?.total_volume)
+	if(REAGENT_TOTAL_VOLUME(reagents))
 		set_color(reagents.get_color())
 		desc += " This one is labeled '[reagents.get_primary_reagent_name()]'."
 

--- a/code/modules/clothing/masks/smokable.dm
+++ b/code/modules/clothing/masks/smokable.dm
@@ -55,7 +55,7 @@
 
 /obj/item/clothing/mask/smokable/proc/smoke(amount, manual)
 	smoketime -= amount
-	if(reagents && reagents.total_volume) // check if it has any reagents at all
+	if(reagents && REAGENT_TOTAL_VOLUME(reagents)) // check if it has any reagents at all
 		var/smoke_loc = loc
 		if(ishuman(loc))
 			var/mob/living/human/user = loc
@@ -120,7 +120,7 @@
 
 /obj/item/clothing/mask/smokable/fluid_act(var/datum/reagents/fluids)
 	..()
-	if(!QDELETED(src) && fluids?.total_volume && !waterproof && lit)
+	if(!QDELETED(src) && REAGENT_TOTAL_VOLUME(fluids) && !waterproof && lit)
 		var/turf/location = get_turf(src)
 		if(location)
 			location.hotspot_expose(700, 5)
@@ -147,7 +147,7 @@
 		if(flavor_text)
 			var/turf/T = get_turf(src)
 			T.visible_message(flavor_text)
-		smoke_amount = reagents.total_volume / smoketime
+		smoke_amount = REAGENT_TOTAL_VOLUME(reagents) / smoketime
 		START_PROCESSING(SSobj, src)
 
 /obj/item/clothing/mask/smokable/extinguish_fire(mob/user, no_message = FALSE)
@@ -392,11 +392,11 @@
 		if(!ATOM_IS_OPEN_CONTAINER(glass))
 			to_chat(user, SPAN_NOTICE("You need to take the lid off first."))
 			return TRUE
-		var/transfered = glass.reagents.trans_to_obj(src, glass.reagents.total_volume)
+		var/transfered = glass.reagents.trans_to_obj(src, REAGENT_TOTAL_VOLUME(glass.reagents))
 		if(transfered)	//if reagents were transfered, show the message
 			to_chat(user, SPAN_NOTICE("You dip \the [src] into \the [glass]."))
 		else			//if not, either the beaker was empty, or the cigarette was full
-			if(!glass.reagents.total_volume)
+			if(!REAGENT_TOTAL_VOLUME(glass.reagents))
 				to_chat(user, SPAN_NOTICE("[glass] is empty."))
 			else
 				to_chat(user, SPAN_NOTICE("[src] is full."))
@@ -549,7 +549,7 @@
 			return TRUE
 		smoketime = 1000
 		if(grown.reagents)
-			grown.reagents.trans_to_obj(src, grown.reagents.total_volume)
+			grown.reagents.trans_to_obj(src, REAGENT_TOTAL_VOLUME(grown.reagents))
 		SetName("[grown.name]-packed [initial(name)]")
 		qdel(grown)
 		update_icon()

--- a/code/modules/clothing/spacesuits/rig/modules/utility.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/utility.dm
@@ -192,13 +192,13 @@
 	if(!ATOM_IS_OPEN_CONTAINER(input_item))
 		return 0
 
-	if(!input_item.reagents || !input_item.reagents.total_volume)
+	if(!input_item.reagents || !REAGENT_TOTAL_VOLUME(input_item.reagents))
 		to_chat(user, "\The [input_item] is empty.")
 		return 0
 
 	// Magical chemical filtration system, do not question it.
 	var/total_transferred = 0
-	for(var/decl/material/reagent as anything in input_item.reagents.reagent_volumes)
+	for(var/decl/material/reagent as anything in REAGENT_VOLUMES(input_item.reagents))
 		for(var/chargetype in charges)
 			var/datum/rig_charge/charge = charges[chargetype]
 			if(charge.product_type == reagent.type)

--- a/code/modules/crafting/handmade_items.dm
+++ b/code/modules/crafting/handmade_items.dm
@@ -86,12 +86,12 @@
 
 /obj/item/chems/glass/handmade/bottle/beer/populate_reagents()
 	. = ..()
-	add_to_reagents(/decl/material/liquid/alcohol/beer, reagents.maximum_volume)
+	add_to_reagents(/decl/material/liquid/alcohol/beer, REAGENT_MAXIMUM_VOLUME(reagents))
 
 /obj/item/chems/glass/handmade/bottle/tall/wine/populate_reagents()
 	. = ..()
-	add_to_reagents(/decl/material/liquid/alcohol/wine, reagents.maximum_volume)
+	add_to_reagents(/decl/material/liquid/alcohol/wine, REAGENT_MAXIMUM_VOLUME(reagents))
 
 /obj/item/chems/glass/handmade/bottle/wide/whiskey/populate_reagents()
 	. = ..()
-	add_to_reagents(/decl/material/liquid/alcohol/whiskey, reagents.maximum_volume)
+	add_to_reagents(/decl/material/liquid/alcohol/whiskey, REAGENT_MAXIMUM_VOLUME(reagents))

--- a/code/modules/crafting/metalwork/metalwork_items.dm
+++ b/code/modules/crafting/metalwork/metalwork_items.dm
@@ -33,23 +33,23 @@
 	if(istype(used_item, /obj/item/chems) && ATOM_IS_OPEN_CONTAINER(used_item) && used_item.reagents)
 
 		// Pour contents into the crucible.
-		if(used_item.reagents.total_volume)
+		if(REAGENT_TOTAL_VOLUME(used_item.reagents))
 			var/obj/item/chems/pouring = used_item
 			if(pouring.standard_pour_into(user, src))
 				return TRUE
 
 		// Attempting to skim off slag.
 		// TODO: check for appropriate vessel material? Check melting point against temperature of crucible?
-		if(reagents?.total_volume && length(reagents.reagent_volumes) > 1)
+		if(REAGENT_TOTAL_VOLUME(reagents) && length(REAGENT_VOLUMES(reagents)) > 1)
 			var/removing = min(amount_per_transfer_from_this, REAGENTS_FREE_SPACE(used_item.reagents))
-			if(removing < length(reagents.reagent_volumes)-1)
+			if(removing < length(REAGENT_VOLUMES(reagents))-1)
 				to_chat(user, SPAN_WARNING("\The [used_item] is full."))
 				return TRUE
 			// Remove a portion, excepting the primary reagent.
-			var/old_amt = used_item.reagents.total_volume
+			var/old_amt = REAGENT_TOTAL_VOLUME(used_item.reagents)
 			var/decl/material/primary_mat = reagents.get_primary_reagent_decl()
 			reagents.trans_to_holder(used_item.reagents, removing, skip_reagents = list(primary_mat.type))
-			to_chat(user, SPAN_NOTICE("You skim [used_item.reagents.total_volume-old_amt] unit\s of slag from the top of \the [primary_mat]."))
+			to_chat(user, SPAN_NOTICE("You skim [REAGENT_TOTAL_VOLUME(used_item.reagents)-old_amt] unit\s of slag from the top of \the [primary_mat]."))
 			return TRUE
 
 	return ..()

--- a/code/modules/crafting/pottery/pottery_moulds.dm
+++ b/code/modules/crafting/pottery/pottery_moulds.dm
@@ -82,15 +82,15 @@
 	if(!product_type)
 		return FALSE
 
-	if(reagents?.total_volume <= 0)
+	if(REAGENT_TOTAL_VOLUME(reagents) <= 0)
 		to_chat(user, SPAN_WARNING("\The [src] is empty!"))
 		return TRUE
 
-	if(reagents.total_volume < reagents.maximum_volume)
+	if(REAGENT_TOTAL_VOLUME(reagents) < REAGENT_MAXIMUM_VOLUME(reagents))
 		to_chat(user, SPAN_WARNING("\The [src] is not full yet!"))
 		return TRUE
 
-	for(var/decl/material/reagent as anything in reagents.reagent_volumes)
+	for(var/decl/material/reagent as anything in REAGENT_VOLUMES(reagents))
 		if(reagent.melting_point && temperature >= reagent.melting_point)
 			to_chat(user, SPAN_WARNING("The contents of \the [src] are still molten! Wait for it to cool down."))
 			return TRUE
@@ -109,11 +109,11 @@
 	product.dropInto(loc)
 
 	reagents.remove_reagent(product_mat.type, REAGENT_VOLUME(reagents, product_mat.type))
-	for(var/decl/material/reagent as anything in reagents.reagent_volumes)
+	for(var/decl/material/reagent as anything in REAGENT_VOLUMES(reagents))
 		if(reagent.type == product_mat.type)
 			continue
 		LAZYINITLIST(product.matter)
-		product.matter[reagent.type] += max(1, round(reagents.reagent_volumes[reagent] / REAGENT_UNITS_PER_MATERIAL_UNIT))
+		product.matter[reagent.type] += max(1, round(REAGENT_VOLUME(reagents, reagent) / REAGENT_UNITS_PER_MATERIAL_UNIT))
 	reagents.clear_reagents()
 	if(length(product_metadata))
 		product.take_mould_metadata(product_metadata)

--- a/code/modules/crafting/working/quern.dm
+++ b/code/modules/crafting/working/quern.dm
@@ -3,21 +3,20 @@
 	max_storage_space = DEFAULT_BOX_STORAGE
 
 /obj/structure/working/quern
-	name       = "quern-stone"
-	desc       = "A pair of heavy stones connected by an axle, used to grind plants and minerals into powder."
-	icon       = 'icons/obj/structures/quern.dmi'
-	material   = /decl/material/solid/stone/granite
-	color      = /decl/material/solid/stone/granite::color
-	storage    = /datum/storage/hopper/mortar/quern
-	work_skill = SKILL_COOKING // Maybe?
-	var/tmp/volume = 1000 // Same as reagent dispensers. Possibly too large?
+	name        = "quern-stone"
+	desc        = "A pair of heavy stones connected by an axle, used to grind plants and minerals into powder."
+	icon        = 'icons/obj/structures/quern.dmi'
+	material    = /decl/material/solid/stone/granite
+	color       = /decl/material/solid/stone/granite::color
+	storage     = /datum/storage/hopper/mortar/quern
+	work_skill  = SKILL_COOKING // Maybe?
+	chem_volume = 1000 // Same as reagent dispensers. Possibly too large?
 	var/amount_dispensed              = 10
 	var/tmp/possible_transfer_amounts = @"[10,25,50,100,500]"
 
 /obj/structure/working/quern/Initialize()
 	. = ..()
 	atom_flags |= ATOM_FLAG_OPEN_CONTAINER
-	initialize_reagents()
 
 /obj/structure/working/quern/try_start_working(mob/user)
 
@@ -51,19 +50,12 @@
 	var/decl/material/crushing_material = grinding.get_material()
 	if(!attacking_material || !crushing_material || attacking_material.hardness <= crushing_material.hardness)
 		return FALSE
-	if(REAGENTS_FREE_SPACE(reagents) < grinding.reagents?.total_volume)
+	if(REAGENTS_FREE_SPACE(reagents) < REAGENT_TOTAL_VOLUME(grinding.reagents))
 		return FALSE
-	if(grinding.reagents?.total_volume) // if it has no reagents, skip all the fluff and destroy it instantly
-		grinding.reagents.trans_to(src, grinding.reagents.total_volume)
+	if(REAGENT_TOTAL_VOLUME(grinding.reagents)) // if it has no reagents, skip all the fluff and destroy it instantly
+		grinding.reagents.trans_to(src, REAGENT_TOTAL_VOLUME(grinding.reagents))
 	QDEL_NULL(grinding)
 	return TRUE
-
-/obj/structure/working/quern/initialize_reagents(populate = TRUE)
-	if(!reagents)
-		create_reagents(volume)
-	else
-		reagents.maximum_volume = max(reagents.maximum_volume, volume)
-	. = ..()
 
 /obj/structure/working/quern/set_reagent_amount_dispensed(new_amount)
 	amount_dispensed = new_amount

--- a/code/modules/detectivework/tools/luminol.dm
+++ b/code/modules/detectivework/tools/luminol.dm
@@ -9,4 +9,4 @@
 	chem_volume = 250
 
 /obj/item/chems/spray/luminol/populate_reagents()
-	add_to_reagents(/decl/material/liquid/luminol, reagents.maximum_volume)
+	add_to_reagents(/decl/material/liquid/luminol, REAGENT_MAXIMUM_VOLUME(reagents))

--- a/code/modules/detectivework/tools/rag.dm
+++ b/code/modules/detectivework/tools/rag.dm
@@ -39,7 +39,7 @@
 		extinguish_fire()
 		return TRUE
 
-	if(reagents?.total_volume)
+	if(REAGENT_TOTAL_VOLUME(reagents))
 		remove_contents(user)
 		return TRUE
 
@@ -62,7 +62,7 @@
 /obj/item/chems/rag/update_name()
 	if(is_on_fire())
 		name_prefix = "burning"
-	else if(reagents && reagents.total_volume)
+	else if(reagents && REAGENT_TOTAL_VOLUME(reagents))
 		name_prefix = "damp"
 	else
 		name_prefix = "dry"
@@ -78,19 +78,19 @@
 /obj/item/chems/rag/proc/remove_contents(mob/user, atom/trans_dest = null)
 	if(!trans_dest && !user.loc)
 		return
-	if(reagents?.total_volume <= 0)
+	if(REAGENT_TOTAL_VOLUME(reagents) <= 0)
 		return
 	var/target_text = trans_dest? "\the [trans_dest]" : "\the [user.loc]"
 	user.visible_message(
 		SPAN_NOTICE("\The [user] begins to wring out [src] over [target_text]."),
 		SPAN_NOTICE("You begin to wring out \the [src] over [target_text].")
 	)
-	if(!do_after(user, reagents.total_volume*5, progress = 0) || !reagents?.total_volume) //50 for a fully soaked rag
+	if(!do_after(user, REAGENT_TOTAL_VOLUME(reagents)*5, progress = 0) || !REAGENT_TOTAL_VOLUME(reagents)) //50 for a fully soaked rag
 		return
 	if(trans_dest)
-		reagents.trans_to(trans_dest, reagents.total_volume)
+		reagents.trans_to(trans_dest, REAGENT_TOTAL_VOLUME(reagents))
 	else
-		reagents.splash(user.loc, reagents.total_volume)
+		reagents.splash(user.loc, REAGENT_TOTAL_VOLUME(reagents))
 	user.visible_message(
 		SPAN_NOTICE("\The [user] wrings out \the [src] over [target_text]."),
 		SPAN_NOTICE("You finish to wringing out \the [src].")
@@ -99,7 +99,7 @@
 
 /obj/item/chems/rag/proc/wipe_down(atom/target, mob/user)
 
-	if(!reagents?.total_volume)
+	if(!REAGENT_TOTAL_VOLUME(reagents))
 		to_chat(user, SPAN_WARNING("The [initial(name)] is dry."))
 		return
 
@@ -120,7 +120,7 @@
 		target.ignite_fire()
 		return TRUE
 
-	if(reagents.total_volume)
+	if(REAGENT_TOTAL_VOLUME(reagents))
 		if(user.get_target_zone() != BP_MOUTH)
 			wipe_down(target, user)
 			return TRUE
@@ -184,8 +184,8 @@
 	var/total_fuel = 0
 	var/total_volume = 0
 	if(reagents)
-		total_volume += reagents.total_volume
-		for(var/decl/material/reagent as anything in reagents.reagent_volumes)
+		total_volume += REAGENT_TOTAL_VOLUME(reagents)
+		for(var/decl/material/reagent as anything in REAGENT_VOLUMES(reagents))
 			total_fuel += REAGENT_VOLUME(reagents, reagent) * reagent.accelerant_value
 	. = (total_fuel >= 2 && total_fuel >= total_volume*0.5)
 
@@ -233,7 +233,7 @@
 		qdel(src)
 		return
 
-	if(reagents?.total_volume)
-		remove_from_reagents(/decl/material/liquid/fuel, reagents.maximum_volume/25)
+	if(REAGENT_TOTAL_VOLUME(reagents))
+		remove_from_reagents(/decl/material/liquid/fuel, REAGENT_MAXIMUM_VOLUME(reagents)/25)
 	update_name()
 	burn_time--

--- a/code/modules/economy/_worth.dm
+++ b/code/modules/economy/_worth.dm
@@ -10,7 +10,7 @@
 /atom/proc/get_single_monetary_worth()
 	. = get_base_value() * get_value_multiplier()
 	if(reagents)
-		for(var/decl/material/reagent as anything in reagents.reagent_volumes)
+		for(var/decl/material/reagent as anything in REAGENT_VOLUMES(reagents))
 			. += reagent.get_value() * REAGENT_VOLUME(reagents, reagent) * REAGENT_WORTH_MULTIPLIER
 	. = max(0, round(.))
 

--- a/code/modules/fabrication/fabricator_intake.dm
+++ b/code/modules/fabrication/fabricator_intake.dm
@@ -6,7 +6,7 @@
 /obj/machinery/fabricator/proc/take_reagents(var/obj/item/thing, var/mob/user, var/destructive = FALSE)
 	if(!thing.reagents || (!destructive && !ATOM_IS_OPEN_CONTAINER(thing)))
 		return SUBSTANCE_TAKEN_NONE
-	for(var/decl/material/reagent as anything in thing.reagents.reagent_volumes)
+	for(var/decl/material/reagent as anything in REAGENT_VOLUMES(thing.reagents))
 		if(!base_storage_capacity[reagent.type])
 			continue
 		var/taking_reagent = min(REAGENT_VOLUME(thing.reagents, reagent), floor((storage_capacity[reagent.type] - stored_material[reagent.type]) * REAGENT_UNITS_PER_MATERIAL_UNIT))
@@ -24,7 +24,7 @@
 		// Otherwise take the first applicable and useful reagent.
 		if(stored_material[reagent.type] == storage_capacity[reagent.type])
 			return SUBSTANCE_TAKEN_FULL
-		else if(thing.reagents.total_volume > 0)
+		else if(REAGENT_TOTAL_VOLUME(thing.reagents) > 0)
 			return SUBSTANCE_TAKEN_SOME
 		else
 			return SUBSTANCE_TAKEN_ALL

--- a/code/modules/fluids/_fluid.dm
+++ b/code/modules/fluids/_fluid.dm
@@ -22,7 +22,7 @@
 /atom/movable/fluid_overlay/on_update_icon()
 
 	var/datum/reagents/loc_reagents = loc?.reagents
-	var/reagent_volume = loc_reagents?.total_volume
+	var/reagent_volume = REAGENT_TOTAL_VOLUME(loc_reagents)
 
 	// Update layer.
 	var/new_layer
@@ -108,7 +108,7 @@ var/global/list/_fluid_edge_mask_cache = list()
 	sleep(0)
 	updating_edge_mask = FALSE
 
-	if(loc?.reagents?.total_volume <= FLUID_PUDDLE)
+	if(REAGENT_TOTAL_VOLUME(loc?.reagents) <= FLUID_PUDDLE)
 		remove_filter("fluid_edge_mask")
 		return
 
@@ -117,7 +117,7 @@ var/global/list/_fluid_edge_mask_cache = list()
 	var/list/connections
 	for(var/checkdir in global.alldirs)
 		var/turf/neighbor = get_step_resolving_mimic(loc, checkdir)
-		if(!neighbor || neighbor.density || neighbor?.reagents?.total_volume > FLUID_PUDDLE)
+		if(!neighbor || neighbor.density || REAGENT_TOTAL_VOLUME(neighbor?.reagents) > FLUID_PUDDLE)
 			LAZYADD(connections, checkdir)
 		else
 			LAZYADD(ignored, checkdir)

--- a/code/modules/food/cooking/_recipe.dm
+++ b/code/modules/food/cooking/_recipe.dm
@@ -122,7 +122,7 @@ var/global/list/_cooking_recipe_cache = list()
 
 /decl/recipe/proc/check_reagents(datum/reagents/avail_reagents)
 	// SHOULD_BE_PURE(TRUE) Due to use of GET_DECL() in REAGENT_VOLUME, this cannot be pure.
-	if(length(avail_reagents?.reagent_volumes) < length(reagents))
+	if(length(REAGENT_VOLUMES(avail_reagents)) < length(reagents))
 		return FALSE
 	for(var/reagent in reagents)
 		if(REAGENT_VOLUME(avail_reagents, reagent) < reagents[reagent])
@@ -185,8 +185,8 @@ var/global/list/_cooking_recipe_cache = list()
 
 	if(!istype(container) || QDELETED(container) || !container.simulated)
 		CRASH("Recipe trying to create a result with null or invalid container: [container || "NULL"], [container?.simulated || "NULL"]")
-	if(!container.reagents?.maximum_volume)
-		CRASH("Recipe trying to create a result in a container with null or zero capacity reagent holder: [container.reagents?.maximum_volume || "NULL"]")
+	if(!REAGENT_MAXIMUM_VOLUME(container.reagents))
+		CRASH("Recipe trying to create a result in a container with null or zero capacity reagent holder: [istype(reagents) ? REAGENT_MAXIMUM_VOLUME(container.reagents) : "NULL"]")
 
 	if(ispath(result, /atom/movable))
 		return create_result_atom(container, used_ingredients)
@@ -194,7 +194,7 @@ var/global/list/_cooking_recipe_cache = list()
 	if(ispath(result, /decl/material))
 		var/created_volume = result_quantity
 		for(var/obj/item/ingredient in (used_ingredients[RECIPE_COMPONENT_ITEMS]|used_ingredients[RECIPE_COMPONENT_FRUIT]))
-			created_volume += ingredient.reagents?.total_volume
+			created_volume += REAGENT_TOTAL_VOLUME(ingredient.reagents)
 
 		container.reagents?.add_reagent(result, created_volume, get_result_data(container, used_ingredients))
 		return null
@@ -297,14 +297,14 @@ var/global/list/_cooking_recipe_cache = list()
 	for(var/atom/item as anything in used_ingredients[RECIPE_COMPONENT_ITEMS])
 		if(item.reagents)
 			if(buffer)
-				item.reagents.trans_to_holder(buffer, item.reagents.total_volume)
+				item.reagents.trans_to_holder(buffer, REAGENT_TOTAL_VOLUME(item.reagents))
 			else
 				item.reagents.clear_reagents()
 		item.physically_destroyed()
 	for(var/atom/fruit as anything in used_ingredients[RECIPE_COMPONENT_FRUIT])
 		if(fruit.reagents)
 			if(buffer)
-				fruit.reagents.trans_to_holder(buffer, fruit.reagents.total_volume)
+				fruit.reagents.trans_to_holder(buffer, REAGENT_TOTAL_VOLUME(fruit.reagents))
 			else
 				fruit.reagents.clear_reagents()
 		fruit.physically_destroyed()
@@ -340,18 +340,18 @@ var/global/list/_cooking_recipe_cache = list()
 		holder = temporary_holder
 		if(length(.) > 1)
 			for(var/atom/movable/result_obj in .)
-				result_obj.reagents.trans_to_holder(holder, result_obj.reagents.total_volume)
+				result_obj.reagents.trans_to_holder(holder, REAGENT_TOTAL_VOLUME(result_obj.reagents))
 
 	switch(reagent_mix)
 
 		if(REAGENT_SUM)
 			//Sum is easy, just shove the entire buffer into the result
-			buffer.trans_to_holder(holder, buffer.total_volume)
+			buffer.trans_to_holder(holder, REAGENT_TOTAL_VOLUME(buffer))
 
 		if(REAGENT_MAX)
 			//We want the highest of each.
 			//Iterate through everything in buffer. If the target has less than the buffer, then top it up
-			for (var/decl/material/reagent as anything in buffer.reagent_volumes)
+			for (var/decl/material/reagent as anything in REAGENT_VOLUMES(buffer))
 				var/rvol = REAGENT_VOLUME(holder, reagent)
 				var/bvol = REAGENT_VOLUME(buffer, reagent)
 				if (rvol < bvol)
@@ -361,7 +361,7 @@ var/global/list/_cooking_recipe_cache = list()
 		if(REAGENT_MIN)
 			//Min is slightly more complex. We want the result to have the lowest from each side
 			//But zero will not count. Where a side has zero its ignored and the side with a nonzero value is used
-			for (var/decl/material/reagent as anything in buffer.reagent_volumes)
+			for (var/decl/material/reagent as anything in REAGENT_VOLUMES(buffer))
 				var/rvol = REAGENT_VOLUME(holder, reagent)
 				var/bvol = REAGENT_VOLUME(buffer, reagent)
 				if (rvol == 0) //If the target has zero of this reagent
@@ -376,7 +376,7 @@ var/global/list/_cooking_recipe_cache = list()
 	if(length(.) > 1)
 		// If we're here, then holder is a buffer containing the total reagents
 		// for all the results. So now we redistribute it among them.
-		var/total = round(holder.total_volume / length(.))
+		var/total = round(REAGENT_TOTAL_VOLUME(holder) / length(.))
 		for(var/atom/result as anything in .)
 			holder.trans_to(result, total)
 

--- a/code/modules/food/cooking/cooking_vessels/_cooking_vessel.dm
+++ b/code/modules/food/cooking/cooking_vessels/_cooking_vessel.dm
@@ -37,7 +37,7 @@
 
 	// Fill or take from the vessel.
 	if(used_item.reagents && ATOM_IS_OPEN_CONTAINER(used_item))
-		if(used_item.reagents.total_volume)
+		if(REAGENT_TOTAL_VOLUME(used_item.reagents))
 			if(istype(used_item, /obj/item/chems))
 				var/obj/item/chems/vessel = used_item
 				if(vessel.standard_pour_into(user, src))
@@ -66,16 +66,18 @@
 		return TRUE
 	if(handle_eaten_by_mob(user, target) != EATEN_INVALID)
 		return TRUE
+
+	var/total_vol = REAGENT_TOTAL_VOLUME(reagents)
 	if(user.check_intent(I_FLAG_HARM))
 		if(standard_splash_mob(user,target))
 			return TRUE
-		if(reagents && reagents.total_volume)
+		if(reagents && total_vol)
 			to_chat(user, SPAN_DANGER("You splash the contents of \the [src] onto \the [target]."))
-			reagents.splash(target, reagents.total_volume)
+			reagents.splash(target, total_vol)
 			return TRUE
-	else if(reagents && reagents.total_volume)
+	else if(reagents && total_vol)
 		to_chat(user, SPAN_NOTICE("You splash a small amount of the contents of \the [src] onto \the [target]."))
-		reagents.splash(target, min(reagents.total_volume, 5))
+		reagents.splash(target, min(total_vol, 5))
 		return TRUE
 	. = ..()
 // End boilerplate.
@@ -87,18 +89,18 @@
 	for(var/obj/item/thing in get_stored_inventory())
 		. += "\the [thing]"
 
-	if(reagents?.total_volume)
-		for(var/decl/material/reagent as anything in reagents.solid_volumes)
-			. += "[reagents.solid_volumes[reagent]]u of [reagent.get_reagent_name(reagents, MAT_PHASE_SOLID)]"
+	if(REAGENT_TOTAL_VOLUME(reagents))
+		for(var/decl/material/reagent as anything in REAGENT_SOLID_VOLUMES(reagents))
+			. += "[SOLID_VOLUME(reagents, reagent)]u of [reagent.get_reagent_name(reagents, MAT_PHASE_SOLID)]"
 
 		var/datum/gas_mixture/environment = loc?.return_air()
 		var/ambient_pressure = environment ? environment.return_pressure() : ONE_ATMOSPHERE
-		for(var/decl/material/reagent as anything in reagents.liquid_volumes)
+		for(var/decl/material/reagent as anything in REAGENT_LIQUID_VOLUMES(reagents))
 			var/reagent_name = reagent.get_reagent_name(reagents, MAT_PHASE_LIQUID)
 			if(reagent.phase_at_temperature(temperature, ambient_pressure) == MAT_PHASE_GAS && reagent.soup_hot_desc)
-				. += "[reagents.liquid_volumes[reagent]]u of [reagent.soup_hot_desc] [reagent_name]"
+				. += "[LIQUID_VOLUME(reagents, reagent)]u of [reagent.soup_hot_desc] [reagent_name]"
 			else
-				. += "[reagents.liquid_volumes[reagent]]u of [reagent_name]"
+				. += "[LIQUID_VOLUME(reagents, reagent)]u of [reagent_name]"
 
 /obj/item/chems/cooking_vessel/get_examine_strings(mob/user, distance, infix, suffix)
 	. = ..()

--- a/code/modules/food/cooking/cooking_vessels/pot.dm
+++ b/code/modules/food/cooking/cooking_vessels/pot.dm
@@ -39,7 +39,7 @@
 
 		last_boil_temp = use_temperature
 		var/next_boil_status = FALSE
-		for(var/decl/material/reagent as anything in reagents?.reagent_volumes)
+		for(var/decl/material/reagent as anything in REAGENT_VOLUMES(reagents))
 			if(reagent.phase_at_temperature(use_temperature, ambient_pressure) == MAT_PHASE_GAS)
 				next_boil_status = TRUE
 				break

--- a/code/modules/food/cooking/recipes/recipe_soup.dm
+++ b/code/modules/food/cooking/recipes/recipe_soup.dm
@@ -58,7 +58,7 @@
 					ingredients[meat.meat_name]++
 
 	if(precursor_type)
-		var/list/precursor_data = LAZYACCESS(container.reagents?.reagent_data, precursor_type)
+		var/list/precursor_data =  REAGENT_DATA(container.reagents, precursor_type)
 		var/list/precursor_taste = LAZYACCESS(precursor_data, DATA_TASTE)
 		if(length(precursor_taste))
 			for(var/taste in precursor_taste)

--- a/code/modules/food/utensils/_utensil.dm
+++ b/code/modules/food/utensils/_utensil.dm
@@ -104,7 +104,7 @@
 	else
 		show_slice_message(user, tool, src)
 
-	var/reagents_per_slice = max(1, round(reagents.total_volume / slice_num))
+	var/reagents_per_slice = max(1, round(REAGENT_TOTAL_VOLUME(reagents) / slice_num))
 	for(var/i = 1 to slice_num)
 		var/atom/movable/slice = create_slice()
 		if(slice)

--- a/code/modules/hydroponics/grown.dm
+++ b/code/modules/hydroponics/grown.dm
@@ -22,8 +22,8 @@
 /obj/item/food/grown/handle_centrifuge_process(obj/machinery/centrifuge/centrifuge)
 	if(!(. = ..()))
 		return
-	if(reagents?.total_volume)
-		reagents.trans_to_holder(centrifuge.loaded_beaker.reagents, reagents.total_volume)
+	if(REAGENT_TOTAL_VOLUME(reagents))
+		reagents.trans_to_holder(centrifuge.loaded_beaker.reagents, REAGENT_TOTAL_VOLUME(reagents))
 	for(var/obj/item/thing in contents)
 		thing.dropInto(centrifuge.loc)
 	for(var/atom/movable/thing in convert_matter_to_lumps())
@@ -96,8 +96,8 @@
 	. = ..(mapload, material_key, skip_plate) //Init reagents
 
 	update_desc()
-	if(reagents.total_volume > 0)
-		bitesize = 1 + round(reagents.total_volume / 2, 1)
+	if(REAGENT_TOTAL_VOLUME(reagents) > 0)
+		bitesize = 1 + round(REAGENT_TOTAL_VOLUME(reagents) / 2, 1)
 	update_icon()
 
 /obj/item/food/grown/populate_reagents()
@@ -143,7 +143,7 @@
 
 		var/list/descriptors = list()
 
-		for(var/decl/material/reagent as anything in reagents.reagent_volumes)
+		for(var/decl/material/reagent as anything in REAGENT_VOLUMES(reagents))
 			if(reagent.fruit_descriptor)
 				descriptors |= reagent.fruit_descriptor
 			if(reagent.reflectiveness >= MAT_VALUE_SHINY)
@@ -285,9 +285,9 @@ var/global/list/_wood_materials = list(
 			return TRUE
 
 		var/obj/item/clothing/mask/smokable/cigarette/rolled/R = new(get_turf(src))
-		R.create_or_update_reagents(max(R.reagents?.maximum_volume, reagents?.total_volume))
+		R.create_or_update_reagents(max(REAGENT_MAXIMUM_VOLUME(R.reagents), REAGENT_TOTAL_VOLUME(reagents)))
 		R.brand = "[src] handrolled in \the [used_item]."
-		reagents.trans_to_holder(R.reagents, R.reagents.total_volume)
+		reagents.trans_to_holder(R.reagents, REAGENT_TOTAL_VOLUME(R.reagents))
 		to_chat(user, SPAN_NOTICE("You roll \the [src] into \the [used_item]."))
 		user.put_in_active_hand(R)
 		qdel(used_item)
@@ -308,7 +308,7 @@ var/global/list/_wood_materials = list(
 	. = ..()
 
 	if(seed && seed.get_trait(TRAIT_STINGS))
-		if(!reagents || reagents.total_volume <= 0)
+		if(!reagents || REAGENT_TOTAL_VOLUME(reagents) <= 0)
 			return
 		remove_any_reagents(rand(1,3))
 		seed.thrown_at(src, target)
@@ -347,7 +347,7 @@ var/global/list/_wood_materials = list(
 		var/mob/living/human/H = user
 		if(istype(H) && H.get_equipped_item(slot_gloves_str))
 			return
-		if(!reagents || reagents.total_volume <= 0)
+		if(!reagents || REAGENT_TOTAL_VOLUME(reagents) <= 0)
 			return
 		remove_any_reagents(rand(1,3)) //Todo, make it actually remove the reagents the seed uses.
 		var/affected = pick(BP_R_HAND,BP_L_HAND)

--- a/code/modules/hydroponics/seed.dm
+++ b/code/modules/hydroponics/seed.dm
@@ -209,7 +209,7 @@
 	make_splat(T, thrown)
 
 	var/datum/reagents/splat_reagents = thrown?.reagents
-	if(!splat_reagents?.maximum_volume) // if thrown doesn't exist or has no reagents, use the seed's default reagents.
+	if(!REAGENT_MAXIMUM_VOLUME(splat_reagents)) // if thrown doesn't exist or has no reagents, use the seed's default reagents.
 		splat_reagents = new /datum/reagents(INFINITY, global.temp_reagents_holder)
 		var/potency = get_trait(TRAIT_POTENCY)
 		var/list/seed_chems = get_chemical_composition()

--- a/code/modules/hydroponics/trays/tray.dm
+++ b/code/modules/hydroponics/trays/tray.dm
@@ -230,12 +230,12 @@
 
 	if(!reagents) return
 
-	if(reagents.total_volume <= 0)
+	if(REAGENT_TOTAL_VOLUME(reagents) <= 0)
 		return
 
-	reagents.trans_to_obj(temp_chem_holder, min(reagents.total_volume,rand(1,3)))
+	reagents.trans_to_obj(temp_chem_holder, min(REAGENT_TOTAL_VOLUME(reagents),rand(1,3)))
 
-	for(var/decl/material/reagent as anything in temp_chem_holder.reagents.reagent_volumes)
+	for(var/decl/material/reagent as anything in REAGENT_VOLUMES(temp_chem_holder.reagents))
 
 		var/reagent_total = REAGENT_VOLUME(temp_chem_holder.reagents, reagent)
 

--- a/code/modules/hydroponics/trays/tray_process.dm
+++ b/code/modules/hydroponics/trays/tray_process.dm
@@ -6,15 +6,15 @@
 	var/growth_rate = get_growth_rate()
 	var/turf/my_turf = get_turf(src)
 	if(istype(my_turf) && !closed_system)
-		var/space_left = reagents ? (reagents.maximum_volume - reagents.total_volume) : 0
-		if(space_left > 0 && reagents.total_volume < 10)
+		var/space_left = reagents ? (REAGENT_MAXIMUM_VOLUME(reagents) - REAGENT_TOTAL_VOLUME(reagents)) : 0
+		if(space_left > 0 && REAGENT_TOTAL_VOLUME(reagents) < 10)
 			// Handle nearby smoke if any.
 			for(var/obj/effect/effect/smoke/chem/smoke in view(1, src))
-				if(smoke.reagents.total_volume)
+				if(REAGENT_TOTAL_VOLUME(smoke.reagents))
 					smoke.reagents.trans_to_obj(src, 5, copy = 1)
 			// Handle environmental effects like weather and flooding.
-			if(my_turf.reagents?.total_volume)
-				my_turf.reagents.trans_to_obj(src, min(space_left, min(my_turf.reagents.total_volume, rand(5,10))))
+			if(REAGENT_TOTAL_VOLUME(my_turf.reagents))
+				my_turf.reagents.trans_to_obj(src, min(space_left, min(REAGENT_TOTAL_VOLUME(my_turf.reagents), rand(5,10))))
 			if(istype(my_turf.weather?.weather_system?.current_state, /decl/state/weather/rain))
 				var/decl/state/weather/rain/rain = my_turf.weather.weather_system.current_state
 				if(rain.is_liquid)

--- a/code/modules/hydroponics/trays/tray_soil.dm
+++ b/code/modules/hydroponics/trays/tray_soil.dm
@@ -80,14 +80,14 @@
 		return
 	if(closed_system || !reagents || waterlevel >= 100)
 		return
-	if((reagents.maximum_volume - reagents.total_volume) <= 0 || reagents.total_volume >= 10)
+	if((REAGENT_MAXIMUM_VOLUME(reagents) - REAGENT_TOTAL_VOLUME(reagents)) <= 0 || REAGENT_TOTAL_VOLUME(reagents) >= 10)
 		return
 	for(var/step_dir in global.alldirs)
 		var/turf/neighbor = get_step_resolving_mimic(src, step_dir)
-		if(neighbor == my_turf || !neighbor?.reagents?.total_volume || !Adjacent(neighbor))
+		if(neighbor == my_turf || !REAGENT_TOTAL_VOLUME(neighbor?.reagents) || !Adjacent(neighbor))
 			continue
 		neighbor.reagents.trans_to_obj(src, rand(2,3))
-		if((reagents.maximum_volume - reagents.total_volume) <= 0 || reagents.total_volume >= 10)
+		if((REAGENT_MAXIMUM_VOLUME(reagents) - REAGENT_TOTAL_VOLUME(reagents)) <= 0 || REAGENT_TOTAL_VOLUME(reagents) >= 10)
 			break
 	return ..()
 

--- a/code/modules/implants/implant_types/chem.dm
+++ b/code/modules/implants/implant_types/chem.dm
@@ -42,11 +42,11 @@ var/global/list/chem_implants = list()
 
 /obj/item/implant/chem/attackby(obj/item/used_item, mob/user)
 	if(istype(used_item, /obj/item/chems/syringe))
-		if(reagents.total_volume >= reagents.maximum_volume)
+		if(REAGENT_TOTAL_VOLUME(reagents) >= REAGENT_MAXIMUM_VOLUME(reagents))
 			to_chat(user, SPAN_WARNING("\The [src] is full."))
 		else if(do_after(user, 0.5 SECONDS, src))
 			used_item.reagents.trans_to_obj(src, 5)
-			to_chat(user, SPAN_NOTICE("You inject 5 units of the solution. The syringe now contains [used_item.reagents.total_volume] units."))
+			to_chat(user, SPAN_NOTICE("You inject 5 units of the solution. The syringe now contains [REAGENT_TOTAL_VOLUME(used_item.reagents)] units."))
 		return TRUE
 	return ..()
 

--- a/code/modules/interactions/interactions_reagents.dm
+++ b/code/modules/interactions/interactions_reagents.dm
@@ -4,7 +4,7 @@
 	examine_desc = "dip an item into $TARGET_THEM$"
 
 /decl/interaction_handler/dip_item/is_possible(atom/target, mob/user, obj/item/prop)
-	return ..() && target != prop && target.reagents?.total_volume >= FLUID_MINIMUM_TRANSFER && istype(prop) && target.can_be_poured_from(user, prop)
+	return ..() && target != prop && REAGENT_TOTAL_VOLUME(target.reagents) >= FLUID_MINIMUM_TRANSFER && istype(prop) && target.can_be_poured_from(user, prop)
 
 /decl/interaction_handler/dip_item/invoked(atom/target, mob/user, obj/item/prop)
 	user.visible_message(SPAN_NOTICE("\The [user] dips \the [prop] into \the [target.reagents.get_primary_reagent_name()]."))
@@ -13,7 +13,7 @@
 		var/transferring = min(target_obj.get_food_default_transfer_amount(user), REAGENTS_FREE_SPACE(prop.reagents))
 		if(transferring)
 			target.reagents.trans_to_holder(prop.reagents, transferring)
-	if(target.reagents?.total_volume >= FLUID_MINIMUM_TRANSFER)
+	if(REAGENT_TOTAL_VOLUME(target.reagents) >= FLUID_MINIMUM_TRANSFER)
 		prop.fluid_act(target.reagents)
 	return TRUE
 
@@ -25,7 +25,7 @@
 /decl/interaction_handler/fill_from/is_possible(atom/target, mob/user, obj/item/prop)
 	if(!(. = ..()))
 		return
-	if(target == prop || target.reagents?.total_volume < FLUID_PUDDLE)
+	if(target == prop || REAGENT_TOTAL_VOLUME(target.reagents) < FLUID_PUDDLE)
 		return FALSE
 	if(!istype(prop) || (!isitem(target) && !istype(target, /obj/structure)))
 		return FALSE
@@ -52,7 +52,7 @@
 /decl/interaction_handler/empty_into/is_possible(atom/target, mob/user, obj/item/prop)
 	if(!(. = ..()))
 		return
-	if(target == prop || !istype(prop) || prop.reagents?.total_volume <= 0)
+	if(target == prop || !istype(prop) || REAGENT_TOTAL_VOLUME(prop.reagents) <= 0)
 		return FALSE
 	return target.can_be_poured_into(user, prop) && prop.can_be_poured_from(user, target)
 
@@ -128,7 +128,7 @@
 		target.show_food_no_mouth_message(user, user)
 		return
 
-	if(!target?.reagents?.total_volume)
+	if(!REAGENT_TOTAL_VOLUME(target?.reagents))
 		target.show_food_empty_message(user, EATING_METHOD_DRINK)
 		return
 

--- a/code/modules/lights/light_bulbs_tubes.dm
+++ b/code/modules/lights/light_bulbs_tubes.dm
@@ -125,10 +125,10 @@
 // if a syringe, can inject flammable liquids to make it explode
 /obj/item/light/attackby(var/obj/item/used_item, var/mob/user)
 	..()
-	if(istype(used_item, /obj/item/chems/syringe) && used_item.reagents?.total_volume)
+	if(istype(used_item, /obj/item/chems/syringe) && REAGENT_TOTAL_VOLUME(used_item.reagents))
 		var/obj/item/chems/syringe/S = used_item
 		to_chat(user, "You inject the solution into \the [src].")
-		for(var/decl/material/reagent as anything in S.reagents?.reagent_volumes)
+		for(var/decl/material/reagent as anything in REAGENT_VOLUMES(S.reagents))
 			if(reagent.accelerant_value > FUEL_VALUE_ACCELERANT)
 				rigged = TRUE
 				log_and_message_admins("injected a light with flammable reagents, rigging it to explode.", user)

--- a/code/modules/materials/definitions/liquids/materials_liquid_toxins.dm
+++ b/code/modules/materials/definitions/liquids/materials_liquid_toxins.dm
@@ -168,7 +168,7 @@
 	M.add_chemical_effect(CE_NOPULSE, 1)
 
 /decl/material/liquid/zombiepowder/on_leaving_metabolism(datum/reagents/metabolism/holder)
-	var/mob/M = holder?.my_atom
+	var/mob/M = REAGENT_GET_ATOM(holder)
 	if(istype(M))
 		M.status_flags &= ~FAKEDEATH
 	. = ..()

--- a/code/modules/materials/definitions/liquids/materials_liquid_water.dm
+++ b/code/modules/materials/definitions/liquids/materials_liquid_water.dm
@@ -34,7 +34,8 @@
 	coated_adjective = "wet"
 
 /decl/material/liquid/water/build_coated_name(datum/reagents/coating, list/accumulator)
-	if(length(coating.reagent_volumes) > 1)
+	var/coating_volumes = REAGENT_VOLUMES(coating)
+	if(length(coating_volumes) > 1)
 		accumulator.Insert(1, "dilute") // dilute always comes first! also this is intentionally not colored in component color mode
 		return // don't insert 'wet'
 	..()
@@ -50,7 +51,7 @@
 /decl/material/liquid/water/get_reagent_name(datum/reagents/holder, phase = MAT_PHASE_LIQUID)
 	. = ..()
 	// length == 1 implies primary reagent, so checking both is redundant
-	if(phase == MAT_PHASE_LIQUID && length(holder?.reagent_volumes) == 1)
+	if(phase == MAT_PHASE_LIQUID && length(REAGENT_VOLUMES(holder)) == 1)
 		return "fresh [.]"
 	return
 

--- a/code/modules/materials/definitions/solids/materials_solid_elements.dm
+++ b/code/modules/materials/definitions/solids/materials_solid_elements.dm
@@ -43,9 +43,10 @@
 /decl/material/solid/carbon/affect_ingest(var/mob/living/M, var/removed, var/datum/reagents/holder)
 	. = ..()
 	var/datum/reagents/ingested = M.get_ingested_reagents()
-	if(ingested && LAZYLEN(ingested.reagent_volumes) > 1)
-		var/effect = 1 / (LAZYLEN(ingested.reagent_volumes) - 1)
-		for(var/decl/material/reagent as anything in ingested.reagent_volumes)
+	var/ingested_volumes = REAGENT_VOLUMES(ingested)
+	if(ingested && LAZYLEN(ingested_volumes) > 1)
+		var/effect = 1 / (LAZYLEN(ingested_volumes) - 1)
+		for(var/decl/material/reagent as anything in ingested_volumes)
 			if(reagent.type != type)
 				ingested.remove_reagent(reagent, removed * effect)
 

--- a/code/modules/materials/material_data.dm
+++ b/code/modules/materials/material_data.dm
@@ -5,7 +5,12 @@
 		.[DATA_INGREDIENT_FLAGS] |= allergen_flags
 
 /decl/material/proc/mix_data(var/datum/reagents/reagents, var/list/newdata, var/amount)
-	reagents.cached_color = null // colour masking may change
+
+	if(!istype(reagents))
+		return
+
+	UNLINT(reagents.cached_color = null) // colour masking may change
+
 	. = REAGENT_DATA(reagents, src)
 	if(!length(newdata) || !islist(newdata))
 		return

--- a/code/modules/materials/material_debris.dm
+++ b/code/modules/materials/material_debris.dm
@@ -135,7 +135,7 @@
 		return
 	if((REALTIMEOFDAY - time_created) < 5 SECONDS)
 		return
-	if(!QDELETED(src) && fluids?.total_liquid_volume >= FLUID_SLURRY)
+	if(!QDELETED(src) && REAGENT_TOTAL_LIQUID_VOLUME(fluids) >= FLUID_SLURRY)
 		var/free_space = REAGENTS_FREE_SPACE(fluids)
 		for(var/matter_type in matter)
 			if(free_space <= MINIMUM_CHEMICAL_VOLUME)

--- a/code/modules/materials/material_display.dm
+++ b/code/modules/materials/material_display.dm
@@ -1,8 +1,9 @@
 /decl/material/proc/get_presentation_name(var/obj/item/prop)
-	if(islist(prop?.reagents?.reagent_data))
-		. = LAZYACCESS(prop.reagents.reagent_data[src], DATA_MASK_NAME)
+	var/list/presentation_data = REAGENT_DATA(prop.reagents, src)
+	if(islist(presentation_data))
+		. = LAZYACCESS(presentation_data, DATA_MASK_NAME)
 	. ||= glass_name || get_reagent_name(prop?.reagents)
-	if(prop?.reagents?.total_volume)
+	if(REAGENT_TOTAL_VOLUME(prop?.reagents))
 		. = build_presentation_name_from_reagents(prop, .)
 
 /decl/material/proc/build_presentation_name_from_reagents(var/obj/item/prop, var/supplied)
@@ -16,7 +17,7 @@
 
 /decl/material/proc/get_presentation_desc(var/obj/item/prop)
 	. = glass_desc
-	if(prop?.reagents?.total_volume)
+	if(REAGENT_TOTAL_VOLUME(prop?.reagents))
 		. = build_presentation_desc_from_reagents(prop, .)
 
 /decl/material/proc/build_presentation_desc_from_reagents(var/obj/item/prop, var/supplied)
@@ -29,8 +30,9 @@
 
 /decl/material/proc/get_reagent_name(datum/reagents/holder, phase = MAT_PHASE_LIQUID)
 
-	if(istype(holder) && holder.reagent_data)
-		var/list/rdata = holder.reagent_data[src]
+	var/reagent_data = REAGENT_DATA(holder, src)
+	if(istype(holder) && islist(reagent_data))
+		var/list/rdata = reagent_data[src]
 		if(rdata)
 			var/data_name = rdata[DATA_MASK_NAME]
 			if(data_name)
@@ -54,8 +56,9 @@
 	return "something"
 
 /decl/material/proc/get_reagent_color(datum/reagents/holder)
-	if(istype(holder) && holder.reagent_data)
-		var/list/rdata = holder.reagent_data[src]
+	var/list/reagent_data = REAGENT_DATA(holder, src)
+	if(istype(holder) && islist(reagent_data))
+		var/list/rdata = reagent_data[src]
 		if(rdata)
 			var/data_color = rdata[DATA_MASK_COLOR]
 			if(data_color)

--- a/code/modules/materials/material_drying.dm
+++ b/code/modules/materials/material_drying.dm
@@ -1,6 +1,6 @@
 /obj/item/stack/material/fluid_act(var/datum/reagents/fluids)
 	. = ..()
-	if(!QDELETED(src) && fluids?.total_volume && material?.tans_to)
+	if(!QDELETED(src) && REAGENT_TOTAL_VOLUME(fluids) && material?.tans_to)
 		if(!dried_type)
 			dried_type = type
 		drying_wetness = get_max_drying_wetness()

--- a/code/modules/materials/material_metabolism.dm
+++ b/code/modules/materials/material_metabolism.dm
@@ -57,7 +57,8 @@
 
 	if(length(vapor_products))
 		var/result_volume = REAGENT_VOLUME(holder, src)
-		var/temperature = holder?.my_atom?.temperature || T20C
+		var/atom/reagent_atom = REAGENT_GET_ATOM(holder)
+		var/temperature = reagent_atom?.temperature || T20C
 		for(var/vapor in vapor_products)
 			touching_turf.assume_gas(vapor, (result_volume * vapor_products[vapor]), temperature)
 		holder.remove_reagent(src, result_volume)

--- a/code/modules/mechs/equipment/engineering.dm
+++ b/code/modules/mechs/equipment/engineering.dm
@@ -32,10 +32,10 @@
 	icon_state = "mech_exting"
 
 /obj/item/chems/spray/extinguisher/mech/get_hardpoint_maptext()
-	return "[reagents.total_volume]/[reagents.maximum_volume]"
+	return "[REAGENT_TOTAL_VOLUME(reagents)]/[REAGENT_MAXIMUM_VOLUME(reagents)]"
 
 /obj/item/chems/spray/extinguisher/mech/get_hardpoint_status_value()
-	return reagents.total_volume/reagents.maximum_volume
+	return REAGENT_TOTAL_VOLUME(reagents)/REAGENT_MAXIMUM_VOLUME(reagents)
 
 /obj/item/mech_equipment/mounted_system/extinguisher
 	icon_state = "mech_exting"

--- a/code/modules/mining/machinery/material_compressor.dm
+++ b/code/modules/mining/machinery/material_compressor.dm
@@ -16,8 +16,8 @@
 		for(var/obj/item/O in input_turf)
 			if(!O.simulated || O.anchored)
 				continue
-			for(var/decl/material/reagent as anything in O.reagents?.reagent_volumes)
-				stored[reagent.type] = stored[reagent.type] + floor((O.reagents.reagent_volumes[reagent] / REAGENT_UNITS_PER_MATERIAL_UNIT) * 0.75) // liquid reagents, lossy
+			for(var/decl/material/reagent as anything in REAGENT_VOLUMES(O.reagents))
+				stored[reagent.type] = stored[reagent.type] + floor((REAGENT_VOLUME(O.reagents, reagent) / REAGENT_UNITS_PER_MATERIAL_UNIT) * 0.75) // liquid reagents, lossy
 			for(var/mat in O.matter)
 				stored[mat] = stored[mat] + O.matter[mat]
 			qdel(O)

--- a/code/modules/mining/machinery/material_extractor.dm
+++ b/code/modules/mining/machinery/material_extractor.dm
@@ -70,7 +70,7 @@
 	if(!use_power || (stat & (BROKEN|NOPOWER)))
 		return
 
-	if(reagents?.total_volume >= MAX_LIQUID)
+	if(REAGENT_TOTAL_VOLUME(reagents) >= MAX_LIQUID)
 		return
 
 	if(input_turf)
@@ -83,8 +83,8 @@
 					eating.dropInto(output_turf)
 				continue
 			eaten++
-			if(eating.reagents?.total_volume)
-				eating.reagents.trans_to_obj(src, eating.reagents.total_volume)
+			if(REAGENT_TOTAL_VOLUME(eating.reagents))
+				eating.reagents.trans_to_obj(src, REAGENT_TOTAL_VOLUME(eating.reagents))
 			for(var/mtype in eating.matter)
 				add_to_reagents(mtype, floor(eating.matter[mtype] * REAGENT_UNITS_PER_MATERIAL_UNIT))
 			qdel(eating)
@@ -97,7 +97,7 @@
 		return
 
 	var/adjusted_reagents = FALSE
-	for(var/decl/material/reagent as anything in reagents.reagent_volumes)
+	for(var/decl/material/reagent as anything in REAGENT_VOLUMES(reagents))
 		adjusted_reagents = max(adjusted_reagents, process_non_liquid(reagent))
 
 	if(adjusted_reagents)
@@ -199,10 +199,10 @@
 
 	if(href_list["dispense"])
 		var/reagent_index = text2num(href_list["dispense"])
-		if(!reagent_index || length(reagents.reagent_volumes) < reagent_index)
+		if(!reagent_index || length(REAGENT_VOLUMES(reagents)) < reagent_index)
 			return TOPIC_HANDLED
 
-		var/mtype = reagents.reagent_volumes[reagent_index]
+		var/mtype = REAGENT_VOLUME(reagents, reagent_index)
 
 		// Only liquids are allowed to dispense. Otherwise, try to process the reagent.
 		if(process_non_liquid(mtype))
@@ -232,20 +232,20 @@
 
 	data["dispense_amount"] = dispense_amount
 	if(output_container)
-		var/curr_volume = output_container.reagents?.total_volume || 0
-		var/max_volume  = output_container.reagents?.maximum_volume || 0
+		var/curr_volume = REAGENT_TOTAL_VOLUME(output_container.reagents)
+		var/max_volume  = REAGENT_MAXIMUM_VOLUME(output_container.reagents)
 
 		data["container"] = "[output_container.name] ([curr_volume] / [max_volume] U)"
 
 	data["reagents"] = list()
 	var/index = 0
-	for(var/decl/material/reagent as anything in reagents.reagent_volumes)
+	for(var/decl/material/reagent as anything in REAGENT_VOLUMES(reagents))
 		index += 1
 		// TODO: Must be revised once state changes are in. Reagent names might be a litle odd in the meantime.
 		var/is_liquid = reagent.phase_at_temperature(temperature, ONE_ATMOSPHERE) == MAT_PHASE_LIQUID
-		data["reagents"] += list(list("label" = "[reagent.liquid_name] ([reagents.reagent_volumes[reagent]] U)", "index" = index, "liquid" = is_liquid))
+		data["reagents"] += list(list("label" = "[reagent.liquid_name] ([REAGENT_VOLUME(reagents, reagent)] U)", "index" = index, "liquid" = is_liquid))
 
-	data["full"] = reagents.total_volume >= MAX_LIQUID
+	data["full"] = REAGENT_TOTAL_VOLUME(reagents) >= MAX_LIQUID
 	data["gas_pressure"] = gas_contents?.return_pressure()
 	return data
 

--- a/code/modules/mining/machinery/material_smelter.dm
+++ b/code/modules/mining/machinery/material_smelter.dm
@@ -31,7 +31,7 @@
 	if(!(. = ..()) || !reagents)
 		return
 
-	for(var/decl/material/reagent as anything in reagents.reagent_volumes)
+	for(var/decl/material/reagent as anything in REAGENT_VOLUMES(reagents))
 		show_materials |= reagent.type
 
 /obj/machinery/material_processing/smeltery/ProcessAtomTemperature()
@@ -70,8 +70,8 @@
 					eating.dropInto(output_turf)
 				continue
 			eaten++
-			if(eating.reagents?.total_volume)
-				eating.reagents.trans_to_obj(src, floor(eating.reagents.total_volume * 0.75)) // liquid reagents, lossy
+			if(REAGENT_TOTAL_VOLUME(eating.reagents))
+				eating.reagents.trans_to_obj(src, floor(REAGENT_TOTAL_VOLUME(eating.reagents) * 0.75)) // liquid reagents, lossy
 			for(var/mtype in eating.matter)
 				add_to_reagents(mtype, floor(eating.matter[mtype] * REAGENT_UNITS_PER_MATERIAL_UNIT))
 			qdel(eating)

--- a/code/modules/mob/living/bot/farmbot.dm
+++ b/code/modules/mob/living/bot/farmbot.dm
@@ -40,7 +40,7 @@
 	. = ..()
 	. += "<br>Water tank: "
 	if(tank)
-		. += "[tank.reagents.total_volume]/[tank.reagents.maximum_volume]"
+		. += "[REAGENT_TOTAL_VOLUME(tank.reagents)]/[REAGENT_MAXIMUM_VOLUME(tank.reagents)]"
 	else
 		. += "error: not found"
 
@@ -118,7 +118,7 @@
 			if(confirmTarget(tray))
 				target = tray
 				return
-		if(!target && refills_water && tank && tank.reagents.total_volume < tank.reagents.maximum_volume)
+		if(!target && refills_water && tank && REAGENT_TOTAL_VOLUME(tank.reagents) < REAGENT_MAXIMUM_VOLUME(tank.reagents))
 			for(var/obj/structure/hygiene/sink/source in view(7, src))
 				target = source
 				return
@@ -171,13 +171,13 @@
 		update_icon()
 		T.update_icon()
 	else if(istype(A, /obj/structure/hygiene/sink))
-		if(!tank || tank.reagents.total_volume >= tank.reagents.maximum_volume)
+		if(!tank || REAGENT_TOTAL_VOLUME(tank.reagents) >= REAGENT_MAXIMUM_VOLUME(tank.reagents))
 			return TRUE
 		action = "water"
 		update_icon()
 		visible_message("<span class='notice'>[src] starts refilling its tank from \the [A].</span>")
 		busy = 1
-		while(do_after(src, 10) && tank.reagents.total_volume < tank.reagents.maximum_volume)
+		while(do_after(src, 10) && REAGENT_TOTAL_VOLUME(tank.reagents) < REAGENT_MAXIMUM_VOLUME(tank.reagents))
 			tank.add_to_reagents(/decl/material/liquid/water, 100)
 			if(prob(5))
 				playsound(loc, 'sound/effects/slosh.ogg', 25, 1)
@@ -228,7 +228,7 @@
 		return 0
 
 	if(istype(target, /obj/structure/hygiene/sink))
-		if(!tank || tank.reagents.total_volume >= tank.reagents.maximum_volume)
+		if(!tank || REAGENT_TOTAL_VOLUME(tank.reagents) >= REAGENT_MAXIMUM_VOLUME(tank.reagents))
 			return 0
 		return 1
 
@@ -242,13 +242,13 @@
 	if(tray.dead && removes_dead || tray.harvest && collects_produce)
 		return FARMBOT_COLLECT
 
-	else if(refills_water && tray.waterlevel < 40 && !tray.reagents.has_reagent(/decl/material/liquid/water) && (tank?.reagents.total_volume > 0))
+	else if(refills_water && tray.waterlevel < 40 && !tray.reagents.has_reagent(/decl/material/liquid/water) && (REAGENT_TOTAL_VOLUME(tank?.reagents) > 0))
 		return FARMBOT_WATER
 
 	else if(uproots_weeds && tray.weedlevel > 3)
 		return FARMBOT_UPROOT
 
-	else if(replaces_nutriment && tray.nutrilevel < 1 && tray.reagents.total_volume < 1)
+	else if(replaces_nutriment && tray.nutrilevel < 1 && REAGENT_TOTAL_VOLUME(tray.reagents) < 1)
 		return FARMBOT_NUTRIMENT
 
 	return 0

--- a/code/modules/mob/living/bot/medibot.dm
+++ b/code/modules/mob/living/bot/medibot.dm
@@ -199,7 +199,7 @@
 	. = ..()
 	. += "<br>Beaker: "
 	if(reagent_glass)
-		. += "<A href='byond://?src=\ref[src];command=eject'>Loaded \[[reagent_glass.reagents.total_volume]/[reagent_glass.reagents.maximum_volume]\]</a>"
+		. += "<A href='byond://?src=\ref[src];command=eject'>Loaded \[[REAGENT_TOTAL_VOLUME(reagent_glass.reagents)]/[REAGENT_MAXIMUM_VOLUME(reagent_glass.reagents)]\]</a>"
 	else
 		. += "None loaded"
 
@@ -306,7 +306,7 @@
 
 	// If they're injured, we're using a beaker, and they don't have on of the chems in the beaker
 	if(reagent_glass && use_beaker && ((patient.get_damage(BRUTE) >= heal_threshold) || (patient.get_damage(TOX) >= heal_threshold) || (patient.get_damage(TOX) >= heal_threshold) || (patient.get_damage(OXY) >= (heal_threshold + 15))))
-		for(var/decl/material/reagent as anything in reagent_glass.reagents.reagent_volumes)
+		for(var/decl/material/reagent as anything in REAGENT_VOLUMES(reagent_glass.reagents))
 			if(!patient.reagents.has_reagent(reagent))
 				return 1
 			continue

--- a/code/modules/mob/living/human/examine.dm
+++ b/code/modules/mob/living/human/examine.dm
@@ -64,8 +64,8 @@
 
 /decl/human_examination/contact_reagents/do_examine(mob/user, distance, mob/living/human/source, hideflags, decl/pronouns/pronouns)
 	var/datum/reagents/touching_reagents = source.get_contact_reagents()
-	if(touching_reagents?.total_volume >= 1)
-		var/saturation = touching_reagents.total_volume / touching_reagents.maximum_volume
+	if(REAGENT_TOTAL_VOLUME(touching_reagents) >= 1)
+		var/saturation = REAGENT_TOTAL_VOLUME(touching_reagents) / REAGENT_MAXIMUM_VOLUME(touching_reagents)
 		if(saturation > 0.9)
 			. += "[pronouns.He] [pronouns.is] completely saturated."
 		else if(saturation > 0.6)

--- a/code/modules/mob/living/human/human.dm
+++ b/code/modules/mob/living/human/human.dm
@@ -302,7 +302,7 @@
 	var/obj/item/organ/internal/stomach/stomach = get_organ(BP_STOMACH, /obj/item/organ/internal/stomach)
 	var/nothing_to_puke = FALSE
 	if(should_have_organ(BP_STOMACH))
-		if(!stomach || (stomach.ingested.total_volume <= 0 && stomach.contents.len == 0))
+		if(!stomach || (REAGENT_TOTAL_VOLUME(stomach.ingested) <= 0 && stomach.contents.len == 0))
 			nothing_to_puke = TRUE
 	else if(!(locate(/mob) in contents))
 		nothing_to_puke = TRUE
@@ -328,8 +328,8 @@
 	var/turf/location = loc
 	if(istype(location) && location.simulated)
 		var/obj/effect/decal/cleanable/vomit/splat = new /obj/effect/decal/cleanable/vomit(location)
-		if(stomach.ingested.total_volume)
-			stomach.ingested.trans_to_obj(splat, min(15, stomach.ingested.total_volume))
+		if(REAGENT_TOTAL_VOLUME(stomach.ingested))
+			stomach.ingested.trans_to_obj(splat, min(15, REAGENT_TOTAL_VOLUME(stomach.ingested)))
 		handle_additional_vomit_reagents(splat)
 		splat.update_icon()
 
@@ -880,7 +880,7 @@
 
 /mob/living/human/fluid_act(var/datum/reagents/fluids)
 	..()
-	if(!QDELETED(src) && fluids?.total_volume)
+	if(!QDELETED(src) && REAGENT_TOTAL_VOLUME(fluids))
 		species.fluid_act(src, fluids)
 
 /mob/living/human/proc/set_background_value(var/cat_type, var/decl/background_detail/_background, var/defer_language_update)

--- a/code/modules/mob/living/human/human_blood.dm
+++ b/code/modules/mob/living/human/human_blood.dm
@@ -30,18 +30,20 @@
 		make_blood()
 
 	if(!should_have_organ(BP_HEART))
-		vessel.clear_reagents()
-		vessel.maximum_volume = 0
+		if(istype(vessel))
+			vessel.clear_reagents()
+			REAGENT_SET_MAX_VOL(vessel, 0)
 		return
 
-	if(vessel.total_volume < species.blood_volume)
-		vessel.maximum_volume = species.blood_volume
-		adjust_blood(species.blood_volume - vessel.total_volume)
-	else if(vessel.total_volume > species.blood_volume)
-		vessel.remove_any(vessel.total_volume - species.blood_volume)
-		vessel.maximum_volume = species.blood_volume
+	if(istype(vessel))
+		if(REAGENT_TOTAL_VOLUME(vessel) < species.blood_volume)
+			REAGENT_SET_MAX_VOL(vessel, species.blood_volume)
+			adjust_blood(species.blood_volume - REAGENT_TOTAL_VOLUME(vessel))
+		else if(REAGENT_TOTAL_VOLUME(vessel) > species.blood_volume)
+			vessel.remove_any(REAGENT_TOTAL_VOLUME(vessel) - species.blood_volume)
+			REAGENT_SET_MAX_VOL(vessel, species.blood_volume)
 
-	LAZYSET(vessel.reagent_data, species.blood_reagent, list(
+	REAGENT_SET_DATA(vessel, species.blood_reagent, list(
 		DATA_BLOOD_DONOR      = weakref(src),
 		DATA_BLOOD_SPECIES    = get_species_name(),
 		DATA_BLOOD_DNA        = get_unique_enzymes(),
@@ -54,9 +56,9 @@
 /mob/living/human/proc/drip(var/amt, var/tar = src, var/ddir)
 	var/datum/reagents/bloodstream = get_injected_reagents()
 	if(remove_blood(amt))
-		if(bloodstream.total_volume && vessel.total_volume)
-			var/chem_share = round(0.3 * amt * (bloodstream.total_volume/vessel.total_volume), 0.01)
-			bloodstream.remove_any(chem_share * bloodstream.total_volume)
+		if(REAGENT_TOTAL_VOLUME(bloodstream) && REAGENT_TOTAL_VOLUME(vessel))
+			var/chem_share = round(0.3 * amt * (REAGENT_TOTAL_VOLUME(bloodstream) / REAGENT_TOTAL_VOLUME(vessel)), 0.01)
+			bloodstream.remove_any(chem_share * REAGENT_TOTAL_VOLUME(bloodstream))
 		blood_splatter(tar, src, (ddir && ddir>0), spray_dir = ddir)
 		return amt
 	return 0
@@ -154,7 +156,7 @@
 	if(stress_modifier)
 		amount *= 1-(get_config_value(/decl/config/num/health_stress_blood_recovery_constant) * stress_modifier)
 
-	var/blood_volume_raw = vessel.total_volume
+	var/blood_volume_raw = REAGENT_TOTAL_VOLUME(vessel)
 	amount = max(0,min(amount, species.blood_volume - blood_volume_raw))
 	if(amount)
 		adjust_blood(amount, get_blood_data())
@@ -170,16 +172,16 @@
 		reagents.trans_to_obj(container, amount)
 		return 1
 
-	if(vessel.total_volume < amount)
+	if(REAGENT_TOTAL_VOLUME(vessel) < amount)
 		return null
 	if(vessel.has_reagent(species.blood_reagent))
-		LAZYSET(vessel.reagent_data, species.blood_reagent, get_blood_data())
+		REAGENT_SET_DATA(vessel, species.blood_reagent, get_blood_data())
 	vessel.trans_to_holder(container.reagents, amount)
 	return 1
 
 //Percentage of maximum blood volume.
 /mob/living/human/proc/get_blood_volume()
-	return species.blood_volume ? round((vessel.total_volume/species.blood_volume)*100) : 0
+	return species.blood_volume ? round((REAGENT_TOTAL_VOLUME(vessel)/species.blood_volume)*100) : 0
 
 //Percentage of maximum blood volume, affected by the condition of circulation organs
 /mob/living/human/proc/get_blood_circulation()

--- a/code/modules/mob/living/human/human_organs.dm
+++ b/code/modules/mob/living/human/human_organs.dm
@@ -219,8 +219,8 @@
 	if(!(. = ..()))
 		return
 	//Move some blood over to the organ
-	if(!BP_IS_PROSTHETIC(O) && O.species && O.reagents?.total_volume < 5)
-		vessel.trans_to(O, 5 - O.reagents.total_volume, 1, 1)
+	if(!BP_IS_PROSTHETIC(O) && O.species && REAGENT_TOTAL_VOLUME(O.reagents) < 5)
+		vessel.trans_to(O, 5 - REAGENT_TOTAL_VOLUME(O.reagents), 1, 1)
 
 
 /mob/living/human/is_asystole()

--- a/code/modules/mob/living/life.dm
+++ b/code/modules/mob/living/life.dm
@@ -271,10 +271,10 @@
 	if(!loc)
 		return
 	var/datum/reagents/touching_reagents = get_contact_reagents()
-	if(touching_reagents?.total_volume <= FLUID_MINIMUM_TRANSFER)
+	if(REAGENT_TOTAL_VOLUME(touching_reagents) <= FLUID_MINIMUM_TRANSFER)
 		touching_reagents?.clear_reagents()
 		return
-	var/drip_amount = max(FLUID_MINIMUM_TRANSFER, round(touching_reagents.total_volume * 0.2))
+	var/drip_amount = max(FLUID_MINIMUM_TRANSFER, round(REAGENT_TOTAL_VOLUME(touching_reagents) * 0.2))
 	if(drip_amount)
 		touching_reagents.trans_to(loc, drip_amount)
 

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -805,22 +805,22 @@ default behaviour is:
 		var/inhale_amount = 0
 		if(inhaled)
 			inhale_amount = rand(2,5)
-			T.reagents?.trans_to_holder(inhaled, min(T.reagents.total_volume, inhale_amount))
+			T.reagents?.trans_to_holder(inhaled, min(REAGENT_TOTAL_VOLUME(T.reagents), inhale_amount))
 		if(ingested)
 			var/ingest_amount = 5 - inhale_amount
-			reagents?.trans_to_holder(ingested, min(T.reagents.total_volume, ingest_amount))
+			reagents?.trans_to_holder(ingested, min(REAGENT_TOTAL_VOLUME(T.reagents), ingest_amount))
 
 	T.show_bubbles()
 	return TRUE // Presumably chemical smoke can't be breathed while you're underwater.
 
 /mob/living/fluid_act(var/datum/reagents/fluids)
 	..()
-	if(QDELETED(src) || fluids?.total_volume < FLUID_PUDDLE)
+	if(QDELETED(src) || REAGENT_TOTAL_VOLUME(fluids) < FLUID_PUDDLE)
 		return
 	fluids.touch_mob(src)
-	if(QDELETED(src) || fluids?.total_volume < FLUID_PUDDLE)
+	if(QDELETED(src) || REAGENT_TOTAL_VOLUME(fluids) < FLUID_PUDDLE)
 		return
-	var/on_turf = fluids.my_atom == get_turf(src)
+	var/on_turf = REAGENT_GET_ATOM(fluids) == get_turf(src)
 	for(var/atom/movable/A as anything in get_equipped_items(TRUE))
 		if(!A.simulated)
 			continue
@@ -829,12 +829,12 @@ default behaviour is:
 		if(on_turf && !A.submerged())
 			continue
 		A.fluid_act(fluids)
-		if(QDELETED(src) || !fluids.total_volume)
+		if(QDELETED(src) || !REAGENT_TOTAL_VOLUME(fluids))
 			return
 	// TODO: review saturation logic so we can end up with more than like 15 water in our contact reagents.
 	var/datum/reagents/touching_reagents = get_contact_reagents()
 	if(touching_reagents)
-		var/saturation =  min(fluids.total_volume, round(mob_size * 1.5 * reagent_permeability()) - touching_reagents.total_volume)
+		var/saturation =  min(REAGENT_TOTAL_VOLUME(fluids), round(mob_size * 1.5 * reagent_permeability()) - REAGENT_TOTAL_VOLUME(touching_reagents))
 		if(saturation > 0)
 			fluids.trans_to_holder(touching_reagents, saturation)
 
@@ -985,7 +985,8 @@ default behaviour is:
 
 /mob/living/proc/get_food_satiation(consumption_method = EATING_METHOD_EAT)
 	. = (consumption_method == EATING_METHOD_EAT) ? get_nutrition() : get_hydration()
-	. += get_ingested_reagents()?.total_volume * 5
+	var/datum/reagents/ingested = get_ingested_reagents()
+	. += REAGENT_TOTAL_VOLUME(ingested) * 5
 
 /mob/living/proc/get_ingested_reagents()
 	RETURN_TYPE(/datum/reagents)
@@ -1370,7 +1371,7 @@ default behaviour is:
 	//flush away reagents on the skin
 	var/datum/reagents/touching_reagents = get_contact_reagents()
 	if(touching_reagents)
-		var/remove_amount = touching_reagents.maximum_volume * reagent_permeability() //take off your suit first
+		var/remove_amount = REAGENT_MAXIMUM_VOLUME(touching_reagents) * reagent_permeability() //take off your suit first
 		touching_reagents.remove_any(remove_amount)
 
 	var/obj/item/mask = get_equipped_item(slot_wear_mask_str)
@@ -1554,11 +1555,11 @@ default behaviour is:
 	var/obj/item/clothing/shoes/shoes = get_equipped_item(slot_shoes_str)
 	if(istype(shoes))
 		shoes.handle_movement(src, MOVING_QUICKLY(src))
-		if(shoes.coating && shoes.coating.total_volume > 1)
+		if(shoes.coating && REAGENT_TOTAL_VOLUME(shoes.coating) > 1)
 			source = shoes
 	else
 		for(var/obj/item/organ/external/stomper in get_organs_by_categories(global.child_stance_limbs))
-			if(stomper.coating?.total_volume > 1)
+			if(REAGENT_TOTAL_VOLUME(stomper.coating) > 1)
 				source = stomper
 				break
 
@@ -1571,7 +1572,10 @@ default behaviour is:
 	if(!use_move_trail)
 		return
 
-	var/decl/material/contaminant = source.coating.reagent_volumes[1] // take [1] instead of primary reagent to match what remove_any will probably remove
+	if(!istype(source.coating))
+		return
+
+	var/decl/material/contaminant = UNLINT(source.coating.reagent_volumes[1]) // take [1] instead of primary reagent to match what remove_any will probably remove
 	if(!T.can_show_coating_footprints(contaminant))
 		return
 	/// An associative list of DNA unique enzymes -> blood type. Used by forensics, mostly.
@@ -1946,7 +1950,7 @@ default behaviour is:
 			. += SPAN_WARNING("\The [src] will be ready to be sheared in [ceil((shearable.next_fleece-world.time) / 10)] second\s.")
 	if(has_extension(src, /datum/extension/milkable))
 		var/datum/extension/milkable/milkable = get_extension(src, /datum/extension/milkable)
-		if(milkable.udder.total_volume > 0)
+		if(REAGENT_TOTAL_VOLUME(milkable.udder) > 0)
 			. += SPAN_NOTICE("\The [src] can be milked into a bucket or other container.")
 		else
 			. += SPAN_WARNING("\The [src] cannot currently be milked.")

--- a/code/modules/mob/living/living_blood.dm
+++ b/code/modules/mob/living/living_blood.dm
@@ -18,7 +18,7 @@
 		data[DATA_BLOOD_SPECIES] = species_name
 
 	var/list/temp_chem = list()
-	for(var/decl/material/reagent as anything in reagents?.reagent_volumes)
+	for(var/decl/material/reagent as anything in REAGENT_VOLUMES(reagents))
 		temp_chem[reagent.type] = REAGENT_VOLUME(reagents, reagent)
 	data[DATA_BLOOD_TRACE_CHEM]  = temp_chem
 	data[DATA_BLOOD_DOSE_CHEM]   = _chem_doses?.Copy() || list()

--- a/code/modules/mob/living/living_breath.dm
+++ b/code/modules/mob/living/living_breath.dm
@@ -132,7 +132,7 @@
 			return
 
 	for(var/obj/effect/effect/smoke/chem/smoke in view(1, src))
-		if(smoke.reagents.total_volume)
+		if(REAGENT_TOTAL_VOLUME(smoke.reagents))
 			smoke.reagents.trans_to_mob(src, 5, CHEM_INGEST, copy = 1)
 			smoke.reagents.trans_to_mob(src, 5, CHEM_INJECT, copy = 1)
 			// I dunno, maybe the reagents enter the blood stream through the lungs?

--- a/code/modules/mob/living/silicon/robot/flying/module_flying_emergency.dm
+++ b/code/modules/mob/living/silicon/robot/flying/module_flying_emergency.dm
@@ -70,8 +70,8 @@
 
 /obj/item/robot_module/flying/emergency/respawn_consumable(var/mob/living/silicon/robot/robot, var/amount)
 	var/obj/item/chems/spray/PS = emag
-	if(PS && PS.reagents.total_volume < PS.reagents.maximum_volume)
-		var/adding = min(PS.reagents.maximum_volume-PS.reagents.total_volume, 2*amount)
+	if(PS && REAGENT_TOTAL_VOLUME(PS.reagents) < REAGENT_MAXIMUM_VOLUME(PS.reagents))
+		var/adding = min(REAGENT_MAXIMUM_VOLUME(PS.reagents)-REAGENT_TOTAL_VOLUME(PS.reagents), 2*amount)
 		if(adding > 0)
 			PS.add_to_reagents(/decl/material/liquid/acid/polyacid, adding)
 	..()

--- a/code/modules/mob/living/silicon/robot/flying/module_flying_forensics.dm
+++ b/code/modules/mob/living/silicon/robot/flying/module_flying_forensics.dm
@@ -41,8 +41,8 @@
 	if(!luminol)
 		luminol = new(src)
 		equipment += luminol
-	if(luminol.reagents.total_volume < luminol.reagents.maximum_volume)
-		var/adding = min(luminol.reagents.maximum_volume-luminol.reagents.total_volume, 2*amount)
+	if(REAGENT_TOTAL_VOLUME(luminol.reagents) < REAGENT_MAXIMUM_VOLUME(luminol.reagents))
+		var/adding = min(REAGENT_MAXIMUM_VOLUME(luminol.reagents)-REAGENT_TOTAL_VOLUME(luminol.reagents), 2*amount)
 		if(adding > 0)
 			luminol.add_to_reagents(/decl/material/liquid/luminol, adding)
 	..()

--- a/code/modules/mob/living/simple_animal/hostile/vagrant.dm
+++ b/code/modules/mob/living/simple_animal/hostile/vagrant.dm
@@ -54,7 +54,7 @@
 			gripping = null
 
 		else if(gripping.should_have_organ(BP_HEART))
-			var/blood_volume = round(gripping.vessel.total_volume)
+			var/blood_volume = round(REAGENT_TOTAL_VOLUME(gripping.vessel))
 			if(blood_volume > 5)
 				gripping.vessel.remove_any(blood_per_tick)
 				heal_overall_damage(health_per_tick)

--- a/code/modules/mob/transform_procs.dm
+++ b/code/modules/mob/transform_procs.dm
@@ -253,7 +253,7 @@
 	log_admin("[key_name(src)] has transformed into a zombie!")
 	SET_STATUS_MAX(src, STAT_WEAK, 5)
 	if (should_have_organ(BP_HEART))
-		adjust_blood(species.blood_volume - vessel.total_volume)
+		adjust_blood(species.blood_volume - REAGENT_TOTAL_VOLUME(vessel))
 	for (var/o in get_external_organs())
 		var/obj/item/organ/organ = o
 		if (!BP_IS_PROSTHETIC(organ))

--- a/code/modules/organs/internal/heart.dm
+++ b/code/modules/organs/internal/heart.dm
@@ -147,7 +147,7 @@
 							blood_max += wound.damage / 40
 
 			if(temp.status & ORGAN_ARTERY_CUT)
-				var/bleed_amount = floor((owner.vessel.total_volume / (temp.applied_pressure || !open_wound ? 400 : 250))*temp.arterial_bleed_severity)
+				var/bleed_amount = floor((REAGENT_TOTAL_VOLUME(owner.vessel) / (temp.applied_pressure || !open_wound ? 400 : 250))*temp.arterial_bleed_severity)
 				if(bleed_amount)
 					if(open_wound)
 						blood_max += bleed_amount

--- a/code/modules/organs/internal/lungs.dm
+++ b/code/modules/organs/internal/lungs.dm
@@ -37,20 +37,19 @@
 /obj/item/organ/internal/lungs/initialize_reagents(populate)
 	if(!inhaled)
 		inhaled = new/datum/reagents/metabolism(240, (owner || src), CHEM_INHALE)
-	if(!inhaled.my_atom)
-		inhaled.my_atom = src
+	REAGENT_SET_ATOM(inhaled, src)
 	. = ..()
 
 /obj/item/organ/internal/lungs/do_install(mob/living/human/target, obj/item/organ/external/affected, in_place)
 	if(!(. = ..()))
 		return
-	inhaled.my_atom = owner
+	REAGENT_SET_ATOM(inhaled, owner)
 	inhaled.parent = owner
 
 /obj/item/organ/internal/lungs/do_uninstall(in_place, detach, ignore_children)
 	. = ..()
 	if(inhaled)
-		inhaled.my_atom = src
+		REAGENT_SET_ATOM(inhaled, src)
 		inhaled.parent = null
 
 /obj/item/organ/internal/lungs/proc/can_drown()
@@ -376,5 +375,5 @@
 	last_cough = world.time
 
 	// Coughing clears out 1-2 reagents from the lungs.
-	if(lung.inhaled.total_volume > 0 && loc)
+	if(REAGENT_TOTAL_VOLUME(lung.inhaled) > 0 && loc)
 		lung.inhaled.splash(loc, rand(1, 2))

--- a/code/modules/organs/internal/stomach.dm
+++ b/code/modules/organs/internal/stomach.dm
@@ -24,26 +24,25 @@
 /obj/item/organ/internal/stomach/initialize_reagents(populate)
 	if(!ingested)
 		ingested = new/datum/reagents/metabolism(240, (owner || src), CHEM_INGEST)
-	if(!ingested.my_atom)
-		ingested.my_atom = src
+	REAGENT_SET_ATOM(ingested, src)
 	. = ..()
+
+/obj/item/organ/internal/stomach/do_install()
+	. = ..()
+	REAGENT_SET_ATOM(ingested, owner)
+	ingested.parent = owner
 
 /obj/item/organ/internal/stomach/do_uninstall(in_place, detach, ignore_children)
 	. = ..()
 	if(ingested) //Don't bother if we're destroying
-		ingested.my_atom = src
+		REAGENT_SET_ATOM(ingested, src)
 		ingested.parent = null
-
-/obj/item/organ/internal/stomach/do_install()
-	. = ..()
-	ingested.my_atom = owner
-	ingested.parent = owner
 
 /obj/item/organ/internal/stomach/proc/can_eat_atom(var/atom/movable/food)
 	return !isnull(get_devour_time(food))
 
 /obj/item/organ/internal/stomach/proc/is_full(var/atom/movable/food)
-	var/total = floor(ingested.total_volume / 10)
+	var/total = floor(REAGENT_TOTAL_VOLUME(ingested) / 10)
 	for(var/a in contents + food)
 		if(ismob(a))
 			var/mob/M = a
@@ -123,7 +122,7 @@
 			owner.seizure()
 
 		// Alcohol counts as double volume for the purposes of vomit probability
-		var/effective_volume = ingested.total_volume + alcohol_volume
+		var/effective_volume = REAGENT_TOTAL_VOLUME(ingested) + alcohol_volume
 
 		// Just over the limit, the probability will be low. It rises a lot such that at double ingested it's 64% chance.
 		var/vomit_probability = (effective_volume / STOMACH_VOLUME) ** 6

--- a/code/modules/organs/organ.dm
+++ b/code/modules/organs/organ.dm
@@ -129,7 +129,7 @@
 	if(bodytype)
 		reagent_to_add = bodytype.edible_reagent // can set this to null and skip the next block
 	if(reagent_to_add)
-		add_to_reagents(reagent_to_add, reagents.maximum_volume)
+		add_to_reagents(reagent_to_add, REAGENT_MAXIMUM_VOLUME(reagents))
 
 /obj/item/organ/proc/copy_from_mob_snapshot(var/datum/mob_snapshot/supplied_appearance)
 	if(supplied_appearance != organ_appearance) // Hacky. Is this ever used? Do any organs ever have DNA set before setup_as_organic?
@@ -236,7 +236,7 @@
 		return
 
 	if(!owner && reagents)
-		if(prob(40) && reagents.total_volume >= 0.1)
+		if(prob(40) && REAGENT_TOTAL_VOLUME(reagents) >= 0.1)
 			if(reagents.has_reagent(/decl/material/liquid/blood))
 				blood_splatter(get_turf(src), src, 1)
 			remove_any_reagents(0.1)
@@ -261,8 +261,9 @@
 /obj/item/organ/proc/handle_ailment(var/datum/ailment/ailment)
 	if(ailment.treated_by_reagent_type)
 		for(var/datum/reagents/source as anything in owner.get_metabolizing_reagent_holders())
-			for(var/decl/material/reagent as anything in source.reagent_volumes)
-				if(ailment.treated_by_medication(reagent.type, source.reagent_volumes[reagent]))
+			var/source_volumes = REAGENT_VOLUMES(source)
+			for(var/decl/material/reagent as anything in source_volumes)
+				if(ailment.treated_by_medication(reagent.type, source_volumes[reagent]))
 					ailment.was_treated_by_medication(source, reagent.type)
 					return
 	if(ailment.treated_by_chem_effect && owner.has_chemical_effect(ailment.treated_by_chem_effect, ailment.treated_by_chem_effect_strength))
@@ -423,8 +424,8 @@
 	var/obj/item/food/organ/yum = new(get_turf(src))
 	yum.SetName(name)
 	yum.appearance = src
-	if(reagents && reagents.total_volume)
-		reagents.trans_to(yum, reagents.total_volume)
+	if(reagents && REAGENT_TOTAL_VOLUME(reagents))
+		reagents.trans_to(yum, REAGENT_TOTAL_VOLUME(reagents))
 	transfer_fingerprints_to(yum)
 	if(user)
 		user.put_in_active_hand(yum)

--- a/code/modules/paperwork/pen/quill_and_ink.dm
+++ b/code/modules/paperwork/pen/quill_and_ink.dm
@@ -88,7 +88,7 @@
 		if(current_uses >= quill.max_uses)
 			to_chat(user, SPAN_WARNING("\The [quill] doesn't need any more ink!"))
 			return TRUE
-		if(reagents?.total_liquid_volume <= 0)
+		if(REAGENT_TOTAL_LIQUID_VOLUME(reagents) <= 0)
 			to_chat(user, SPAN_WARNING("\The [src] is empty!"))
 			return TRUE
 		to_chat(user, SPAN_NOTICE("You dip \the [quill] into \the [src]."))

--- a/code/modules/paperwork/pen/reagent_pen.dm
+++ b/code/modules/paperwork/pen/reagent_pen.dm
@@ -16,7 +16,7 @@
 				to_chat(user, SPAN_NOTICE("You begin hunting for an injection port on your suit."))
 			if(!user.do_skilled(INJECTION_PORT_DELAY, SKILL_MEDICAL, target))
 				return TRUE
-		if(reagents.total_volume)
+		if(REAGENT_TOTAL_VOLUME(reagents))
 			if(target.reagents)
 				var/contained_reagents = reagents.get_reagents()
 				var/trans = reagents.trans_to_mob(target, 30, CHEM_INJECT)
@@ -35,4 +35,4 @@
 	desc = "It's \a [stroke_color_name] [medium_name] pen with a sharp point and a carefully engraved \"Waffle Co.\"."
 
 /obj/item/pen/reagent/sleepy/populate_reagents()
-	add_to_reagents(/decl/material/liquid/paralytics, round(reagents.maximum_volume/2))
+	add_to_reagents(/decl/material/liquid/paralytics, round(REAGENT_MAXIMUM_VOLUME(reagents)/2))

--- a/code/modules/paperwork/toner_cartridge.dm
+++ b/code/modules/paperwork/toner_cartridge.dm
@@ -18,12 +18,12 @@
 
 /obj/item/chems/toner_cartridge/populate_reagents()
 	//Normally this would be toner powder, but probably not worth making a material for that.
-	add_to_reagents(/decl/material/liquid/paint,         reagents.maximum_volume/2)
-	add_to_reagents(/decl/material/liquid/pigment/black, reagents.maximum_volume/2)
+	add_to_reagents(/decl/material/liquid/paint,         REAGENT_MAXIMUM_VOLUME(reagents)/2)
+	add_to_reagents(/decl/material/liquid/pigment/black, REAGENT_MAXIMUM_VOLUME(reagents)/2)
 
 /obj/item/chems/toner_cartridge/dump_contents(atom/forced_loc = loc, mob/user)
 	. = ..()
-	reagents?.splash(get_turf(forced_loc), reagents.total_volume)
+	reagents?.splash(get_turf(forced_loc), REAGENT_TOTAL_VOLUME(reagents))
 
 /obj/item/chems/toner_cartridge/physically_destroyed(skip_qdel)
 	material.place_shards(get_turf(src), 2)
@@ -40,7 +40,7 @@
 
 /obj/item/chems/toner_cartridge/proc/get_amount_toner_max()
 	//Since ink is paint + pigment in a 1:1 ratio, only half the volume is actually usable
-	return round(reagents.maximum_volume / 2, 0.01)
+	return round(REAGENT_MAXIMUM_VOLUME(reagents) / 2, 0.01)
 
 /obj/item/chems/toner_cartridge/proc/use_toner(var/amount)
 	if(!reagents)

--- a/code/modules/power/fuel_assembly/fuel_compressor.dm
+++ b/code/modules/power/fuel_assembly/fuel_compressor.dm
@@ -120,8 +120,8 @@
 	return add_material(used_item, user) || ..()
 
 /obj/machinery/fuel_compressor/proc/add_material(var/obj/item/thing, var/mob/user)
-	if(istype(thing) && thing.reagents && thing.reagents.total_volume && ATOM_IS_OPEN_CONTAINER(thing))
-		for(var/decl/material/reagent as anything in thing.reagents.reagent_volumes)
+	if(istype(thing) && thing.reagents && REAGENT_TOTAL_VOLUME(thing.reagents) && ATOM_IS_OPEN_CONTAINER(thing))
+		for(var/decl/material/reagent as anything in REAGENT_VOLUMES(thing.reagents))
 			var/taking_reagent = REAGENT_VOLUME(thing.reagents, reagent)
 			thing.remove_from_reagents(reagent, taking_reagent)
 			stored_material[reagent.type] += taking_reagent

--- a/code/modules/power/port_gen.dm
+++ b/code/modules/power/port_gen.dm
@@ -366,8 +366,8 @@
 	data["fuel_type"] = capitalize(sheet_name)
 
 	data["uses_coolant"] = !!reagents
-	data["coolant_stored"] = reagents?.total_volume
-	data["coolant_capacity"] = reagents?.maximum_volume
+	data["coolant_stored"] = REAGENT_TOTAL_VOLUME(reagents)
+	data["coolant_capacity"] = REAGENT_MAXIMUM_VOLUME(reagents)
 
 	ui = SSnano.try_update_ui(user, src, ui_key, ui, data, force_open)
 	if (!ui)
@@ -461,7 +461,7 @@
 
 /obj/machinery/port_gen/pacman/super/potato/get_examine_strings(mob/user, distance, infix, suffix)
 	. = ..()
-	. += "Auxilary tank shows [reagents.total_volume]u of liquid in it."
+	. += "Auxilary tank shows [REAGENT_TOTAL_VOLUME(reagents)]u of liquid in it."
 
 /obj/machinery/port_gen/pacman/super/potato/UseFuel()
 	if(reagents.has_reagent(/decl/material/liquid/alcohol/vodka))

--- a/code/modules/projectiles/ammunition/chemdart.dm
+++ b/code/modules/projectiles/ammunition/chemdart.dm
@@ -10,10 +10,10 @@
 	chem_volume = 15
 
 /obj/item/projectile/bullet/chemdart/on_hit(var/atom/target, var/blocked = 0, var/def_zone = null)
-	if(reagents?.total_volume && blocked < 100 && isliving(target))
+	if(REAGENT_TOTAL_VOLUME(reagents) && blocked < 100 && isliving(target))
 		var/mob/living/L = target
 		if(L.can_inject(null, def_zone) == CAN_INJECT)
-			reagents.trans_to_mob(L, reagents.total_volume, CHEM_INJECT)
+			reagents.trans_to_mob(L, REAGENT_TOTAL_VOLUME(reagents), CHEM_INJECT)
 
 /obj/item/ammo_casing/chemdart
 	name = "chemical dart"

--- a/code/modules/projectiles/guns/launcher/syringe_gun.dm
+++ b/code/modules/projectiles/guns/launcher/syringe_gun.dm
@@ -60,7 +60,7 @@
 			//unfortuately we don't know where the dart will actually hit, since that's done by the parent.
 			if(L.can_inject(null, ran_zone(TT.target_zone, 30, L)) == CAN_INJECT && syringe.reagents)
 				var/reagent_log = syringe.reagents.get_reagents()
-				syringe.reagents.trans_to_mob(L, syringe.reagents.total_volume, CHEM_INJECT)
+				syringe.reagents.trans_to_mob(L, REAGENT_TOTAL_VOLUME(syringe.reagents), CHEM_INJECT)
 				admin_inject_log(TT.thrower? TT.thrower : null, L, src, reagent_log, 15, violent=1)
 
 		syringe.break_syringe(ishuman(hit_atom)? hit_atom : null)

--- a/code/modules/projectiles/guns/projectile/dartgun.dm
+++ b/code/modules/projectiles/guns/projectile/dartgun.dm
@@ -57,10 +57,11 @@
 	if (beakers.len)
 		. += SPAN_NOTICE("\The [src] contains:")
 		for(var/obj/item/chems/glass/beaker/B in beakers)
-			if(B.reagents && LAZYLEN(B.reagents?.reagent_volumes))
-				for(var/decl/material/reagent as anything in B.reagents.liquid_volumes)
+			var/reagent_volumes = REAGENT_VOLUMES(B.reagents)
+			if(B.reagents && LAZYLEN(reagent_volumes))
+				for(var/decl/material/reagent as anything in REAGENT_LIQUID_VOLUMES(B.reagents))
 					. += SPAN_NOTICE("[LIQUID_VOLUME(B.reagents, reagent)] units of [reagent.get_reagent_name(B.reagents, MAT_PHASE_LIQUID)]")
-				for(var/decl/material/reagent as anything in B.reagents.solid_volumes)
+				for(var/decl/material/reagent as anything in REAGENT_SOLID_VOLUMES(B.reagents))
 					. += SPAN_NOTICE("[SOLID_VOLUME(B.reagents, reagent)] units of [reagent.get_reagent_name(B.reagents, MAT_PHASE_SOLID)]")
 
 /obj/item/gun/projectile/dartgun/attackby(obj/item/used_item, mob/user)
@@ -90,7 +91,7 @@
 //fills the given dart with reagents
 /obj/item/gun/projectile/dartgun/proc/fill_dart(var/obj/item/projectile/bullet/chemdart/dart)
 	if(length(mixing))
-		var/mix_amount = dart.reagents?.total_volume/length(mixing)
+		var/mix_amount = REAGENT_TOTAL_VOLUME(dart.reagents)/length(mixing)
 		for(var/obj/item/chems/glass/beaker/B in mixing)
 			B.reagents.trans_to_obj(dart, mix_amount)
 
@@ -109,8 +110,9 @@
 			if(!istype(B)) continue
 
 			dat += "Beaker [i] contains: "
-			if(B.reagents && LAZYLEN(B.reagents.reagent_volumes))
-				for(var/decl/material/reagent as anything in B.reagents.reagent_volumes)
+			var/reagent_volumes = REAGENT_VOLUMES(B.reagents)
+			if(LAZYLEN(reagent_volumes))
+				for(var/decl/material/reagent as anything in REAGENT_VOLUMES(B.reagents))
 					dat += "<br>    [REAGENT_VOLUME(B.reagents, reagent)] unit\s of [reagent.get_reagent_name(B.reagents)], "
 				if(B in mixing)
 					dat += "<A href='byond://?src=\ref[src];stop_mix=[i]'><font color='green'>Mixing</font></A> "

--- a/code/modules/reagents/Chemistry-Grinder.dm
+++ b/code/modules/reagents/Chemistry-Grinder.dm
@@ -74,7 +74,7 @@
 		if(used_item.storage)
 			var/failed = TRUE
 			for(var/obj/item/G in used_item)
-				if(!G.reagents || !G.reagents.total_volume)
+				if(!G.reagents || !REAGENT_TOTAL_VOLUME(G.reagents))
 					continue
 				failed = FALSE
 				used_item.storage.remove_from_storage(user, G, src)
@@ -105,7 +105,7 @@
 			to_chat(user, SPAN_NOTICE("\The [grind_material.solid_name] cannot be ground down to any usable reagents."))
 			return TRUE
 
-	else if(!used_item.reagents?.total_volume)
+	else if(!REAGENT_TOTAL_VOLUME(used_item.reagents))
 		to_chat(user, SPAN_NOTICE("\The [used_item] is not suitable for grinding."))
 		return TRUE
 
@@ -133,7 +133,7 @@
 
 	data["beakercontents"] = list()
 	if(beaker?.reagents)
-		for(var/decl/material/reagent as anything in beaker.reagents.reagent_volumes)
+		for(var/decl/material/reagent as anything in REAGENT_VOLUMES(beaker.reagents))
 			data["beakercontents"] += "<b>[capitalize(reagent.get_reagent_name(beaker.reagents))]</b> ([REAGENT_VOLUME(beaker.reagents, reagent)]u)"
 
 	ui = SSnano.try_update_ui(user, src, ui_key, ui, data, force_open)
@@ -182,7 +182,7 @@
 		return FALSE
 
 	// Sanity check.
-	if (!beaker || (beaker.reagents.total_volume >= beaker.reagents.maximum_volume))
+	if (!beaker || (REAGENT_TOTAL_VOLUME(beaker.reagents) >= REAGENT_MAXIMUM_VOLUME(beaker.reagents)))
 		return FALSE
 
 	attempt_skill_effect(user)
@@ -197,7 +197,7 @@
 	// Process.
 	for (var/obj/item/thing in holdingitems)
 
-		var/remaining_volume = beaker.reagents.maximum_volume - beaker.reagents.total_volume
+		var/remaining_volume = REAGENT_MAXIMUM_VOLUME(beaker.reagents) - REAGENT_TOTAL_VOLUME(beaker.reagents)
 		if(remaining_volume <= 0)
 			break
 
@@ -216,7 +216,7 @@
 				continue
 
 		else if(thing.reagents)
-			thing.reagents.trans_to(beaker, thing.reagents.total_volume, skill_factor)
+			thing.reagents.trans_to(beaker, REAGENT_TOTAL_VOLUME(thing.reagents), skill_factor)
 			holdingitems -= thing
 			qdel(thing)
 
@@ -274,4 +274,4 @@
 		return
 	visible_message(SPAN_NOTICE("\The [src] whirrs violently and spills its contents all over \the [user]!"))
 	if(beaker?.reagents)
-		beaker.reagents.splash(user, beaker.reagents.total_volume)
+		beaker.reagents.splash(user, REAGENT_TOTAL_VOLUME(beaker.reagents))

--- a/code/modules/reagents/Chemistry-Holder.dm
+++ b/code/modules/reagents/Chemistry-Holder.dm
@@ -11,9 +11,9 @@ var/global/datum/reagents/sink/infinite_reagent_sink = new
 	return reagents?.remove_any(amount, defer_update, removed_phases, skip_reagents)
 
 /atom/proc/get_reagent_space()
-	if(!reagents?.maximum_volume)
+	if(!REAGENT_MAXIMUM_VOLUME(reagents))
 		return 0
-	return reagents.maximum_volume - reagents.total_volume
+	return REAGENT_MAXIMUM_VOLUME(reagents) - REAGENT_TOTAL_VOLUME(reagents)
 
 /atom/proc/get_reagents()
 	return reagents
@@ -55,23 +55,21 @@ var/global/datum/reagents/sink/infinite_reagent_sink = new
 	vapor?.update_values()
 	liquids?.update_total()
 
+// These vars are privated due to the potential for reagents to be either null, a list, or a datum.
+// Always use the REAGENT_FOO macros!
 /datum/reagents
-	var/primary_reagent
-	var/primary_solid
-	var/primary_liquid
-	var/list/reagent_volumes
-
-	var/list/liquid_volumes
-	var/list/solid_volumes		// This should be taken as powders/flakes, rather than large solid pieces of material.
-
-	var/list/reagent_data
-	var/total_volume = 0
-	var/maximum_volume = 120
-
-	var/total_liquid_volume // Used to determine when to create fluids in the world and the like.
-
-	var/atom/my_atom
-	var/cached_color
+	VAR_PRIVATE/list/reagent_volumes
+	VAR_PRIVATE/list/liquid_volumes
+	VAR_PRIVATE/list/solid_volumes // This should be taken as powders/flakes, rather than large solid pieces of material.
+	VAR_PRIVATE/list/reagent_data
+	VAR_PRIVATE/atom/my_atom
+	VAR_PRIVATE/cached_color
+	VAR_PRIVATE/primary_reagent
+	VAR_PRIVATE/primary_solid
+	VAR_PRIVATE/primary_liquid
+	VAR_PRIVATE/total_volume = 0
+	VAR_PRIVATE/total_liquid_volume // Used to determine when to create fluids in the world and the like.
+	VAR_PRIVATE/maximum_volume = 120
 
 /datum/reagents/New(var/maximum_volume = 120, var/atom/my_atom)
 	src.maximum_volume = maximum_volume
@@ -910,7 +908,7 @@ var/global/datum/reagents/sink/infinite_reagent_sink = new
 	. = trans_to_holder(target.reagents, amount, multiplier, copy, defer_update = defer_update, transferred_phases = transferred_phases)
 	// Deferred updates are presumably being done by SSfluids.
 	// Do an immediate fluid_act call rather than waiting for SSfluids to proc.
-	if(!defer_update && target.reagents.total_volume >= FLUID_PUDDLE)
+	if(!defer_update && REAGENT_TOTAL_VOLUME(target.reagents) >= FLUID_PUDDLE)
 		target.fluid_act(target.reagents)
 
  // Objects may or may not have reagents; if they do, it's probably a beaker or something and we need to transfer properly; otherwise, just touch.
@@ -979,22 +977,25 @@ var/global/datum/reagents/sink/infinite_reagent_sink = new
 
 /* Atom reagent creation - use it all the time */
 /atom/proc/create_reagents(var/max_vol)
-	if(reagents)
+	if(istype(reagents))
 		log_debug("Attempted to create a new reagents holder when already referencing one: [log_info_line(src)]")
-		reagents.maximum_volume = max(reagents.maximum_volume, max_vol)
-	else
+		REAGENT_SET_MAX_VOL(reagents, max(REAGENT_MAXIMUM_VOLUME(reagents), max_vol))
+	else if(!reagents)
 		reagents = new/datum/reagents(max_vol, src)
+	else
+		return
 	return reagents
 
 /atom/proc/create_or_update_reagents(_vol, override_volume)
-	if(reagents)
+	if(isnull(reagents))
+		return create_reagents(_vol)
+	if(istype(reagents))
 		if(override_volume)
-			reagents.maximum_volume = _vol // should we remove excess reagents here?
+			REAGENT_SET_MAX_VOL(reagents, _vol) // should we remove excess reagents here?
 		else
-			reagents.maximum_volume = max(reagents.maximum_volume, _vol)
+			REAGENT_SET_MAX_VOL(reagents, max(REAGENT_MAXIMUM_VOLUME(reagents), _vol))
 		reagents.update_total()
 		return reagents
-	return create_reagents(_vol)
 
 /// Infinite reagent sink: nothing is ever actually added to it, useful for complex, filtered deletion of reagents without holder churn.
 /datum/reagents/sink

--- a/code/modules/reagents/Chemistry-Machinery.dm
+++ b/code/modules/reagents/Chemistry-Machinery.dm
@@ -32,7 +32,7 @@
 	var/bottle_lid_color = COLOR_OFF_WHITE
 
 /obj/machinery/chem_master/proc/get_remaining_volume()
-	return reagents ? clamp(reagents.maximum_volume - reagents.total_volume, 0, reagents.maximum_volume) : 0
+	return reagents ? clamp(REAGENT_MAXIMUM_VOLUME(reagents) - REAGENT_TOTAL_VOLUME(reagents), 0, REAGENT_MAXIMUM_VOLUME(reagents)) : 0
 
 /obj/machinery/chem_master/attackby(var/obj/item/used_item, var/mob/user)
 
@@ -167,7 +167,7 @@
 		else if (href_list["createpill"] || href_list["createpill_multiple"])
 			var/count = 1
 
-			if(reagents.total_volume/count < 1) //Sanity checking.
+			if(REAGENT_TOTAL_VOLUME(reagents)/count < 1) //Sanity checking.
 				return TOPIC_HANDLED
 
 			if (href_list["createpill_multiple"])
@@ -176,14 +176,14 @@
 					return TOPIC_HANDLED
 				count = clamp(count, 1, max_pill_count)
 
-			var/amount_per_pill = min(reagents.total_volume/count, 30)
+			var/amount_per_pill = min(REAGENT_TOTAL_VOLUME(reagents)/count, 30)
 			if(amount_per_pill < 1) // Sanity checking.
 				return TOPIC_HANDLED
 
 			var/name = sanitize_safe(input(usr,"Name:","Name your pill!","[reagents.get_primary_reagent_name()] ([amount_per_pill]u)"), MAX_NAME_LEN)
 			if(!CanInteract(user, state))
 				return TOPIC_HANDLED
-			if(reagents.total_volume/count < 1) //Sanity checking.
+			if(REAGENT_TOTAL_VOLUME(reagents)/count < 1) //Sanity checking.
 				return TOPIC_HANDLED
 			while (count-- && count >= 0)
 				var/obj/item/chems/pill/dispensed/P = new(loc)
@@ -219,7 +219,7 @@
 
 /obj/machinery/chem_master/proc/fetch_contaminants(mob/user, datum/reagents/reagents, decl/material/main_reagent)
 	. = list()
-	for(var/decl/material/reagent as anything in reagents.reagent_volumes)
+	for(var/decl/material/reagent as anything in REAGENT_VOLUMES(reagents))
 		if(reagent != main_reagent && prob(user.skill_fail_chance(core_skill, 100)))
 			. += reagent
 
@@ -282,11 +282,11 @@
 			dat += "<A href='byond://?src=\ref[src];ejectp=1'>Eject Pill Bottle \[[loaded_pill_bottle.contents.len]/[loaded_pill_bottle.storage.max_storage_space]\]</A><BR><BR>"
 		else
 			dat += "No pill bottle inserted.<BR><BR>"
-		if(!R.total_volume)
+		if(!REAGENT_TOTAL_VOLUME(R))
 			dat += "Beaker is empty."
 		else
 			dat += "Add to buffer:<BR>"
-			for(var/decl/material/reagent as anything in R.reagent_volumes)
+			for(var/decl/material/reagent as anything in REAGENT_VOLUMES(R))
 				dat += "[reagent.use_name], [REAGENT_VOLUME(R, reagent)] Units - "
 				dat += "<A href='byond://?src=\ref[src];analyze=\ref[reagent]'>(Analyze)</A> "
 				dat += "<A href='byond://?src=\ref[src];add=\ref[reagent];amount=1'>(1)</A> "
@@ -296,8 +296,8 @@
 				dat += "<A href='byond://?src=\ref[src];addcustom=\ref[reagent]'>(Custom)</A><BR>"
 
 		dat += "<HR>Transfer to <A href='byond://?src=\ref[src];toggle=1'>[(!mode ? "disposal" : "beaker")]:</A><BR>"
-		if(reagents.total_volume)
-			for(var/decl/material/reagent as anything in reagents.reagent_volumes)
+		if(REAGENT_TOTAL_VOLUME(reagents))
+			for(var/decl/material/reagent as anything in REAGENT_VOLUMES(reagents))
 				dat += "[reagent.use_name], [REAGENT_VOLUME(reagents, reagent)] Units - "
 				dat += "<A href='byond://?src=\ref[src];analyze=\ref[reagent]'>(Analyze)</A> "
 				dat += "<A href='byond://?src=\ref[src];remove=\ref[reagent];amount=1'>(1)</A> "

--- a/code/modules/reagents/chems/chems_blood.dm
+++ b/code/modules/reagents/chems/chems_blood.dm
@@ -52,7 +52,7 @@
 	if(!istype(touching_turf) || REAGENT_VOLUME(holder, src) < 3)
 		return
 	var/weakref/donor = LAZYACCESS(data, DATA_BLOOD_DONOR)
-	blood_splatter(touching_turf, donor?.resolve() || holder.my_atom, 1)
+	blood_splatter(touching_turf, donor?.resolve() || REAGENT_GET_ATOM(holder), 1)
 
 /decl/material/liquid/blood/affect_ingest(var/mob/living/M, var/removed, var/datum/reagents/holder)
 	. = ..()

--- a/code/modules/reagents/chems/chems_compounds.dm
+++ b/code/modules/reagents/chems/chems_compounds.dm
@@ -30,8 +30,9 @@
 		H.update_eyes()
 
 /decl/material/liquid/glowsap/on_leaving_metabolism(datum/reagents/metabolism/holder)
-	if(ishuman(holder?.my_atom))
-		var/mob/living/human/H = holder.my_atom
+	var/my_atom = REAGENT_GET_ATOM(holder)
+	if(ishuman(my_atom))
+		var/mob/living/human/H = my_atom
 		addtimer(CALLBACK(H, TYPE_PROC_REF(/mob/living/human, update_eyes)), 5 SECONDS)
 	. = ..()
 
@@ -382,7 +383,7 @@
 	var/list/data = REAGENT_DATA(holder, src)
 	if(world.time > LAZYACCESS(data, DATA_COOLDOWN_TIME) + 3 MINUTES)
 		LAZYSET(data, DATA_COOLDOWN_TIME, world.time)
-		LAZYSET(holder.reagent_data, type, data)
+		REAGENT_SET_DATA(holder, type, data)
 		to_chat(M, SPAN_NOTICE("You feel faintly sore in the throat."))
 
 /decl/material/liquid/nanitefluid

--- a/code/modules/reagents/chems/chems_drugs.dm
+++ b/code/modules/reagents/chems/chems_drugs.dm
@@ -66,7 +66,7 @@
 
 	if(update_data)
 		LAZYSET(data, DATA_COOLDOWN_TIME, world.time)
-		LAZYSET(holder.reagent_data, type, data)
+		REAGENT_SET_DATA(holder, type, data)
 
 /decl/material/liquid/nicotine/affect_overdose(mob/living/victim, total_dose)
 	..()
@@ -256,7 +256,7 @@
 
 /decl/material/liquid/glowsap/gleam/on_leaving_metabolism(datum/reagents/metabolism/holder)
 	. = ..()
-	var/mob/M = holder?.my_atom
+	var/mob/M = REAGENT_GET_ATOM(holder)
 	if(istype(M))
 		M.remove_client_color(/datum/client_color/noir/thirdeye)
 

--- a/code/modules/reagents/chems/chems_medicines.dm
+++ b/code/modules/reagents/chems/chems_medicines.dm
@@ -133,12 +133,12 @@
 
 	var/removing = (4 * removed * antitoxin_strength)
 	var/datum/reagents/ingested = M.get_ingested_reagents()
-	for(var/decl/material/reagent as anything in ingested?.reagent_volumes)
+	for(var/decl/material/reagent as anything in REAGENT_VOLUMES(ingested))
 		if((remove_generic && reagent.toxicity) || (reagent.type in remove_toxins))
 			ingested.remove_reagent(reagent, removing)
 			return
 
-	for(var/decl/material/reagent as anything in M.reagents?.reagent_volumes)
+	for(var/decl/material/reagent as anything in REAGENT_VOLUMES(M.reagents))
 		if((remove_generic && reagent.toxicity) || (reagent.type in remove_toxins))
 			M.remove_from_reagents(reagent, removing)
 			return
@@ -368,7 +368,7 @@
 	var/charges = removed * DETOXIFIER_EFFECTIVENESS
 	var/dosecharges = CHEM_DOSE(M, src) * DETOXIFIER_DOSE_EFFECTIVENESS
 	for(var/datum/reagents/container as anything in M.get_metabolizing_reagent_holders())
-		for(var/decl/material/reagent as anything in container.reagent_volumes)
+		for(var/decl/material/reagent as anything in REAGENT_VOLUMES(container))
 			var/decl/material/liquid/painkillers/painkiller = reagent
 			if(!istype(painkiller) || !painkiller.narcotic)
 				continue

--- a/code/modules/reagents/chems/chems_painkillers.dm
+++ b/code/modules/reagents/chems/chems_painkillers.dm
@@ -130,7 +130,7 @@
 		return
 	var/datum/reagents/ingested = M.get_ingested_reagents()
 	if(ingested)
-		var/list/pool = M.reagents.reagent_volumes | ingested.reagent_volumes
+		var/list/pool = REAGENT_VOLUMES(M.reagents) | REAGENT_VOLUMES(ingested)
 		for(var/reagent in pool)
 			var/decl/material/liquid/alcohol/booze = reagent
 			if(!istype(booze) ||CHEM_DOSE(M, reagent) < 2) //let them experience false security at first

--- a/code/modules/reagents/chems/chems_psychiatric.dm
+++ b/code/modules/reagents/chems/chems_psychiatric.dm
@@ -27,7 +27,7 @@
 
 	if(update_data)
 		LAZYSET(data, DATA_COOLDOWN_TIME, world.time)
-		LAZYSET(holder.reagent_data, type, data)
+		REAGENT_SET_DATA(holder, type, data)
 
 /// Returns TRUE to signal that the effect should go on cooldown.
 /decl/material/liquid/accumulated/proc/positive_effect(mob/living/victim, removed, datum/reagents/holder, is_off_cooldown)

--- a/code/modules/reagents/cocktails.dm
+++ b/code/modules/reagents/cocktails.dm
@@ -68,17 +68,17 @@
 	. = length(ratios)
 
 /decl/cocktail/proc/matches(var/obj/item/prop)
-	if(length(ratios) > length(prop.reagents.reagent_volumes))
+	if(length(ratios) > length(REAGENT_VOLUMES(prop.reagents)))
 		return FALSE
 	var/list/check_ratios
 	var/i = 0
 	for(var/rtype in ratios)
 		i++
-		if(!prop.reagents.has_reagent(rtype) || (order_specific && prop.reagents.reagent_volumes[i] != rtype))
+		if(!prop.reagents.has_reagent(rtype) || (order_specific && REAGENT_VOLUME(prop.reagents, i) != rtype))
 			return FALSE
 		if(isnum(ratios[rtype]))
 			LAZYSET(check_ratios, rtype, ratios[rtype])
-	var/effective_volume = prop.reagents.total_volume
+	var/effective_volume = REAGENT_TOTAL_VOLUME(prop.reagents)
 	if(!(/decl/material/solid/ice in ratios))
 		effective_volume -= REAGENT_VOLUME(prop.reagents, /decl/material/solid/ice)
 	for(var/rtype in check_ratios)

--- a/code/modules/reagents/dispenser/cartridge.dm
+++ b/code/modules/reagents/dispenser/cartridge.dm
@@ -13,18 +13,19 @@
 
 /obj/item/chems/chem_disp_cartridge/Initialize()
 	. = ..()
-	if(reagents?.primary_reagent && !_reagent_label)
-		_reagent_label = reagents.get_primary_reagent_name()
+	var/decl/material/primary_reagent = istype(reagents) && reagents.get_primary_reagent_decl()
+	if(primary_reagent && !_reagent_label)
+		_reagent_label = primary_reagent.name
 	if(_reagent_label)
 		setLabel(_reagent_label)
 
 /obj/item/chems/chem_disp_cartridge/get_examine_strings(mob/user, distance, infix, suffix)
 	. = ..()
-	. += "It has a capacity of [reagents?.maximum_volume || 0] unit\s."
-	if(reagents?.total_volume <= 0)
+	. += "It has a capacity of [REAGENT_MAXIMUM_VOLUME(reagents)] unit\s."
+	if(REAGENT_TOTAL_VOLUME(reagents) <= 0)
 		. += "It is empty."
 	else
-		. += "It contains [reagents?.total_volume || 0] unit\s of reagents."
+		. += "It contains [REAGENT_TOTAL_VOLUME(reagents)] unit\s of reagents."
 	if(!ATOM_IS_OPEN_CONTAINER(src))
 		. += "The cap is sealed."
 
@@ -72,8 +73,9 @@
 		if(user.check_intent(I_FLAG_HARM))
 			if(standard_splash_mob(user,target))
 				return TRUE
-			if(reagents && reagents.total_volume)
+			var/total_vol = REAGENT_TOTAL_VOLUME(reagents)
+			if(reagents && total_vol)
 				to_chat(user, SPAN_DANGER("You splash the contents of \the [src] onto \the [target]."))
-				reagents.splash(target, reagents.total_volume) //FIXME: probably shouldn't throw the whole 500 units at the mob, since the bottle neck is a bottle neck.
+				reagents.splash(target, total_vol) //FIXME: probably shouldn't throw the whole 500 units at the mob, since the bottle neck is a bottle neck.
 				return TRUE
 	return ..()

--- a/code/modules/reagents/dispenser/cartridge_presets.dm
+++ b/code/modules/reagents/dispenser/cartridge_presets.dm
@@ -9,7 +9,7 @@
  * CART_TYPE: the type suffix to append to the cartridge type path.
  * REAGENT_TYPE: The reagent decl path to fill the cartridge with.
  */
-#define DEFINE_CARTRIDGE_FOR_CHEM(CART_TYPE, REAGENT_TYPE) /obj/item/chems/chem_disp_cartridge/##CART_TYPE/populate_reagents(){add_to_reagents(REAGENT_TYPE, reagents.maximum_volume);}
+#define DEFINE_CARTRIDGE_FOR_CHEM(CART_TYPE, REAGENT_TYPE) /obj/item/chems/chem_disp_cartridge/##CART_TYPE/populate_reagents(){add_to_reagents(REAGENT_TYPE, REAGENT_MAXIMUM_VOLUME(reagents));}
 
 // Multiple
 DEFINE_CARTRIDGE_FOR_CHEM(water, /decl/material/liquid/water)

--- a/code/modules/reagents/dispenser/cartridge_spawn.dm
+++ b/code/modules/reagents/dispenser/cartridge_spawn.dm
@@ -8,7 +8,7 @@
 		if("medium") cartridge_type = /obj/item/chems/chem_disp_cartridge/medium
 		if("large") cartridge_type = /obj/item/chems/chem_disp_cartridge
 	var/obj/item/chems/chem_disp_cartridge/cartridge = new cartridge_type(usr.loc)
-	cartridge.add_to_reagents(reagent_type, cartridge.reagents?.maximum_volume)
+	cartridge.add_to_reagents(reagent_type, REAGENT_MAXIMUM_VOLUME(cartridge.reagents))
 	var/reagent_name = cartridge.reagents.get_primary_reagent_name()
 	cartridge.setLabel(reagent_name)
 	log_and_message_admins("spawned a [size] reagent container containing [reagent_name] ([reagent_type])")

--- a/code/modules/reagents/dispenser/dispenser2.dm
+++ b/code/modules/reagents/dispenser/dispenser2.dm
@@ -146,14 +146,15 @@
 	data["isBeakerLoaded"] = container ? 1 : 0
 	data["glass"] = accept_drinking
 	var beakerD[0]
-	if(LAZYLEN(container?.reagents?.reagent_volumes))
-		for(var/decl/material/reagent as anything in container.reagents.reagent_volumes)
+	var/beaker_volumes = REAGENT_VOLUMES(container?.reagents)
+	if(LAZYLEN(beaker_volumes))
+		for(var/decl/material/reagent as anything in REAGENT_VOLUMES(container.reagents))
 			beakerD[++beakerD.len] = list("name" = reagent.use_name, "volume" = REAGENT_VOLUME(container.reagents, reagent))
 	data["beakerContents"] = beakerD
 
 	if(container) // Container has had null reagents in the past; may be due to qdel without clearing reference.
-		data["beakerCurrentVolume"] = container.reagents?.total_volume || 0
-		data["beakerMaxVolume"] = container.reagents?.maximum_volume || 0
+		data["beakerCurrentVolume"] = REAGENT_TOTAL_VOLUME(container.reagents)
+		data["beakerMaxVolume"] = REAGENT_MAXIMUM_VOLUME(container.reagents)
 	else
 		data["beakerCurrentVolume"] = null
 		data["beakerMaxVolume"] = null
@@ -161,7 +162,7 @@
 	var chemicals[0]
 	for(var/label in cartridges)
 		var/obj/item/chems/chem_disp_cartridge/C = cartridges[label]
-		chemicals[++chemicals.len] = list("label" = label, "amount" = C.reagents.total_volume)
+		chemicals[++chemicals.len] = list("label" = label, "amount" = REAGENT_TOTAL_VOLUME(C.reagents))
 	data["chemicals"] = chemicals
 
 	// update the ui if it exists, returns null if no ui is passed/found

--- a/code/modules/reagents/reactions/_reaction.dm
+++ b/code/modules/reagents/reactions/_reaction.dm
@@ -52,7 +52,7 @@
 /decl/chemical_reaction/proc/process(var/datum/reagents/holder, var/limit)
 	var/data = send_data(holder)
 
-	var/reaction_volume = holder.maximum_volume
+	var/reaction_volume = REAGENT_GET_MAX_VOL(holder)
 	for(var/reactant in required_reagents)
 		var/A = CHEMS_QUANTIZE(REAGENT_VOLUME(holder, reactant) / required_reagents[reactant] / limit)  // How much of this reagent we are allowed to use
 		if(reaction_volume > A)

--- a/code/modules/reagents/reactions/reaction_grenade_reaction.dm
+++ b/code/modules/reagents/reactions/reaction_grenade_reaction.dm
@@ -133,7 +133,7 @@
 	..()
 	var/atom/location = holder.get_reaction_loc(chemical_reaction_flags)
 	if(location)
-		if(istype(location, /obj/item/sealant_tank) && location.reagents?.maximum_volume)
+		if(istype(location, /obj/item/sealant_tank) && REAGENT_MAXIMUM_VOLUME(location.reagents))
 			location.reagents.add_reagent(/decl/material/liquid/foam, created_volume)
 			return
 		location = get_turf(location)

--- a/code/modules/reagents/reactions/reaction_recipe_food.dm
+++ b/code/modules/reagents/reactions/reaction_recipe_food.dm
@@ -33,7 +33,7 @@
 /decl/chemical_reaction/recipe/food/dairy/send_data(var/datum/reagents/holder, var/reaction_limit)
 	. = ..()
 	for(var/reagent in required_reagents)
-		var/list/data = LAZYACCESS(holder.reagent_data, reagent)
+		var/list/data = REAGENT_DATA(holder, reagent)
 		if(!islist(data))
 			continue
 		for(var/milk_key in milk_data_keys)

--- a/code/modules/reagents/reactions/reaction_synthesis.dm
+++ b/code/modules/reagents/reactions/reaction_synthesis.dm
@@ -37,10 +37,11 @@
 	) // Interferes with resin globules.
 
 /decl/chemical_reaction/synthesis/crystalization/can_happen(datum/reagents/holder)
-	. = ..() && length(holder.reagent_volumes) > 1
+	var/holder_volumes = REAGENT_VOLUMES(holder)
+	. = ..() && length(holder_volumes) > 1
 	if(.)
 		. = FALSE
-		for(var/decl/material/reagent as anything in holder.reagent_volumes)
+		for(var/decl/material/reagent as anything in holder_volumes)
 			if(reagent.type != /decl/material/liquid/crystal_agent && REAGENT_VOLUME(holder, reagent) >= REAGENT_UNITS_PER_MATERIAL_SHEET)
 				return TRUE
 
@@ -48,7 +49,7 @@
 	var/location = get_turf(holder.get_reaction_loc(chemical_reaction_flags))
 	if(location)
 		var/list/removing_reagents = list()
-		for(var/decl/material/reagent as anything in holder.reagent_volumes)
+		for(var/decl/material/reagent as anything in REAGENT_VOLUMES(holder))
 			if(reagent.type != /decl/material/liquid/crystal_agent)
 				var/solidifying = floor(REAGENT_VOLUME(holder, reagent) / REAGENT_UNITS_PER_MATERIAL_SHEET)
 				if(solidifying)
@@ -67,10 +68,11 @@
 	inhibitors = list(/decl/material/liquid/crystal_agent)
 
 /decl/chemical_reaction/synthesis/aerogel/can_happen(datum/reagents/holder)
-	. = ..() && length(holder.reagent_volumes) > 1
+	var/holder_volumes = REAGENT_VOLUMES(holder)
+	. = ..() && length(holder_volumes) > 1
 	if(.)
 		. = FALSE
-		for(var/decl/material/reagent as anything in holder.reagent_volumes)
+		for(var/decl/material/reagent as anything in holder_volumes)
 			if(REAGENT_VOLUME(holder, reagent) < REAGENT_UNITS_PER_MATERIAL_SHEET)
 				continue
 			if(reagent.default_solid_form != /obj/item/stack/material/aerogel)
@@ -81,7 +83,7 @@
 	var/location = get_turf(holder.get_reaction_loc(chemical_reaction_flags))
 	if(location)
 		var/list/removing_reagents = list()
-		for(var/decl/material/reagent as anything in holder.reagent_volumes)
+		for(var/decl/material/reagent as anything in REAGENT_VOLUMES(holder))
 			if(reagent.default_solid_form == /obj/item/stack/material/aerogel)
 				var/solidifying = floor(REAGENT_VOLUME(holder, reagent) / REAGENT_UNITS_PER_MATERIAL_SHEET)
 				if(solidifying)

--- a/code/modules/reagents/reagent_container_edibility.dm
+++ b/code/modules/reagents/reagent_container_edibility.dm
@@ -1,5 +1,5 @@
 /obj/item/chems/get_edible_material_amount(var/mob/eater)
-	return ATOM_IS_OPEN_CONTAINER(src) && reagents?.total_volume
+	return ATOM_IS_OPEN_CONTAINER(src) && REAGENT_TOTAL_VOLUME(reagents)
 
 /obj/item/chems/get_food_default_transfer_amount(mob/eater)
 	return eater?.get_eaten_transfer_amount(amount_per_transfer_from_this)

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -99,16 +99,16 @@
 
 	// Skimming off cream, repurposed from crucibles.
 	// TODO: potentially make this an alt interaction and unify with slag skimming.
-	if(istype(used_item, /obj/item/chems) && ATOM_IS_OPEN_CONTAINER(used_item) && used_item.reagents?.maximum_volume && reagents?.total_volume && length(reagents.reagent_volumes) > 1)
+	if(istype(used_item, /obj/item/chems) && ATOM_IS_OPEN_CONTAINER(used_item) && REAGENT_MAXIMUM_VOLUME(used_item.reagents) && REAGENT_TOTAL_VOLUME(reagents) && length(REAGENT_VOLUMES(reagents)) > 1)
 		var/list/skimmable_reagents = reagents.get_skimmable_reagents()
 		if(length(skimmable_reagents))
 			var/removing = min(amount_per_transfer_from_this, REAGENTS_FREE_SPACE(used_item.reagents))
 			if(removing <= 0)
 				to_chat(user, SPAN_WARNING("\The [used_item] is full."))
 			else
-				var/old_amt = used_item.reagents.total_volume
-				reagents.trans_to_holder(used_item.reagents, removing, skip_reagents = (reagents.reagent_volumes - skimmable_reagents))
-				to_chat(user, SPAN_NOTICE("You skim [used_item.reagents.total_volume-old_amt] unit\s of [used_item.reagents.get_primary_reagent_name()] from the top of \the [reagents.get_primary_reagent_name()]."))
+				var/old_amt = REAGENT_TOTAL_VOLUME(used_item.reagents)
+				reagents.trans_to_holder(used_item.reagents, removing, skip_reagents = (REAGENT_VOLUMES(reagents) - skimmable_reagents))
+				to_chat(user, SPAN_NOTICE("You skim [REAGENT_TOTAL_VOLUME(used_item.reagents)-old_amt] unit\s of [used_item.reagents.get_primary_reagent_name()] from the top of \the [reagents.get_primary_reagent_name()]."))
 			return TRUE
 
 	if(used_item.user_can_attack_with(user, silent = TRUE))
@@ -147,7 +147,7 @@
 /obj/item/chems/shatter(consumed)
 	//Skip splashing if we are in nullspace, since splash isn't null guarded
 	if(loc)
-		reagents.splash(get_turf(src), reagents.total_volume)
+		reagents.splash(get_turf(src), REAGENT_TOTAL_VOLUME(reagents))
 	. = ..()
 
 /obj/item/chems/proc/set_detail_color(var/new_color)
@@ -161,17 +161,17 @@
 
 	. = ..()
 
-	if(QDELETED(src) || !reagents?.total_volume || !ATOM_IS_OPEN_CONTAINER(src) || !isatom(loc))
+	if(QDELETED(src) || !REAGENT_TOTAL_VOLUME(reagents) || !ATOM_IS_OPEN_CONTAINER(src) || !isatom(loc))
 		return
 
 	// Vaporize anything over its boiling point.
 	var/update_reagents = FALSE
 	var/datum/gas_mixture/environment = loc?.return_air()
 	var/ambient_pressure = environment ? environment.return_pressure() : ONE_ATMOSPHERE
-	for(var/decl/material/reagent as anything in reagents.reagent_volumes)
+	for(var/decl/material/reagent as anything in REAGENT_VOLUMES(reagents))
 		if(reagent.can_boil_to_gas && reagent.phase_at_temperature(temperature, ambient_pressure) == MAT_PHASE_GAS)
 			// TODO: reduce atom temperature?
-			var/removing = min(reagent.boil_evaporation_per_run, reagents.reagent_volumes[reagent])
+			var/removing = min(reagent.boil_evaporation_per_run, REAGENT_VOLUME(reagents, reagent))
 			reagents.remove_reagent(reagent, removing, defer_update = TRUE, removed_phases = MAT_PHASE_LIQUID)
 			update_reagents = TRUE
 			loc.take_vaporized_reagent(reagent, removing)
@@ -179,7 +179,7 @@
 		reagents.update_total()
 
 /obj/item/chems/take_vaporized_reagent(reagent, amount)
-	if(!reagents?.maximum_volume)
+	if(!REAGENT_MAXIMUM_VOLUME(reagents))
 		return ..()
 	var/take_reagent = min(amount, REAGENTS_FREE_SPACE(reagents))
 	if(take_reagent > 0)
@@ -228,4 +228,4 @@
 	var/turf/T = get_turf(user)
 	if(T)
 		to_chat(user, SPAN_NOTICE("You empty \the [target] onto the floor."))
-		target.reagents.trans_to(T, target.reagents.total_volume)
+		target.reagents.trans_to(T, REAGENT_TOTAL_VOLUME(target.reagents))

--- a/code/modules/reagents/reagent_containers/_glass.dm
+++ b/code/modules/reagents/reagent_containers/_glass.dm
@@ -47,8 +47,8 @@
 	. = ..()
 	if(distance > 2)
 		return
-	if(reagents?.total_volume)
-		. += SPAN_NOTICE("It contains [reagents.total_volume] units of reagents.")
+	if(REAGENT_TOTAL_VOLUME(reagents))
+		. += SPAN_NOTICE("It contains [REAGENT_TOTAL_VOLUME(reagents)] units of reagents.")
 	else
 		. += SPAN_NOTICE("It is empty.")
 	if(!ATOM_IS_OPEN_CONTAINER(src))
@@ -58,7 +58,7 @@
 	return TRUE
 
 /obj/item/chems/glass/proc/should_drink_from(mob/drinker)
-	. = reagents?.total_volume > 0
+	. = REAGENT_TOTAL_VOLUME(reagents) > 0
 	if(.)
 		var/decl/material/drinking = reagents.get_primary_reagent_decl()
 		return drinking ? !drinking.is_unsafe_to_drink(drinker) : FALSE
@@ -125,22 +125,23 @@ var/global/list/lid_check_glass_types = list()
 		return TRUE
 	if(handle_eaten_by_mob(user, target) != EATEN_INVALID)
 		return TRUE
+	var/total_vol = REAGENT_TOTAL_VOLUME(reagents)
 	if(user.check_intent(I_FLAG_HARM))
 		if(standard_splash_mob(user,target))
 			return TRUE
-		if(reagents && reagents.total_volume)
+		if(reagents && total_vol)
 			to_chat(user, SPAN_DANGER("You splash the contents of \the [src] onto \the [target]."))
-			reagents.splash(target, reagents.total_volume)
+			reagents.splash(target, total_vol)
 			return TRUE
-	else if(reagents && reagents.total_volume)
+	else if(reagents && total_vol)
 		to_chat(user, SPAN_NOTICE("You splash a small amount of the contents of \the [src] onto \the [target]."))
-		reagents.splash(target, min(reagents.total_volume, 5))
+		reagents.splash(target, min(total_vol, 5))
 		return TRUE
 	. = ..()
 
 // Drinking out of bowls.
 /obj/item/chems/glass/get_edible_material_amount(mob/eater)
-	return reagents?.total_volume
+	return REAGENT_TOTAL_VOLUME(reagents)
 
 /obj/item/chems/glass/get_utensil_food_type()
 	return /obj/item/food/lump
@@ -157,11 +158,11 @@ var/global/list/lid_check_glass_types = list()
 		if(utensil.loaded_food)
 			to_chat(user, SPAN_WARNING("You already have something on \the [utensil]."))
 			return TRUE
-		if(!reagents?.total_volume)
+		if(!REAGENT_TOTAL_VOLUME(reagents))
 			to_chat(user, SPAN_WARNING("\The [src] is empty."))
 			return TRUE
 		separate_food_chunk(utensil, user)
-		if(utensil.loaded_food?.reagents?.total_volume)
+		if(REAGENT_TOTAL_VOLUME(utensil.loaded_food?.reagents))
 			to_chat(user, SPAN_NOTICE("You scoop up some of \the [utensil.loaded_food.reagents.get_primary_reagent_name()] with \the [utensil]."))
 		return TRUE
 
@@ -169,7 +170,7 @@ var/global/list/lid_check_glass_types = list()
 
 /obj/item/chems/glass/get_alt_interactions(mob/user)
 	. = ..()
-	if(reagents?.total_volume >= FLUID_PUDDLE)
+	if(REAGENT_TOTAL_VOLUME(reagents) >= FLUID_PUDDLE)
 		LAZYADD(., /decl/interaction_handler/dip_item)
 		LAZYADD(., /decl/interaction_handler/fill_from)
 	if(user?.get_active_held_item())

--- a/code/modules/reagents/reagent_containers/beaker.dm
+++ b/code/modules/reagents/reagent_containers/beaker.dm
@@ -15,7 +15,7 @@
 
 /obj/item/chems/glass/beaker/get_examine_strings(mob/user, distance, infix, suffix)
 	. = ..()
-	. += "It can hold up to [reagents?.maximum_volume] units."
+	. += "It can hold up to [REAGENT_MAXIMUM_VOLUME(reagents)] units."
 
 /obj/item/chems/glass/beaker/on_picked_up(mob/user, atom/old_loc)
 	. = ..()
@@ -31,9 +31,9 @@
 
 /obj/item/chems/glass/beaker/update_overlays()
 
-	if(reagents?.total_volume)
+	if(REAGENT_TOTAL_VOLUME(reagents))
 		var/image/filling = mutable_appearance(icon, "[icon_state]1", reagents.get_color())
-		var/percent = round((reagents.total_volume / reagents.maximum_volume) * 100)
+		var/percent = round((REAGENT_TOTAL_VOLUME(reagents) / REAGENT_MAXIMUM_VOLUME(reagents)) * 100)
 		switch(percent)
 			if(0 to 9)			filling.icon_state = "[icon_state]1"
 			if(10 to 24) 		filling.icon_state = "[icon_state]10"
@@ -60,7 +60,7 @@
 /obj/item/chems/glass/beaker/throw_impact(atom/hit_atom)
 	. = ..()
 	if(ATOM_IS_OPEN_CONTAINER(src))
-		reagents.splash(hit_atom, rand(reagents.total_volume*0.25,reagents.total_volume), min_spill = 60, max_spill = 100)
+		reagents.splash(hit_atom, rand(REAGENT_TOTAL_VOLUME(reagents)*0.25,REAGENT_TOTAL_VOLUME(reagents)), min_spill = 60, max_spill = 100)
 	take_damage(rand(4,8))
 
 /obj/item/chems/glass/beaker/large
@@ -181,4 +181,4 @@
 	chem_volume = 120
 
 /obj/item/chems/glass/beaker/sulfuric/populate_reagents()
-	add_to_reagents(/decl/material/liquid/acid, reagents.maximum_volume)
+	add_to_reagents(/decl/material/liquid/acid, REAGENT_MAXIMUM_VOLUME(reagents))

--- a/code/modules/reagents/reagent_containers/blood_pack.dm
+++ b/code/modules/reagents/reagent_containers/blood_pack.dm
@@ -27,14 +27,14 @@
 /obj/item/chems/ivbag/on_reagent_change()
 	if(!(. = ..()))
 		return
-	if(reagents?.total_volume > reagents?.maximum_volume / 2)
+	if(REAGENT_TOTAL_VOLUME(reagents) > REAGENT_MAXIMUM_VOLUME(reagents) / 2)
 		w_class = ITEM_SIZE_NORMAL
 	else
 		w_class = ITEM_SIZE_SMALL
 
 /obj/item/chems/ivbag/on_update_icon()
 	. = ..()
-	var/percent = round(reagents?.total_volume / reagents?.maximum_volume * 100)
+	var/percent = round(REAGENT_TOTAL_VOLUME(reagents) / REAGENT_MAXIMUM_VOLUME(reagents) * 100)
 	if(percent)
 		add_overlay(overlay_image(icon, "[round(percent,25)]", reagents.get_color()))
 	add_overlay(attached? "dongle" : "top")
@@ -68,7 +68,7 @@
 	if(!(src in M.get_held_items()))
 		return
 
-	if(!reagents.total_volume)
+	if(!REAGENT_TOTAL_VOLUME(reagents))
 		return
 
 	reagents.trans_to_mob(attached, amount_per_transfer_from_this, CHEM_INJECT)
@@ -88,7 +88,7 @@
 
 /obj/item/chems/ivbag/blood/populate_reagents()
 	if(blood_fill_type)
-		add_to_reagents(blood_fill_type, reagents.maximum_volume, get_initial_blood_data())
+		add_to_reagents(blood_fill_type, REAGENT_MAXIMUM_VOLUME(reagents), get_initial_blood_data())
 
 /obj/item/chems/ivbag/blood/nanoblood
 	label_text = "synthetic"

--- a/code/modules/reagents/reagent_containers/borghypo.dm
+++ b/code/modules/reagents/reagent_containers/borghypo.dm
@@ -44,7 +44,7 @@
 	. = ..()
 	var/list/reagent_ids = get_generated_reagents()
 	for(var/decl/material/reagent in decls_repository.get_decls_unassociated(reagent_ids))
-		reagents.add_reagent(reagent.type, round(reagents.maximum_volume / length(reagent_ids)))
+		reagents.add_reagent(reagent.type, round(REAGENT_MAXIMUM_VOLUME(reagents) / length(reagent_ids)))
 	START_PROCESSING(SSobj, src)
 
 /obj/item/chems/borghypo/Destroy()
@@ -61,7 +61,7 @@
 	if(!robot?.cell)
 		return
 	var/list/reagent_ids = get_generated_reagents()
-	var/max_per_reagent = round(reagents.maximum_volume / length(reagent_ids))
+	var/max_per_reagent = round(REAGENT_MAXIMUM_VOLUME(reagents) / length(reagent_ids))
 	for(var/reagent in reagent_ids)
 		var/has_reagent = REAGENT_VOLUME(reagents, GET_DECL(reagent))
 		if(has_reagent < max_per_reagent)
@@ -128,7 +128,7 @@
 		return
 	var/list/reagent_ids = get_generated_reagents()
 	var/decl/material/reagent = GET_DECL(reagent_ids[mode])
-	. += SPAN_NOTICE("It is currently producing [reagent.use_name] and has [REAGENT_VOLUME(reagents, reagent)] out of [round(reagents.maximum_volume / length(reagent_ids))] units left.")
+	. += SPAN_NOTICE("It is currently producing [reagent.use_name] and has [REAGENT_VOLUME(reagents, reagent)] out of [round(REAGENT_MAXIMUM_VOLUME(reagents) / length(reagent_ids))] units left.")
 
 /obj/item/chems/borghypo/service
 	name = "cyborg drink synthesizer"

--- a/code/modules/reagents/reagent_containers/bowl.dm
+++ b/code/modules/reagents/reagent_containers/bowl.dm
@@ -155,18 +155,18 @@
 		add_to_reagents(filling, fillings[filling])
 
 /obj/item/chems/glass/bowl/mystery/update_name()
-	if(!drained && reagents?.total_volume)
+	if(!drained && REAGENT_TOTAL_VOLUME(reagents))
 		SetName("mystery soup")
 	else
 		..()
 
 /obj/item/chems/glass/bowl/mystery/on_reagent_change()
-	if(reagents?.total_volume <= 0)
+	if(REAGENT_TOTAL_VOLUME(reagents) <= 0)
 		drained = TRUE
 	. = ..()
 
 /obj/item/chems/glass/bowl/mystery/update_container_desc()
-	if(!drained && reagents?.total_volume)
+	if(!drained && REAGENT_TOTAL_VOLUME(reagents))
 		desc = "The mystery is, why aren't you eating it?"
 	else
 		..()

--- a/code/modules/reagents/reagent_containers/bucket.dm
+++ b/code/modules/reagents/reagent_containers/bucket.dm
@@ -30,7 +30,7 @@
 
 /obj/item/chems/glass/bucket/attackby(var/obj/item/used_item, mob/user)
 	if(istype(used_item, /obj/item/mop))
-		if(reagents.total_volume < 1)
+		if(REAGENT_TOTAL_VOLUME(reagents) < 1)
 			to_chat(user, SPAN_WARNING("\The [src] is empty!"))
 		else if(REAGENTS_FREE_SPACE(used_item.reagents) >= 5)
 			reagents.trans_to_obj(used_item, 5)
@@ -44,7 +44,7 @@
 /obj/item/chems/glass/bucket/get_reagents_overlay(state_prefix)
 	if(!ATOM_IS_OPEN_CONTAINER(src))
 		return null // no overlay while closed!
-	if(!reagents || (reagents.total_volume / reagents.maximum_volume) < 0.8)
+	if(!reagents || (REAGENT_TOTAL_VOLUME(reagents) / REAGENT_MAXIMUM_VOLUME(reagents)) < 0.8)
 		return null // must be at least 80% full to show
 	return ..()
 

--- a/code/modules/reagents/reagent_containers/condiments/__condiment.dm
+++ b/code/modules/reagents/reagent_containers/condiments/__condiment.dm
@@ -17,7 +17,7 @@
 	. = ..()
 	var/decl/condiment_appearance/condiment = GET_DECL(initial_condiment_type)
 	if(condiment?.condiment_type)
-		add_to_reagents(condiment.condiment_type, reagents.maximum_volume)
+		add_to_reagents(condiment.condiment_type, REAGENT_MAXIMUM_VOLUME(reagents))
 
 /obj/item/chems/condiment/attackby(var/obj/item/used_item, var/mob/user)
 	if(IS_PEN(used_item))
@@ -51,7 +51,8 @@
 /obj/item/chems/condiment/proc/get_current_condiment_appearance()
 	if(!morphic_container)
 		return GET_DECL(initial_condiment_type)
-	switch(LAZYLEN(reagents?.reagent_volumes))
+	var/reagent_volumes = REAGENT_VOLUMES(reagents)
+	switch(LAZYLEN(reagent_volumes))
 		if(0)
 			return GET_DECL(/decl/condiment_appearance/empty)
 		if(1)

--- a/code/modules/reagents/reagent_containers/drinkingglass/drinkingglass.dm
+++ b/code/modules/reagents/reagent_containers/drinkingglass/drinkingglass.dm
@@ -46,38 +46,41 @@ var/global/const/DRINK_ICON_NOISY = "noise"
 		. /= HOLLOW_OBJECT_MATTER_MULTIPLIER
 
 /obj/item/chems/drinks/glass2/proc/has_ice()
-	if(LAZYLEN(reagents.reagent_volumes))
+	var/reagent_volumes = REAGENT_VOLUMES(reagents)
+	if(LAZYLEN(reagent_volumes))
 		var/decl/material/R = reagents.get_primary_reagent_decl()
 		if(!((R.type == /decl/material/solid/ice) || ("ice" in R.glass_special))) // if it's not a cup of ice, and it's not already supposed to have ice in, see if the bartender's put ice in it
-			if(reagents.has_reagent(/decl/material/solid/ice, reagents.total_volume / 10)) // 10% ice by volume
+			if(reagents.has_reagent(/decl/material/solid/ice, REAGENT_TOTAL_VOLUME(reagents) / 10)) // 10% ice by volume
 				return 1
 
 	return 0
 
 /obj/item/chems/drinks/glass2/proc/has_fizz()
-	if(LAZYLEN(reagents.reagent_volumes))
+	var/reagent_volumes = REAGENT_VOLUMES(reagents)
+	if(LAZYLEN(reagent_volumes))
 		var/decl/material/primary_reagent = reagents.get_primary_reagent_decl()
 		if(("fizz" in primary_reagent.glass_special))
 			return 1
 		var/totalfizzy = 0
-		for(var/decl/material/reagent as anything in reagents.reagent_volumes)
+		for(var/decl/material/reagent as anything in REAGENT_VOLUMES(reagents))
 			if("fizz" in reagent.glass_special)
 				totalfizzy += REAGENT_VOLUME(reagents, reagent)
-		if(totalfizzy >= reagents.total_volume / 5) // 20% fizzy by volume
+		if(totalfizzy >= REAGENT_TOTAL_VOLUME(reagents) / 5) // 20% fizzy by volume
 			return 1
 	return 0
 
 /obj/item/chems/drinks/glass2/proc/has_vapor()
-	if(LAZYLEN(reagents.reagent_volumes) > 0)
+	var/reagent_volumes = REAGENT_VOLUMES(reagents)
+	if(LAZYLEN(reagent_volumes) > 0)
 		if(temperature > T0C + 40)
 			return 1
 		var/decl/material/primary_reagent = reagents.get_primary_reagent_decl()
 		if(!("vapor" in primary_reagent.glass_special))
 			var/totalvape = 0
-			for(var/decl/material/reagent as anything in reagents.reagent_volumes)
+			for(var/decl/material/reagent as anything in REAGENT_VOLUMES(reagents))
 				if("vapor" in reagent.glass_special)
 					totalvape += REAGENT_VOLUME(reagents, reagent)
-			if(totalvape >= reagents.maximum_volume * 0.6) // 60% vapor by container volume
+			if(totalvape >= REAGENT_MAXIMUM_VOLUME(reagents) * 0.6) // 60% vapor by container volume
 				return 1
 	return 0
 
@@ -134,7 +137,8 @@ var/global/const/DRINK_ICON_NOISY = "noise"
 	underlays.Cut()
 	icon_state = base_icon
 
-	if (LAZYLEN(reagents?.reagent_volumes) > 0)
+	var/reagent_volumes = REAGENT_VOLUMES(reagents)
+	if (LAZYLEN(reagent_volumes) > 0)
 		var/decl/material/R = reagents.get_primary_reagent_decl()
 		if(R.cocktail_ingredient)
 			for(var/decl/cocktail/cocktail in SSmaterials.get_cocktails_by_primary_ingredient(R.type))
@@ -204,7 +208,7 @@ var/global/const/DRINK_ICON_NOISY = "noise"
 			playsound(src, "shatter", 30, 1)
 			if(reagents)
 				user.visible_message("<span class='notice'>The contents of \the [src] splash all over [user]!</span>")
-				reagents.splash(user, reagents.total_volume)
+				reagents.splash(user, REAGENT_TOTAL_VOLUME(reagents))
 			qdel(src)
 			return TRUE
 		user.visible_message("<span class='notice'>[user] gently strikes \the [src] with a spoon, calling the room to attention.</span>")
@@ -220,7 +224,7 @@ var/global/const/DRINK_ICON_NOISY = "noise"
 		update_icon()
 
 /obj/item/chems/drinks/glass2/physically_destroyed(var/skip_qdel)
-	reagents.splash(loc, reagents.total_volume)
+	reagents.splash(loc, REAGENT_TOTAL_VOLUME(reagents))
 	if(istype(material))
 		playsound(src, "shatter", 30, 1)
 		material.place_shards(get_turf(src), w_class)

--- a/code/modules/reagents/reagent_containers/drinkingglass/glass_types.dm
+++ b/code/modules/reagents/reagent_containers/drinkingglass/glass_types.dm
@@ -160,7 +160,7 @@
 	base_name = "#1 monkey cup"
 
 /obj/item/chems/drinks/glass2/coffeecup/punitelli/populate_reagents()
-	add_to_reagents(/decl/material/liquid/drink/juice/banana, reagents.maximum_volume)
+	add_to_reagents(/decl/material/liquid/drink/juice/banana, REAGENT_MAXIMUM_VOLUME(reagents))
 
 /obj/item/chems/drinks/glass2/coffeecup/rainbow
 	name = "rainbow coffee cup"

--- a/code/modules/reagents/reagent_containers/drinks.dm
+++ b/code/modules/reagents/reagent_containers/drinks.dm
@@ -67,28 +67,29 @@
 	. = ..()
 	if(distance > 1)
 		return
-	if(!reagents || reagents.total_volume == 0)
+	var/total_volume = REAGENT_TOTAL_VOLUME(reagents)
+	var/max_volume   = REAGENT_MAXIMUM_VOLUME(reagents)
+	if(total_volume <= 0)
 		. += SPAN_NOTICE("\The [src] is empty!")
-	else if (reagents.total_volume <= reagents.maximum_volume * 0.25)
+	else if (total_volume <= max_volume * 0.25)
 		. += SPAN_NOTICE("\The [src] is almost empty!")
-	else if (reagents.total_volume <= reagents.maximum_volume * 0.66)
+	else if (total_volume <= max_volume * 0.66)
 		. += SPAN_NOTICE("\The [src] is half full!")
-	else if (reagents.total_volume <= reagents.maximum_volume * 0.90)
+	else if (total_volume <= max_volume * 0.90)
 		. += SPAN_NOTICE("\The [src] is almost full!")
 	else
 		. += SPAN_NOTICE("\The [src] is full!")
 
 /obj/item/chems/drinks/proc/get_filling_state()
-	var/percent = round((reagents.total_volume / reagents.maximum_volume) * 100)
+	var/percent = round((REAGENT_TOTAL_VOLUME(reagents) / REAGENT_MAXIMUM_VOLUME(reagents)) * 100)
 	for(var/k in cached_json_decode(filling_states))
 		if(percent <= k)
 			return k
 
 /obj/item/chems/drinks/on_update_icon()
 	. = ..()
-	if(LAZYLEN(reagents?.reagent_volumes) && filling_states)
+	if(REAGENT_TOTAL_VOLUME(reagents) && filling_states)
 		add_overlay(overlay_image(icon, "[base_icon][get_filling_state()]", reagents.get_color()))
-
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Drinks. END
@@ -120,7 +121,7 @@
 	center_of_mass = @'{"x":16,"y":9}'
 
 /obj/item/chems/drinks/milk/populate_reagents()
-	add_to_reagents(/decl/material/liquid/drink/milk, reagents.maximum_volume, data = list(DATA_MILK_DONOR = "cow"))
+	add_to_reagents(/decl/material/liquid/drink/milk, REAGENT_MAXIMUM_VOLUME(reagents), data = list(DATA_MILK_DONOR = "cow"))
 
 /obj/item/chems/drinks/soymilk
 	name = "soymilk carton"
@@ -130,7 +131,7 @@
 	center_of_mass = @'{"x":16,"y":9}'
 
 /obj/item/chems/drinks/soymilk/populate_reagents()
-	add_to_reagents(/decl/material/liquid/drink/milk/soymilk, reagents.maximum_volume)
+	add_to_reagents(/decl/material/liquid/drink/milk/soymilk, REAGENT_MAXIMUM_VOLUME(reagents))
 
 /obj/item/chems/drinks/milk/smallcarton
 	name = "small milk carton"
@@ -138,14 +139,14 @@
 	icon_state = "mini-milk"
 
 /obj/item/chems/drinks/milk/smallcarton/populate_reagents()
-	add_to_reagents(/decl/material/liquid/drink/milk, reagents.maximum_volume)
+	add_to_reagents(/decl/material/liquid/drink/milk, REAGENT_MAXIMUM_VOLUME(reagents))
 
 /obj/item/chems/drinks/milk/smallcarton/chocolate
 	name = "small chocolate milk carton"
 	desc = "It's milk! This one is in delicious chocolate flavour."
 
 /obj/item/chems/drinks/milk/smallcarton/chocolate/populate_reagents()
-	add_to_reagents(/decl/material/liquid/drink/milk/chocolate, reagents.maximum_volume)
+	add_to_reagents(/decl/material/liquid/drink/milk/chocolate, REAGENT_MAXIMUM_VOLUME(reagents))
 
 /obj/item/chems/drinks/coffee
 	name = "cup of coffee"
@@ -154,7 +155,7 @@
 	center_of_mass = @'{"x":15,"y":10}'
 
 /obj/item/chems/drinks/coffee/populate_reagents()
-	add_to_reagents(/decl/material/liquid/drink/coffee, reagents.maximum_volume)
+	add_to_reagents(/decl/material/liquid/drink/coffee, REAGENT_MAXIMUM_VOLUME(reagents))
 
 /obj/item/chems/drinks/ice
 	name = "cup of ice"
@@ -163,7 +164,7 @@
 	center_of_mass = @'{"x":15,"y":10}'
 
 /obj/item/chems/drinks/ice/populate_reagents()
-	add_to_reagents(/decl/material/solid/ice, reagents.maximum_volume)
+	add_to_reagents(/decl/material/solid/ice, REAGENT_MAXIMUM_VOLUME(reagents))
 
 /obj/item/chems/drinks/h_chocolate
 	name = "cup of hot cocoa"
@@ -173,7 +174,7 @@
 	center_of_mass = @'{"x":15,"y":13}'
 
 /obj/item/chems/drinks/h_chocolate/populate_reagents()
-	add_to_reagents(/decl/material/liquid/drink/hot_coco, reagents.maximum_volume)
+	add_to_reagents(/decl/material/liquid/drink/hot_coco, REAGENT_MAXIMUM_VOLUME(reagents))
 
 /obj/item/chems/drinks/dry_ramen
 	name = "cup ramen"
@@ -183,7 +184,7 @@
 	center_of_mass = @'{"x":16,"y":11}'
 
 /obj/item/chems/drinks/dry_ramen/populate_reagents()
-	add_to_reagents(/decl/material/liquid/drink/dry_ramen, reagents.maximum_volume)
+	add_to_reagents(/decl/material/liquid/drink/dry_ramen, REAGENT_MAXIMUM_VOLUME(reagents))
 
 /obj/item/chems/drinks/sillycup
 	name = "paper cup"
@@ -195,7 +196,7 @@
 
 /obj/item/chems/drinks/sillycup/on_update_icon()
 	. = ..()
-	if(reagents?.total_volume)
+	if(REAGENT_TOTAL_VOLUME(reagents))
 		icon_state = "water_cup"
 	else
 		icon_state = "water_cup_e"
@@ -283,19 +284,19 @@
 	desc = "A tall plastic cup of hot black tea."
 
 /obj/item/chems/drinks/tea/black/populate_reagents()
-	add_to_reagents(/decl/material/liquid/drink/tea/black, reagents.maximum_volume)
+	add_to_reagents(/decl/material/liquid/drink/tea/black, REAGENT_MAXIMUM_VOLUME(reagents))
 
 /obj/item/chems/drinks/tea/green
 	name = "cup of green tea"
 	desc = "A tall plastic cup of hot green tea."
 
 /obj/item/chems/drinks/tea/green/populate_reagents()
-	add_to_reagents(/decl/material/liquid/drink/tea/green, reagents.maximum_volume)
+	add_to_reagents(/decl/material/liquid/drink/tea/green, REAGENT_MAXIMUM_VOLUME(reagents))
 
 /obj/item/chems/drinks/tea/chai
 	name = "cup of chai tea"
 	desc = "A tall plastic cup of hot chai tea."
 
 /obj/item/chems/drinks/tea/chai/populate_reagents()
-	add_to_reagents(/decl/material/liquid/drink/tea/chai, reagents.maximum_volume)
+	add_to_reagents(/decl/material/liquid/drink/tea/chai, REAGENT_MAXIMUM_VOLUME(reagents))
 

--- a/code/modules/reagents/reagent_containers/drinks/bottle.dm
+++ b/code/modules/reagents/reagent_containers/drinks/bottle.dm
@@ -55,9 +55,9 @@
 
 	// Dump reagents onto the turf.
 	var/turf/T = against ? get_turf(against) : get_turf(newloc)
-	if(reagents?.total_volume)
+	if(REAGENT_TOTAL_VOLUME(reagents))
 		visible_message(SPAN_DANGER("The contents of \the [src] splash all over \the [against || T]!"))
-		reagents.splash(against || T, reagents.total_volume)
+		reagents.splash(against || T, REAGENT_TOTAL_VOLUME(reagents))
 	if(!T)
 		qdel(src)
 		return
@@ -124,9 +124,9 @@
 		// bottle contents will be tainted by having the rag dipped
 		// in it.
 		if(rag && rag.reagents)
-			rag.reagents.trans_to(src, rag.reagents.total_volume)
+			rag.reagents.trans_to(src, REAGENT_TOTAL_VOLUME(rag.reagents))
 			if(reagents)
-				reagents.trans_to(rag, min(reagents.total_volume, rag.reagents.maximum_volume))
+				reagents.trans_to(rag, min(REAGENT_TOTAL_VOLUME(reagents), REAGENT_MAXIMUM_VOLUME(rag.reagents)))
 			rag.update_name()
 
 		atom_flags &= ~ATOM_FLAG_OPEN_CONTAINER
@@ -177,7 +177,7 @@
 	//The reagents in the bottle splash all over the target, thanks for the idea Nodrak
 	if(reagents)
 		user.visible_message(SPAN_NOTICE("The contents of \the [src] splash all over [target]!"))
-		reagents.splash(target, reagents.total_volume)
+		reagents.splash(target, REAGENT_TOTAL_VOLUME(reagents))
 		if(rag?.is_on_fire() && istype(target))
 			target.ignite_fire()
 
@@ -250,7 +250,7 @@
 	center_of_mass = @'{"x":16,"y":4}'
 
 /obj/item/chems/drinks/bottle/gin/populate_reagents()
-	add_to_reagents(/decl/material/liquid/alcohol/gin, reagents.maximum_volume)
+	add_to_reagents(/decl/material/liquid/alcohol/gin, REAGENT_MAXIMUM_VOLUME(reagents))
 
 /obj/item/chems/drinks/bottle/whiskey
 	name = "Uncle Git's Special Reserve"
@@ -259,7 +259,7 @@
 	center_of_mass = @'{"x":16,"y":3}'
 
 /obj/item/chems/drinks/bottle/whiskey/populate_reagents()
-	add_to_reagents(/decl/material/liquid/alcohol/whiskey, reagents.maximum_volume)
+	add_to_reagents(/decl/material/liquid/alcohol/whiskey, REAGENT_MAXIMUM_VOLUME(reagents))
 
 /obj/item/chems/drinks/bottle/agedwhiskey
 	name = "aged whiskey"
@@ -268,7 +268,7 @@
 	center_of_mass = @'{"x":16,"y":3}'
 
 /obj/item/chems/drinks/bottle/agedwhiskey/populate_reagents()
-	add_to_reagents(/decl/material/liquid/alcohol/aged_whiskey, reagents.maximum_volume)
+	add_to_reagents(/decl/material/liquid/alcohol/aged_whiskey, REAGENT_MAXIMUM_VOLUME(reagents))
 
 /obj/item/chems/drinks/bottle/vodka
 	name = "Tunguska Triple Distilled"
@@ -277,7 +277,7 @@
 	center_of_mass = @'{"x":17,"y":3}'
 
 /obj/item/chems/drinks/bottle/vodka/populate_reagents()
-	add_to_reagents(/decl/material/liquid/alcohol/vodka, reagents.maximum_volume)
+	add_to_reagents(/decl/material/liquid/alcohol/vodka, REAGENT_MAXIMUM_VOLUME(reagents))
 
 /obj/item/chems/drinks/bottle/tequila
 	name = "Caccavo Guaranteed Quality tequila"
@@ -286,7 +286,7 @@
 	center_of_mass = @'{"x":16,"y":3}'
 
 /obj/item/chems/drinks/bottle/tequila/populate_reagents()
-	add_to_reagents(/decl/material/liquid/alcohol/tequila, reagents.maximum_volume)
+	add_to_reagents(/decl/material/liquid/alcohol/tequila, REAGENT_MAXIMUM_VOLUME(reagents))
 
 /obj/item/chems/drinks/bottle/patron
 	name = "Wrapp Artiste Patron"
@@ -295,7 +295,7 @@
 	center_of_mass = @'{"x":16,"y":6}'
 
 /obj/item/chems/drinks/bottle/patron/populate_reagents()
-	add_to_reagents(/decl/material/liquid/alcohol/tequila, reagents.maximum_volume - 5)
+	add_to_reagents(/decl/material/liquid/alcohol/tequila, REAGENT_MAXIMUM_VOLUME(reagents) - 5)
 	add_to_reagents(/decl/material/solid/metal/silver,     5)
 
 /obj/item/chems/drinks/bottle/rum
@@ -305,7 +305,7 @@
 	center_of_mass = @'{"x":16,"y":8}'
 
 /obj/item/chems/drinks/bottle/rum/populate_reagents()
-	add_to_reagents(/decl/material/liquid/alcohol/rum, reagents.maximum_volume)
+	add_to_reagents(/decl/material/liquid/alcohol/rum, REAGENT_MAXIMUM_VOLUME(reagents))
 
 /obj/item/chems/drinks/bottle/holywater
 	name = "Flask of Holy Water"
@@ -314,7 +314,7 @@
 	center_of_mass = @'{"x":17,"y":10}'
 
 /obj/item/chems/drinks/bottle/holywater/populate_reagents()
-	add_to_reagents(/decl/material/liquid/water, reagents.maximum_volume, list(DATA_WATER_HOLINESS = TRUE))
+	add_to_reagents(/decl/material/liquid/water, REAGENT_MAXIMUM_VOLUME(reagents), list(DATA_WATER_HOLINESS = TRUE))
 
 /obj/item/chems/drinks/bottle/vermouth
 	name = "Goldeneye Vermouth"
@@ -323,7 +323,7 @@
 	center_of_mass = @'{"x":17,"y":3}'
 
 /obj/item/chems/drinks/bottle/vermouth/populate_reagents()
-	add_to_reagents(/decl/material/liquid/alcohol/vermouth, reagents.maximum_volume)
+	add_to_reagents(/decl/material/liquid/alcohol/vermouth, REAGENT_MAXIMUM_VOLUME(reagents))
 
 /obj/item/chems/drinks/bottle/kahlua
 	name = "Robert Robust's Coffee Liqueur"
@@ -332,7 +332,7 @@
 	center_of_mass = @'{"x":17,"y":3}'
 
 /obj/item/chems/drinks/bottle/kahlua/populate_reagents()
-	add_to_reagents(/decl/material/liquid/alcohol/coffee, reagents.maximum_volume)
+	add_to_reagents(/decl/material/liquid/alcohol/coffee, REAGENT_MAXIMUM_VOLUME(reagents))
 
 /obj/item/chems/drinks/bottle/goldschlager
 	name = "College Girl Goldschlager"
@@ -341,7 +341,7 @@
 	center_of_mass = @'{"x":15,"y":3}'
 
 /obj/item/chems/drinks/bottle/goldschlager/populate_reagents()
-	add_to_reagents(/decl/material/liquid/alcohol/vodka, reagents.maximum_volume - 5)
+	add_to_reagents(/decl/material/liquid/alcohol/vodka, REAGENT_MAXIMUM_VOLUME(reagents) - 5)
 	add_to_reagents(/decl/material/solid/metal/gold,     5)
 
 /obj/item/chems/drinks/bottle/cognac
@@ -351,7 +351,7 @@
 	center_of_mass = @'{"x":16,"y":6}'
 
 /obj/item/chems/drinks/bottle/cognac/populate_reagents()
-	add_to_reagents(/decl/material/liquid/alcohol/cognac, reagents.maximum_volume)
+	add_to_reagents(/decl/material/liquid/alcohol/cognac, REAGENT_MAXIMUM_VOLUME(reagents))
 
 /obj/item/chems/drinks/bottle/wine
 	name = "Doublebeard Bearded Special Wine"
@@ -360,7 +360,7 @@
 	center_of_mass = @'{"x":16,"y":4}'
 
 /obj/item/chems/drinks/bottle/wine/populate_reagents()
-	add_to_reagents(/decl/material/liquid/alcohol/wine, reagents.maximum_volume)
+	add_to_reagents(/decl/material/liquid/alcohol/wine, REAGENT_MAXIMUM_VOLUME(reagents))
 
 /obj/item/chems/drinks/bottle/absinthe
 	name = "Jailbreaker Verte"
@@ -369,7 +369,7 @@
 	center_of_mass = @'{"x":16,"y":6}'
 
 /obj/item/chems/drinks/bottle/absinthe/populate_reagents()
-	add_to_reagents(/decl/material/liquid/alcohol/absinthe, reagents.maximum_volume)
+	add_to_reagents(/decl/material/liquid/alcohol/absinthe, REAGENT_MAXIMUM_VOLUME(reagents))
 
 /obj/item/chems/drinks/bottle/melonliquor
 	name = "Emeraldine Melon Liquor"
@@ -378,7 +378,7 @@
 	center_of_mass = @'{"x":16,"y":6}'
 
 /obj/item/chems/drinks/bottle/melonliquor/populate_reagents()
-	add_to_reagents(/decl/material/liquid/alcohol/melonliquor, reagents.maximum_volume)
+	add_to_reagents(/decl/material/liquid/alcohol/melonliquor, REAGENT_MAXIMUM_VOLUME(reagents))
 
 /obj/item/chems/drinks/bottle/bluecuracao
 	name = "Miss Blue Curacao"
@@ -387,7 +387,7 @@
 	center_of_mass = @'{"x":16,"y":6}'
 
 /obj/item/chems/drinks/bottle/bluecuracao/populate_reagents()
-	add_to_reagents(/decl/material/liquid/alcohol/bluecuracao, reagents.maximum_volume)
+	add_to_reagents(/decl/material/liquid/alcohol/bluecuracao, REAGENT_MAXIMUM_VOLUME(reagents))
 
 /obj/item/chems/drinks/bottle/herbal
 	name = "Liqueur d'Herbe"
@@ -396,7 +396,7 @@
 	center_of_mass = @'{"x":16,"y":6}'
 
 /obj/item/chems/drinks/bottle/herbal/populate_reagents()
-	add_to_reagents(/decl/material/liquid/alcohol/herbal, reagents.maximum_volume)
+	add_to_reagents(/decl/material/liquid/alcohol/herbal, REAGENT_MAXIMUM_VOLUME(reagents))
 
 /obj/item/chems/drinks/bottle/grenadine
 	name = "Briar Rose Grenadine Syrup"
@@ -405,7 +405,7 @@
 	center_of_mass = @'{"x":16,"y":6}'
 
 /obj/item/chems/drinks/bottle/grenadine/populate_reagents()
-	add_to_reagents(/decl/material/liquid/drink/grenadine, reagents.maximum_volume)
+	add_to_reagents(/decl/material/liquid/drink/grenadine, REAGENT_MAXIMUM_VOLUME(reagents))
 
 /obj/item/chems/drinks/bottle/cola
 	name = "\improper Space Cola"
@@ -414,7 +414,7 @@
 	center_of_mass = @'{"x":16,"y":6}'
 
 /obj/item/chems/drinks/bottle/cola/populate_reagents()
-	add_to_reagents(/decl/material/liquid/drink/cola, reagents.maximum_volume)
+	add_to_reagents(/decl/material/liquid/drink/cola, REAGENT_MAXIMUM_VOLUME(reagents))
 
 /obj/item/chems/drinks/bottle/space_up
 	name = "\improper Space-Up"
@@ -423,7 +423,7 @@
 	center_of_mass = @'{"x":16,"y":6}'
 
 /obj/item/chems/drinks/bottle/space_up/populate_reagents()
-	add_to_reagents(/decl/material/liquid/drink/lemonade, reagents.maximum_volume)
+	add_to_reagents(/decl/material/liquid/drink/lemonade, REAGENT_MAXIMUM_VOLUME(reagents))
 
 /obj/item/chems/drinks/bottle/space_mountain_wind
 	name = "\improper Space Mountain Wind"
@@ -432,7 +432,7 @@
 	center_of_mass = @'{"x":16,"y":6}'
 
 /obj/item/chems/drinks/bottle/space_mountain_wind/populate_reagents()
-	add_to_reagents(/decl/material/liquid/drink/citrussoda, reagents.maximum_volume)
+	add_to_reagents(/decl/material/liquid/drink/citrussoda, REAGENT_MAXIMUM_VOLUME(reagents))
 
 /obj/item/chems/drinks/bottle/pwine
 	name = "Warlock's Velvet"
@@ -441,7 +441,7 @@
 	center_of_mass = @'{"x":16,"y":4}'
 
 /obj/item/chems/drinks/bottle/pwine/populate_reagents()
-	add_to_reagents(/decl/material/liquid/alcohol/pwine, reagents.maximum_volume)
+	add_to_reagents(/decl/material/liquid/alcohol/pwine, REAGENT_MAXIMUM_VOLUME(reagents))
 
 /obj/item/chems/drinks/bottle/sake
 	name = "Takeo Sadow's Combined Sake"
@@ -450,7 +450,7 @@
 	center_of_mass = @'{"x":16,"y":4}'
 
 /obj/item/chems/drinks/bottle/sake/populate_reagents()
-	add_to_reagents(/decl/material/liquid/alcohol/sake, reagents.maximum_volume)
+	add_to_reagents(/decl/material/liquid/alcohol/sake, REAGENT_MAXIMUM_VOLUME(reagents))
 
 
 /obj/item/chems/drinks/bottle/champagne
@@ -462,7 +462,7 @@
 	var/opening
 
 /obj/item/chems/drinks/bottle/champagne/populate_reagents()
-	add_to_reagents(/decl/material/liquid/alcohol/champagne, reagents.maximum_volume)
+	add_to_reagents(/decl/material/liquid/alcohol/champagne, REAGENT_MAXIMUM_VOLUME(reagents))
 
 /obj/item/chems/drinks/bottle/champagne/open(mob/user)
 	if(ATOM_IS_OPEN_CONTAINER(src))
@@ -497,7 +497,7 @@
 	center_of_mass = @'{"x":16,"y":6}'
 
 /obj/item/chems/drinks/bottle/jagermeister/populate_reagents()
-	add_to_reagents(/decl/material/liquid/alcohol/jagermeister, reagents.maximum_volume)
+	add_to_reagents(/decl/material/liquid/alcohol/jagermeister, REAGENT_MAXIMUM_VOLUME(reagents))
 
 //////////////////////////PREMIUM ALCOHOL ///////////////////////
 /obj/item/chems/drinks/bottle/premiumvodka
@@ -512,7 +512,7 @@
 
 /obj/item/chems/drinks/bottle/premiumvodka/populate_reagents()
 	make_random_name()
-	add_to_reagents(/decl/material/liquid/alcohol/vodka/premium, reagents.maximum_volume)
+	add_to_reagents(/decl/material/liquid/alcohol/vodka/premium, REAGENT_MAXIMUM_VOLUME(reagents))
 
 /obj/item/chems/drinks/bottle/premiumwine
 	name = "Uve De Blanc"
@@ -530,7 +530,7 @@
 	var/agedyear = rand(global.using_map.game_year - aged_max, global.using_map.game_year - aged_min)
 	set_custom_name(make_random_name())
 	desc += " This bottle is marked as [agedyear] Vintage."
-	add_to_reagents(/decl/material/liquid/alcohol/wine/premium, reagents.maximum_volume)
+	add_to_reagents(/decl/material/liquid/alcohol/wine/premium, REAGENT_MAXIMUM_VOLUME(reagents))
 
 //////////////////////////JUICES AND STUFF ///////////////////////
 
@@ -548,7 +548,7 @@
 	pickup_sound = 'sound/foley/paperpickup2.ogg'
 
 /obj/item/chems/drinks/bottle/orangejuice/populate_reagents()
-	add_to_reagents(/decl/material/liquid/drink/juice/orange, reagents.maximum_volume)
+	add_to_reagents(/decl/material/liquid/drink/juice/orange, REAGENT_MAXIMUM_VOLUME(reagents))
 
 /obj/item/chems/drinks/bottle/cream
 	name = "Milk Cream"
@@ -564,7 +564,7 @@
 	pickup_sound = 'sound/foley/paperpickup2.ogg'
 
 /obj/item/chems/drinks/bottle/cream/populate_reagents()
-	add_to_reagents(/decl/material/liquid/drink/milk/cream, reagents.maximum_volume, data = list(DATA_MILK_DONOR = "cow"))
+	add_to_reagents(/decl/material/liquid/drink/milk/cream, REAGENT_MAXIMUM_VOLUME(reagents), data = list(DATA_MILK_DONOR = "cow"))
 
 /obj/item/chems/drinks/bottle/tomatojuice
 	name = "Tomato Juice"
@@ -580,7 +580,7 @@
 	pickup_sound = 'sound/foley/paperpickup2.ogg'
 
 /obj/item/chems/drinks/bottle/tomatojuice/populate_reagents()
-	add_to_reagents(/decl/material/liquid/drink/juice/tomato, reagents.maximum_volume)
+	add_to_reagents(/decl/material/liquid/drink/juice/tomato, REAGENT_MAXIMUM_VOLUME(reagents))
 
 /obj/item/chems/drinks/bottle/limejuice
 	name = "Lime Juice"
@@ -596,7 +596,7 @@
 	pickup_sound = 'sound/foley/paperpickup2.ogg'
 
 /obj/item/chems/drinks/bottle/limejuice/populate_reagents()
-	add_to_reagents(/decl/material/liquid/drink/juice/lime, reagents.maximum_volume)
+	add_to_reagents(/decl/material/liquid/drink/juice/lime, REAGENT_MAXIMUM_VOLUME(reagents))
 
 //Small bottles
 /obj/item/chems/drinks/bottle/small
@@ -613,7 +613,7 @@
 	center_of_mass = @'{"x":16,"y":12}'
 
 /obj/item/chems/drinks/bottle/small/beer/populate_reagents()
-	add_to_reagents(/decl/material/liquid/alcohol/beer, reagents.maximum_volume)
+	add_to_reagents(/decl/material/liquid/alcohol/beer, REAGENT_MAXIMUM_VOLUME(reagents))
 
 /obj/item/chems/drinks/bottle/small/ale
 	name = "\improper Magm-Ale"
@@ -623,7 +623,7 @@
 	center_of_mass = @'{"x":16,"y":10}'
 
 /obj/item/chems/drinks/bottle/small/ale/populate_reagents()
-	add_to_reagents(/decl/material/liquid/alcohol/ale, reagents.maximum_volume)
+	add_to_reagents(/decl/material/liquid/alcohol/ale, REAGENT_MAXIMUM_VOLUME(reagents))
 
 /obj/item/chems/drinks/bottle/small/gingerbeer
 	name = "Ginger Beer"
@@ -632,4 +632,4 @@
 	center_of_mass = @'{"x":16,"y":12}'
 
 /obj/item/chems/drinks/bottle/small/gingerbeer/populate_reagents()
-	add_to_reagents(/decl/material/liquid/drink/gingerbeer, reagents.maximum_volume)
+	add_to_reagents(/decl/material/liquid/drink/gingerbeer, REAGENT_MAXIMUM_VOLUME(reagents))

--- a/code/modules/reagents/reagent_containers/drinks/cans.dm
+++ b/code/modules/reagents/reagent_containers/drinks/cans.dm
@@ -17,7 +17,7 @@
 	center_of_mass = @'{"x":16,"y":10}'
 
 /obj/item/chems/drinks/cans/cola/populate_reagents()
-	add_to_reagents(/decl/material/liquid/drink/cola, reagents.maximum_volume)
+	add_to_reagents(/decl/material/liquid/drink/cola, REAGENT_MAXIMUM_VOLUME(reagents))
 
 /obj/item/chems/drinks/cans/waterbottle
 	name = "bottled water"
@@ -27,7 +27,7 @@
 	material = /decl/material/solid/organic/plastic
 
 /obj/item/chems/drinks/cans/waterbottle/populate_reagents()
-	add_to_reagents(/decl/material/liquid/water, reagents.maximum_volume)
+	add_to_reagents(/decl/material/liquid/water, REAGENT_MAXIMUM_VOLUME(reagents))
 
 /obj/item/chems/drinks/cans/waterbottle/open(mob/user)
 	playsound(loc,'sound/effects/bonebreak1.ogg', rand(10,50), 1)
@@ -41,7 +41,7 @@
 	center_of_mass = @'{"x":16,"y":10}'
 
 /obj/item/chems/drinks/cans/space_mountain_wind/populate_reagents()
-	add_to_reagents(/decl/material/liquid/drink/citrussoda, reagents.maximum_volume)
+	add_to_reagents(/decl/material/liquid/drink/citrussoda, REAGENT_MAXIMUM_VOLUME(reagents))
 
 /obj/item/chems/drinks/cans/thirteenloko
 	name = "\improper Thirteen Loko"
@@ -50,7 +50,7 @@
 	center_of_mass = @'{"x":16,"y":8}'
 
 /obj/item/chems/drinks/cans/thirteenloko/populate_reagents()
-	add_to_reagents(/decl/material/liquid/alcohol/thirteenloko, reagents.maximum_volume)
+	add_to_reagents(/decl/material/liquid/alcohol/thirteenloko, REAGENT_MAXIMUM_VOLUME(reagents))
 
 /obj/item/chems/drinks/cans/dr_gibb
 	name = "\improper Dr. Gibb"
@@ -59,7 +59,7 @@
 	center_of_mass = @'{"x":16,"y":10}'
 
 /obj/item/chems/drinks/cans/dr_gibb/populate_reagents()
-	add_to_reagents(/decl/material/liquid/drink/cherrycola, reagents.maximum_volume)
+	add_to_reagents(/decl/material/liquid/drink/cherrycola, REAGENT_MAXIMUM_VOLUME(reagents))
 
 /obj/item/chems/drinks/cans/starkist
 	name = "\improper Star-Kist"
@@ -68,7 +68,7 @@
 	center_of_mass = @'{"x":16,"y":10}'
 
 /obj/item/chems/drinks/cans/starkist/populate_reagents()
-	add_to_reagents(/decl/material/liquid/drink/orangecola, reagents.maximum_volume)
+	add_to_reagents(/decl/material/liquid/drink/orangecola, REAGENT_MAXIMUM_VOLUME(reagents))
 
 /obj/item/chems/drinks/cans/space_up
 	name = "\improper Space-Up"
@@ -77,7 +77,7 @@
 	center_of_mass = @'{"x":16,"y":10}'
 
 /obj/item/chems/drinks/cans/space_up/populate_reagents()
-	add_to_reagents(/decl/material/liquid/drink/lemonade, reagents.maximum_volume)
+	add_to_reagents(/decl/material/liquid/drink/lemonade, REAGENT_MAXIMUM_VOLUME(reagents))
 
 /obj/item/chems/drinks/cans/lemon_lime
 	name = "\improper Lemon-Lime"
@@ -86,7 +86,7 @@
 	center_of_mass = @'{"x":16,"y":10}'
 
 /obj/item/chems/drinks/cans/lemon_lime/populate_reagents()
-	add_to_reagents(/decl/material/liquid/drink/lemon_lime, reagents.maximum_volume)
+	add_to_reagents(/decl/material/liquid/drink/lemon_lime, REAGENT_MAXIMUM_VOLUME(reagents))
 
 /obj/item/chems/drinks/cans/iced_tea
 	name = "\improper Vrisk Serket Iced Tea"
@@ -95,7 +95,7 @@
 	center_of_mass = @'{"x":16,"y":10}'
 
 /obj/item/chems/drinks/cans/iced_tea/populate_reagents()
-	add_to_reagents(/decl/material/liquid/drink/tea/black, reagents.maximum_volume - 5)
+	add_to_reagents(/decl/material/liquid/drink/tea/black, REAGENT_MAXIMUM_VOLUME(reagents) - 5)
 	add_to_reagents(/decl/material/solid/ice,              5)
 
 /obj/item/chems/drinks/cans/grape_juice
@@ -105,7 +105,7 @@
 	center_of_mass = @'{"x":16,"y":10}'
 
 /obj/item/chems/drinks/cans/grape_juice/populate_reagents()
-	add_to_reagents(/decl/material/liquid/drink/juice/grape, reagents.maximum_volume)
+	add_to_reagents(/decl/material/liquid/drink/juice/grape, REAGENT_MAXIMUM_VOLUME(reagents))
 
 /obj/item/chems/drinks/cans/tonic
 	name = "\improper T-Borg's Tonic Water"
@@ -114,7 +114,7 @@
 	center_of_mass = @'{"x":16,"y":10}'
 
 /obj/item/chems/drinks/cans/tonic/populate_reagents()
-	add_to_reagents(/decl/material/liquid/drink/tonic, reagents.maximum_volume)
+	add_to_reagents(/decl/material/liquid/drink/tonic, REAGENT_MAXIMUM_VOLUME(reagents))
 
 /obj/item/chems/drinks/cans/sodawater
 	name = "soda water"
@@ -123,7 +123,7 @@
 	center_of_mass = @'{"x":16,"y":10}'
 
 /obj/item/chems/drinks/cans/sodawater/populate_reagents()
-	add_to_reagents(/decl/material/liquid/drink/sodawater, reagents.maximum_volume)
+	add_to_reagents(/decl/material/liquid/drink/sodawater, REAGENT_MAXIMUM_VOLUME(reagents))
 
 /obj/item/chems/drinks/cans/beastenergy
 	name = "Beast Energy"
@@ -132,7 +132,7 @@
 	center_of_mass = @'{"x":16,"y":6}'
 
 /obj/item/chems/drinks/cans/beastenergy/populate_reagents()
-	add_to_reagents(/decl/material/liquid/drink/beastenergy, reagents.maximum_volume)
+	add_to_reagents(/decl/material/liquid/drink/beastenergy, REAGENT_MAXIMUM_VOLUME(reagents))
 
 //Items exclusive to the BODA machine on deck 4 and wherever else it pops up. First two are a bit jokey. Second two are genuine article.
 
@@ -143,7 +143,7 @@
 	center_of_mass = @'{"x":16,"y":10}'
 
 /obj/item/chems/drinks/cans/syndicolax/populate_reagents()
-	add_to_reagents(/decl/material/liquid/drink/juice/potato, reagents.maximum_volume)
+	add_to_reagents(/decl/material/liquid/drink/juice/potato, REAGENT_MAXIMUM_VOLUME(reagents))
 
 /obj/item/chems/drinks/cans/artbru
 	name = "\improper Arstotzka Bru"
@@ -152,7 +152,7 @@
 	center_of_mass = @'{"x":16,"y":10}'
 
 /obj/item/chems/drinks/cans/artbru/populate_reagents()
-	add_to_reagents(/decl/material/liquid/drink/juice/turnip, reagents.maximum_volume)
+	add_to_reagents(/decl/material/liquid/drink/juice/turnip, REAGENT_MAXIMUM_VOLUME(reagents))
 
 /obj/item/chems/drinks/cans/syndicola
 	name = "\improper TerraCola"
@@ -161,7 +161,7 @@
 	center_of_mass = @'{"x":16,"y":10}'
 
 /obj/item/chems/drinks/cans/syndicola/populate_reagents()
-	add_to_reagents(/decl/material/liquid/water,     reagents.maximum_volume - 5)
+	add_to_reagents(/decl/material/liquid/water,     REAGENT_MAXIMUM_VOLUME(reagents) - 5)
 	add_to_reagents(/decl/material/solid/metal/iron, 5)
 
 /obj/item/chems/drinks/glass2/square/boda
@@ -170,7 +170,7 @@
 	center_of_mass = @'{"x":16,"y":10}'
 
 /obj/item/chems/drinks/glass2/square/boda/populate_reagents()
-	add_to_reagents(/decl/material/liquid/drink/sodawater, reagents.maximum_volume)
+	add_to_reagents(/decl/material/liquid/drink/sodawater, REAGENT_MAXIMUM_VOLUME(reagents))
 
 /obj/item/chems/drinks/glass2/square/bodaplus
 	name = "tri kopeiki sirop boda"
@@ -189,8 +189,9 @@
 				/decl/material/liquid/drink/juice/banana,
 				/decl/material/liquid/drink/juice/berry,
 				/decl/material/liquid/drink/juice/watermelon))
-	add_to_reagents(/decl/material/liquid/drink/sodawater, reagents.maximum_volume / 2)
-	add_to_reagents(reag, reagents.maximum_volume / 2)
+	var/half_max_vol = REAGENT_MAXIMUM_VOLUME(reagents) / 2
+	add_to_reagents(/decl/material/liquid/drink/sodawater, half_max_vol)
+	add_to_reagents(reag, half_max_vol)
 
 
 //Canned alcohols.
@@ -202,7 +203,7 @@
 	center_of_mass = @'{"x":16,"y":10}'
 
 /obj/item/chems/drinks/cans/speer/populate_reagents()
-	add_to_reagents(/decl/material/liquid/alcohol/beer/good, reagents.maximum_volume)
+	add_to_reagents(/decl/material/liquid/alcohol/beer/good, REAGENT_MAXIMUM_VOLUME(reagents))
 
 /obj/item/chems/drinks/cans/ale
 	name = "\improper Magm-Ale"
@@ -211,4 +212,4 @@
 	center_of_mass = @'{"x":16,"y":10}'
 
 /obj/item/chems/drinks/cans/ale/populate_reagents()
-	add_to_reagents(/decl/material/liquid/alcohol/ale, reagents.maximum_volume)
+	add_to_reagents(/decl/material/liquid/alcohol/ale, REAGENT_MAXIMUM_VOLUME(reagents))

--- a/code/modules/reagents/reagent_containers/drinks/cocktailshaker.dm
+++ b/code/modules/reagents/reagent_containers/drinks/cocktailshaker.dm
@@ -19,14 +19,14 @@
 		return
 	else
 		user.visible_message(SPAN_NOTICE("\The [user] shakes \the [src] gingerly."), SPAN_NOTICE("You shake \the [src] gingerly."))
-		if(prob(15) && (reagents && reagents.total_volume))
+		if(prob(15) && (reagents && REAGENT_TOTAL_VOLUME(reagents)))
 			user.visible_message(SPAN_WARNING("\The [user] spills the contents of \the [src] over themselves!"), SPAN_WARNING("You spill the contents of \the [src] over yourself!"))
-			reagents.splash(user, reagents.total_volume)
+			reagents.splash(user, REAGENT_TOTAL_VOLUME(reagents))
 		else
 			mix()
 
 /obj/item/chems/drinks/shaker/proc/mix()
-	if(reagents && reagents.total_volume)
+	if(reagents && REAGENT_TOTAL_VOLUME(reagents))
 		atom_flags &= ~ATOM_FLAG_NO_REACT
 		HANDLE_REACTIONS(reagents)
 		addtimer(CALLBACK(src, PROC_REF(stop_react)), SSmaterials.wait)

--- a/code/modules/reagents/reagent_containers/drinks/juicebox.dm
+++ b/code/modules/reagents/reagent_containers/drinks/juicebox.dm
@@ -70,7 +70,7 @@
 	desc = "A small cardboard juicebox with a cartoon apple on it."
 
 /obj/item/chems/drinks/juicebox/apple/populate_reagents()
-	add_to_reagents(/decl/material/liquid/drink/juice/apple, reagents.maximum_volume)
+	add_to_reagents(/decl/material/liquid/drink/juice/apple, REAGENT_MAXIMUM_VOLUME(reagents))
 
 /obj/item/chems/drinks/juicebox/apple/Initialize()
 	. = ..()
@@ -81,7 +81,7 @@
 	desc = "A small cardboard juicebox with a cartoon orange on it."
 
 /obj/item/chems/drinks/juicebox/orange/populate_reagents()
-	add_to_reagents(/decl/material/liquid/drink/juice/orange, reagents.maximum_volume)
+	add_to_reagents(/decl/material/liquid/drink/juice/orange, REAGENT_MAXIMUM_VOLUME(reagents))
 
 /obj/item/chems/drinks/juicebox/orange/Initialize()
 	. = ..()
@@ -92,7 +92,7 @@
 	desc = "A small cardboard juicebox with some cartoon grapes on it."
 
 /obj/item/chems/drinks/juicebox/grape/populate_reagents()
-	add_to_reagents(/decl/material/liquid/drink/juice/grape, reagents.maximum_volume)
+	add_to_reagents(/decl/material/liquid/drink/juice/grape, REAGENT_MAXIMUM_VOLUME(reagents))
 
 /obj/item/chems/drinks/juicebox/grape/Initialize()
 	. = ..()
@@ -114,7 +114,7 @@
 	var/decl/material/J = pick(drinktypes)
 	add_to_reagents(J, 20)
 	add_to_reagents(pick(drinktypes - J), 5)
-	return reagents.reagent_volumes
+	return REAGENT_VOLUMES(reagents)
 
 /obj/item/chems/drinks/juicebox/sensible_random/populate_reagents()
 	var/list/chosen_reagents = juice_it()

--- a/code/modules/reagents/reagent_containers/dropper.dm
+++ b/code/modules/reagents/reagent_containers/dropper.dm
@@ -18,7 +18,7 @@
 	if(!target.reagents || !proximity)
 		return
 
-	if(reagents.total_volume)
+	if(REAGENT_TOTAL_VOLUME(reagents))
 
 		if(!REAGENTS_FREE_SPACE(target.reagents))
 			to_chat(user, SPAN_WARNING("\The [target] is full."))
@@ -52,12 +52,12 @@
 						return
 
 			var/mob/living/M = target
-			var/contained = REAGENT_LIST(src)
+			var/contained = REAGENT_LIST(reagents)
 			admin_attack_log(user, M, "Squirted their victim with \a [src] (Reagents: [contained])", "Were squirted with \a [src] (Reagents: [contained])", "used \a [src] (Reagents: [contained]) to squirt at")
 
 			var/spill_amt = M.incapacitated()? 0 : 30
-			trans += reagents.splash(M, reagents.total_volume/2, max_spill = spill_amt)
-			trans += reagents.trans_to_mob(M, reagents.total_volume/2, CHEM_INJECT) //I guess it gets into the bloodstream through the eyes or something
+			trans += reagents.splash(M, REAGENT_TOTAL_VOLUME(reagents)/2, max_spill = spill_amt)
+			trans += reagents.trans_to_mob(M, REAGENT_TOTAL_VOLUME(reagents)/2, CHEM_INJECT) //I guess it gets into the bloodstream through the eyes or something
 			user.visible_message(SPAN_DANGER("[user] squirts something into \the [target]'s eyes!"), SPAN_DANGER("You squirt [trans] unit\s into \the [target]'s eyes!"))
 			return
 		else
@@ -70,7 +70,7 @@
 			to_chat(user, SPAN_NOTICE("You cannot directly remove reagents from [target]."))
 			return
 
-		if(!target.reagents || !target.reagents.total_volume)
+		if(!target.reagents || !REAGENT_TOTAL_VOLUME(target.reagents))
 			to_chat(user, SPAN_NOTICE("[target] is empty."))
 			return
 
@@ -86,7 +86,7 @@
 
 /obj/item/chems/dropper/on_update_icon()
 	. = ..()
-	if(reagents?.total_volume)
+	if(REAGENT_TOTAL_VOLUME(reagents))
 		icon_state = "dropper1"
 	else
 		icon_state = "dropper0"

--- a/code/modules/reagents/reagent_containers/food.dm
+++ b/code/modules/reagents/reagent_containers/food.dm
@@ -69,7 +69,7 @@
 
 /obj/item/food/lump/on_reagent_change()
 	. = ..()
-	if(reagents?.total_volume)
+	if(REAGENT_TOTAL_VOLUME(reagents))
 		SetName(reagents.get_primary_reagent_name())
 		filling_color = reagents.get_color()
 	else
@@ -86,7 +86,7 @@
 
 // Does not rely on ATOM_IS_OPEN_CONTAINER because we want to be able to pour in but not out.
 /obj/item/food/can_be_poured_into(atom/source)
-	return (reagents?.maximum_volume > 0)
+	return (REAGENT_MAXIMUM_VOLUME(reagents) > 0)
 
 /obj/item/food/attack_self(mob/user)
 	if(is_edible(user) && handle_eaten_by_mob(user, user) != EATEN_INVALID)
@@ -191,9 +191,8 @@
 		.[DATA_INGREDIENT_FLAGS] |= allergen_flags
 
 /obj/item/food/proc/set_nutriment_data(list/newdata)
-	if(reagents?.total_volume && reagents.has_reagent(nutriment_type, 1))
-		LAZYINITLIST(reagents.reagent_data)
-		reagents.reagent_data[nutriment_type] = newdata
+	if(REAGENT_TOTAL_VOLUME(reagents) && reagents.has_reagent(nutriment_type, 1))
+		REAGENT_SET_DATA(reagents, nutriment_type, newdata)
 
 /obj/item/food/get_utensil_food_type()
 	return _utensil_food_type
@@ -205,8 +204,8 @@
 	bitecount++
 
 /obj/item/food/proc/add_allergen_flags(new_flags)
-	for(var/decl/material/reagent as anything in reagents.reagent_volumes)
+	for(var/decl/material/reagent as anything in REAGENT_VOLUMES(reagents))
 		var/list/newdata = reagent.mix_data(reagents, list(DATA_INGREDIENT_FLAGS = new_flags))
 		if(newdata)
-			LAZYSET(reagents.reagent_data, reagent, newdata)
+			REAGENT_SET_DATA(reagents, reagent, newdata)
 

--- a/code/modules/reagents/reagent_containers/food/burgers.dm
+++ b/code/modules/reagents/reagent_containers/food/burgers.dm
@@ -114,7 +114,7 @@
 
 /obj/item/food/roburgerbig/populate_reagents()
 	. = ..()
-	add_to_reagents(/decl/material/liquid/nanitefluid, reagents.maximum_volume)
+	add_to_reagents(/decl/material/liquid/nanitefluid, REAGENT_MAXIMUM_VOLUME(reagents))
 
 /obj/item/food/xenoburger
 	name = "xenoburger"

--- a/code/modules/reagents/reagent_containers/food/canned/_canned.dm
+++ b/code/modules/reagents/reagent_containers/food/canned/_canned.dm
@@ -63,7 +63,7 @@
 	return //Bypass searching through the whole icon file for a filling icon
 
 /obj/item/food/can/can_be_poured_into(atom/source)
-	return (reagents?.maximum_volume > 0) && ATOM_IS_OPEN_CONTAINER(src)
+	return (REAGENT_MAXIMUM_VOLUME(reagents) > 0) && ATOM_IS_OPEN_CONTAINER(src)
 
 //Just a short line of Canned Consumables, great for treasure in faraway abandoned outposts
 

--- a/code/modules/reagents/reagent_containers/food/dairy/_dairy.dm
+++ b/code/modules/reagents/reagent_containers/food/dairy/_dairy.dm
@@ -19,11 +19,11 @@
 
 	. = ..()
 
-	if(!reagents?.total_volume)
+	if(!REAGENT_TOTAL_VOLUME(reagents))
 		return
 
-	var/list/data = LAZYACCESS(reagents?.reagent_data, nutriment_type)
-	var/milk_name =  LAZYACCESS(data, data_name_field)
+	var/list/data = REAGENT_DATA(reagents, nutriment_type)
+	var/milk_name = LAZYACCESS(data, data_name_field)
 	if(milk_name)
 		set_dairy_name(milk_name)
 		set_color(LAZYACCESS(data, data_color_field) || get_default_dairy_color())

--- a/code/modules/reagents/reagent_containers/food/eggs.dm
+++ b/code/modules/reagents/reagent_containers/food/eggs.dm
@@ -22,7 +22,7 @@
 	if(!(proximity && ATOM_IS_OPEN_CONTAINER(O))) // Must be adjacent and open.
 		return
 	to_chat(user, "You crack \the [src] into \the [O].")
-	reagents.trans_to(O, reagents.total_volume)
+	reagents.trans_to(O, REAGENT_TOTAL_VOLUME(reagents))
 	qdel(src)
 
 /obj/item/food/egg/throw_impact(atom/hit_atom)
@@ -30,7 +30,7 @@
 	if(QDELETED(src))
 		return // Could potentially happen with unscupulous atoms on hitby() throwing again, etc.
 	new/obj/effect/decal/cleanable/egg_smudge(src.loc)
-	reagents.splash(hit_atom, reagents.total_volume)
+	reagents.splash(hit_atom, REAGENT_TOTAL_VOLUME(reagents))
 	visible_message("<span class='warning'>\The [src] has been squashed!</span>","<span class='warning'>You hear a smack.</span>")
 	qdel(src)
 

--- a/code/modules/reagents/reagent_containers/food/sandwich.dm
+++ b/code/modules/reagents/reagent_containers/food/sandwich.dm
@@ -40,7 +40,7 @@
 			return TRUE
 		to_chat(user, "<span class='warning'>You layer [used_item] over \the [src].</span>")
 		var/obj/item/chems/F = used_item
-		F.reagents.trans_to_obj(src, F.reagents.total_volume)
+		F.reagents.trans_to_obj(src, REAGENT_TOTAL_VOLUME(F.reagents))
 		ingredients += used_item
 		update_icon()
 		return TRUE

--- a/code/modules/reagents/reagent_containers/food/sliceable/_sliceable.dm
+++ b/code/modules/reagents/reagent_containers/food/sliceable/_sliceable.dm
@@ -35,7 +35,7 @@
 	if(filled)
 		var/obj/item/food/whole = new whole_path()
 		if(whole && whole.slice_num)
-			var/reagent_amount = whole.reagents.total_volume/whole.slice_num
+			var/reagent_amount = REAGENT_TOTAL_VOLUME(whole.reagents)/whole.slice_num
 			whole.reagents.trans_to_obj(src, reagent_amount)
 
 		qdel(whole)

--- a/code/modules/reagents/reagent_containers/food/sushi.dm
+++ b/code/modules/reagents/reagent_containers/food/sushi.dm
@@ -26,7 +26,7 @@
 			fish_type = "tofu"
 
 		if(topping.reagents)
-			topping.reagents.trans_to(src, topping.reagents.total_volume)
+			topping.reagents.trans_to(src, REAGENT_TOTAL_VOLUME(topping.reagents))
 
 		var/mob/M = topping.loc
 		if(istype(M)) M.drop_from_inventory(topping)
@@ -35,7 +35,7 @@
 	if(istype(rice))
 		if(rice.reagents)
 			rice.reagents.trans_to(src, 1)
-		if(!rice.reagents || !rice.reagents.total_volume)
+		if(!rice.reagents || !REAGENT_TOTAL_VOLUME(rice.reagents))
 			var/mob/M = rice.loc
 			if(istype(M)) M.drop_from_inventory(rice)
 			qdel(rice)
@@ -98,7 +98,7 @@
 		bitesize = slices
 		update_icon()
 		if(used_item.reagents)
-			used_item.reagents.trans_to(src, used_item.reagents.total_volume)
+			used_item.reagents.trans_to(src, REAGENT_TOTAL_VOLUME(used_item.reagents))
 		qdel(used_item)
 		return TRUE
 

--- a/code/modules/reagents/reagent_containers/food_edibility.dm
+++ b/code/modules/reagents/reagent_containers/food_edibility.dm
@@ -1,5 +1,5 @@
 /obj/item/food/get_edible_material_amount(mob/eater)
-	return reagents?.total_volume
+	return REAGENT_TOTAL_VOLUME(reagents)
 
 /obj/item/food/get_food_consumption_method(mob/eater)
 	return EATING_METHOD_EAT

--- a/code/modules/reagents/reagent_containers/glass/bottle.dm
+++ b/code/modules/reagents/reagent_containers/glass/bottle.dm
@@ -38,8 +38,8 @@
 	update_icon()
 
 /obj/item/chems/glass/bottle/update_overlays()
-	if(reagents?.total_volume)
-		var/percent = round(reagents.total_volume / reagents.maximum_volume * 100, 25)
+	if(REAGENT_TOTAL_VOLUME(reagents))
+		var/percent = round(REAGENT_TOTAL_VOLUME(reagents) / REAGENT_MAXIMUM_VOLUME(reagents) * 100, 25)
 		add_overlay(mutable_appearance(icon, "[icon_state]_filling_[percent]", reagents.get_color()))
 	var/image/overglass = mutable_appearance(icon, "[icon_state]_over", color)
 	overglass.alpha = alpha * ((alpha/255) ** 3)
@@ -59,7 +59,7 @@
 /obj/item/chems/glass/bottle/populate_reagents()
 	SHOULD_CALL_PARENT(TRUE)
 	. = ..()
-	if(reagents?.total_volume > 0 && autolabel && !label_text) // don't override preset labels
+	if(REAGENT_TOTAL_VOLUME(reagents) > 0 && autolabel && !label_text) // don't override preset labels
 		label_text = reagents.get_primary_reagent_name()
 		update_name()
 
@@ -67,46 +67,46 @@
 	desc = "A small bottle. Contains stabilizer - used to stabilize patients."
 
 /obj/item/chems/glass/bottle/stabilizer/populate_reagents()
-	add_to_reagents(/decl/material/liquid/stabilizer, reagents.maximum_volume)
+	add_to_reagents(/decl/material/liquid/stabilizer, REAGENT_MAXIMUM_VOLUME(reagents))
 	. = ..()
 
 /obj/item/chems/glass/bottle/bromide
 	desc = "A small bottle of bromide. Do not drink, it is poisonous."
 
 /obj/item/chems/glass/bottle/bromide/populate_reagents()
-	add_to_reagents(/decl/material/liquid/bromide, reagents.maximum_volume)
+	add_to_reagents(/decl/material/liquid/bromide, REAGENT_MAXIMUM_VOLUME(reagents))
 	. = ..()
 
 /obj/item/chems/glass/bottle/cyanide
 	desc = "A small bottle of cyanide. Bitter almonds?"
 
 /obj/item/chems/glass/bottle/cyanide/populate_reagents()
-	add_to_reagents(/decl/material/liquid/cyanide, reagents.maximum_volume / 2) //volume changed to match chloral
+	add_to_reagents(/decl/material/liquid/cyanide, REAGENT_MAXIMUM_VOLUME(reagents) / 2) //volume changed to match chloral
 	. = ..()
 
 /obj/item/chems/glass/bottle/sedatives
 	desc = "A small bottle of soporific medication. Just the fumes make you sleepy."
 
 /obj/item/chems/glass/bottle/sedatives/populate_reagents()
-	add_to_reagents(/decl/material/liquid/sedatives, reagents.maximum_volume)
+	add_to_reagents(/decl/material/liquid/sedatives, REAGENT_MAXIMUM_VOLUME(reagents))
 	. = ..()
 
 /obj/item/chems/glass/bottle/antitoxin
 	desc = "A small bottle of antitoxins. Counters poisons, and repairs damage. A wonder drug."
 
 /obj/item/chems/glass/bottle/antitoxin/populate_reagents()
-	add_to_reagents(/decl/material/liquid/antitoxins, reagents.maximum_volume)
+	add_to_reagents(/decl/material/liquid/antitoxins, REAGENT_MAXIMUM_VOLUME(reagents))
 	. = ..()
 
 /obj/item/chems/glass/bottle/mutagenics
 	desc = "A small bottle of unstable mutagen. Randomly changes the DNA structure of whoever comes in contact."
 
 /obj/item/chems/glass/bottle/mutagenics/populate_reagents()
-	add_to_reagents(/decl/material/liquid/mutagenics, reagents.maximum_volume)
+	add_to_reagents(/decl/material/liquid/mutagenics, REAGENT_MAXIMUM_VOLUME(reagents))
 	. = ..()
 
 /obj/item/chems/glass/bottle/ammonia/populate_reagents()
-	add_to_reagents(/decl/material/gas/ammonia, reagents.maximum_volume)
+	add_to_reagents(/decl/material/gas/ammonia, REAGENT_MAXIMUM_VOLUME(reagents))
 	. = ..()
 
 /obj/item/chems/glass/bottle/eznutrient
@@ -117,7 +117,7 @@
 	material = /decl/material/solid/organic/plastic
 
 /obj/item/chems/glass/bottle/eznutrient/populate_reagents()
-	add_to_reagents(/decl/material/liquid/fertilizer, reagents.maximum_volume)
+	add_to_reagents(/decl/material/liquid/fertilizer, REAGENT_MAXIMUM_VOLUME(reagents))
 	. = ..()
 
 /obj/item/chems/glass/bottle/left4zed
@@ -128,8 +128,8 @@
 	material = /decl/material/solid/organic/plastic
 
 /obj/item/chems/glass/bottle/left4zed/populate_reagents()
-	var/mutagen_amount = round(reagents.maximum_volume / 6)
-	add_to_reagents(/decl/material/liquid/fertilizer, reagents.maximum_volume - mutagen_amount)
+	var/mutagen_amount = round(REAGENT_MAXIMUM_VOLUME(reagents) / 6)
+	add_to_reagents(/decl/material/liquid/fertilizer, REAGENT_MAXIMUM_VOLUME(reagents) - mutagen_amount)
 	add_to_reagents(/decl/material/liquid/mutagenics, mutagen_amount)
 	. = ..()
 
@@ -141,13 +141,13 @@
 	material = /decl/material/solid/organic/plastic
 
 /obj/item/chems/glass/bottle/robustharvest/populate_reagents()
-	var/amonia_amount = round(reagents.maximum_volume / 6)
-	add_to_reagents(/decl/material/liquid/fertilizer, reagents.maximum_volume - amonia_amount)
+	var/amonia_amount = round(REAGENT_MAXIMUM_VOLUME(reagents) / 6)
+	add_to_reagents(/decl/material/liquid/fertilizer, REAGENT_MAXIMUM_VOLUME(reagents) - amonia_amount)
 	add_to_reagents(/decl/material/gas/ammonia,       amonia_amount)
 	. = ..()
 
 /obj/item/chems/glass/bottle/pacid/populate_reagents()
-	add_to_reagents(/decl/material/liquid/acid/polyacid, reagents.maximum_volume)
+	add_to_reagents(/decl/material/liquid/acid/polyacid, REAGENT_MAXIMUM_VOLUME(reagents))
 	. = ..()
 /obj/item/chems/glass/bottle/adminordrazine
 	desc = "A small bottle. Contains the liquid essence of the gods."
@@ -156,19 +156,19 @@
 	label_color = COLOR_CYAN_BLUE
 
 /obj/item/chems/glass/bottle/adminordrazine/populate_reagents()
-	add_to_reagents(/decl/material/liquid/adminordrazine, reagents.maximum_volume)
+	add_to_reagents(/decl/material/liquid/adminordrazine, REAGENT_MAXIMUM_VOLUME(reagents))
 	. = ..()
 
 /obj/item/chems/glass/bottle/capsaicin
 	desc = "A small bottle. Contains hot sauce."
 
 /obj/item/chems/glass/bottle/capsaicin/populate_reagents()
-	add_to_reagents(/decl/material/liquid/capsaicin, reagents.maximum_volume)
+	add_to_reagents(/decl/material/liquid/capsaicin, REAGENT_MAXIMUM_VOLUME(reagents))
 	. = ..()
 
 /obj/item/chems/glass/bottle/frostoil
 	desc = "A small bottle. Contains cold sauce."
 
 /obj/item/chems/glass/bottle/frostoil/populate_reagents()
-	add_to_reagents(/decl/material/liquid/frostoil, reagents.maximum_volume)
+	add_to_reagents(/decl/material/liquid/frostoil, REAGENT_MAXIMUM_VOLUME(reagents))
 	. = ..()

--- a/code/modules/reagents/reagent_containers/glass/bottle/robot.dm
+++ b/code/modules/reagents/reagent_containers/glass/bottle/robot.dm
@@ -16,7 +16,7 @@
 	desc = "A small bottle. Contains stabilizer - used to stabilize patients."
 
 /obj/item/chems/glass/bottle/robot/stabilizer/populate_reagents()
-	add_to_reagents(/decl/material/liquid/stabilizer, reagents.maximum_volume)
+	add_to_reagents(/decl/material/liquid/stabilizer, REAGENT_MAXIMUM_VOLUME(reagents))
 	. = ..()
 
 /obj/item/chems/glass/bottle/robot/antitoxin
@@ -26,5 +26,5 @@
 	icon_state = "bottle-4"
 
 /obj/item/chems/glass/bottle/robot/antitoxin/populate_reagents()
-	add_to_reagents(/decl/material/liquid/antitoxins, reagents.maximum_volume)
+	add_to_reagents(/decl/material/liquid/antitoxins, REAGENT_MAXIMUM_VOLUME(reagents))
 	. = ..()

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -38,7 +38,7 @@
 
 /obj/item/chems/hypospray/use_on_mob(mob/living/target, mob/living/user, animate = TRUE)
 
-	if(!reagents?.total_volume)
+	if(!REAGENT_TOTAL_VOLUME(reagents))
 		to_chat(user, SPAN_WARNING("\The [src] is empty."))
 		return TRUE
 
@@ -62,7 +62,7 @@
 		if(!user.do_skilled(time, SKILL_MEDICAL, target))
 			return TRUE
 
-	if(single_use && reagents.total_volume <= 0) // currently only applies to autoinjectors
+	if(single_use && REAGENT_TOTAL_VOLUME(reagents) <= 0) // currently only applies to autoinjectors
 		atom_flags &= ~ATOM_FLAG_OPEN_CONTAINER // Prevents autoinjectors to be refilled.
 
 	to_chat(user, SPAN_NOTICE("You inject [target] with [src]."))
@@ -71,10 +71,10 @@
 	user.visible_message(SPAN_WARNING("[user] injects [target] with [src]."))
 
 	if(target.reagents)
-		var/contained = REAGENT_LIST(src)
+		var/contained = REAGENT_LIST(reagents)
 		var/trans = reagents.trans_to_mob(target, amount_per_transfer_from_this, CHEM_INJECT)
 		admin_inject_log(user, target, src, contained, trans)
-		to_chat(user, SPAN_NOTICE("[trans] unit\s injected. [reagents.total_volume] unit\s remaining in \the [src]."))
+		to_chat(user, SPAN_NOTICE("[trans] unit\s injected. [REAGENT_TOTAL_VOLUME(reagents)] unit\s remaining in \the [src]."))
 
 	return TRUE
 
@@ -115,8 +115,8 @@
 		V.update_icon()
 
 	loaded_vial = V
-	create_or_update_reagents(loaded_vial.reagents.maximum_volume, override_volume = TRUE)
-	loaded_vial.reagents.trans_to_holder(reagents, reagents.maximum_volume)
+	create_or_update_reagents(REAGENT_MAXIMUM_VOLUME(loaded_vial.reagents), override_volume = TRUE)
+	loaded_vial.reagents.trans_to_holder(reagents, REAGENT_MAXIMUM_VOLUME(reagents))
 
 	if(user)
 		user.visible_message(SPAN_NOTICE("[user] has loaded [V] into \the [src]."), SPAN_NOTICE("[usermessage]"))
@@ -126,10 +126,10 @@
 	return TRUE
 
 /obj/item/chems/hypospray/vial/proc/remove_vial(var/mob/user, var/swap_mode, var/should_update_icon = TRUE)
-	if(!loaded_vial)
+	if(!loaded_vial || !istype(reagents))
 		return
-	reagents.trans_to_holder(loaded_vial.reagents, reagents.maximum_volume)
-	reagents.maximum_volume = 0
+	reagents.trans_to_holder(loaded_vial.reagents, REAGENT_MAXIMUM_VOLUME(reagents))
+	REAGENT_SET_MAX_VOL(reagents, 0)
 	loaded_vial.update_icon()
 	if(user)
 		user.put_in_hands(loaded_vial)
@@ -190,8 +190,8 @@
 /obj/item/chems/hypospray/autoinjector/populate_reagents()
 	SHOULD_CALL_PARENT(TRUE)
 	. = ..()
-	if(reagents?.total_volume > 0 && autolabel && !label_text) // don't override preset labels
-		label_text = "[reagents.get_primary_reagent_name()], [reagents.total_volume]u"
+	if(REAGENT_TOTAL_VOLUME(reagents) > 0 && autolabel && !label_text) // don't override preset labels
+		label_text = "[reagents.get_primary_reagent_name()], [REAGENT_TOTAL_VOLUME(reagents)]u"
 
 /obj/item/chems/hypospray/autoinjector/use_on_mob(mob/living/target, mob/living/user, animate = TRUE)
 	. = ..()
@@ -200,12 +200,12 @@
 
 /obj/item/chems/hypospray/autoinjector/on_update_icon()
 	. = ..()
-	if(reagents?.total_volume <= 0)
+	if(REAGENT_TOTAL_VOLUME(reagents) <= 0)
 		icon_state = "[icon_state]_used"
 
 /obj/item/chems/hypospray/autoinjector/get_examine_strings(mob/user, distance, infix, suffix)
 	. = ..(user)
-	if(reagents?.total_volume)
+	if(REAGENT_TOTAL_VOLUME(reagents))
 		. += SPAN_NOTICE("It is currently loaded.")
 	else
 		. += SPAN_NOTICE("It is spent.")
@@ -214,14 +214,14 @@
 // Autoinjector - Stabilizer
 ////////////////////////////////////////////////////////////////////////////////
 /obj/item/chems/hypospray/autoinjector/stabilizer/populate_reagents()
-	add_to_reagents(/decl/material/liquid/stabilizer, reagents.maximum_volume)
+	add_to_reagents(/decl/material/liquid/stabilizer, REAGENT_MAXIMUM_VOLUME(reagents))
 	. = ..()
 
 ////////////////////////////////////////////////////////////////////////////////
 // Autoinjector - Adrenaline
 ////////////////////////////////////////////////////////////////////////////////
 /obj/item/chems/hypospray/autoinjector/adrenaline/populate_reagents()
-	add_to_reagents(/decl/material/liquid/adrenaline, reagents.maximum_volume)
+	add_to_reagents(/decl/material/liquid/adrenaline, REAGENT_MAXIMUM_VOLUME(reagents))
 	. = ..()
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -231,7 +231,7 @@
 	detail_color = COLOR_GREEN
 
 /obj/item/chems/hypospray/autoinjector/detox/populate_reagents()
-	add_to_reagents(/decl/material/liquid/antitoxins, reagents.maximum_volume)
+	add_to_reagents(/decl/material/liquid/antitoxins, REAGENT_MAXIMUM_VOLUME(reagents))
 	. = ..()
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -241,7 +241,7 @@
 	detail_color = COLOR_PURPLE
 
 /obj/item/chems/hypospray/autoinjector/pain/populate_reagents()
-	add_to_reagents(/decl/material/liquid/painkillers, reagents.maximum_volume)
+	add_to_reagents(/decl/material/liquid/painkillers, REAGENT_MAXIMUM_VOLUME(reagents))
 	. = ..()
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -251,7 +251,7 @@
 	detail_color = COLOR_AMBER
 
 /obj/item/chems/hypospray/autoinjector/antirad/populate_reagents()
-	add_to_reagents(/decl/material/liquid/antirads, reagents.maximum_volume)
+	add_to_reagents(/decl/material/liquid/antirads, REAGENT_MAXIMUM_VOLUME(reagents))
 	. = ..()
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -261,7 +261,7 @@
 	detail_color = COLOR_DARK_GRAY
 
 /obj/item/chems/hypospray/autoinjector/hallucinogenics/populate_reagents()
-	add_to_reagents(/decl/material/liquid/hallucinogenics, reagents.maximum_volume)
+	add_to_reagents(/decl/material/liquid/hallucinogenics, REAGENT_MAXIMUM_VOLUME(reagents))
 	. = ..()
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -274,9 +274,9 @@
 
 /obj/item/chems/hypospray/autoinjector/clotting/populate_reagents()
 	. = ..()
-	var/amt = round(reagents.maximum_volume*0.5)
+	var/amt = round(REAGENT_MAXIMUM_VOLUME(reagents)*0.5)
 	add_to_reagents(/decl/material/liquid/stabilizer, amt)
-	add_to_reagents(/decl/material/liquid/clotting_agent, (reagents.maximum_volume - amt))
+	add_to_reagents(/decl/material/liquid/clotting_agent, (REAGENT_MAXIMUM_VOLUME(reagents) - amt))
 
 ////////////////////////////////////////////////////////////////////////////////
 // Autoinjector - Empty

--- a/code/modules/reagents/reagent_containers/inhaler.dm
+++ b/code/modules/reagents/reagent_containers/inhaler.dm
@@ -28,7 +28,7 @@
 	. = ..()
 	for(var/T in starts_with)
 		add_to_reagents(T, starts_with[T])
-	if(ATOM_IS_OPEN_CONTAINER(src) && reagents.total_volume > 0)
+	if(ATOM_IS_OPEN_CONTAINER(src) && REAGENT_TOTAL_VOLUME(reagents) > 0)
 		atom_flags &= ~ATOM_FLAG_OPEN_CONTAINER
 	update_icon()
 
@@ -37,7 +37,7 @@
 	. = ..()
 	if(ATOM_IS_OPEN_CONTAINER(src))
 		add_overlay("[icon_state]_loaded")
-	if(reagents?.total_volume > 0)
+	if(REAGENT_TOTAL_VOLUME(reagents) > 0)
 		add_overlay("[icon_state]_reagents")
 
 /obj/item/chems/inhaler/use_on_mob(mob/living/target, mob/living/user, animate = TRUE)
@@ -49,7 +49,7 @@
 		to_chat(user, SPAN_NOTICE("You must secure the reagents inside \the [src] before using it!"))
 		return FALSE
 
-	if(!reagents.total_volume)
+	if(!REAGENT_TOTAL_VOLUME(reagents))
 		to_chat(user, SPAN_WARNING("\The [src] is empty."))
 		return TRUE
 
@@ -78,12 +78,12 @@
 			SPAN_NOTICE("You stick \the [src] in \the [target]'s mouth and press the injection button.")
 		)
 
-	var/contained = REAGENT_LIST(src)
+	var/contained = REAGENT_LIST(reagents)
 	var/trans = reagents.trans_to_mob(target, amount_per_transfer_from_this, CHEM_INHALE)
 	if(trans)
 		admin_inject_log(user, target, src, contained, trans)
 		playsound(src.loc, 'sound/effects/hypospray.ogg', 50, 1)
-		to_chat(user, SPAN_NOTICE("[trans] units administered. [reagents.total_volume] units remaining in \the [src]."))
+		to_chat(user, SPAN_NOTICE("[trans] units administered. [REAGENT_TOTAL_VOLUME(reagents)] units remaining in \the [src]."))
 		used = TRUE
 
 	update_icon()
@@ -91,7 +91,7 @@
 
 /obj/item/chems/inhaler/attack_self(mob/user)
 	if(ATOM_IS_OPEN_CONTAINER(src))
-		if(reagents.total_volume > 0)
+		if(REAGENT_TOTAL_VOLUME(reagents) > 0)
 			to_chat(user, SPAN_NOTICE("With a quick twist of \the [src]'s lid, you secure the reagents inside."))
 			atom_flags &= ~ATOM_FLAG_OPEN_CONTAINER
 			update_icon()
@@ -112,7 +112,7 @@
 /obj/item/chems/inhaler/get_examine_strings(mob/user, distance, infix, suffix)
 	. = ..(user)
 	if(distance <= 1)
-		if(reagents.total_volume > 0)
+		if(REAGENT_TOTAL_VOLUME(reagents) > 0)
 			. += SPAN_NOTICE("It is currently loaded.")
 		else
 			. += SPAN_WARNING("It is spent.")

--- a/code/modules/reagents/reagent_containers/mortar.dm
+++ b/code/modules/reagents/reagent_containers/mortar.dm
@@ -37,11 +37,11 @@
 	if(attacking_material.hardness <= crushing_material.hardness)
 		to_chat(user, SPAN_NOTICE("\The [used_item] is not hard enough to crush \the [crushing_item]."))
 		return TRUE
-	if(REAGENTS_FREE_SPACE(reagents) < crushing_item.reagents.total_volume)
+	if(REAGENTS_FREE_SPACE(reagents) < REAGENT_TOTAL_VOLUME(crushing_item.reagents))
 		to_chat(user, SPAN_WARNING("\The [src] is too full to grind \the [crushing_item], it'd spill everywhere!"))
 		return TRUE
-	if(crushing_item.reagents?.total_volume) // if it has no reagents, skip all the fluff and destroy it instantly
-		var/stamina_to_consume = max(crushing_item.reagents.total_volume * (1 + user.get_stamina_skill_mod()/2), 5)
+	if(REAGENT_TOTAL_VOLUME(crushing_item.reagents)) // if it has no reagents, skip all the fluff and destroy it instantly
+		var/stamina_to_consume = max(REAGENT_TOTAL_VOLUME(crushing_item.reagents) * (1 + user.get_stamina_skill_mod()/2), 5)
 		if(stamina_to_consume > 100) // TODO: add user.get_max_stamina()?
 			to_chat(user, SPAN_WARNING("\The [crushing_item] is too large for you to grind in \the [src]!"))
 			return TRUE
@@ -58,7 +58,7 @@
 		if(QDELETED(crushing_item))
 			return TRUE // already been ground!
 		user.adjust_stamina(-stamina_to_consume)
-		crushing_item.reagents.trans_to(src, crushing_item.reagents.total_volume, skill_factor)
+		crushing_item.reagents.trans_to(src, REAGENT_TOTAL_VOLUME(crushing_item.reagents), skill_factor)
 		to_chat(user, SPAN_NOTICE("You finish grinding \the [crushing_item] with \the [used_item]."))
 	QDEL_NULL(crushing_item)
 	// If there's more to crush, try looping

--- a/code/modules/reagents/reagent_containers/packets.dm
+++ b/code/modules/reagents/reagent_containers/packets.dm
@@ -29,7 +29,7 @@
 	icon = 'icons/obj/food/condiments/packets/packet_white.dmi'
 
 /obj/item/chems/packet/salt/populate_reagents()
-	add_to_reagents(/decl/material/solid/sodiumchloride, reagents.maximum_volume/2)
+	add_to_reagents(/decl/material/solid/sodiumchloride, REAGENT_MAXIMUM_VOLUME(reagents)/2)
 
 /obj/item/chems/packet/pepper
 	name = "pepper packet"
@@ -37,7 +37,7 @@
 	icon = 'icons/obj/food/condiments/packets/packet_black.dmi'
 
 /obj/item/chems/packet/pepper/populate_reagents()
-	add_to_reagents(/decl/material/solid/blackpepper, reagents.maximum_volume/2)
+	add_to_reagents(/decl/material/solid/blackpepper, REAGENT_MAXIMUM_VOLUME(reagents)/2)
 
 /obj/item/chems/packet/sugar
 	name = "sugar packet"
@@ -45,7 +45,7 @@
 	icon = 'icons/obj/food/condiments/packets/packet_white.dmi'
 
 /obj/item/chems/packet/sugar/populate_reagents()
-	add_to_reagents(/decl/material/liquid/nutriment/sugar, reagents.maximum_volume/2)
+	add_to_reagents(/decl/material/liquid/nutriment/sugar, REAGENT_MAXIMUM_VOLUME(reagents)/2)
 
 /obj/item/chems/packet/jelly
 	name = "jelly packet"
@@ -53,7 +53,7 @@
 	icon = 'icons/obj/food/condiments/packets/packet_medium.dmi'
 
 /obj/item/chems/packet/jelly/populate_reagents()
-	add_to_reagents(/decl/material/liquid/nutriment/cherryjelly, reagents.maximum_volume)
+	add_to_reagents(/decl/material/liquid/nutriment/cherryjelly, REAGENT_MAXIMUM_VOLUME(reagents))
 
 /obj/item/chems/packet/honey
 	name = "honey packet"
@@ -61,7 +61,7 @@
 	icon = 'icons/obj/food/condiments/packets/packet_medium.dmi'
 
 /obj/item/chems/packet/honey/populate_reagents()
-	add_to_reagents(/decl/material/liquid/nutriment/honey, reagents.maximum_volume)
+	add_to_reagents(/decl/material/liquid/nutriment/honey, REAGENT_MAXIMUM_VOLUME(reagents))
 
 /obj/item/chems/packet/honey_fake
 	name = "'honey' packet"
@@ -69,7 +69,7 @@
 	icon = 'icons/obj/food/condiments/packets/packet_medium.dmi'
 
 /obj/item/chems/packet/honey_fake/populate_reagents()
-	add_to_reagents(/decl/material/liquid/nutriment/sugar, reagents.maximum_volume)
+	add_to_reagents(/decl/material/liquid/nutriment/sugar, REAGENT_MAXIMUM_VOLUME(reagents))
 
 /obj/item/chems/packet/capsaicin
 	name = "hot sauce packet"
@@ -77,7 +77,7 @@
 	icon = 'icons/obj/food/condiments/packets/packet_red.dmi'
 
 /obj/item/chems/packet/capsaicin/populate_reagents()
-	add_to_reagents(/decl/material/liquid/capsaicin, reagents.maximum_volume/2)
+	add_to_reagents(/decl/material/liquid/capsaicin, REAGENT_MAXIMUM_VOLUME(reagents)/2)
 
 /obj/item/chems/packet/ketchup
 	name = "ketchup packet"
@@ -85,7 +85,7 @@
 	icon = 'icons/obj/food/condiments/packets/packet_red.dmi'
 
 /obj/item/chems/packet/ketchup/populate_reagents()
-	add_to_reagents(/decl/material/liquid/nutriment/ketchup, reagents.maximum_volume/2)
+	add_to_reagents(/decl/material/liquid/nutriment/ketchup, REAGENT_MAXIMUM_VOLUME(reagents)/2)
 
 /obj/item/chems/packet/mayo
 	name = "mayonnaise packet"
@@ -93,7 +93,7 @@
 	icon = 'icons/obj/food/condiments/packets/packet_white.dmi'
 
 /obj/item/chems/packet/mayo/populate_reagents()
-	add_to_reagents(/decl/material/liquid/nutriment/mayo, reagents.maximum_volume/2)
+	add_to_reagents(/decl/material/liquid/nutriment/mayo, REAGENT_MAXIMUM_VOLUME(reagents)/2)
 
 /obj/item/chems/packet/soy
 	name = "soy sauce packet"
@@ -101,56 +101,56 @@
 	icon = 'icons/obj/food/condiments/packets/packet_black.dmi'
 
 /obj/item/chems/packet/soy/populate_reagents()
-	add_to_reagents(/decl/material/liquid/nutriment/soysauce, reagents.maximum_volume/2)
+	add_to_reagents(/decl/material/liquid/nutriment/soysauce, REAGENT_MAXIMUM_VOLUME(reagents)/2)
 
 /obj/item/chems/packet/coffee
 	name = "instant coffee powder packet"
 	desc = "Contains 5u of instant coffee powder. Mix with 25u of water."
 
 /obj/item/chems/packet/coffee/populate_reagents()
-	add_to_reagents(/decl/material/liquid/nutriment/coffee/instant, reagents.maximum_volume/2)
+	add_to_reagents(/decl/material/liquid/nutriment/coffee/instant, REAGENT_MAXIMUM_VOLUME(reagents)/2)
 
 /obj/item/chems/packet/tea
 	name = "instant tea powder packet"
 	desc = "Contains 5u of instant black tea powder. Mix with 25u of water."
 
 /obj/item/chems/packet/tea/populate_reagents()
-	add_to_reagents(/decl/material/liquid/nutriment/tea/instant, reagents.maximum_volume/2)
+	add_to_reagents(/decl/material/liquid/nutriment/tea/instant, REAGENT_MAXIMUM_VOLUME(reagents)/2)
 
 /obj/item/chems/packet/cocoa
 	name = "cocoa powder packet"
 	desc = "Contains 5u of cocoa powder. Mix with 25u of water and heat."
 
 /obj/item/chems/packet/cocoa/populate_reagents()
-	add_to_reagents(/decl/material/liquid/nutriment/coco, reagents.maximum_volume/2)
+	add_to_reagents(/decl/material/liquid/nutriment/coco, REAGENT_MAXIMUM_VOLUME(reagents)/2)
 
 /obj/item/chems/packet/grape
 	name = "grape juice powder packet"
 	desc = "Contains 5u of powdered grape juice. Mix with 15u of water."
 
 /obj/item/chems/packet/grape/populate_reagents()
-	add_to_reagents(/decl/material/liquid/nutriment/instantjuice/grape, reagents.maximum_volume/2)
+	add_to_reagents(/decl/material/liquid/nutriment/instantjuice/grape, REAGENT_MAXIMUM_VOLUME(reagents)/2)
 
 /obj/item/chems/packet/orange
 	name = "orange juice powder packet"
 	desc = "Contains 5u of powdered orange juice. Mix with 15u of water."
 
 /obj/item/chems/packet/orange/populate_reagents()
-	add_to_reagents(/decl/material/liquid/nutriment/instantjuice/orange, reagents.maximum_volume/2)
+	add_to_reagents(/decl/material/liquid/nutriment/instantjuice/orange, REAGENT_MAXIMUM_VOLUME(reagents)/2)
 
 /obj/item/chems/packet/watermelon
 	name = "watermelon juice powder packet"
 	desc = "Contains 5u of powdered watermelon juice. Mix with 15u of water."
 
 /obj/item/chems/packet/watermelon/populate_reagents()
-	add_to_reagents(/decl/material/liquid/nutriment/instantjuice/watermelon, reagents.maximum_volume/2)
+	add_to_reagents(/decl/material/liquid/nutriment/instantjuice/watermelon, REAGENT_MAXIMUM_VOLUME(reagents)/2)
 
 /obj/item/chems/packet/apple
 	name = "apple juice powder packet"
 	desc = "Contains 5u of powdered apple juice. Mix with 15u of water."
 
 /obj/item/chems/packet/apple/populate_reagents()
-	add_to_reagents(/decl/material/liquid/nutriment/instantjuice/apple, reagents.maximum_volume/2)
+	add_to_reagents(/decl/material/liquid/nutriment/instantjuice/apple, REAGENT_MAXIMUM_VOLUME(reagents)/2)
 
 /obj/item/chems/packet/protein
 	name = "protein powder packet"
@@ -158,35 +158,35 @@
 	icon = 'icons/obj/food/condiments/packets/packet_medium.dmi'
 
 /obj/item/chems/packet/protein/populate_reagents()
-	add_to_reagents(/decl/material/solid/organic/meat, reagents.maximum_volume/2)
+	add_to_reagents(/decl/material/solid/organic/meat, REAGENT_MAXIMUM_VOLUME(reagents)/2)
 
 /obj/item/chems/packet/crayon
 	name = "crayon powder packet"
 	desc = "Contains 10u of powdered crayon. Mix with 30u of water."
 
 /obj/item/chems/packet/crayon/populate_reagents()
-	add_to_reagents(/decl/material/liquid/pigment, reagents.maximum_volume)
+	add_to_reagents(/decl/material/liquid/pigment, REAGENT_MAXIMUM_VOLUME(reagents))
 
 /obj/item/chems/packet/crayon/red/populate_reagents()
-	add_to_reagents(/decl/material/liquid/pigment/red, reagents.maximum_volume)
+	add_to_reagents(/decl/material/liquid/pigment/red, REAGENT_MAXIMUM_VOLUME(reagents))
 
 /obj/item/chems/packet/crayon/orange/populate_reagents()
-	add_to_reagents(/decl/material/liquid/pigment/orange, reagents.maximum_volume)
+	add_to_reagents(/decl/material/liquid/pigment/orange, REAGENT_MAXIMUM_VOLUME(reagents))
 
 /obj/item/chems/packet/crayon/yellow/populate_reagents()
-	add_to_reagents(/decl/material/liquid/pigment/yellow, reagents.maximum_volume)
+	add_to_reagents(/decl/material/liquid/pigment/yellow, REAGENT_MAXIMUM_VOLUME(reagents))
 
 /obj/item/chems/packet/crayon/green/populate_reagents()
-	add_to_reagents(/decl/material/liquid/pigment/green, reagents.maximum_volume)
+	add_to_reagents(/decl/material/liquid/pigment/green, REAGENT_MAXIMUM_VOLUME(reagents))
 
 /obj/item/chems/packet/crayon/blue/populate_reagents()
-	add_to_reagents(/decl/material/liquid/pigment/blue, reagents.maximum_volume)
+	add_to_reagents(/decl/material/liquid/pigment/blue, REAGENT_MAXIMUM_VOLUME(reagents))
 
 /obj/item/chems/packet/crayon/purple/populate_reagents()
-	add_to_reagents(/decl/material/liquid/pigment/purple, reagents.maximum_volume)
+	add_to_reagents(/decl/material/liquid/pigment/purple, REAGENT_MAXIMUM_VOLUME(reagents))
 
 /obj/item/chems/packet/crayon/grey/populate_reagents()
-	add_to_reagents(/decl/material/liquid/pigment/grey, reagents.maximum_volume)
+	add_to_reagents(/decl/material/liquid/pigment/grey, REAGENT_MAXIMUM_VOLUME(reagents))
 
 /obj/item/chems/packet/crayon/brown/populate_reagents()
-	add_to_reagents(/decl/material/liquid/pigment/brown, reagents.maximum_volume)
+	add_to_reagents(/decl/material/liquid/pigment/brown, REAGENT_MAXIMUM_VOLUME(reagents))

--- a/code/modules/reagents/reagent_containers/pill.dm
+++ b/code/modules/reagents/reagent_containers/pill.dm
@@ -36,8 +36,8 @@
 /obj/item/chems/pill/populate_reagents()
 	SHOULD_CALL_PARENT(TRUE)
 	. = ..()
-	if(reagents?.total_volume > 0 && autolabel && !label_text) // don't override preset labels
-		label_text = "[reagents.get_primary_reagent_name()], [reagents.total_volume]u"
+	if(REAGENT_TOTAL_VOLUME(reagents) > 0 && autolabel && !label_text) // don't override preset labels
+		label_text = "[reagents.get_primary_reagent_name()], [REAGENT_TOTAL_VOLUME(reagents)]u"
 
 /obj/item/chems/pill/on_update_icon()
 	. = ..()
@@ -55,13 +55,13 @@
 
 /obj/item/chems/pill/afterattack(obj/target, mob/user, proximity)
 	if(proximity && ATOM_IS_OPEN_CONTAINER(target) && target.reagents)
-		if(!target.reagents.total_volume)
+		if(!REAGENT_TOTAL_VOLUME(target.reagents))
 			to_chat(user, SPAN_WARNING("\The [target] is empty. You can't dissolve \the [src] in it."))
 			return
 		to_chat(user, SPAN_NOTICE("You dissolve \the [src] in \the [target]."))
 		user.visible_message(SPAN_NOTICE("\The [user] puts something in \the [target]."), range = 2)
-		admin_attacker_log(user, "spiked \a [target] with a pill. Reagents: [REAGENT_LIST(src)]")
-		reagents.trans_to(target, reagents.total_volume)
+		admin_attacker_log(user, "spiked \a [target] with a pill. Reagents: [REAGENT_LIST(reagents)]")
+		reagents.trans_to(target, REAGENT_TOTAL_VOLUME(reagents))
 		qdel(src)
 		return
 	return ..()
@@ -77,7 +77,7 @@
 	chem_volume = 50
 
 /obj/item/chems/pill/bromide/populate_reagents()
-	add_to_reagents(/decl/material/liquid/bromide, reagents.maximum_volume)
+	add_to_reagents(/decl/material/liquid/bromide, REAGENT_MAXIMUM_VOLUME(reagents))
 	. = ..()
 
 /obj/item/chems/pill/cyanide
@@ -88,7 +88,7 @@
 	autolabel = FALSE
 
 /obj/item/chems/pill/cyanide/populate_reagents()
-	add_to_reagents(/decl/material/liquid/cyanide, reagents.maximum_volume)
+	add_to_reagents(/decl/material/liquid/cyanide, REAGENT_MAXIMUM_VOLUME(reagents))
 	. = ..()
 
 /obj/item/chems/pill/adminordrazine

--- a/code/modules/reagents/reagent_containers/pill_edibility.dm
+++ b/code/modules/reagents/reagent_containers/pill_edibility.dm
@@ -2,10 +2,10 @@
 	return EATING_METHOD_EAT
 
 /obj/item/chems/pill/get_edible_material_amount(var/mob/eater)
-	return reagents?.total_volume
+	return REAGENT_TOTAL_VOLUME(reagents)
 
 /obj/item/chems/pill/get_food_default_transfer_amount(mob/eater)
-	return reagents?.total_volume // Always eat it in one bite.
+	return REAGENT_TOTAL_VOLUME(reagents) // Always eat it in one bite.
 
 /obj/item/chems/pill/show_feed_message_start(mob/user, mob/target, consumption_method = EATING_METHOD_EAT)
 	target = target || user

--- a/code/modules/reagents/reagent_containers/retort.dm
+++ b/code/modules/reagents/reagent_containers/retort.dm
@@ -18,10 +18,10 @@
 	material   = /decl/material/solid/stone/pottery
 
 /obj/item/chems/glass/retort/update_overlays()
-	if(reagents?.total_volume && (!material || material.opacity < 1))
+	if(REAGENT_TOTAL_VOLUME(reagents) && (!material || material.opacity < 1))
 		var/datum/gas_mixture/environment = loc?.return_air()
 		var/ambient_pressure = environment ? environment.return_pressure() : ONE_ATMOSPHERE
-		for(var/decl/material/reagent as anything in reagents.reagent_volumes)
+		for(var/decl/material/reagent as anything in REAGENT_VOLUMES(reagents))
 			if(reagent.phase_at_temperature(temperature, ambient_pressure) == MAT_PHASE_GAS)
 				add_overlay(overlay_image(icon, "[icon_state]-fill-boil", reagents.get_color(), (RESET_ALPHA|RESET_COLOR)))
 				return

--- a/code/modules/reagents/reagent_containers/spray.dm
+++ b/code/modules/reagents/reagent_containers/spray.dm
@@ -40,7 +40,7 @@
 		if(standard_dispenser_refill(user, A))
 			return
 
-	if(reagents.total_volume < amount_per_transfer_from_this)
+	if(REAGENT_TOTAL_VOLUME(reagents) < amount_per_transfer_from_this)
 		to_chat(user, SPAN_WARNING("\The [src] is empty!"))
 		return
 
@@ -101,7 +101,7 @@
 /obj/item/chems/spray/get_examine_strings(mob/user, distance, infix, suffix)
 	. = ..()
 	if(loc == user)
-		. += "[round(reagents.total_volume)] unit\s left."
+		. += "[round(REAGENT_TOTAL_VOLUME(reagents))] unit\s left."
 	if(has_safety() && distance <= 1)
 		. += "The safety is [safety ? "on" : "off"]."
 
@@ -137,21 +137,21 @@
 	particle_move_delay = 6
 
 /obj/item/chems/spray/cleaner/populate_reagents()
-	add_to_reagents(/decl/material/liquid/cleaner, reagents.maximum_volume)
+	add_to_reagents(/decl/material/liquid/cleaner, REAGENT_MAXIMUM_VOLUME(reagents))
 
 /obj/item/chems/spray/antiseptic
 	name = "antiseptic spray"
 	desc = "Great for hiding incriminating bloodstains and sterilizing scalpels."
 
 /obj/item/chems/spray/antiseptic/populate_reagents()
-	add_to_reagents(/decl/material/liquid/antiseptic, reagents.maximum_volume)
+	add_to_reagents(/decl/material/liquid/antiseptic, REAGENT_MAXIMUM_VOLUME(reagents))
 
 /obj/item/chems/spray/hair_remover
 	name = "hair remover"
 	desc = "Very effective at removing hair, feathers, spines and horns."
 
 /obj/item/chems/spray/hair_remover/populate_reagents()
-	add_to_reagents(/decl/material/liquid/hair_remover, reagents.maximum_volume)
+	add_to_reagents(/decl/material/liquid/hair_remover, REAGENT_MAXIMUM_VOLUME(reagents))
 
 /obj/item/chems/spray/pepper
 	name = "pepperspray"
@@ -164,7 +164,7 @@
 	safety = TRUE
 
 /obj/item/chems/spray/pepper/populate_reagents()
-	add_to_reagents(/decl/material/liquid/capsaicin/condensed, reagents.maximum_volume)
+	add_to_reagents(/decl/material/liquid/capsaicin/condensed, REAGENT_MAXIMUM_VOLUME(reagents))
 
 /obj/item/chems/spray/pepper/has_safety()
 	return TRUE
@@ -180,7 +180,7 @@
 	chem_volume = 10
 
 /obj/item/chems/spray/waterflower/populate_reagents()
-	add_to_reagents(/decl/material/liquid/water, reagents.maximum_volume)
+	add_to_reagents(/decl/material/liquid/water, REAGENT_MAXIMUM_VOLUME(reagents))
 
 /obj/item/chems/spray/chemsprayer
 	name = "chem sprayer"
@@ -204,7 +204,7 @@
 	var/list/the_targets = list(T, T1, T2)
 
 	for(var/a = 1 to 3)
-		if(reagents.total_volume < 1)
+		if(REAGENT_TOTAL_VOLUME(reagents) < 1)
 			break
 		create_chempuff(the_targets[a], rand(6, 8))
 	return
@@ -218,7 +218,7 @@
 	chem_volume = 100
 
 /obj/item/chems/spray/plantbgone/populate_reagents()
-	add_to_reagents(/decl/material/liquid/weedkiller, reagents.maximum_volume)
+	add_to_reagents(/decl/material/liquid/weedkiller, REAGENT_MAXIMUM_VOLUME(reagents))
 
 /obj/item/chems/spray/cleaner/deodorant
 	name = "deodorant"

--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -33,7 +33,7 @@
 /obj/item/chems/syringe/populate_reagents()
 	SHOULD_CALL_PARENT(TRUE)
 	. = ..()
-	if(reagents.total_volume > 0 && autolabel && !label_text) // don't override preset labels
+	if(REAGENT_TOTAL_VOLUME(reagents) > 0 && autolabel && !label_text) // don't override preset labels
 		label_text = reagents.get_primary_reagent_name()
 		update_name()
 
@@ -99,12 +99,12 @@
 		icon_state = "[icon_state]_broken"
 		return
 	var/rounded_vol = 0
-	if (reagents?.total_volume > 0)
-		rounded_vol = clamp(round((reagents.total_volume / max(1, reagents.maximum_volume * 15)),5), 5, 15)
+	if (REAGENT_TOTAL_VOLUME(reagents) > 0)
+		rounded_vol = clamp(round((REAGENT_TOTAL_VOLUME(reagents) / max(1, REAGENT_MAXIMUM_VOLUME(reagents) * 15)),5), 5, 15)
 	if(ismob(loc))
 		add_overlay((mode == SYRINGE_DRAW)? "[icon_state]_draw" : "[icon_state]_inject")
 	icon_state = "[icon_state]_[rounded_vol]"
-	if(reagents?.total_volume)
+	if(REAGENT_TOTAL_VOLUME(reagents))
 		var/image/filling = image(icon, "[icon_state]_underlay")
 		filling.color = reagents.get_color()
 		filling.appearance_flags |= RESET_COLOR
@@ -125,13 +125,13 @@
 		return
 
 	if(ismob(target))//Blood!
-		if(reagents.total_volume)
+		if(REAGENT_TOTAL_VOLUME(reagents))
 			to_chat(user, SPAN_NOTICE("There is already a blood sample in this syringe."))
 			return
 		if(ishuman(target))
 			var/amount = REAGENTS_FREE_SPACE(reagents)
 			var/mob/living/human/T = target
-			if(!T.vessel?.total_volume)
+			if(!REAGENT_TOTAL_VOLUME(T.vessel))
 				to_chat(user, SPAN_WARNING("You are unable to locate any blood."))
 				return
 
@@ -168,7 +168,7 @@
 			user.visible_message(SPAN_NOTICE("\The [user] takes a blood sample from \the [target]."))
 
 	else //if not mob
-		if(!target.reagents.total_volume)
+		if(!REAGENT_TOTAL_VOLUME(target.reagents))
 			to_chat(user, SPAN_NOTICE("[target] is empty."))
 			return
 
@@ -190,7 +190,7 @@
 		syringestab(target, user)
 		return
 
-	if(!reagents.total_volume)
+	if(!REAGENT_TOTAL_VOLUME(reagents))
 		to_chat(user, SPAN_NOTICE("The syringe is empty."))
 		mode = SYRINGE_DRAW
 		return
@@ -211,8 +211,8 @@
 		return
 
 	var/trans = reagents.trans_to(target, amount_per_transfer_from_this)
-	to_chat(user, SPAN_NOTICE("You inject \the [target] with [trans] units of the solution. \The [src] now contains [src.reagents.total_volume] units."))
-	if(reagents.total_volume <= 0 && mode == SYRINGE_INJECT)
+	to_chat(user, SPAN_NOTICE("You inject \the [target] with [trans] units of the solution. \The [src] now contains [REAGENT_TOTAL_VOLUME(src.reagents)] units."))
+	if(REAGENT_TOTAL_VOLUME(reagents) <= 0 && mode == SYRINGE_INJECT)
 		mode = SYRINGE_DRAW
 		update_icon()
 
@@ -257,11 +257,11 @@
 	var/trans = reagents.trans_to_mob(target, amount_per_transfer_from_this, CHEM_INJECT)
 
 	if(target != user)
-		user.visible_message(SPAN_WARNING("\the [user] injects \the [target] with [visible_name]!"), SPAN_NOTICE("You inject \the [target] with [trans] units of the solution. \The [src] now contains [src.reagents.total_volume] units."))
+		user.visible_message(SPAN_WARNING("\the [user] injects \the [target] with [visible_name]!"), SPAN_NOTICE("You inject \the [target] with [trans] units of the solution. \The [src] now contains [REAGENT_TOTAL_VOLUME(src.reagents)] units."))
 	else
-		to_chat(user, SPAN_NOTICE("You inject yourself with [trans] units of the solution. \The [src] now contains [src.reagents.total_volume] units."))
+		to_chat(user, SPAN_NOTICE("You inject yourself with [trans] units of the solution. \The [src] now contains [REAGENT_TOTAL_VOLUME(src.reagents)] units."))
 
-	if(reagents.total_volume <= 0 && mode == SYRINGE_INJECT)
+	if(REAGENT_TOTAL_VOLUME(reagents) <= 0 && mode == SYRINGE_INJECT)
 		mode = SYRINGE_DRAW
 		update_icon()
 
@@ -297,7 +297,7 @@
 		user.visible_message(SPAN_DANGER("[user] stabs [target] with [src.name]!"))
 		target.apply_damage(3, BRUTE)
 
-	var/syringestab_amount_transferred = rand(0, (reagents.total_volume - 5)) //nerfed by popular demand
+	var/syringestab_amount_transferred = rand(0, (REAGENT_TOTAL_VOLUME(reagents) - 5)) //nerfed by popular demand
 	var/contained_reagents = reagents.get_reagents()
 	var/trans = reagents.trans_to_mob(target, syringestab_amount_transferred, CHEM_INJECT)
 	if(isnull(trans)) trans = 0
@@ -326,7 +326,7 @@
 
 /obj/item/chems/syringe/ld50_syringe/populate_reagents()
 	SHOULD_CALL_PARENT(FALSE)
-	add_to_reagents(/decl/material/liquid/heartstopper, reagents.maximum_volume)
+	add_to_reagents(/decl/material/liquid/heartstopper, REAGENT_MAXIMUM_VOLUME(reagents))
 
 /obj/item/chems/syringe/ld50_syringe/drawReagents(var/target, var/mob/user)
 	if(ismob(target)) // No drawing 60 units of blood at once
@@ -343,7 +343,7 @@
 	mode = SYRINGE_INJECT
 
 /obj/item/chems/syringe/stabilizer/populate_reagents()
-	add_to_reagents(/decl/material/liquid/stabilizer, reagents.maximum_volume)
+	add_to_reagents(/decl/material/liquid/stabilizer, REAGENT_MAXIMUM_VOLUME(reagents))
 	return ..()
 
 /obj/item/chems/syringe/antitoxin
@@ -351,7 +351,7 @@
 	mode = SYRINGE_INJECT
 
 /obj/item/chems/syringe/antitoxin/populate_reagents()
-	add_to_reagents(/decl/material/liquid/antitoxins, reagents.maximum_volume)
+	add_to_reagents(/decl/material/liquid/antitoxins, REAGENT_MAXIMUM_VOLUME(reagents))
 	return ..()
 
 /obj/item/chems/syringe/antibiotic
@@ -359,7 +359,7 @@
 	mode = SYRINGE_INJECT
 
 /obj/item/chems/syringe/antibiotic/populate_reagents()
-	add_to_reagents(/decl/material/liquid/antibiotics, reagents.maximum_volume)
+	add_to_reagents(/decl/material/liquid/antibiotics, REAGENT_MAXIMUM_VOLUME(reagents))
 	return ..()
 
 /obj/item/chems/syringe/drugs
@@ -367,7 +367,7 @@
 	mode = SYRINGE_INJECT
 
 /obj/item/chems/syringe/drugs/populate_reagents()
-	var/vol_each = round(reagents.maximum_volume / 3)
+	var/vol_each = round(REAGENT_MAXIMUM_VOLUME(reagents) / 3)
 	add_to_reagents(/decl/material/liquid/psychoactives,   vol_each)
 	add_to_reagents(/decl/material/liquid/hallucinogenics, vol_each)
 	add_to_reagents(/decl/material/liquid/presyncopics,    vol_each)
@@ -378,7 +378,7 @@
 	mode = SYRINGE_INJECT
 
 /obj/item/chems/syringe/steroid/populate_reagents()
-	var/vol_third = round(reagents.maximum_volume/3)
+	var/vol_third = round(REAGENT_MAXIMUM_VOLUME(reagents)/3)
 	add_to_reagents(/decl/material/liquid/adrenaline,   vol_third)
 	add_to_reagents(/decl/material/liquid/amphetamines, 2 * vol_third)
 	return ..()

--- a/code/modules/reagents/reagent_dispenser.dm
+++ b/code/modules/reagents/reagent_dispenser.dm
@@ -30,7 +30,7 @@
 /obj/structure/reagent_dispensers/on_reagent_change()
 	if(!(. = ..()))
 		return
-	if(reagents?.total_volume > 0)
+	if(REAGENT_TOTAL_VOLUME(reagents) > 0)
 		tool_interaction_flags &= ~TOOL_INTERACTION_DECONSTRUCT
 	else
 		tool_interaction_flags |= TOOL_INTERACTION_DECONSTRUCT
@@ -38,7 +38,7 @@
 /obj/structure/reagent_dispensers/proc/leak()
 	var/turf/T = get_turf(src)
 	if(reagents && T)
-		reagents.trans_to_turf(T, min(reagents.total_volume, FLUID_PUDDLE))
+		reagents.trans_to_turf(T, min(REAGENT_TOTAL_VOLUME(reagents), FLUID_PUDDLE))
 
 /obj/structure/reagent_dispensers/Move()
 	. = ..()
@@ -85,7 +85,7 @@
 	movable_flags             = MOVABLE_FLAG_WHEELED
 
 /obj/structure/reagent_dispensers/watertank/populate_reagents()
-	add_to_reagents(/decl/material/liquid/water, reagents.maximum_volume)
+	add_to_reagents(/decl/material/liquid/water, REAGENT_MAXIMUM_VOLUME(reagents))
 
 /obj/structure/reagent_dispensers/watertank/high
 	name = "high-capacity water tank"
@@ -116,7 +116,7 @@
 	var/obj/item/assembly_holder/rig
 
 /obj/structure/reagent_dispensers/fueltank/populate_reagents()
-	add_to_reagents(/decl/material/liquid/fuel, reagents.maximum_volume)
+	add_to_reagents(/decl/material/liquid/fuel, REAGENT_MAXIMUM_VOLUME(reagents))
 
 /obj/structure/reagent_dispensers/fueltank/get_examine_strings(mob/user, distance, infix, suffix)
 	. = ..()
@@ -198,7 +198,7 @@
 	amount_dispensed = 45
 
 /obj/structure/reagent_dispensers/peppertank/populate_reagents()
-	add_to_reagents(/decl/material/liquid/capsaicin/condensed, reagents.maximum_volume)
+	add_to_reagents(/decl/material/liquid/capsaicin/condensed, REAGENT_MAXIMUM_VOLUME(reagents))
 
 /obj/structure/reagent_dispensers/water_cooler
 	name                      = "water cooler"
@@ -215,7 +215,7 @@
 	var/tmp/cup_type          = /obj/item/chems/drinks/sillycup
 
 /obj/structure/reagent_dispensers/water_cooler/populate_reagents()
-	add_to_reagents(/decl/material/liquid/water, reagents.maximum_volume)
+	add_to_reagents(/decl/material/liquid/water, REAGENT_MAXIMUM_VOLUME(reagents))
 
 /obj/structure/reagent_dispensers/water_cooler/attack_hand(var/mob/user)
 	if(user.check_dexterity(DEXTERITY_HOLD_ITEM, TRUE))
@@ -251,7 +251,7 @@
 /obj/structure/reagent_dispensers/water_cooler/on_reagent_change()
 	. = ..()
 	// Bubbles in top of cooler.
-	if(reagents?.total_volume)
+	if(REAGENT_TOTAL_VOLUME(reagents))
 		var/vend_state = "[icon_state]-vend"
 		if(check_state_in_icon(vend_state, icon))
 			flick(vend_state, src)
@@ -266,7 +266,7 @@
 	matter           = list(/decl/material/solid/metal/stainlesssteel = MATTER_AMOUNT_TRACE)
 
 /obj/structure/reagent_dispensers/beerkeg/populate_reagents()
-	add_to_reagents(/decl/material/liquid/alcohol/beer, reagents.maximum_volume)
+	add_to_reagents(/decl/material/liquid/alcohol/beer, REAGENT_MAXIMUM_VOLUME(reagents))
 
 /obj/structure/reagent_dispensers/acid
 	name             = "sulfuric acid dispenser"
@@ -277,7 +277,7 @@
 	density          = FALSE
 
 /obj/structure/reagent_dispensers/acid/populate_reagents()
-	add_to_reagents(/decl/material/liquid/acid, reagents.maximum_volume)
+	add_to_reagents(/decl/material/liquid/acid, REAGENT_MAXIMUM_VOLUME(reagents))
 
 //Interactions
 /obj/structure/reagent_dispensers/get_alt_interactions(var/mob/user)

--- a/code/modules/scanners/breath.dm
+++ b/code/modules/scanners/breath.dm
@@ -100,9 +100,9 @@
 			print_reagent_default_message = FALSE
 
 		var/datum/reagents/inhaled = target.get_inhaled_reagents()
-		if(inhaled && inhaled.total_volume)
+		if(inhaled && REAGENT_TOTAL_VOLUME(inhaled))
 			var/unknown = 0
-			for(var/decl/material/reagent as anything in inhaled.reagent_volumes)
+			for(var/decl/material/reagent as anything in REAGENT_VOLUMES(inhaled))
 				if(reagent.scannable)
 					print_reagent_default_message = FALSE
 					. += "<span class='scan_notice'>[capitalize(reagent.gas_name)] found in subject's breath.</span>"

--- a/code/modules/scanners/health.dm
+++ b/code/modules/scanners/health.dm
@@ -241,10 +241,10 @@
 	. += "[b]Reagent scan:[endb]"
 
 	var/print_reagent_default_message = TRUE
-	if(H.reagents.total_volume)
+	if(REAGENT_TOTAL_VOLUME(H.reagents))
 		var/unknown = 0
 		var/reagentdata[0]
-		for(var/decl/material/reagent as anything in H.reagents.reagent_volumes)
+		for(var/decl/material/reagent as anything in REAGENT_VOLUMES(H.reagents))
 			if(reagent.scannable)
 				print_reagent_default_message = FALSE
 				reagentdata[reagent.type] = "<span class='scan_notice'>[round(REAGENT_VOLUME(H.reagents, reagent), 1)]u [reagent.use_name]</span>"
@@ -260,10 +260,10 @@
 			. += "<span class='scan_warning'>Warning: Unknown substance[(unknown>1)?"s":""] detected in subject's blood.</span>"
 
 	var/datum/reagents/touching_reagents = H.get_contact_reagents()
-	if(touching_reagents && touching_reagents.total_volume)
+	if(touching_reagents && REAGENT_TOTAL_VOLUME(touching_reagents))
 		var/unknown = 0
 		var/reagentdata[0]
-		for(var/decl/material/reagent as anything in touching_reagents.reagent_volumes)
+		for(var/decl/material/reagent as anything in REAGENT_VOLUMES(touching_reagents))
 			if(reagent.scannable)
 				print_reagent_default_message = FALSE
 				reagentdata[reagent.type] = "<span class='scan_notice'>[round(REAGENT_VOLUME(H.reagents, reagent), 1)]u [reagent.name]</span>"
@@ -279,9 +279,9 @@
 			. += "<span class='scan_warning'>Warning: Unknown substance[(unknown>1)?"s":""] detected on subject's body.</span>"
 
 	var/datum/reagents/ingested = H.get_ingested_reagents()
-	if(ingested && ingested.total_volume)
+	if(ingested && REAGENT_TOTAL_VOLUME(ingested))
 		var/unknown = 0
-		for(var/decl/material/reagent as anything in ingested.reagent_volumes)
+		for(var/decl/material/reagent as anything in REAGENT_VOLUMES(ingested))
 			if(reagent.scannable)
 				print_reagent_default_message = FALSE
 				. += "<span class='scan_notice'>[capitalize(reagent.use_name)] found in subject's stomach.</span>"
@@ -292,9 +292,9 @@
 			. += "<span class='scan_warning'>Non-medical reagent[(unknown > 1)?"s":""] found in subject's stomach.</span>"
 
 	var/datum/reagents/inhaled = H.get_inhaled_reagents()
-	if(inhaled && inhaled.total_volume)
+	if(inhaled && REAGENT_TOTAL_VOLUME(inhaled))
 		var/unknown = 0
-		for(var/decl/material/reagent as anything in inhaled.reagent_volumes)
+		for(var/decl/material/reagent as anything in REAGENT_VOLUMES(inhaled))
 			if(reagent.scannable)
 				print_reagent_default_message = FALSE
 				. += "<span class='scan_notice'>[capitalize(reagent.use_name)] found in subject's lungs.</span>"

--- a/code/modules/scanners/mass_spectrometer.dm
+++ b/code/modules/scanners/mass_spectrometer.dm
@@ -17,11 +17,11 @@
 /obj/item/scanner/spectrometer/on_update_icon()
 	. = ..()
 	icon_state = get_world_inventory_state()
-	if(reagents?.total_volume)
+	if(REAGENT_TOTAL_VOLUME(reagents))
 		icon_state += "_loaded"
 
 /obj/item/scanner/spectrometer/is_valid_scan_target(atom/O)
-	if(!O.reagents || !O.reagents.total_volume)
+	if(!O.reagents || !REAGENT_TOTAL_VOLUME(O.reagents))
 		return FALSE
 	return (O.atom_flags & ATOM_FLAG_OPEN_CONTAINER) || istype(O, /obj/item/chems/syringe)
 
@@ -38,22 +38,22 @@
 /obj/item/scanner/spectrometer/attack_self(mob/user)
 	if(!can_use(user))
 		return
-	if(reagents.total_volume)
+	if(REAGENT_TOTAL_VOLUME(reagents))
 		scan(src, user)
 	else
 		..()
 
 /proc/mass_spectrometer_scan(var/datum/reagents/reagents, mob/user, var/details)
-	if(!reagents?.total_volume)
+	if(!REAGENT_TOTAL_VOLUME(reagents))
 		return SPAN_WARNING("No sample to scan.")
 	var/list/blood_traces = list()
 	var/list/blood_doses = list()
 
-	if(length(reagents.reagent_volumes) == 1 && istype(reagents.primary_reagent, /decl/material/liquid/random))
-		var/decl/material/liquid/random/random = reagents.primary_reagent
+	var/decl/material/liquid/random/random = reagents.get_primary_reagent_decl()
+	if(length(REAGENT_VOLUMES(reagents)) == 1 && istype(random))
 		return random.get_scan_data(user)
 
-	for(var/decl/material/reagent as anything in reagents.reagent_volumes)
+	for(var/decl/material/reagent as anything in REAGENT_VOLUMES(reagents))
 		if(!istype(reagent, /decl/material/liquid/blood))
 			return SPAN_WARNING("The sample was contaminated! Please insert another sample.")
 		var/data = REAGENT_DATA(reagents, reagent)

--- a/code/modules/scanners/plant.dm
+++ b/code/modules/scanners/plant.dm
@@ -78,12 +78,13 @@
 			dat += "<tr><td><b>[uppertext(trait_name)]</b></td><td>[general_data[trait_name]]</td></tr>"
 	dat += "</table>"
 
-	if(LAZYLEN(grown_reagents?.reagent_volumes))
+	var/grown_volumes = REAGENT_VOLUMES(grown_reagents)
+	if(LAZYLEN(grown_volumes))
 		dat += "<h2>Reagent Data</h2>"
 		dat += "<br>This sample contains: "
-		for(var/decl/material/reagent as anything in grown_reagents.liquid_volumes)
+		for(var/decl/material/reagent as anything in REAGENT_LIQUID_VOLUMES(grown_reagents))
 			dat += "<br>- [reagent.get_reagent_name(grown_reagents, MAT_PHASE_LIQUID)], [LIQUID_VOLUME(grown_reagents, reagent)] unit(s)"
-		for(var/decl/material/reagent as anything in grown_reagents.solid_volumes)
+		for(var/decl/material/reagent as anything in REAGENT_SOLID_VOLUMES(grown_reagents))
 			dat += "<br>- [reagent.get_reagent_name(grown_reagents, MAT_PHASE_SOLID)], [SOLID_VOLUME(grown_reagents, reagent)] unit(s)"
 
 	dat += "<h2>Other Data</h2>"

--- a/code/modules/scanners/reagents.dm
+++ b/code/modules/scanners/reagents.dm
@@ -17,11 +17,12 @@
 /proc/reagent_scan_results(obj/O, details = 0)
 	if(isnull(O.reagents))
 		return list("No significant chemical agents found in [O].")
-	if(!LAZYLEN(O.reagents.reagent_volumes))
+	var/chem_volumes = REAGENT_VOLUMES(O.reagents)
+	if(!LAZYLEN(chem_volumes))
 		return list("No active chemical agents found in [O].")
 	. = list("Chemicals found in [O]:")
-	var/one_percent = O.reagents.total_volume / 100
-	for (var/decl/material/reagent as anything in O.reagents.reagent_volumes)
+	var/one_percent = REAGENT_TOTAL_VOLUME(O.reagents) / 100
+	for (var/decl/material/reagent as anything in REAGENT_VOLUMES(O.reagents))
 		. += "[reagent.name][details ? ": [REAGENT_VOLUME(O.reagents, reagent) / one_percent]%" : ""]"
 
 /obj/item/scanner/reagent/adv

--- a/code/modules/scent/_scent.dm
+++ b/code/modules/scent/_scent.dm
@@ -125,9 +125,9 @@ To add a scent extension to an atom using a reagent's info, where reagent. is th
 /proc/get_smelliest_reagent(var/datum/reagents/holder)
 	var/decl/material/smelliest
 	var/scent_intensity
-	if(!holder || !holder.total_volume)
+	if(!holder || !REAGENT_TOTAL_VOLUME(holder))
 		return
-	for(var/decl/material/reagent as anything in holder.reagent_volumes)
+	for(var/decl/material/reagent as anything in REAGENT_VOLUMES(holder))
 		if(!reagent.scent)
 			continue
 		var/decl/scent_intensity/scent = GET_DECL(reagent.scent_intensity)

--- a/code/modules/sealant_gun/sealant_injector.dm
+++ b/code/modules/sealant_gun/sealant_injector.dm
@@ -1,8 +1,8 @@
 /obj/item/chems/chem_disp_cartridge/foaming_agent/populate_reagents()
-	add_to_reagents(/decl/material/liquid/foaming_agent, reagents.maximum_volume)
+	add_to_reagents(/decl/material/liquid/foaming_agent, REAGENT_MAXIMUM_VOLUME(reagents))
 
 /obj/item/chems/chem_disp_cartridge/polyacid/populate_reagents()
-	add_to_reagents(/decl/material/liquid/acid/polyacid, reagents.maximum_volume)
+	add_to_reagents(/decl/material/liquid/acid/polyacid, REAGENT_MAXIMUM_VOLUME(reagents))
 
 /obj/structure/sealant_injector
 	name = "sealant tank injector"
@@ -63,18 +63,18 @@
 		to_chat(user, SPAN_WARNING("There is no tank loaded."))
 		return TRUE
 
-	var/fill_space = floor(loaded_tank.reagents?.maximum_volume - loaded_tank.reagents?.total_volume) / 5
+	var/fill_space = floor(REAGENT_MAXIMUM_VOLUME(loaded_tank.reagents) - REAGENT_TOTAL_VOLUME(loaded_tank.reagents)) / 5
 	if(fill_space <= 0)
 		to_chat(user, SPAN_WARNING("\The [loaded_tank] is full."))
 		return TRUE
 
 	var/injected = FALSE
 	for(var/obj/item/chems/chem_disp_cartridge/cart in cartridges)
-		if(cart.reagents?.total_volume <= cartridges[cart])
+		if(REAGENT_TOTAL_VOLUME(cart.reagents) <= cartridges[cart])
 			visible_message("\The [src] flashes a red 'empty' light above \the [cart].")
 			continue
 		injected = TRUE
-		cart.reagents.trans_to_holder(loaded_tank.reagents, min(cart.reagents.total_volume, cartridges[cart] * fill_space))
+		cart.reagents.trans_to_holder(loaded_tank.reagents, min(REAGENT_TOTAL_VOLUME(cart.reagents), cartridges[cart] * fill_space))
 	if(injected)
 		playsound(loc, 'sound/effects/refill.ogg', 50, 1)
 

--- a/code/modules/sealant_gun/sealant_tank.dm
+++ b/code/modules/sealant_gun/sealant_tank.dm
@@ -8,7 +8,7 @@
 
 /obj/item/sealant_tank/on_update_icon()
 	. = ..()
-	add_overlay("fill_[floor((reagents.total_volume/reagents.maximum_volume) * 5)]")
+	add_overlay("fill_[floor((REAGENT_TOTAL_VOLUME(reagents)/REAGENT_MAXIMUM_VOLUME(reagents)) * 5)]")
 
 /obj/item/sealant_tank/get_examine_strings(mob/user, distance, infix, suffix)
 	. = ..()
@@ -16,7 +16,7 @@
 		. += SPAN_NOTICE("\The [src] has about [REAGENT_VOLUME(reagents, /decl/material/liquid/foam) || 0] charge\s of sealant left.")
 
 /obj/item/sealant_tank/mapped/populate_reagents()
-	reagents.add_reagent(/decl/material/liquid/foam, reagents.maximum_volume)
+	reagents.add_reagent(/decl/material/liquid/foam, REAGENT_MAXIMUM_VOLUME(reagents))
 
 /obj/item/sealant_tank/physically_destroyed(var/skip_qdel)
 	var/turf/my_turf = get_turf(src)

--- a/code/modules/surgery/necrotic.dm
+++ b/code/modules/surgery/necrotic.dm
@@ -170,7 +170,7 @@
 	C.reagents.trans_to_holder(temp_reagents, amount)
 	var/usable_amount = temp_reagents.has_reagent(/decl/material/liquid/regenerator)
 	temp_reagents.clear_reagent(/decl/material/liquid/regenerator) //We'll manually calculate how much it should heal
-	temp_reagents.trans_to_mob(target, temp_reagents.total_volume, CHEM_INJECT) //And if there was something else, toss it in
+	temp_reagents.trans_to_mob(target, REAGENT_TOTAL_VOLUME(temp_reagents), CHEM_INJECT) //And if there was something else, toss it in
 
 	if (usable_amount > 1)
 		var/obj/item/organ/O = target.get_organ(target_organ)

--- a/code/modules/surgery/other.dm
+++ b/code/modules/surgery/other.dm
@@ -207,7 +207,7 @@
 	var/temp_holder = new/obj()
 	var/datum/reagents/temp_reagents = new(amount, temp_holder)
 	container.reagents.trans_to_holder(temp_reagents, amount)
-	var/trans = temp_reagents.trans_to_mob(target, temp_reagents.total_volume, CHEM_INJECT) //technically it's contact, but the reagents are being applied to internal tissue
+	var/trans = temp_reagents.trans_to_mob(target, REAGENT_TOTAL_VOLUME(temp_reagents), CHEM_INJECT) //technically it's contact, but the reagents are being applied to internal tissue
 	if (trans > 0)
 		user.visible_message("<span class='notice'>[user] rubs [target]'s [affected.name] down with \the [tool]'s contents</span>.", \
 			"<span class='notice'>You rub [target]'s [affected.name] down with \the [tool]'s contents.</span>")
@@ -240,15 +240,15 @@
 	if(!valid_container)
 		return FALSE
 
-	if(!container.reagents?.total_volume)
+	if(!REAGENT_TOTAL_VOLUME(container.reagents))
 		return FALSE
 
 	// This check means it's impure.
-	if(length(container.reagents.reagent_volumes) > length(sterilizing_reagents))
+	if(length(REAGENT_VOLUMES(container.reagents)) > length(sterilizing_reagents))
 		return FALSE
 
 	// Check if we have sterilizing reagents and -only- sterilizing reagents.
-	for(var/decl/material/reagent as anything in container.reagents.reagent_volumes)
+	for(var/decl/material/reagent as anything in REAGENT_VOLUMES(container.reagents))
 		if(!(reagent in sterilizing_reagents))
 			return FALSE
 		. = TRUE

--- a/code/modules/vehicles/engine.dm
+++ b/code/modules/vehicles/engine.dm
@@ -98,14 +98,14 @@
 
 /// Attempts to burn a sample of the fuel in our reagent holder. Returns TRUE if enough fuel points are produced to move, otherwise returns FALSE.
 /obj/item/engine/thermal/proc/burn_fuel()
-	if(!reagents || reagents.total_volume <= 0 || broken)
+	if(!reagents || REAGENT_TOTAL_VOLUME(reagents) <= 0 || broken)
 		return FALSE
-	reagents.trans_to_holder(combustion_chamber, min(reagents.total_volume, 15))
+	reagents.trans_to_holder(combustion_chamber, min(REAGENT_TOTAL_VOLUME(reagents), 15))
 	var/multiplier = 0
 	var/actually_flammable = FALSE
-	for(var/decl/material/reagent as anything in temp_reagents_holder.reagents.reagent_volumes)
+	for(var/decl/material/reagent as anything in REAGENT_VOLUMES(temp_reagents_holder.reagents))
 		var/new_multiplier = 1
-		var/reagent_volume = combustion_chamber.reagent_volumes[reagent]
+		var/reagent_volume = REAGENT_VOLUME(combustion_chamber, reagent)
 		if(reagent.accelerant_value < FUEL_VALUE_NONE) // suppresses fires rather than starts them
 			// this means that FUEL_VALUE_SUPPRESSANT is on par with water in the old code
 			new_multiplier = -(FUEL_VALUE_SUPPRESSANT + reagent.accelerant_value) / 2 * 0.4

--- a/code/modules/xenoarcheaology/artifacts/artifact.dm
+++ b/code/modules/xenoarcheaology/artifacts/artifact.dm
@@ -136,7 +136,7 @@
 
 /obj/structure/artifact/fluid_act(datum/reagents/fluids)
 	..()
-	if(!QDELETED(src) && fluids?.total_volume)
+	if(!QDELETED(src) && REAGENT_TOTAL_VOLUME(fluids))
 		check_triggers(/datum/artifact_trigger/proc/on_fluid_act, fluids)
 
 // Premade subtypes for mapping or testing.

--- a/code/modules/xenoarcheaology/machinery/geosample_scanner.dm
+++ b/code/modules/xenoarcheaology/machinery/geosample_scanner.dm
@@ -78,14 +78,14 @@
 			//#TODO: The add coolant stuff could probably be handled by the default reagent handling code. And the emptying could be done with an alt interaction.
 			if(choice == "Add coolant")
 				var/obj/item/chems/glass/G = used_item
-				var/amount_transferred = min(src.reagents.maximum_volume - src.reagents.total_volume, G.reagents.total_volume)
+				var/amount_transferred = min(REAGENT_MAXIMUM_VOLUME(reagents) - REAGENT_TOTAL_VOLUME(src.reagents), REAGENT_TOTAL_VOLUME(G.reagents))
 				G.reagents.trans_to(src, amount_transferred)
 				to_chat(user, SPAN_INFO("You empty [amount_transferred]u of coolant into [src]."))
 				update_coolant()
 				return TRUE
 			else if(choice == "Empty coolant")
 				var/obj/item/chems/glass/G = used_item
-				var/amount_transferred = min(G.reagents.maximum_volume - G.reagents.total_volume, src.reagents.total_volume)
+				var/amount_transferred = min(REAGENT_MAXIMUM_VOLUME(G.reagents) - REAGENT_TOTAL_VOLUME(G.reagents), REAGENT_TOTAL_VOLUME(src.reagents))
 				src.reagents.trans_to(G, amount_transferred)
 				to_chat(user, SPAN_INFO("You remove [amount_transferred]u of coolant from [src]."))
 				update_coolant()
@@ -112,7 +112,7 @@
 	fresh_coolant = 0
 	coolant_purity = 0
 	var/num_reagent_types = 0
-	for(var/decl/material/reagent as anything in reagents.reagent_volumes)
+	for(var/decl/material/reagent as anything in REAGENT_VOLUMES(reagents))
 		var/cur_purity = coolant_reagents_purity[reagent.type]
 		if(!cur_purity)
 			cur_purity = 0.1
@@ -144,7 +144,7 @@
 	//
 	data["coolant_usage_rate"] = "[coolant_usage_rate]"
 	data["unused_coolant_abs"] = round(fresh_coolant)
-	data["unused_coolant_per"] = round(fresh_coolant / reagents.maximum_volume * 100)
+	data["unused_coolant_per"] = round(fresh_coolant / REAGENT_MAXIMUM_VOLUME(reagents) * 100)
 	data["coolant_purity"] = "[coolant_purity * 100]"
 	//
 	data["optimal_wavelength"] = round(optimal_wavelength)

--- a/code/unit_tests/chemistry_tests.dm
+++ b/code/unit_tests/chemistry_tests.dm
@@ -62,13 +62,13 @@
 		var/datum/reagents/checking = get_first_reagent_holder(from)
 		if(!checking)
 			return "first holder is null."
-		if(checking?.total_volume != from_remaining_target)
-			return "first holder should have [from_remaining_target]u remaining but has [checking.total_volume]u."
+		if(REAGENT_TOTAL_VOLUME(checking) != from_remaining_target)
+			return "first holder should have [from_remaining_target]u remaining but has [REAGENT_TOTAL_VOLUME(checking)]u."
 		checking = get_second_reagent_holder(target)
 		if(!checking)
 			return "second holder is null."
-		if(checking?.total_volume != to_holding_target)
-			return "second holder should hold [to_holding_target]u but has [checking.total_volume]u."
+		if(REAGENT_TOTAL_VOLUME(checking) != to_holding_target)
+			return "second holder should hold [to_holding_target]u but has [REAGENT_TOTAL_VOLUME(checking)]u."
 
 /datum/unit_test/chemistry/proc/validate_holders(var/atom/from, var/atom/target)
 	if(QDELETED(from))
@@ -219,7 +219,7 @@
 
 	// Cleanup pt. 2
 	chem_refs.Cut()
-	if(spawn_spot.reagents?.total_volume)
+	if(REAGENT_TOTAL_VOLUME(spawn_spot.reagents))
 		spawn_spot.reagents.clear_reagents()
 		failures += "- spawn turf had fluids post-test"
 

--- a/mods/content/beekeeping/hive_frame.dm
+++ b/mods/content/beekeeping/hive_frame.dm
@@ -8,7 +8,7 @@
 
 /obj/item/hive_frame/on_reagent_change()
 	. = ..()
-	if(reagents?.total_volume)
+	if(REAGENT_TOTAL_VOLUME(reagents))
 		SetName("filled [initial(name)] ([reagents.get_primary_reagent_name()])")
 	else
 		SetName(initial(name))
@@ -19,7 +19,7 @@
 	var/mesh_state = "[icon_state]-mesh"
 	if(check_state_in_icon(mesh_state, icon))
 		add_overlay(overlay_image(icon, mesh_state, COLOR_WHITE, RESET_COLOR))
-	if(reagents?.total_volume)
+	if(REAGENT_TOTAL_VOLUME(reagents))
 		var/comb_state = "[icon_state]-comb"
 		if(check_state_in_icon(comb_state, icon))
 			add_overlay(overlay_image(icon, comb_state, reagents.get_color(), RESET_COLOR))
@@ -28,8 +28,8 @@
 /obj/item/hive_frame/handle_centrifuge_process(obj/machinery/centrifuge/centrifuge)
 	if(!(. = ..()))
 		return
-	if(reagents.total_volume)
-		reagents.trans_to_holder(centrifuge.loaded_beaker.reagents, reagents.total_volume)
+	if(REAGENT_TOTAL_VOLUME(reagents))
+		reagents.trans_to_holder(centrifuge.loaded_beaker.reagents, REAGENT_TOTAL_VOLUME(reagents))
 	for(var/obj/item/thing in contents)
 		thing.dropInto(centrifuge.loc)
 	if(destroy_on_centrifuge)
@@ -52,4 +52,4 @@
 
 /obj/item/hive_frame/crafted/filled/populate_reagents()
 	. = ..()
-	reagents.add_reagent(/decl/material/liquid/nutriment/honey, reagents?.maximum_volume)
+	reagents.add_reagent(/decl/material/liquid/nutriment/honey, REAGENT_MAXIMUM_VOLUME(reagents))

--- a/mods/content/beekeeping/hives/_hive.dm
+++ b/mods/content/beekeeping/hives/_hive.dm
@@ -71,7 +71,7 @@
 			to_chat(user, "<span class='notice'>There is no place for an another frame.</span>")
 			return TRUE
 		var/obj/item/hive_frame/crafted/H = used_item
-		if(H.reagents?.total_volume)
+		if(REAGENT_TOTAL_VOLUME(H.reagents))
 			to_chat(user, "<span class='notice'>\The [used_item] is full with beeswax and honey, empty it in the extractor first.</span>")
 			return TRUE
 		++frames

--- a/mods/content/bigpharma/extension.dm
+++ b/mods/content/bigpharma/extension.dm
@@ -35,7 +35,7 @@
 
 /datum/extension/obfuscated_medication/pill_bottle/get_original_reagent(var/obj/item/donor)
 	for(var/obj/item/chems/pill/pill in donor?.contents)
-		if(pill.reagents?.total_volume)
+		if(REAGENT_TOTAL_VOLUME(pill.reagents))
 			return pill.reagents.get_primary_reagent_name(codex = TRUE)
 
 /datum/extension/obfuscated_medication/pill_bottle/update_appearance()
@@ -48,7 +48,7 @@
 
 /datum/extension/obfuscated_medication/foil_pack/get_original_reagent(var/obj/item/donor)
 	for(var/obj/item/chems/pill/pill in donor?.contents)
-		if(pill.reagents?.total_volume)
+		if(REAGENT_TOTAL_VOLUME(pill.reagents))
 			return pill.reagents.get_primary_reagent_name(codex = TRUE)
 
 /datum/extension/obfuscated_medication/foil_pack/update_appearance()

--- a/mods/content/blacksmithy/barrel_rim.dm
+++ b/mods/content/blacksmithy/barrel_rim.dm
@@ -36,7 +36,7 @@
 
 /obj/structure/reagent_dispensers/barrel/on_reagent_change()
 	. = ..()
-	if(!metal_material && reagents?.total_volume)
+	if(!metal_material && REAGENT_TOTAL_VOLUME(reagents))
 		physically_destroyed()
 
 // Adding a rim to a crafted barrel.

--- a/mods/content/integrated_electronics/components/input.dm
+++ b/mods/content/integrated_electronics/components/input.dm
@@ -351,8 +351,8 @@
 		var/mr = 0
 		var/tr = 0
 		if(H.reagents)
-			mr = H.reagents.maximum_volume
-			tr = H.reagents.total_volume
+			mr = REAGENT_MAXIMUM_VOLUME(H.reagents)
+			tr = REAGENT_TOTAL_VOLUME(H.reagents)
 		set_pin_data(IC_OUTPUT, 6, mr)
 		set_pin_data(IC_OUTPUT, 7, tr)
 		set_pin_data(IC_OUTPUT, 8, H.density)

--- a/mods/content/integrated_electronics/components/power_passive.dm
+++ b/mods/content/integrated_electronics/components/power_passive.dm
@@ -121,7 +121,7 @@
 /obj/item/integrated_circuit/passive/power/chemical_cell/on_reagent_change(changetype)
 	if(!(. = ..()))
 		return
-	set_pin_data(IC_OUTPUT, 1, reagents?.total_volume || 0)
+	set_pin_data(IC_OUTPUT, 1, REAGENT_TOTAL_VOLUME(reagents))
 	push_data()
 
 /obj/item/integrated_circuit/passive/power/chemical_cell/make_energy()

--- a/mods/content/integrated_electronics/components/reagents.dm
+++ b/mods/content/integrated_electronics/components/reagents.dm
@@ -13,11 +13,11 @@
 
 /obj/item/integrated_circuit/reagent/Initialize()
 	. = ..()
-	if(reagents?.maximum_volume)
+	if(REAGENT_MAXIMUM_VOLUME(reagents))
 		push_vol()
 
 /obj/item/integrated_circuit/reagent/proc/push_vol()
-	set_pin_data(IC_OUTPUT, 1, reagents?.total_volume || 0)
+	set_pin_data(IC_OUTPUT, 1, REAGENT_TOTAL_VOLUME(reagents))
 	push_data()
 
 /obj/item/integrated_circuit/reagent/smoke
@@ -54,7 +54,7 @@
 /obj/item/integrated_circuit/reagent/smoke/do_work(ord)
 	switch(ord)
 		if(1)
-			if(!reagents || (reagents.total_volume < IC_SMOKE_REAGENTS_MINIMUM_UNITS))
+			if(!reagents || (REAGENT_TOTAL_VOLUME(reagents) < IC_SMOKE_REAGENTS_MINIMUM_UNITS))
 				return
 			var/location = get_turf(src)
 			var/datum/effect/effect/system/smoke_spread/chem/S = new
@@ -115,7 +115,7 @@
 	else
 		direction_mode = IC_REAGENTS_INJECT
 	if(isnum(new_amount))
-		new_amount = clamp(new_amount, 0, reagents.maximum_volume)
+		new_amount = clamp(new_amount, 0, REAGENT_MAXIMUM_VOLUME(reagents))
 		transfer_amount = new_amount
 
 
@@ -175,7 +175,7 @@
 		return
 
 	if(direction_mode == IC_REAGENTS_INJECT)
-		if(!reagents.total_volume || !AM.reagents || !REAGENTS_FREE_SPACE(AM.reagents))
+		if(!REAGENT_TOTAL_VOLUME(reagents) || !REAGENTS_FREE_SPACE(AM?.reagents))
 			activate_pin(3)
 			return
 
@@ -204,7 +204,7 @@
 			reagents.trans_to(AM, transfer_amount)
 
 	else if(direction_mode == IC_REAGENTS_DRAW)
-		if(reagents.total_volume >= reagents.maximum_volume)
+		if(REAGENT_TOTAL_VOLUME(reagents) >= REAGENT_MAXIMUM_VOLUME(reagents))
 			acting_object.visible_message("\The [acting_object] tries to draw from [AM], but the injector is full.")
 			activate_pin(3)
 			return
@@ -217,7 +217,7 @@
 			var/injection_delay = 3 SECONDS
 			if(injection_status == INJECTION_PORT)
 				injection_delay += INJECTION_PORT_DELAY
-			if(!H.vessel?.total_volume || !injection_status)
+			if(!REAGENT_TOTAL_VOLUME(H.vessel) || !injection_status)
 				activate_pin(3)
 				return
 			H.visible_message(
@@ -228,7 +228,7 @@
 			return
 
 		else
-			if(!AM.reagents.total_volume)
+			if(!REAGENT_TOTAL_VOLUME(AM.reagents))
 				acting_object.visible_message("<span class='notice'>\The [acting_object] tries to draw from [AM], but it is empty!</span>")
 				activate_pin(3)
 				return
@@ -236,7 +236,7 @@
 			if(!ATOM_IS_OPEN_CONTAINER(AM))
 				activate_pin(3)
 				return
-			tramount = min(tramount, AM.reagents.total_volume)
+			tramount = min(tramount, REAGENT_TOTAL_VOLUME(AM.reagents))
 			AM.reagents.trans_to(src, tramount)
 	activate_pin(2)
 
@@ -372,7 +372,7 @@
 			push_data()
 
 /obj/item/integrated_circuit/reagent/storage/grinder/proc/grind()
-	if(reagents.total_volume >= reagents.maximum_volume)
+	if(REAGENT_TOTAL_VOLUME(reagents) >= REAGENT_MAXIMUM_VOLUME(reagents))
 		activate_pin(3)
 		return FALSE
 	var/obj/item/I = get_pin_data_as_type(IC_INPUT, 1, /obj/item)
@@ -380,12 +380,12 @@
 	if(isnull(I))
 		return FALSE
 
-	if(!I.reagents || !I.reagents.total_volume)
+	if(!I.reagents || !REAGENT_TOTAL_VOLUME(I.reagents))
 		activate_pin(3)
 		return FALSE
 
-	I.reagents.trans_to(src,I.reagents.total_volume)
-	if(!I.reagents.total_volume)
+	I.reagents.trans_to(src,REAGENT_TOTAL_VOLUME(I.reagents))
+	if(!REAGENT_TOTAL_VOLUME(I.reagents))
 		qdel(I)
 
 	activate_pin(2)
@@ -415,7 +415,7 @@
 	switch(ord)
 		if(1)
 			var/cont[0]
-			for(var/decl/material/reagent as anything in reagents.reagent_volumes)
+			for(var/decl/material/reagent as anything in REAGENT_VOLUMES(reagents))
 				cont += reagent.name
 			set_pin_data(IC_OUTPUT, 3, cont)
 			push_data()
@@ -478,10 +478,10 @@
 	if(!ATOM_IS_OPEN_CONTAINER(source) || ismob(source))
 		return
 
-	if(target.reagents.maximum_volume - target.reagents.total_volume <= 0)
+	if(REAGENT_MAXIMUM_VOLUME(target.reagents) - REAGENT_TOTAL_VOLUME(target.reagents) <= 0)
 		return
 
-	for(var/decl/material/reagent as anything in source.reagents.reagent_volumes)
+	for(var/decl/material/reagent as anything in REAGENT_VOLUMES(source.reagents))
 		if(!direction_mode)
 			if(reagent.name in demand)
 				source.reagents.trans_type_to(target, reagent, transfer_amount)

--- a/mods/content/plant_dissection/grown.dm
+++ b/mods/content/plant_dissection/grown.dm
@@ -93,7 +93,7 @@
 	if(!can_dissect || !(segment in segments))
 		return
 
-	if(reagents?.total_volume && segment.contributes_to_reagents)
+	if(REAGENT_TOTAL_VOLUME(reagents) && segment.contributes_to_reagents)
 		for(var/rid in segment.reagents)
 			reagents.remove_reagent(rid, segment.reagents[rid])
 

--- a/mods/content/xenobiology/colours/_colour.dm
+++ b/mods/content/xenobiology/colours/_colour.dm
@@ -25,12 +25,13 @@
 	if(!istype(core) || core.Uses <= 0)
 		return
 
-	for(var/decl/material/reagent as anything in holder.reagent_volumes)
-		if(holder.reagent_volumes[reagent] < 1)
+	var/holder_volumes = REAGENT_VOLUMES(holder)
+	for(var/decl/material/reagent as anything in holder_volumes)
+		if(holder_volumes[reagent] < 1)
 			continue
 		var/call_proc = reaction_procs[reagent]
 		if(call_proc && call(src, call_proc)(holder))
-			holder.remove_reagent(reagent, holder.reagent_volumes[reagent])
+			holder.remove_reagent(reagent, holder_volumes[reagent])
 			. = TRUE
 			break
 

--- a/mods/content/xenobiology/slime/items.dm
+++ b/mods/content/xenobiology/slime/items.dm
@@ -45,7 +45,7 @@
 	add_to_reagents(/decl/material/liquid/slimejelly, 30)
 
 /obj/item/slime_extract/on_reagent_change()
-	if((. = ..()) && reagents?.total_volume)
+	if((. = ..()) && REAGENT_TOTAL_VOLUME(reagents))
 		var/decl/slime_colour/slime_data = GET_DECL(slime_type)
 		slime_data.handle_reaction(reagents)
 

--- a/mods/content/xenobiology/slime/life.dm
+++ b/mods/content/xenobiology/slime/life.dm
@@ -51,7 +51,7 @@
 
 /mob/living/slime/fluid_act(datum/reagents/fluids)
 	. = ..()
-	if(!QDELETED(src) && fluids?.total_volume >= FLUID_SHALLOW && stat == DEAD)
+	if(!QDELETED(src) && REAGENT_TOTAL_VOLUME(fluids) >= FLUID_SHALLOW && stat == DEAD)
 		var/turf/T = get_turf(src)
 		if(T)
 			T.add_to_reagents(/decl/material/liquid/slimejelly, (is_adult ? rand(30, 40) : rand(10, 30)))
@@ -66,7 +66,7 @@
 
 /mob/living/slime/fluid_act(datum/reagents/fluids)
 	. = ..()
-	if(stat == DEAD && fluids?.total_volume && REAGENT_VOLUME(fluids, /decl/material/liquid/water) >= FLUID_SHALLOW)
+	if(stat == DEAD && REAGENT_TOTAL_VOLUME(fluids) && REAGENT_VOLUME(fluids, /decl/material/liquid/water) >= FLUID_SHALLOW)
 		fluids.add_reagent(/decl/material/liquid/slimejelly, (is_adult ? rand(30, 40) : rand(10, 30)))
 		visible_message(SPAN_DANGER("\The [src] melts away...")) // Slimes are water soluble.
 		qdel(src)

--- a/mods/gamemodes/cult/ritual.dm
+++ b/mods/gamemodes/cult/ritual.dm
@@ -29,7 +29,7 @@
 		return
 	if(A.reagents && A.reagents.has_reagent(/decl/material/liquid/water))
 		to_chat(user, SPAN_NOTICE("You desecrate \the [A]."))
-		LAZYSET(A.reagents.reagent_data, /decl/material/liquid/water, list(DATA_WATER_HOLINESS = FALSE))
+		REAGENT_SET_DATA(A.reagents, /decl/material/liquid/water, list(DATA_WATER_HOLINESS = FALSE))
 
 /mob/proc/make_rune(var/rune, var/cost = 5, var/tome_required = 0)
 	var/has_robes = 0
@@ -100,7 +100,7 @@
 	return 0
 
 /mob/living/human/make_rune(var/rune, var/cost, var/tome_required)
-	if(should_have_organ(BP_HEART) && vessel && vessel.total_volume < species.blood_volume * 0.7)
+	if(should_have_organ(BP_HEART) && REAGENT_TOTAL_VOLUME(vessel) < species.blood_volume * 0.7)
 		to_chat(src, "<span class='danger'>You are too weak to draw runes.</span>")
 		return
 	..()

--- a/mods/gamemodes/cult/runes.dm
+++ b/mods/gamemodes/cult/runes.dm
@@ -519,7 +519,7 @@
 		victim = M
 	if(!victim)
 		return fizzle(user)
-	if(victim.vessel.total_volume < 20)
+	if(REAGENT_TOTAL_VOLUME(victim.vessel) < 20)
 		to_chat(user, SPAN_WARNING("This body has no blood in it."))
 		return fizzle(user)
 	victim.vessel.remove_any(20)
@@ -534,7 +534,7 @@
 	var/list/statuses = list()
 	var/charges = 20
 	var/use
-	use = min(charges, user.species.blood_volume - user.vessel.total_volume)
+	use = min(charges, user.species.blood_volume - REAGENT_TOTAL_VOLUME(user.vessel))
 	if(use > 0)
 		user.adjust_blood(use)
 		charges -= use

--- a/mods/species/ascent/machines/ship_machines.dm
+++ b/mods/species/ascent/machines/ship_machines.dm
@@ -53,10 +53,10 @@ MANTIDIFY(/obj/machinery/door/airlock/external/bolted, "mantid airlock", "door")
 
 MANTIDIFY(/obj/item/chems/chem_disp_cartridge, "canister", "chemical storage")
 /obj/item/chems/chem_disp_cartridge/ascent/crystal/populate_reagents()
-	add_to_reagents(/decl/material/liquid/crystal_agent, reagents.maximum_volume)
+	add_to_reagents(/decl/material/liquid/crystal_agent, REAGENT_MAXIMUM_VOLUME(reagents))
 
 /obj/item/chems/chem_disp_cartridge/ascent/bromide/populate_reagents()
-	add_to_reagents(/decl/material/liquid/bromide, reagents.maximum_volume)
+	add_to_reagents(/decl/material/liquid/bromide, REAGENT_MAXIMUM_VOLUME(reagents))
 
 /obj/machinery/sleeper/ascent
 	name = "mantid sleeper"

--- a/mods/species/drakes/drake_organs.dm
+++ b/mods/species/drakes/drake_organs.dm
@@ -20,16 +20,17 @@
 
 /obj/item/organ/internal/drake_gizzard/Process()
 	. = ..()
-	if(owner && owner.stat != DEAD && !is_broken() && sap_crop && sap_crop.total_volume < 10)
+	if(owner && owner.stat != DEAD && !is_broken() && sap_crop && REAGENT_TOTAL_VOLUME(sap_crop) < 10)
 		sap_crop.add_reagent(/decl/material/liquid/sifsap, 0.5)
 
 /obj/item/organ/internal/drake_gizzard/do_uninstall(in_place, detach, ignore_children, update_icon)
 	. = ..()
-	if(sap_crop?.total_volume)
+	var/sap_vol = REAGENT_TOTAL_VOLUME(sap_crop)
+	if(sap_vol)
 		if(reagents)
-			sap_crop.trans_to_holder(reagents, sap_crop.total_volume)
+			sap_crop.trans_to_holder(reagents, sap_vol)
 		else if(isatom(loc))
-			sap_crop.splash(loc, sap_crop.total_volume)
+			sap_crop.splash(loc, sap_vol)
 		sap_crop.clear_reagents()
 
 /obj/item/organ/internal/drake_gizzard/Destroy()
@@ -37,4 +38,4 @@
 	. = ..()
 
 /obj/item/organ/internal/drake_gizzard/get_stat_info()
-	return list("Sap reserve", num2text(round((sap_crop?.total_volume || 0), 0.1)))
+	return list("Sap reserve", num2text(round((REAGENT_TOTAL_VOLUME(sap_crop) || 0), 0.1)))

--- a/mods/species/drakes/sifsap.dm
+++ b/mods/species/drakes/sifsap.dm
@@ -1,6 +1,6 @@
 /proc/drake_spend_sap(mob/living/user, amount)
 	var/obj/item/organ/internal/drake_gizzard/gizzard = user.get_organ(BP_DRAKE_GIZZARD)
-	if(!gizzard?.sap_crop?.total_volume)
+	if(!REAGENT_TOTAL_VOLUME(gizzard?.sap_crop))
 		return FALSE
 	if(!gizzard.sap_crop.has_reagent(/decl/material/liquid/sifsap, amount))
 		return FALSE
@@ -9,13 +9,14 @@
 
 /proc/drake_has_sap(mob/living/user, amount)
 	var/obj/item/organ/internal/drake_gizzard/gizzard = user.get_organ(BP_DRAKE_GIZZARD)
-	return gizzard?.sap_crop?.total_volume >= amount
+	return REAGENT_TOTAL_VOLUME(gizzard?.sap_crop) >= amount
 
 /proc/drake_add_sap(mob/living/user, amount)
 	var/obj/item/organ/internal/drake_gizzard/gizzard = user.get_organ(BP_DRAKE_GIZZARD)
-	if(!gizzard?.sap_crop?.maximum_volume)
+	var/max_volume = REAGENT_MAXIMUM_VOLUME(gizzard?.sap_crop)
+	if(!max_volume)
 		return FALSE
-	if(LAZYACCESS(gizzard.sap_crop.reagent_volumes, /decl/material/liquid/sifsap) >= gizzard.sap_crop.maximum_volume)
+	if(REAGENT_VOLUME(gizzard.sap_crop, /decl/material/liquid/sifsap) >= max_volume)
 		return FALSE
 	gizzard.sap_crop.add_reagent(/decl/material/liquid/sifsap, amount)
 	return TRUE

--- a/mods/species/vox/organs_vox.dm
+++ b/mods/species/vox/organs_vox.dm
@@ -97,8 +97,8 @@
 	if(is_usable())
 
 		// Handle some post-metabolism reagent processing for generally inedible foods.
-		if(ingested.total_volume > 0)
-			for(var/decl/material/reagent as anything in ingested.reagent_volumes)
+		if(REAGENT_TOTAL_VOLUME(ingested) > 0)
+			for(var/decl/material/reagent as anything in REAGENT_VOLUMES(ingested))
 				var/inedible_nutriment_amount = gains_nutriment_from_inedible_reagents[reagent.type]
 				if(inedible_nutriment_amount > 0)
 					owner.adjust_nutrition(inedible_nutriment_amount)


### PR DESCRIPTION
## Description of changes
Replaces direct access to reagent datum vars with macros.

## Why and what will this PR improve
With serde adding the potential for reagents to be a list, more rigorous typechecking is needed. Doing this with a macro allows for avoiding proc overhead while also enforcing typechecking.

## Authorship
Myself.

## Changelog
Nothing player-facing.