### PR TITLE
Fix missing abstract_type values for power machines

### DIFF
--- a/code/modules/power/debug_items.dm
+++ b/code/modules/power/debug_items.dm
@@ -1,4 +1,5 @@
-/obj/machinery/power/debug_items/
+/obj/machinery/power/debug_items
+	abstract_type = /obj/machinery/power/debug_items
 	icon = 'icons/obj/power.dmi'
 	icon_state = "tracker"
 	anchored = TRUE

--- a/code/modules/power/power.dm
+++ b/code/modules/power/power.dm
@@ -9,6 +9,7 @@
 /////////////////////////////
 
 /obj/machinery/power
+	abstract_type = /obj/machinery/power
 	name = null
 	icon = 'icons/obj/power.dmi'
 	anchored = TRUE


### PR DESCRIPTION
## Description of changes
Split out of #5120. Sets `abstract_type` for `/obj/machinery/power` and `/obj/machinery/power/debug_item`. In theory you could have spawned the latter and used it to get a readout of info about the powernet, but it has no name, so I figure that's just a happy accident and there's no downside to making it abstract.

## Why and what will this PR improve
Makes abstract types abstract.

## Authorship
Me