### PR TITLE
Improve code quality in powernet and cable code

### DIFF
--- a/code/modules/admin/verbs/atmosdebug.dm
+++ b/code/modules/admin/verbs/atmosdebug.dm
@@ -7,14 +7,14 @@
 	SSstatistics.add_field_details("admin_verb","CPOW") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 	for (var/datum/powernet/PN in SSmachines.powernets)
-		if (!PN.nodes || !PN.nodes.len)
+		if (!LAZYLEN(PN.nodes))
 			if(PN.cables && (PN.cables.len > 1))
 				var/obj/structure/cable/C = PN.cables[1]
 				var/area/A = get_area(C.loc)
 				to_chat(usr, "Powernet with no nodes! (number [PN.number]) - example cable at [C.x], [C.y], [C.z] in area [A?.proper_name]")
 
-		if (!PN.cables || (PN.cables.len < 10))
-			if(PN.cables && (PN.cables.len > 1))
-				var/obj/structure/cable/C = PN.cables[1]
-				var/area/A = get_area(C.loc)
-				to_chat(usr, "Powernet with fewer than 10 cables! (number [PN.number]) - example cable at [C.x], [C.y], [C.z] in area [A?.proper_name]")
+		var/cable_count = LAZYLEN(PN.cables)
+		if (cable_count > 1 && cable_count < 10)
+			var/obj/structure/cable/C = PN.cables[1]
+			var/area/A = get_area(C.loc)
+			to_chat(usr, "Powernet with fewer than 10 cables! (number [PN.number]) - example cable at [C.x], [C.y], [C.z] in area [A?.proper_name]")

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -452,10 +452,10 @@ var/global/list/obj/structure/cable/all_cables = list()
 	var/turf/T1 = loc
 	if(!T1) return
 
-	var/list/cablelist = cable_list(T1, src, 0) //find the other cables that ended in the centre of the turf, with or without a powernet
-	if(length(cablelist))
+	var/obj/structure/cable/other_cable = get_matching_cable(T1, src, 0) // find a cable to start a replacement network from, if it exists
+	if(other_cable)
 		var/datum/powernet/PN = new()
-		propagate_network(cablelist[1],PN) //propagates the new powernet beginning at the source cable
+		propagate_network(other_cable,PN) //propagates the new powernet beginning at the source cable
 
 		if(PN.is_empty()) //can happen with machines made nodeless when smoothing cables
 			qdel(PN)
@@ -463,16 +463,16 @@ var/global/list/obj/structure/cable/all_cables = list()
 // cut the cable's powernet at this cable and updates the powergrid
 /obj/structure/cable/proc/cut_cable_from_powernet()
 	var/turf/T1 = loc
-	var/list/P_list
+	var/obj/structure/cable/other_cable
 	if(!T1)	return
 	if(d1)
 		T1 = get_zstep_resolving_mimic(T1, d1)
-		P_list = cable_list(T1, src, d1) // what adjacently joins on to cut cable...
+		other_cable = get_matching_cable(T1, src, d1) // check our adjacent turf for connecting cables first
+	if(!other_cable)
+		other_cable = get_matching_cable(loc, src, d1) // and fall back to our own turf if we don't find one
 
-	P_list += cable_list(loc, src, d1)//... and on turf
 
-
-	if(!length(P_list))//if nothing in both list, then the cable was a lone cable, just delete it and its powernet
+	if(!other_cable) // if we didn't find another cable, then the cable was a lone cable, just delete it and its powernet
 		powernet.remove_cable(src)
 
 		for(var/obj/machinery/power/P in T1)//check if it was powering a machine
@@ -485,7 +485,7 @@ var/global/list/obj/structure/cable/all_cables = list()
 	powernet.remove_cable(src) //remove the cut cable from its powernet
 
 	var/datum/powernet/newPN = new()// creates a new powernet...
