### PR TITLE
Move actors into a modpack

### DIFF
--- a/maps/modpack_testing/modpack_testing.dm
+++ b/maps/modpack_testing/modpack_testing.dm
@@ -3,6 +3,7 @@
 	#include "modpack_testing_lobby.dm"
 	#include "blank.dmm"
 
+	#include "../../mods/content/actors.dm"
 	#include "../../mods/content/mundane.dm"
 	#include "../../mods/content/scaling_descriptors.dm"
 

--- a/mods/content/actors.dm
+++ b/mods/content/actors.dm
@@ -1,3 +1,10 @@
+#ifndef MODPACK_ACTORS
+#define MODPACK_ACTORS
+#endif
+
+/decl/modpack/actors
+	name = "Actor Special Role"
+
 /decl/special_role/actor
 	name = "Actor"
 	name_plural = "Actors"
@@ -8,11 +15,14 @@
 	hard_cap_round = 10
 	initial_spawn_req = 1
 	initial_spawn_target = 1
-	show_objectives_on_creation = 0 //actors are not antagonists and do not need the antagonist greet text
+	show_objectives_on_creation = FALSE //actors are not antagonists and do not need the antagonist greet text
 	required_language = /decl/language/human/common
 	default_outfit = /decl/outfit/actor
 	default_access = list()
 	id_title = "Actor"
+
+/obj/abstract/landmark/actor_spawn
+	name = "ActorSpawn"
 
 /decl/outfit/actor
 	name =    "Special Role - Actor"
@@ -35,6 +45,10 @@
 
 	var/decl/special_role/actors = GET_DECL(/decl/special_role/actor)
 	if(!MayRespawn(1) || !actors.can_become_antag(usr.mind, 1))
+		return
+
+	if(!LAZYLEN(actors.starting_locations))
+		to_chat(usr, "Actors do not have a spawn location on this map, and are unavailable.")
 		return
 
 	var/choice = alert("Are you sure you'd like to join as an actor?", "Confirmation","Yes", "No")

--- a/nebula.dme
+++ b/nebula.dme
@@ -775,7 +775,6 @@
 #include "code\game\antagonist\antagonist_place.dm"
 #include "code\game\antagonist\antagonist_print.dm"
 #include "code\game\antagonist\antagonist_update.dm"
-#include "code\game\antagonist\outsider\actors.dm"
 #include "code\game\antagonist\outsider\ert.dm"
 #include "code\game\antagonist\station\provocateur.dm"
 #include "code\game\antagonist\station\thrall.dm"


### PR DESCRIPTION
## Description of changes
- Moves actor special role into a modpack.
- Adds a check for actor spawnpoints to the 'join as actor' verb.
- Adds a premade landmark for actor spawnpoints.
The new modpack is now only available on the modpack testing map, because it didn't have any landmarks placed anywhere else (given that we don't have Centcomm).

## Why and what will this PR improve
Actors are defunct (there isn't even a single map that supports them) but they're trivial to keep, so this lets us have our cake and eat it too. Also fixes an issue where trying to join as an actor without a spawnpoint landmark placed would result in a bunch of mobs accumulating in nullspace.

## Authorship
Me.

## Changelog
:cl:
del: The 'join as actor' verb has been removed on all player maps.
/:cl: