### PR TITLE
Use LAZYLEN macro where applicable

### DIFF
--- a/code/_helpers/lists.dm
+++ b/code/_helpers/lists.dm
@@ -176,7 +176,7 @@
 
 //Checks for specific types in specifically structured (Assoc "type" = TRUE) lists ('typecaches')
 /proc/is_type_in_typecache(atom/A, list/cache)
-	if(!cache || !cache.len || !A)
+	if(!LAZYLEN(cache) || !A)
 		return 0
 	return cache[A.type]
 

--- a/code/datums/mind/mind.dm
+++ b/code/datums/mind/mind.dm
@@ -108,7 +108,7 @@
 	out += "</table><hr>"
 	out += "<b>Objectives</b></br>"
 
-	if(objectives && objectives.len)
+	if(LAZYLEN(objectives))
 		var/num = 1
 		for(var/datum/objective/O in objectives)
 			out += "<b>Objective #[num]:</b> [O.explanation_text] "

--- a/code/datums/trading/_trader.dm
+++ b/code/datums/trading/_trader.dm
@@ -67,7 +67,7 @@
 
 /datum/trader/proc/add_to_pool(var/list/pool, var/list/possible, var/base_chance = 100, var/force = 0)
 	var/divisor = 1
-	if(pool && pool.len)
+	if(LAZYLEN(pool))
 		divisor = pool.len
 	if(force || prob(base_chance/divisor))
 		var/new_item = get_possible_item(possible)
@@ -160,7 +160,7 @@
 	return value
 
 /datum/trader/proc/offer_items_for_trade(var/list/offers, var/num, var/turf/location, skill = SKILL_MAX)
-	if(!offers || !offers.len)
+	if(!LAZYLEN(offers))
 		return TRADER_NOT_ENOUGH
 	num = clamp(num, 1, trading_items.len)
 	var/offer_worth = 0
@@ -229,7 +229,7 @@
 	return get_response(TRADER_COMPLIMENT_ACCEPT, "Thank you!")
 
 /datum/trader/proc/trade(var/list/offers, var/num, var/turf/location)
-	if(offers && offers.len)
+	if(LAZYLEN(offers))
 		for(var/offer in offers)
 			if(ismob(offer))
 				var/text = mob_transfer_message
@@ -263,7 +263,7 @@
 /datum/trader/proc/sell_items(var/list/offers, skill = SKILL_MAX)
 	if(!(trade_flags & TRADER_GOODS))
 		return TRADER_NO_GOODS
-	if(!offers || !offers.len)
+	if(!LAZYLEN(offers))
 		return TRADER_NOT_ENOUGH
 
 	var/wanted