-	propagate_network(P_list[1], newPN)//... and propagates it to the other side of the cable
+	propagate_network(other_cable, newPN)//... and propagates it to the other side of the cable
 
 	// Disconnect machines connected to nodes
 	if(d1 == 0) // if we cut a node (O-X) cable

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -418,9 +418,9 @@ var/global/list/obj/structure/cable/all_cables = list()
 					. += C
 		if(cable_dir & (cable_dir - 1)) // Diagonal, check for /\/\/\ style cables along cardinal directions
 			for(var/pair in list(NORTH|SOUTH, EAST|WEST))
-				T = get_step_resolving_mimic(src, cable_dir & pair)
+				T = get_step_resolving_mimic(src, cable_dir & pair) // move either vertically or horizontally
 				if(T)
-					var/req_dir = cable_dir ^ pair
+					var/req_dir = cable_dir ^ pair // flip along the direction we moved, so if we're NORTHEAST we want a cable to our east that's NORTHWEST
 					for(var/obj/structure/cable/C in T)
 						if(C.d1 == req_dir || C.d2 == req_dir)
 							. += C
@@ -452,10 +452,10 @@ var/global/list/obj/structure/cable/all_cables = list()
 	var/turf/T1 = loc
 	if(!T1) return
 
-	var/list/powerlist = power_list(T1,src,0,0) //find the other cables that ended in the centre of the turf, with or without a powernet
-	if(powerlist.len>0)
+	var/list/cablelist = cable_list(T1, src, 0) //find the other cables that ended in the centre of the turf, with or without a powernet
+	if(length(cablelist))
 		var/datum/powernet/PN = new()
-		propagate_network(powerlist[1],PN) //propagates the new powernet beginning at the source cable
+		propagate_network(cablelist[1],PN) //propagates the new powernet beginning at the source cable
 
 		if(PN.is_empty()) //can happen with machines made nodeless when smoothing cables
 			qdel(PN)
@@ -467,12 +467,12 @@ var/global/list/obj/structure/cable/all_cables = list()
 	if(!T1)	return
 	if(d1)
 		T1 = get_zstep_resolving_mimic(T1, d1)
-		P_list = power_list(T1, src, turn(d1,180),0,cable_only = 1)	// what adjacently joins on to cut cable...
+		P_list = cable_list(T1, src, d1) // what adjacently joins on to cut cable...
 
-	P_list += power_list(loc, src, d1, 0, cable_only = 1)//... and on turf
+	P_list += cable_list(loc, src, d1)//... and on turf
 
 
-	if(P_list.len == 0)//if nothing in both list, then the cable was a lone cable, just delete it and its powernet
+	if(!length(P_list))//if nothing in both list, then the cable was a lone cable, just delete it and its powernet
 		powernet.remove_cable(src)
 
 		for(var/obj/machinery/power/P in T1)//check if it was powering a machine

--- a/code/modules/power/power.dm
+++ b/code/modules/power/power.dm
@@ -100,30 +100,17 @@
 // GLOBAL PROCS for powernets handling
 //////////////////////////////////////////
 
-
-// returns a list of all power-related objects (nodes, cable, junctions) in turf,
-// excluding source, that match the direction d
-// if unmarked==1, only return those with no powernet
-/proc/power_list(var/turf/T, var/source, var/d, var/unmarked=0, var/cable_only = 0)
+/// Returns all cables in target_turf matching target_direction, excluding excluded_cable.
+/// If only_no_powernet is TRUE, only cables with no powernet will be returned.
+/proc/cable_list(var/turf/target_turf, var/obj/structure/cable/excluded_cable = null, var/target_direction, only_no_powernet = FALSE)
 	. = list()
