### PR TITLE
Removing assoc list syntax using numerical keys.

### DIFF
--- a/code/controllers/subsystems/event.dm
+++ b/code/controllers/subsystems/event.dm
@@ -28,10 +28,11 @@ SUBSYSTEM_DEF(event)
 /datum/controller/subsystem/event/Initialize()
 
 	if(!event_containers)
+		// Order must conform to EVENT_LEVEL_MUNDANE, EVENT_LEVEL_MODERATE, EVENT_LEVEL_MAJOR.
 		event_containers = list(
-			EVENT_LEVEL_MUNDANE  = new global.using_map.event_container_mundane,
-			EVENT_LEVEL_MODERATE = new global.using_map.event_container_moderate,
-			EVENT_LEVEL_MAJOR    = new global.using_map.event_container_major
+			new global.using_map.event_container_mundane,
+			new global.using_map.event_container_moderate,
+			new global.using_map.event_container_major
 		)
 		all_events = null
 

--- a/code/modules/events/event_container.dm
+++ b/code/modules/events/event_container.dm
@@ -1,4 +1,5 @@
-var/global/list/severity_to_string = list(EVENT_LEVEL_MUNDANE = "Mundane", EVENT_LEVEL_MODERATE = "Moderate", EVENT_LEVEL_MAJOR = "Major")
+// Ordering of these values must confirm to EVENT_LEVEL_MUNDANE, EVENT_LEVEL_MODERATE, EVENT_LEVEL_MAJOR.
+var/global/list/severity_to_string = list("Mundane", "Moderate", "Major")
 
 /datum/event_container
 	var/severity = -1

--- a/code/modules/food/cooking/_recipe.dm
+++ b/code/modules/food/cooking/_recipe.dm
@@ -222,11 +222,8 @@ var/global/list/_cooking_recipe_cache = list()
 
 	// We collected the used ingredients before removing them in case
 	// the result proc needs to check the list for procedural products.
-	var/list/used_ingredients = list(
-		RECIPE_COMPONENT_ITEMS = list(),
-		RECIPE_COMPONENT_FRUIT = list(),
-		RECIPE_COMPONENT_CHEMS = list()
-	)
+	// This mapping is indexed by RECIPE_COMPONENT_FOO defines.
+	var/list/used_ingredients = list(list(), list(), list())
 
 	// Find items we need.
 	var/list/container_contents = container.get_contained_external_atoms()

--- a/maps/~mapsystem/maps.dm
+++ b/maps/~mapsystem/maps.dm
@@ -153,14 +153,15 @@ var/global/const/MAP_HAS_RANK   = 2		//Rank system, also togglable
 		/decl/background_category/religion =  /decl/background_detail/religion/other
 	)
 
+	// Order must conform to ACCESS_REGION_FOO defines.
 	var/access_modify_region = list(
-		ACCESS_REGION_SECURITY = list(access_hos, access_change_ids),
-		ACCESS_REGION_MEDBAY = list(access_cmo, access_change_ids),
-		ACCESS_REGION_RESEARCH = list(access_rd, access_change_ids),
-		ACCESS_REGION_ENGINEERING = list(access_ce, access_change_ids),
-		ACCESS_REGION_COMMAND = list(access_change_ids),
-		ACCESS_REGION_GENERAL = list(access_change_ids),
-		ACCESS_REGION_SUPPLY = list(access_change_ids)
+		list(access_hos, access_change_ids),
+		list(access_cmo, access_change_ids),
+		list(access_rd, access_change_ids),
+		list(access_ce, access_change_ids),
+		list(access_change_ids),
+		list(access_change_ids),
+		list(access_change_ids)
 	)
 	var/secrets_directory
 


### PR DESCRIPTION
New BYOND does not permit numerical keys to be used like assoc keys in basic list().