--- a/code/datums/uplink/uplink_sources.dm
+++ b/code/datums/uplink/uplink_sources.dm
@@ -122,7 +122,7 @@ var/global/list/default_uplink_source_priority = list(
 	if(M.client && M.client.prefs)
 		priority_order = M.client.prefs.uplink_sources
 
-	if(!priority_order || !priority_order.len)
+	if(!LAZYLEN(priority_order))
 		priority_order = list()
 		for(var/entry in global.default_uplink_source_priority)
 			priority_order |= GET_DECL(entry)

--- a/code/game/antagonist/antagonist_objectives.dm
+++ b/code/game/antagonist/antagonist_objectives.dm
@@ -1,7 +1,7 @@
 /decl/special_role/proc/create_global_objectives(var/override=0)
 	if(get_config_value(/decl/config/enum/objectives_disabled) != CONFIG_OBJECTIVE_ALL && !override)
 		return 0
-	if(global_objectives && global_objectives.len)
+	if(LAZYLEN(global_objectives))
 		return 0
 	return 1
 

--- a/code/game/antagonist/antagonist_panel.dm
+++ b/code/game/antagonist/antagonist_panel.dm
@@ -5,7 +5,7 @@
 	if(is_antagonist(player))
 		dat += "<a href='byond://?src=\ref[player];remove_antagonist=\ref[src]'>\[-\]</a>"
 		dat += "<a href='byond://?src=\ref[player];equip_antagonist=\ref[src]'>\[equip\]</a>"
-		if(starting_locations && starting_locations.len)
+		if(LAZYLEN(starting_locations))
 			dat += "<a href='byond://?src=\ref[player];move_antag_to_spawn=\ref[src]'>\[move to spawn\]</a>"
 		if(extra) dat += "[extra]"
 	else
@@ -19,7 +19,7 @@
 
 /decl/special_role/proc/get_check_antag_output(var/datum/admins/calling_admin)
 
-	if(!current_antagonists || !current_antagonists.len)
+	if(!LAZYLEN(current_antagonists))
 		return ""
 
 	var/dat = "<br><table cellspacing=5><tr><td><B>[name_plural]</B></td><td></td></tr>"

--- a/code/game/antagonist/antagonist_place.dm
+++ b/code/game/antagonist/antagonist_place.dm
@@ -21,7 +21,7 @@
 	return
 
 /decl/special_role/proc/place_mob(var/mob/living/mob)
-	if(!starting_locations || !starting_locations.len)
+	if(!LAZYLEN(starting_locations))
 		return
 	var/turf/T = pick_mobless_turf_if_exists(starting_locations)
 	mob.forceMove(T)

--- a/code/game/antagonist/antagonist_print.dm
+++ b/code/game/antagonist/antagonist_print.dm
@@ -19,7 +19,7 @@
 			text += "<br>Their goals for today were..."
 			text += "<br><span class='notice'>[ambitions.summarize()]</span>"
 
-	if(global_objectives && global_objectives.len)
+	if(LAZYLEN(global_objectives))
 		text += "<BR><FONT size = 2>Their objectives were:</FONT>"
 		var/num = 1
 		for(var/datum/objective/O in global_objectives)
@@ -38,7 +38,7 @@
 	var/role
 	if(ply.assigned_role)
 		role = ply.assigned_role
-	else 
+	else
 		role = ply.get_special_role_name("unknown role")
 	role = "\improper [role]"
 

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -134,7 +134,7 @@ var/global/list/additional_antag_types = list()
 	to_world("<B>The current game mode is [capitalize(name)]!</B>")
 	if(round_description) to_world("[round_description]")
 	if(round_autoantag) to_world("Antagonists will be added to the round automagically as needed.")
-	if(antag_templates && antag_templates.len)
+	if(LAZYLEN(antag_templates))
 		var/antag_summary = "<b>Possible antagonist types:</b> "
 		var/i = 1
 		for(var/decl/special_role/antag in antag_templates)
@@ -170,7 +170,7 @@ var/global/list/additional_antag_types = list()
 			if(!antag)
 				continue
 			var/list/potential = list()
-			if(antag_templates && antag_templates.len)
+			if(LAZYLEN(antag_templates))
 				if(antag.flags & ANTAG_OVERRIDE_JOB)
 					potential = antag.pending_antagonists
 				else
@@ -327,7 +327,7 @@ var/global/list/additional_antag_types = list()
 /decl/game_mode/proc/check_finished()
 	if(SSevac.evacuation_controller?.round_over() || station_was_nuked)
 		return 1
-	if(end_on_antag_death && antag_templates && antag_templates.len)
+	if(end_on_antag_death && LAZYLEN(antag_templates))
 		var/has_antags = 0
 		for(var/decl/special_role/antag in antag_templates)
 			if(!antag.antags_are_dead())

--- a/code/game/machinery/_machines_base/machinery_components.dm
+++ b/code/game/machinery/_machines_base/machinery_components.dm
@@ -33,7 +33,7 @@ var/global/list/machine_path_to_circuit_type
 				LAZYINITLIST(uncreated_component_parts)
 				for(var/type in req_components)
 					uncreated_component_parts[type] += (req_components[type] || 1)
-		if(initial_access && length(initial_access) > 0)
+		if(LAZYLEN(initial_access) > 0)
 			for(var/access_list in initial_access)
 				// Each part is an AND component.
 				var/obj/item/stock_parts/network_receiver/network_lock/lock = install_component(/obj/item/stock_parts/network_receiver/network_lock/buildable, refresh_parts = FALSE)

--- a/code/game/objects/effects/decals/Cleanable/tracks.dm
+++ b/code/game/objects/effects/decals/Cleanable/tracks.dm
@@ -27,7 +27,7 @@
 /obj/effect/decal/cleanable/blood/tracks/reveal_blood()
 	// don't reveal non-blood tracks
 	if(ispath(chemical, /decl/material/liquid/blood) && !fluorescent)
-		if(stack && stack.len)
+		if(LAZYLEN(stack))
 			for(var/datum/fluidtrack/track in stack)
 				track.basecolor = COLOR_LUMINOL
 		..()

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -76,7 +76,7 @@
 /obj/item/radio/proc/can_decrypt(var/list/secured)
 	if(decrypt_all_messages)
 		return TRUE
-	if(!secured || !length(secured))
+	if(!LAZYLEN(secured))
 		return TRUE
 	if(!islist(secured))
 		secured = list(secured)

--- a/code/game/turfs/walls/wall_natural_xenoarch.dm
+++ b/code/game/turfs/walls/wall_natural_xenoarch.dm
@@ -78,12 +78,12 @@
 	var/excav_level = P.get_tool_property(TOOL_PICK, TOOL_PROP_EXCAVATION_DEPTH)
 	excavation_level += excav_level
 	//archaeo overlays
-	if(!archaeo_overlay && finds && finds.len)
+	if(!archaeo_overlay && LAZYLEN(finds))
 		var/datum/find/F = finds[1]
 		if(F.excavation_required <= excavation_level + F.view_range)
 			archaeo_overlay = image('icons/turf/excavation_overlays.dmi',"overlay_archaeo[rand(1,3)]")
 			queue_icon_update()
-	else if(archaeo_overlay && (!finds || !finds.len))
+	else if(archaeo_overlay && !LAZYLEN(finds))
 		archaeo_overlay = null
 		queue_icon_update()
 

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -277,7 +277,7 @@ var/global/BSACooldown = 0
 	var/savefile/info = new("data/player_saves/[copytext(key, 1, 2)]/[key]/info.sav")
 	var/list/infos
 	from_file(info, infos)
-	if(!infos || !infos.len) return 0
+	if(!LAZYLEN(infos)) return 0
 	else return 1
 
 

--- a/code/modules/admin/admin_attack_log.dm
+++ b/code/modules/admin/admin_attack_log.dm
@@ -11,7 +11,7 @@
 	message_admins(user ? "[key_name_admin(user)] [message]" : "EVENT [message]")
 
 /proc/log_and_message_admins_many(var/list/mob/users, var/message)
-	if(!users || !users.len)
+	if(!LAZYLEN(users))
 		return
 
 	var/list/user_keys = list()
@@ -95,7 +95,7 @@
 	return FALSE
 
 /proc/admin_attacker_log_many_victims(var/mob/attacker, var/list/mob/victims, var/attacker_message, var/victim_message, var/admin_message)
-	if(!victims || !victims.len)
+	if(!LAZYLEN(victims))
 		return
 
 	for(var/mob/victim in victims)

--- a/code/modules/admin/dbban/functions.dm
+++ b/code/modules/admin/dbban/functions.dm
@@ -415,13 +415,13 @@
 				if(playercid)
 					cidsearch  = "AND `computerid` = '[playercid]' "
 			else
-				if(adminckey && length(adminckey) >= 3)
+				if(length(adminckey) >= 3)
 					adminsearch = "AND `a_ckey` LIKE '[adminckey]%' "
-				if(playerckey && length(playerckey) >= 3)
+				if(length(playerckey) >= 3)
 					playersearch = "AND `ckey` LIKE '[playerckey]%' "
-				if(playerip && length(playerip) >= 3)
+				if(length(playerip) >= 3)
 					ipsearch  = "AND `ip` LIKE '[playerip]%' "
-				if(playercid && length(playercid) >= 7)
+				if(length(playercid) >= 7)
 					cidsearch  = "AND `computerid` LIKE '[playercid]%' "
 
 			if(dbbantype)

--- a/code/modules/augment/passive/boost.dm
+++ b/code/modules/augment/passive/boost.dm
@@ -48,7 +48,7 @@
 			return 1
 
 /obj/item/organ/internal/augment/boost/proc/buff()
-	if(!buffs || !buffs.len)
+	if(!LAZYLEN(buffs))
 		return 0
 	var/list/B = owner.fetch_buffs_of_type(buffpath, 0)
 	for(var/datum/skill_buff/augment/D in B)

--- a/code/modules/client/asset_cache.dm
+++ b/code/modules/client/asset_cache.dm
@@ -67,7 +67,7 @@ You can set verify to TRUE if you want send() to sleep until the client has the 
 		return FALSE
 
 	var/list/unreceived = asset_list - (client.cache + client.sending)
-	if(!unreceived || !unreceived.len)
+	if(!LAZYLEN(unreceived))
 		return 0
 	if (unreceived.len >= ASSET_CACHE_TELL_CLIENT_AMOUNT)
 		to_chat(client, "Sending resources...")

--- a/code/modules/clothing/masks/voice.dm
+++ b/code/modules/clothing/masks/voice.dm
@@ -23,7 +23,7 @@
 	set src in usr
 
 	var/voice = sanitize(name, MAX_NAME_LEN)
-	if(!voice || !length(voice)) return
+	if(!length(voice)) return
 	changer.voice = voice
 	to_chat(usr, "<span class='notice'>You are now mimicking <B>[changer.voice]</B>.</span>")
 

--- a/code/modules/clothing/spacesuits/breaches.dm
+++ b/code/modules/clothing/spacesuits/breaches.dm
@@ -48,7 +48,7 @@
 //Repair a certain amount of brute or burn damage to the suit.
 /obj/item/clothing/suit/space/proc/repair_breaches(var/damtype, var/amount, var/mob/user)
 
-	if(!can_breach || !breaches || !breaches.len)
+	if(!can_breach || !LAZYLEN(breaches))
 		to_chat(user, "There are no breaches to repair on \the [src].")
 		return
 
@@ -146,7 +146,7 @@
 	burn_damage = 0
 	var/all_patched = TRUE
 
-	if(!can_breach || !breaches || !breaches.len)
+	if(!can_breach || !LAZYLEN(breaches))
 		SetName(initial(name))
 		return 0
 
@@ -260,7 +260,7 @@
 
 /obj/item/clothing/suit/space/get_examine_strings(mob/user, distance, infix, suffix)
 	. = ..()
-	if(can_breach && breaches && breaches.len)
+	if(can_breach && LAZYLEN(breaches))
 		for(var/datum/breach/B in breaches)
 			. += SPAN_DANGER("It has \a [B.descriptor].")
 

--- a/code/modules/clothing/spacesuits/rig/modules/modules.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/modules.dm
@@ -118,7 +118,7 @@
 	if(suit_overlay_inactive)
 		suit_overlay = suit_overlay_inactive
 
-	if(charges && charges.len)
+	if(LAZYLEN(charges))
 		var/list/processed_charges = list()
 		for(var/list/charge in charges)
 			var/datum/rig_charge/charge_dat = new

--- a/code/modules/clothing/spacesuits/rig/rig.dm
+++ b/code/modules/clothing/spacesuits/rig/rig.dm
@@ -139,7 +139,7 @@
 
 	START_PROCESSING(SSobj, src)
 
-	if(initial_modules && initial_modules.len)
+	if(LAZYLEN(initial_modules))
 		for(var/path in initial_modules)
 			var/obj/item/rig_module/module = new path(src)
 			installed_modules += module

--- a/code/modules/clothing/spacesuits/rig/rig_attackby.dm
+++ b/code/modules/clothing/spacesuits/rig/rig_attackby.dm
@@ -125,7 +125,7 @@
 			var/list/current_mounts = list()
 			if(cell) current_mounts   += "cell"
 			if(air_supply) current_mounts += "tank"
-			if(installed_modules && installed_modules.len) current_mounts += "system module"
+			if(LAZYLEN(installed_modules)) current_mounts += "system module"
 
 			var/to_remove = input("Which would you like to modify?") as null|anything in current_mounts
 			if(!to_remove)

--- a/code/modules/hydroponics/seed.dm
+++ b/code/modules/hydroponics/seed.dm
@@ -263,7 +263,7 @@
 
 	var/health_change = 0
 	// Handle gas consumption.
-	if(consume_gasses && consume_gasses.len)
+	if(LAZYLEN(consume_gasses))
 		var/missing_gas = 0
 		for(var/gas in consume_gasses)
 			if(LAZYACCESS(environment?.gas, gas) >= consume_gasses[gas])
@@ -284,7 +284,7 @@
 		health_change += rand(1,3) * growth_rate
 
 	// Handle gas production.
-	if(exude_gasses && exude_gasses.len && !check_only)
+	if(LAZYLEN(exude_gasses) && !check_only)
 		for(var/gas in exude_gasses)
 			environment.adjust_gas(gas, max(1,round((exude_gasses[gas]*(get_trait(TRAIT_POTENCY)/5))/exude_gasses.len)))
 
@@ -508,7 +508,7 @@
 
 //Returns a key corresponding to an entry in the global seed list.
 /datum/seed/proc/get_mutant_variant()
-	if(!mutants || !mutants.len || get_trait(TRAIT_IMMUTABLE) > 0) return 0
+	if(!LAZYLEN(mutants) || get_trait(TRAIT_IMMUTABLE) > 0) return 0
 	return pick(mutants)
 
 //Mutates the plant overall (randomly).

--- a/code/modules/hydroponics/spreading/spreading_growth.dm
+++ b/code/modules/hydroponics/spreading/spreading_growth.dm
@@ -62,7 +62,7 @@
 		//Find a victim
 		if(!buckled_mob)
 			var/list/mob/living/targets = targets_in_range()
-			if(targets && targets.len && prob(round(seed.get_trait(TRAIT_POTENCY)/4)))
+			if(LAZYLEN(targets) && prob(round(seed.get_trait(TRAIT_POTENCY)/4)))
 				entangle(pick(targets))
 
 		//Handle the victim

--- a/code/modules/mob/language/language.dm
+++ b/code/modules/mob/language/language.dm
@@ -121,7 +121,7 @@
 	return "..."
 
 /decl/language/proc/scramble_word(var/input)
-	if(!syllables || !syllables.len)
+	if(!LAZYLEN(syllables))
 		return stars(input)
 
 	// If the input is cached already, move it to the end of the cache and return it

--- a/code/modules/mob/living/silicon/robot/modules/_module.dm
+++ b/code/modules/mob/living/silicon/robot/modules/_module.dm
@@ -195,7 +195,7 @@
 			F.update_icon()
 		else if(F.times_used)
 			F.times_used--
-	if(!synths || !synths.len)
+	if(!LAZYLEN(synths))
 		return
 	for(var/datum/matter_synth/T in synths)
 		T.add_charge(T.recharge_rate * rate)

--- a/code/modules/mob/observer/eye/blueprints_eye.dm
+++ b/code/modules/mob/observer/eye/blueprints_eye.dm
@@ -53,7 +53,7 @@
 
 /mob/observer/eye/blueprints/proc/create_area()
 	var/area_name = sanitize_safe(input("New area name:","Area Creation", ""), MAX_NAME_LEN)
-	if(!area_name || !length(area_name))
+	if(!length(area_name))
 		return
 	if(length(area_name) > MAX_NAME_LEN)
 		to_chat(owner, SPAN_WARNING("That name is too long!"))

--- a/code/modules/overmap/ships/machines/fusion_thruster.dm
+++ b/code/modules/overmap/ships/machines/fusion_thruster.dm
@@ -31,7 +31,7 @@
 
 	if(lan)
 		var/list/fusion_cores = lan.get_devices(/obj/machinery/fusion_core)
-		if(fusion_cores && fusion_cores.len)
+		if(LAZYLEN(fusion_cores))
 			harvest_from = fusion_cores[1]
 	return harvest_from
 

--- a/code/modules/paperwork/handlabeler.dm
+++ b/code/modules/paperwork/handlabeler.dm
@@ -131,7 +131,7 @@
 		if(HAND_LABELER_MODE_ADD_NAME)
 			to_chat(user, SPAN_NOTICE("You switch to labeling mode."))
 			var/str = sanitize_safe(input(user,"Label text?", "Set label", label), MAX_LNAME_LEN)
-			if(!str || !length(str))
+			if(!length(str))
 				return
 			label = str
 			mode = HAND_LABELER_MODE_ADD

--- a/code/modules/pointdefense/pointdefense.dm
+++ b/code/modules/pointdefense/pointdefense.dm
@@ -93,7 +93,7 @@
 		var/datum/local_network/lan = pointdefense.get_local_network()
 		if(lan)
 			var/list/pointdefense_controllers = lan.get_devices(/obj/machinery/pointdefense_control)
-			if(pointdefense_controllers && pointdefense_controllers.len > 1)
+			if(LAZYLEN(pointdefense_controllers) > 1)
 				lan.remove_device(src)
 		return TRUE
 	return ..()

--- a/code/modules/power/fusion/kinetic_harvester.dm
+++ b/code/modules/power/fusion/kinetic_harvester.dm
@@ -47,7 +47,7 @@
 
 	if(lan)
 		var/list/fusion_cores = lan.get_devices(/obj/machinery/fusion_core)
-		if(fusion_cores && fusion_cores.len)
+		if(LAZYLEN(fusion_cores))
 			harvest_from = fusion_cores[1]
 	return harvest_from
 

--- a/code/modules/power/powernet.dm
+++ b/code/modules/power/powernet.dm
@@ -101,7 +101,7 @@
 	if(problem > 0)
 		problem = max(problem - 1, 0)
 
-	if(nodes && nodes.len) // Added to fix a bad list bug -- TLE
+	if(LAZYLEN(nodes)) // Added to fix a bad list bug -- TLE
 		for(var/obj/machinery/power/terminal/term in nodes)
 			if( istype( term.master_machine(), /obj/machinery/apc ) )
 				numapc++

--- a/code/modules/random_map/dungeon/room_generation.dm
+++ b/code/modules/random_map/dungeon/room_generation.dm
@@ -18,7 +18,7 @@
 	return 1
 
 /datum/random_room/proc/apply_loot(var/xorigin = 1,var/yorigin = 1,var/zorigin = 1, var/type)
-	if(!item_spawns || !item_spawns.len)
+	if(!LAZYLEN(item_spawns))
 		return 0
 	var/place = pick(item_spawns)
 	if(istype(place,/obj)) //we assume what object we get is some sort of container.

--- a/code/modules/random_map/dungeon/winding_dungeon.dm
+++ b/code/modules/random_map/dungeon/winding_dungeon.dm
@@ -73,10 +73,10 @@
 /datum/random_map/winding_dungeon/proc/get_appropriate_list(var/list/common, var/list/uncommon, var/list/rare, var/x, var/y)
 	var/distance = sqrt((x - round(first_room_x+first_room_width/2)) ** 2 + (y - round(first_room_y+first_room_height/2)) ** 2)
 	if(prob(distance))
-		if(prob(distance/100) && rare && rare.len)
+		if(prob(distance/100) && LAZYLEN(rare))
 			logging("Returning rare list.")
 			return rare
-		else if(uncommon && uncommon.len)
+		else if(LAZYLEN(uncommon))
 			logging("Returning uncommon list.")
 			return uncommon
 	logging("Returning common list.")
@@ -92,12 +92,12 @@
 	var/num_of_loot = round(limit_x * limit_y * loot_multiplier)
 	logging("Attempting to add [num_of_loot] # of loot")
 	var/sanity = 0
-	if((loot_common && loot_common.len) || (loot_uncommon && loot_uncommon.len) || (loot_rare && loot_rare.len)) //no monsters no problem
+	if((LAZYLEN(loot_common)) || (LAZYLEN(loot_uncommon)) || (LAZYLEN(loot_rare))) //no monsters no problem
 		while(rooms.len && num_of_loot > 0)
 			CHECK_TICK
 			var/datum/room/R = pick(rooms)
 			var/list/loot_list = get_appropriate_list(loot_common, loot_uncommon, loot_rare, round(R.x+R.width/2), round(R.y+R.height/2))
-			if(!loot_list || !loot_list.len || R.add_loot(origin_x,origin_y,origin_z,pickweight(loot_list)))
+			if(!LAZYLEN(loot_list) || R.add_loot(origin_x,origin_y,origin_z,pickweight(loot_list)))
 				num_of_loot--
 				sanity -= 10 //we hahve success so more tries
 				continue
@@ -110,7 +110,7 @@
 		rooms -= R
 		qdel(R)
 
-	if((!monsters_common || !monsters_common.len) && (!monsters_uncommon || !monsters_uncommon.len) && (!monsters_rare || !monsters_rare.len)) //no monsters no problem
+	if(!LAZYLEN(monsters_common) && !LAZYLEN(monsters_uncommon) && !LAZYLEN(monsters_rare)) //no monsters no problem
 		logging("No monster lists detected. Not spawning monsters.")
 		return
 
@@ -119,14 +119,14 @@
 
 	while(num_of_monsters > 0)
 		CHECK_TICK
-		if(!monster_available || !monster_available.len)
+		if(!LAZYLEN(monster_available))
 			logging("There are no available turfs left.")
 			num_of_monsters = 0
 			continue
 		var/turf/T = pick(monster_available)
 		monster_available -= T
 		var/list/monster_list = get_appropriate_list(monsters_common, monsters_uncommon, monsters_rare, T.x, T.y)
-		if(monster_list && monster_list.len)
+		if(LAZYLEN(monster_list))
 			var/type = pickweight(monster_list)
 			logging("Generating a monster of type [type] at position ([T.x],[T.y],[origin_z])")
 			var/mob/M = new type(T)

--- a/code/modules/turbolift/turbolift.dm
+++ b/code/modules/turbolift/turbolift.dm
@@ -81,7 +81,7 @@
 	var/current_floor_index = floors.Find(current_floor)
 
 	if(!target_floor)
-		if(!queued_floors || !queued_floors.len)
+		if(!LAZYLEN(queued_floors))
 			return 0
 		target_floor = queued_floors[1]
 		queued_floors -= target_floor

--- a/mods/content/dungeon_loot/loot_pile.dm
+++ b/mods/content/dungeon_loot/loot_pile.dm
@@ -28,7 +28,7 @@
 
 /obj/structure/loot_pile/Initialize()
 	var/list/icon_states_to_use = get_icon_states_to_use()
-	if(icon_states_to_use && icon_states_to_use.len)
+	if(LAZYLEN(icon_states_to_use))
 		icon_state = pick(icon_states_to_use)
 	. = ..()
 

--- a/mods/content/shackles/laws_pref.dm
+++ b/mods/content/shackles/laws_pref.dm
@@ -3,7 +3,7 @@
 	var/is_shackled = FALSE
 
 /datum/preferences/proc/get_lawset()
-	if(!laws || !laws.len)
+	if(!LAZYLEN(laws))
 		return
 	var/datum/ai_laws/custom_lawset = new
 	for(var/law in laws)

--- a/mods/content/ventcrawl/ventcrawl_mob.dm
+++ b/mods/content/ventcrawl/ventcrawl_mob.dm
@@ -67,7 +67,7 @@ var/global/list/ventcrawl_machinery = list(
 	for(var/obj/machinery/atmospherics/unary/U in range(1))
 		if(is_type_in_list(U,ventcrawl_machinery) && Adjacent(U) && U.can_crawl_through())
 			pipes |= U
-	if(!pipes || !pipes.len)
+	if(!LAZYLEN(pipes))
 		to_chat(src, "There are no pipes that you can ventcrawl into within range!")
 		return
 	if(pipes.len == 1)

--- a/mods/mobs/dionaea/mob/gestalt/_gestalt.dm
+++ b/mods/mobs/dionaea/mob/gestalt/_gestalt.dm
@@ -26,7 +26,7 @@
 /obj/structure/diona_gestalt/on_update_icon()
 	..()
 	add_overlay(eyes_overlay)
-	if(nymphs && nymphs.len)
+	if(LAZYLEN(nymphs))
 		var/matrix/M = matrix()
 		M.Scale(clamp(nymphs.len * 0.1, 1, 2))
 		transform = M

--- a/mods/mobs/dionaea/mob/gestalt/gestalt_attacks.dm
+++ b/mods/mobs/dionaea/mob/gestalt/gestalt_attacks.dm
@@ -16,7 +16,7 @@
 /obj/structure/diona_gestalt/explosion_act()
 	SHOULD_CALL_PARENT(FALSE)
 	var/shed_count = rand(1,3)
-	while(shed_count && nymphs && nymphs.len)
+	while(shed_count && LAZYLEN(nymphs))
 		shed_count--
 		shed_atom(forcefully = TRUE)
 


### PR DESCRIPTION
## Description of changes
Replaces `(!foo || !foo.len)` and `(foo && foo.len)` with `!LAZYLEN(foo)` and `LAZYLEN(foo)` respectively. I tried to avoid using it in cases where it was on a string instead of a list, and in those cases just used `length(foo)` on its own because the nullcheck is redundant.

## Why and what will this PR improve
Should be marginally faster, and also easier to read. This is broadly a code-quality cleanup.

## Authorship
Me