-
-	var/reverse = d ? global.reverse_dir[d] : 0
-	for(var/AM in T)
-		if(AM == source)	continue			//we don't want to return source
-
-		if(!cable_only && istype(AM,/obj/machinery/power))
-			var/obj/machinery/power/P = AM
-			if(!unmarked || !P.powernet)		//if unmarked=1 we only return things with no powernet
-				if(d == 0)
-					. += P
-
-		else if(istype(AM,/obj/structure/cable))
-			var/obj/structure/cable/C = AM
-
-			if(!unmarked || !C.powernet)
-				if(C.d1 == d || C.d2 == d || C.d1 == reverse || C.d2 == reverse )
-					. += C
-	return .
+	var/reverse_direction = target_direction ? global.reverse_dir[target_direction] : 0
+	for(var/obj/structure/cable/other_cable in target_turf)
+		if(other_cable == excluded_cable)
+			continue
+		if(!only_no_powernet || !other_cable.powernet)
+			if(other_cable.d1 == target_direction || other_cable.d2 == target_direction || other_cable.d1 == reverse_direction || other_cable.d2 == reverse_direction)
+				. += other_cable
 
 //remove the old powernet and replace it with a new one throughout the network.
 /proc/propagate_network(var/obj/structure/cable/cable, var/datum/powernet/PN)

--- a/code/modules/power/power.dm
+++ b/code/modules/power/power.dm
@@ -102,15 +102,24 @@
 
 /// Returns all cables in target_turf matching target_direction, excluding excluded_cable.
 /// If only_no_powernet is TRUE, only cables with no powernet will be returned.
-/proc/cable_list(var/turf/target_turf, var/obj/structure/cable/excluded_cable = null, var/target_direction, only_no_powernet = FALSE)
+/// Unused, because get_maching_cable or get_connected_cables is usually preferable, but kept just in case.
+/proc/cable_list(var/turf/target_turf, var/obj/structure/cable/excluded_cable = null, var/target_direction)
 	. = list()
 	var/reverse_direction = target_direction ? global.reverse_dir[target_direction] : 0
 	for(var/obj/structure/cable/other_cable in target_turf)
 		if(other_cable == excluded_cable)
 			continue
-		if(!only_no_powernet || !other_cable.powernet)
-			if(other_cable.d1 == target_direction || other_cable.d2 == target_direction || other_cable.d1 == reverse_direction || other_cable.d2 == reverse_direction)
-				. += other_cable
+		if(other_cable.d1 == target_direction || other_cable.d2 == target_direction || other_cable.d1 == reverse_direction || other_cable.d2 == reverse_direction)
+			. += other_cable
+
+/// Like cable_list, but only returns the first cable, since that's all most uses of it check.
+/proc/get_matching_cable(var/turf/target_turf, var/obj/structure/cable/excluded_cable = null, var/target_direction)
+	var/reverse_direction = target_direction ? global.reverse_dir[target_direction] : 0
+	for(var/obj/structure/cable/other_cable in target_turf)
+		if(other_cable == excluded_cable)
+			continue
+		if(other_cable.d1 == target_direction || other_cable.d2 == target_direction || other_cable.d1 == reverse_direction || other_cable.d2 == reverse_direction)
+			return other_cable
 
 //remove the old powernet and replace it with a new one throughout the network.
 /proc/propagate_network(var/obj/structure/cable/cable, var/datum/powernet/PN)

--- a/code/modules/power/powernet.dm
+++ b/code/modules/power/powernet.dm
@@ -101,10 +101,9 @@
 	if(problem > 0)
 		problem = max(problem - 1, 0)
 
-	if(LAZYLEN(nodes)) // Added to fix a bad list bug -- TLE
-		for(var/obj/machinery/power/terminal/term in nodes)
-			if( istype( term.master_machine(), /obj/machinery/apc ) )
-				numapc++
+	for(var/obj/machinery/power/terminal/term in nodes)
+		if( istype( term.master_machine(), /obj/machinery/apc ) )
+			numapc++
 
 	netexcess = avail - load
 


### PR DESCRIPTION
## Description of changes
Adds comments to powernet code. Improves some checks/loops/etc. in powernet and cable code for better performance and readability. Replaces uses of `power_list()` (now `cable_list()`) with `get_matching_cable()`, which is identical but only returns the first one, which is the only one that would ever get used anyway. This avoids a list alloc and potentially speeds up powernet code by quite a bit.

## Why and what will this PR improve
Code quality and performance improvements.

## Authorship
Me