### PR TITLE
Make breaker boxes no longer a power subtype

### DIFF
--- a/code/game/objects/items/circuitboards/machinery/power.dm
+++ b/code/game/objects/items/circuitboards/machinery/power.dm
@@ -29,7 +29,7 @@
 
 /obj/item/stock_parts/circuitboard/breaker
 	name = "circuitboard (breaker box)"
-	build_path = /obj/machinery/power/breakerbox
+	build_path = /obj/machinery/breakerbox
 	board_type = "machine"
 	origin_tech = @'{"powerstorage":4,"engineering":4}'
 	req_components = list(

--- a/code/modules/modular_computers/file_system/programs/engineering/rcon_console.dm
+++ b/code/modules/modular_computers/file_system/programs/engineering/rcon_console.dm
@@ -44,7 +44,7 @@
 
 	// BREAKER DATA (simplified view)
 	var/list/breakerlist[0]
-	for(var/obj/machinery/power/breakerbox/BR in known_breakers)
+	for(var/obj/machinery/breakerbox/BR in known_breakers)
 		breakerlist.Add(list(list(
 		"RCON_tag" = BR.RCon_tag,
 		"enabled" = BR.on
@@ -90,8 +90,8 @@
 			SMES.set_output(outputset)
 
 	if(href_list["toggle_breaker"])
-		var/obj/machinery/power/breakerbox/toggle = null
-		for(var/obj/machinery/power/breakerbox/breaker in known_breakers)
+		var/obj/machinery/breakerbox/toggle = null
+		for(var/obj/machinery/breakerbox/breaker in known_breakers)
 			if(breaker.RCon_tag == href_list["toggle_breaker"])
 				toggle = breaker
 		if(toggle)
@@ -129,7 +129,7 @@
 	known_SMESs = sortTim(known_SMESs, /proc/cmp_rcon_tag_asc)
 
 	known_breakers = new /list()
-	for(var/obj/machinery/power/breakerbox/breaker in SSmachines.machinery)
+	for(var/obj/machinery/breakerbox/breaker in SSmachines.machinery)
 		if(can_connect_to(breaker))
 			known_breakers.Add(breaker)
 
@@ -145,6 +145,6 @@
 		var/obj/machinery/power/smes/buildable/SMES = M
 		return SMES.RCon_tag && SMES.RCon_tag != "NO_TAG" && SMES.RCon
 
-	if(istype(M, /obj/machinery/power/breakerbox))
-		var/obj/machinery/power/breakerbox/breaker = M
+	if(istype(M, /obj/machinery/breakerbox))
+		var/obj/machinery/breakerbox/breaker = M
 		return breaker.RCon_tag != "NO_TAG"

--- a/code/modules/power/breaker_box.dm
+++ b/code/modules/power/breaker_box.dm
@@ -3,7 +3,7 @@
 // Requires 5 seconds to toggle and can be toggled once a minute
 // Used for advanced grid control (read: Substations)
 
-/obj/machinery/power/breakerbox
+/obj/machinery/breakerbox
 	name = "breaker box"
 	icon = 'icons/obj/power.dmi'
 	icon_state = "bbox_off"
@@ -13,7 +13,7 @@
 	construct_state = /decl/machine_construction/default/panel_closed
 	stat_immune = 0
 	uncreated_component_parts = null
-	base_type = /obj/machinery/power/breakerbox
+	base_type = /obj/machinery/breakerbox
 
 	var/icon_state_on = "bbox_on"
 	var/icon_state_off = "bbox_off"
@@ -23,27 +23,27 @@
 	/// If world.time < lock_time, system is locked for interactions.
 	var/lock_time = 0
 
-/obj/machinery/power/breakerbox/activated
+/obj/machinery/breakerbox/activated
 	icon_state = parent_type::icon_state_on
 
 	// Enabled on server startup. Used in substations to keep them in bypass mode.
-/obj/machinery/power/breakerbox/activated/Initialize()
+/obj/machinery/breakerbox/activated/Initialize()
 	..()
 	return INITIALIZE_HINT_LATELOAD
 
-/obj/machinery/power/breakerbox/activated/LateInitialize()
+/obj/machinery/breakerbox/activated/LateInitialize()
 	set_state(TRUE)
 	. = ..()
 
-/obj/machinery/power/breakerbox/get_examine_strings(mob/user, distance, infix, suffix)
+/obj/machinery/breakerbox/get_examine_strings(mob/user, distance, infix, suffix)
 	. = ..()
 	if(on)
 		. += SPAN_GOOD("It seems to be online.")
 	else
 		. += SPAN_WARNING("It seems to be offline.")
 
-/obj/machinery/power/breakerbox/proc/try_toggle_state(mob/living/user, digital = FALSE)
-	if(lock_time < world.time)
+/obj/machinery/breakerbox/proc/try_toggle_state(mob/living/user, digital = FALSE)
+	if(world.time < lock_time) // maybe rename this unlock_time to make it clearer it's the time it unlocks at
 		to_chat(user, SPAN_WARNING("System locked. Please try again later."))
 		return TRUE
 
@@ -68,13 +68,13 @@
 	busy = FALSE
 	return TRUE
 
-/obj/machinery/power/breakerbox/attack_ai(mob/living/silicon/ai/user)
+/obj/machinery/breakerbox/attack_ai(mob/living/silicon/ai/user)
 	return try_toggle_state(user, digital = TRUE)
 
-/obj/machinery/power/breakerbox/physical_attack_hand(mob/user)
+/obj/machinery/breakerbox/physical_attack_hand(mob/user)
 	return try_toggle_state(user, digital = FALSE)
 
-/obj/machinery/power/breakerbox/attackby(obj/item/used_item, mob/user)
+/obj/machinery/breakerbox/attackby(obj/item/used_item, mob/user)
 	if(IS_MULTITOOL(used_item))
 		var/newtag = input(user, "Enter new RCON tag. Use \"NO_TAG\" to disable RCON or leave empty to cancel.", "SMES RCON system") as text
 		if(!CanPhysicallyInteract(user))
@@ -85,11 +85,11 @@
 		return TRUE
 	return ..()
 
-/obj/machinery/power/breakerbox/on_update_icon()
+/obj/machinery/breakerbox/on_update_icon()
 	. = ..()
 	icon_state = on ? icon_state_on : icon_state_off
 
-/obj/machinery/power/breakerbox/proc/set_state(state)
+/obj/machinery/breakerbox/proc/set_state(state)
 	on = state
 	update_icon()
 	if(on)
@@ -121,7 +121,7 @@
 			qdel(C)
 
 // Used by RCON to toggle the breaker box.
-/obj/machinery/power/breakerbox/proc/auto_toggle()
+/obj/machinery/breakerbox/proc/auto_toggle()
 	if(lock_time > world.time)
 		return FALSE // still on cooldown
 	set_state(!on)

--- a/code/modules/power/cable/cable.dm
+++ b/code/modules/power/cable/cable.dm
@@ -44,7 +44,7 @@ var/global/list/obj/structure/cable/all_cables = list()
 	var/d1
 	var/d2
 	var/datum/powernet/powernet
-	var/obj/machinery/power/breakerbox/breaker_box
+	var/obj/machinery/breakerbox/breaker_box
 
 /obj/structure/cable/drain_power(var/drain_check, var/surge, var/amount = 0)
 

--- a/maps/away/bearcat/bearcat-2.dmm
+++ b/maps/away/bearcat/bearcat-2.dmm
@@ -4191,7 +4191,7 @@
 /turf/floor/usedup,
 /area/ship/scrap/maintenance/power)
 "ib" = (
-/obj/machinery/power/breakerbox/activated,
+/obj/machinery/breakerbox/activated,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},

--- a/maps/away/derelict/derelict-station.dmm
+++ b/maps/away/derelict/derelict-station.dmm
@@ -2916,7 +2916,7 @@
 /turf/floor/tiled/dark/airless,
 /area/constructionsite)
 "kt" = (
-/obj/machinery/power/breakerbox,
+/obj/machinery/breakerbox,
 /turf/floor/plating/airless,
 /area/constructionsite)
 "ku" = (

--- a/maps/exodus/exodus-2.dmm
+++ b/maps/exodus/exodus-2.dmm
@@ -6631,7 +6631,7 @@
 /turf/wall/prepainted,
 /area/exodus/maintenance/substation/security)
 "anR" = (
-/obj/machinery/power/breakerbox/activated{
+/obj/machinery/breakerbox/activated{
 	RCon_tag = "Security Substation Bypass"
 	},
 /turf/floor/plating,
@@ -13766,7 +13766,7 @@
 /turf/floor/plating,
 /area/exodus/maintenance/substation/civilian_east)
 "aDv" = (
-/obj/machinery/power/breakerbox/activated{
+/obj/machinery/breakerbox/activated{
 	RCon_tag = "Civilian East Substation Bypass"
 	},
 /turf/floor/plating,
@@ -16993,7 +16993,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
-/obj/machinery/power/breakerbox/activated{
+/obj/machinery/breakerbox/activated{
 	RCon_tag = "Civilian West Substation Bypass"
 	},
 /turf/floor/plating,
@@ -24402,7 +24402,7 @@
 /turf/floor/plating,
 /area/exodus/maintenance/locker)
 "bay" = (
-/obj/machinery/power/breakerbox/activated{
+/obj/machinery/breakerbox/activated{
 	RCon_tag = "Medical Substation Bypass"
 	},
 /turf/floor/plating,
@@ -32916,7 +32916,7 @@
 /turf/floor/tiled/white,
 /area/exodus/medical/exam_room)
 "bsa" = (
-/obj/machinery/power/breakerbox/activated{
+/obj/machinery/breakerbox/activated{
 	RCon_tag = "Command Substation Bypass"
 	},
 /obj/machinery/light,
@@ -51093,7 +51093,7 @@
 /turf/floor/plating,
 /area/exodus/maintenance/cargo)
 "ccA" = (
-/obj/machinery/power/breakerbox/activated{
+/obj/machinery/breakerbox/activated{
 	RCon_tag = "Research Substation Bypass"
 	},
 /turf/floor/plating,
@@ -53849,7 +53849,7 @@
 /turf/floor/tiled/white/monotile,
 /area/exodus/medical/surgery2)
 "cib" = (
-/obj/machinery/power/breakerbox/activated{
+/obj/machinery/breakerbox/activated{
 	RCon_tag = "Engineering Substation Bypass"
 	},
 /turf/floor/plating,

--- a/maps/tradeship/tradeship-2.dmm
+++ b/maps/tradeship/tradeship-2.dmm
@@ -8057,7 +8057,7 @@
 /turf/wall/titanium,
 /area/ship/trade/shuttle/rescue)
 "Za" = (
-/obj/machinery/power/breakerbox/activated,
+/obj/machinery/breakerbox/activated,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},

--- a/tools/map_migrations/5229_breakerbox.txt
+++ b/tools/map_migrations/5229_breakerbox.txt
@@ -1,0 +1,1 @@
+/obj/machinery/power/breakerbox/@SUBTYPES : /obj/machinery/breakerbox{@OLD}


### PR DESCRIPTION
## Description of changes
Split out of #5120.
Breaker boxes are no longer a `/obj/machinery/power` subtype because, well, they don't need to be.

- [x] Tested
- [x] Map migration added

## Why and what will this PR improve
Unnecessary subtyping is unnecessary.

## Authorship
Me