### PR TITLE
Fix blank line in mob examine

### DIFF
--- a/code/modules/mob/living/human/examine.dm
+++ b/code/modules/mob/living/human/examine.dm
@@ -284,7 +284,7 @@
 			continue
 		if(last_divider) // insert the divider from the last entry
 			. += last_divider
-		else if(length(.)) // we already have prior entries, insert our prefix
+		else if(length(.) && examiner.section_prefix) // we already have prior entries, insert our prefix
 			. += examiner.section_prefix
 		. += adding_text
 		last_divider = examiner.section_postfix


### PR DESCRIPTION
## Description of changes
This inserts a null if the section_prefix is null, which becomes a blank line after jointext.

## Why and what will this PR improve
Fixes blank lines in human examine output.