### PR TITLE
Allow quick-equip hotkey to place items in backpacks and wallets

### DIFF
--- a/code/__defines/items_clothing.dm
+++ b/code/__defines/items_clothing.dm
@@ -82,6 +82,7 @@
 #define slot_r_store_str     "slot_r_store"
 #define slot_s_store_str     "slot_s_store"
 #define slot_in_backpack_str "slot_in_backpack"
+#define slot_in_wallet_str   "slot_in_wallet"
 
 // Defined here for consistency, not actually used for slots, just for species clothing offsets.
 #define slot_undershirt_str  "slot_undershirt"

--- a/code/_global_vars/lists/clothing.dm
+++ b/code/_global_vars/lists/clothing.dm
@@ -30,6 +30,7 @@ var/global/list/airtight_slots = list(
 
 var/global/list/abstract_inventory_slots = list(
 	slot_in_backpack_str,
+	slot_in_wallet_str,
 	slot_undershirt_str,
 	slot_underpants_str,
 	slot_socks_str
@@ -40,7 +41,7 @@ var/global/list/vitals_sensor_equip_slots = list(
 )
 
 var/global/list/headphone_slots = list(
-	slot_l_ear_str, 
-	slot_r_ear_str, 
+	slot_l_ear_str,
+	slot_r_ear_str,
 	slot_head_str
 )

--- a/code/_global_vars/lists/names.dm
+++ b/code/_global_vars/lists/names.dm
@@ -6,5 +6,6 @@ var/global/list/verbs =              file2list("config/names/verbs.txt")
 var/global/list/adjectives =         file2list("config/names/adjectives.txt")
 
 var/global/list/abstract_slot_names = list(
-	slot_in_backpack_str = "In Backpack"
+	slot_in_backpack_str = "In Backpack",
+	slot_in_wallet_str = "In Wallet"
 )

--- a/code/datums/inventory_slots/_inventory_slot.dm
+++ b/code/datums/inventory_slots/_inventory_slot.dm
@@ -19,6 +19,8 @@
 	var/requires_slot_flags
 	var/requires_organ_tag
 	var/quick_equip_priority = 0 // Higher priority means it will be checked first. If null, will not be considered for quick equip.
+	/// Additional slot ID(s) to add in quick equip. Will always be added at the lowest priority.
+	var/list/additional_quick_equip_slots
 	/// What depth of fluid is necessary for an item in this slot to be considered submerged?
 	var/fluid_height = FLUID_SHALLOW // we're treating FLUID_SHALLOW as waist level, basically
 

--- a/code/datums/inventory_slots/slots/slot_back.dm
+++ b/code/datums/inventory_slots/slots/slot_back.dm
@@ -8,6 +8,7 @@
 	mob_overlay_layer = HO_BACK_LAYER
 	quick_equip_priority = 14
 	fluid_height = (FLUID_SHALLOW + FLUID_OVER_MOB_HEAD) / 2 // halfway between waist and top of head, so roughly chest level
+	additional_quick_equip_slots = list(slot_in_backpack_str)
 
 /datum/inventory_slot/back/simple
 	requires_organ_tag = null

--- a/code/datums/inventory_slots/slots/slot_id.dm
+++ b/code/datums/inventory_slots/slots/slot_id.dm
@@ -7,6 +7,7 @@
 	mob_overlay_layer = HO_ID_LAYER
 	quick_equip_priority = 13
 	fluid_height = (FLUID_SHALLOW + FLUID_OVER_MOB_HEAD) / 2 // halfway between waist and top of head, so roughly chest level
+	additional_quick_equip_slots = list(slot_in_wallet_str) // try to go as late as possible
 
 /datum/inventory_slot/id/update_mob_equipment_overlay(var/mob/living/user, var/obj/item/prop, var/redraw_mob = TRUE)
 	var/obj/item/clothing/clothes = user.get_equipped_item(slot_w_uniform_str)

--- a/code/game/objects/items/__item.dm
+++ b/code/game/objects/items/__item.dm
@@ -726,6 +726,9 @@
 	if(slot == slot_in_backpack_str)
 		var/obj/item/back = user.get_equipped_item(slot_back_str)
 		return back?.storage?.can_be_inserted(src, user, TRUE)
+	if(slot == slot_in_wallet_str)
+		var/obj/item/wallet = user.get_equipped_item(slot_wear_id_str)
+		return wallet?.storage?.can_be_inserted(src, user, TRUE)
 
 	var/datum/inventory_slot/inv_slot = user.get_inventory_slot_datum(slot)
 	if(!inv_slot)

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -61,6 +61,14 @@
 		else
 			prop.dropInto(loc)
 		return TRUE
+	if(slot == slot_in_wallet_str)
+		remove_from_mob(prop)
+		var/obj/item/wallet = get_equipped_item(slot_wear_id_str)
+		if(wallet)
+			prop.forceMove(wallet)
+		else
+			prop.dropInto(loc)
+		return TRUE
 
 	// Attempt to equip accessories if the slot is already blocked.
 	if(!delete_old_item && get_equipped_item(slot))
@@ -126,9 +134,15 @@
 /mob/proc/equip_to_storage(obj/item/newitem)
 	// Try put it in their backpack
 	var/obj/item/back = get_equipped_item(slot_back_str)
-	if(back?.storage?.can_be_inserted(newitem, null, 1))
+	if(back?.storage?.can_be_inserted(newitem, null, TRUE))
 		back.storage.handle_item_insertion(src, newitem)
 		return back
+
+	// Or in their wallet
+	var/obj/item/wallet = get_equipped_item(slot_wear_id_str)
+	if(wallet?.storage?.can_be_inserted(newitem, null, TRUE))
+		wallet.storage.handle_item_insertion(src, newitem)
+		return wallet
 
 	// Try to place it in any item that can store stuff, on the mob.
 	for(var/obj/item/thing in contents)

--- a/code/modules/mob/living/inventory.dm
+++ b/code/modules/mob/living/inventory.dm
@@ -14,10 +14,16 @@
 		var/list/all_slots = list()
 		for(var/slot in get_inventory_slots())
 			all_slots += get_inventory_slot_datum(slot)
+		var/list/low_priority_slots // Slots that will always be added at the end, in the order of their parent slots' priority.
+		// This is sort of due to technical limitations but mostly due to laziness.
 		for(var/datum/inventory_slot/inv_slot as anything in sortTim(all_slots, /proc/cmp_inventory_slot_desc))
+			if(LAZYLEN(inv_slot.additional_quick_equip_slots))
+				for(var/extra_slot in inv_slot.additional_quick_equip_slots)
+					LAZYADD(low_priority_slots, extra_slot)
 			if(isnull(inv_slot.quick_equip_priority)) // Never quick-equip into some slots.
 				continue
 			_inventory_slot_priority += inv_slot.slot_id
+		_inventory_slot_priority += low_priority_slots
 	return _inventory_slot_priority
 
 /mob/living/get_inventory_slot_datum(var/slot)

--- a/code/modules/mob/living/inventory.dm
+++ b/code/modules/mob/living/inventory.dm
@@ -23,7 +23,8 @@
 			if(isnull(inv_slot.quick_equip_priority)) // Never quick-equip into some slots.
 				continue
 			_inventory_slot_priority += inv_slot.slot_id
-		_inventory_slot_priority += low_priority_slots
+		if(low_priority_slots)
+			_inventory_slot_priority += low_priority_slots
 	return _inventory_slot_priority
 
 /mob/living/get_inventory_slot_datum(var/slot)

--- a/code/modules/species/species_hud.dm
+++ b/code/modules/species/species_hud.dm
@@ -41,6 +41,8 @@
 	equip_slots |= slot_handcuffed_str
 	if(slot_back_str in equip_slots)
 		equip_slots |= slot_in_backpack_str
+	if(slot_wear_id_str in equip_slots)
+		equip_slots |= slot_in_wallet_str
 
 /datum/hud_data/monkey
 	inventory_slots = list(

--- a/maps/~mapsystem/maps.dm
+++ b/maps/~mapsystem/maps.dm
@@ -548,7 +548,7 @@ var/global/const/MAP_HAS_RANK   = 2		//Rank system, also toggleable
 	var/obj/item/passport/pass = new passport_type(get_turf(H))
 	if(istype(pass))
 		pass.set_info(H)
-	if(!H.equip_to_slot(pass, slot_in_backpack_str))
+	if(!H.equip_to_slot(pass, slot_in_wallet_str) && !H.equip_to_slot(pass, slot_in_backpack_str))
 		H.put_in_hands(pass)
 
 /datum/map/proc/populate_overmap_events()


### PR DESCRIPTION
<!-- !! PLEASE, READ THIS !! -->
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/NebulaSS13/Nebula/blob/dev/CONTRIBUTING.md -->
<!-- If you're opening a pull request which changes A LOT of icon/map files: -->
<!-- Add [IDB IGNORE] (to ignore icon file changes) or [MDB IGNORE] (to ignore map file changes) in the PR title. -->
<!-- These tags prevent huge diffs from overloading IconDiffBot and MapDiffBot. -->

## Description of changes
Adds a new 'in wallet' abstract slot which is used to equip things to storage items in the ID slot, similar to the 'in backpack' abstract slot.

Quick-equip will now attempt to place items in backpacks/wallets if no other options work.

Passports will now try to equip inside wallets if possible.

## Why and what will this PR improve
Some equipping QoL functionality. It might be worth making it so that, when triggered by the quick-equip hotkey, it opens the storage menu as well so it doesn't just seem like it disappears? It might also be worth adding 'currently open storage' but I'm unsure how to handle that...

## Authorship
Me, but the concept exists on TG.

## Changelog
:cl:
tweak: The equip hotkey can now place items into backpacks and wallets.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->