### PR TITLE
Make power debug machines not use the power subtype

### DIFF
--- a/code/modules/power/debug_items.dm
+++ b/code/modules/power/debug_items.dm
@@ -1,17 +1,18 @@
-/obj/machinery/power/debug_items
-	abstract_type = /obj/machinery/power/debug_items
+/obj/machinery/debug_items
+	abstract_type = /obj/machinery/debug_items
 	icon = 'icons/obj/power.dmi'
 	icon_state = "tracker"
 	anchored = TRUE
 	density = TRUE
 	var/show_extended_information = 1	// Set to 0 to disable extra information on examining (for example, when used on admin events)
 
-/obj/machinery/power/debug_items/examined_by(mob/user)
+/obj/machinery/debug_items/examined_by(mob/user)
 	. = ..()
 	if(show_extended_information)
 		show_info(user)
 
-/obj/machinery/power/debug_items/proc/show_info(var/mob/user)
+/obj/machinery/debug_items/proc/show_info(var/mob/user)
+	var/datum/powernet/powernet = get_powernet()
 	if(!powernet)
 		to_chat(user, "This device is not connected to a powernet.")
 		return
@@ -25,42 +26,43 @@
 
 
 // An infinite power generator. Adds energy to connected cable.
-/obj/machinery/power/debug_items/infinite_generator
+/obj/machinery/debug_items/infinite_generator
 	name = "Fractal Energy Reactor"
 	desc = "An experimental power generator"
 	var/power_generation_rate = 1000000
 
-/obj/machinery/power/debug_items/infinite_generator/Process()
-	add_avail(power_generation_rate)
+/obj/machinery/debug_items/infinite_generator/Process()
+	generate_power(power_generation_rate)
 
-/obj/machinery/power/debug_items/infinite_generator/show_info(var/mob/user)
+/obj/machinery/debug_items/infinite_generator/show_info(var/mob/user)
 	..()
 	to_chat(user, "Generator is providing [num2text(power_generation_rate, 20)] W")
 
 
 // A cable powersink, without the explosion/network alarms normal powersink causes.
-/obj/machinery/power/debug_items/infinite_cable_powersink
+/obj/machinery/debug_items/infinite_cable_powersink
 	name = "Null Point Core"
 	desc = "An experimental device that disperses energy, used for grid testing purposes."
 	var/power_usage_rate = 0
 	var/last_used = 0
 
-/obj/machinery/power/debug_items/infinite_cable_powersink/Process()
-	last_used = draw_power(power_usage_rate)
+/obj/machinery/debug_items/infinite_cable_powersink/Process()
+	var/datum/powernet/powernet = get_powernet()
+	last_used = powernet.draw_power(power_usage_rate)
 
-/obj/machinery/power/debug_items/infinite_cable_powersink/show_info(var/mob/user)
+/obj/machinery/debug_items/infinite_cable_powersink/show_info(var/mob/user)
 	..()
 	to_chat(user, "Power sink is demanding [num2text(power_usage_rate, 20)] W")
 	to_chat(user, "[num2text(last_used, 20)] W was actually used last tick")
 
 
-/obj/machinery/power/debug_items/infinite_apc_powersink
+/obj/machinery/debug_items/infinite_apc_powersink
 	name = "APC Dummy Load"
 	desc = "A dummy load that connects to an APC, used for load testing purposes."
 	use_power = POWER_USE_ACTIVE
 	active_power_usage = 0
 
-/obj/machinery/power/debug_items/infinite_apc_powersink/show_info(var/mob/user)
+/obj/machinery/debug_items/infinite_apc_powersink/show_info(var/mob/user)
 	..()
 	to_chat(user, "Dummy load is using [num2text(active_power_usage, 20)] W")
 	to_chat(user, "Powered: [!(stat & NOPOWER) ? "YES" : "NO"]")

--- a/code/modules/power/power.dm
+++ b/code/modules/power/power.dm
@@ -2,6 +2,8 @@
 // POWER MACHINERY BASE CLASS
 // This subtype is for machinery which needs to be directly referenced by its parent powernet during powernet processing.
 // This subtype does not encompass all power generating machinery, or machinery that needs to draw from a powernet in general.
+// If you try using this, make sure you can't just use get_powernet() instead. Ideally either the powernet needs to know about it (APCs)
+// or we need to run logic when we connect or disconnect from a powernet (solar panels/trackers).
 //////////////////////////////
 
 /////////////////////////////

--- a/maps/example/example-1.dmm
+++ b/maps/example/example-1.dmm
@@ -334,7 +334,7 @@
 /turf/floor/tiled/dark/monotile,
 /area/example/first)
 "qR" = (
-/obj/machinery/power/debug_items/infinite_generator,
+/obj/machinery/debug_items/infinite_generator,
 /obj/structure/cable/yellow,
 /turf/floor,
 /area/example/first)

--- a/maps/example/example-2.dmm
+++ b/maps/example/example-2.dmm
@@ -436,7 +436,7 @@
 /turf/floor/tiled/steel_grid,
 /area/example/second)
 "Ci" = (
-/obj/machinery/power/debug_items/infinite_generator,
+/obj/machinery/debug_items/infinite_generator,
 /obj/structure/cable/yellow,
 /turf/floor/tiled/white,
 /area/example/second)

--- a/maps/example/example-3.dmm
+++ b/maps/example/example-3.dmm
@@ -198,7 +198,7 @@
 /turf/floor/tiled/steel_grid,
 /area/example/third)
 "GA" = (
-/obj/machinery/power/debug_items/infinite_generator,
+/obj/machinery/debug_items/infinite_generator,
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},

--- a/mods/species/ascent/machines/ship_machines.dm
+++ b/mods/species/ascent/machines/ship_machines.dm
@@ -149,7 +149,7 @@ MANTIDIFY(/obj/item/chems/chem_disp_cartridge, "canister", "chemical storage")
 
 // This is an absolutely stupid machine. Basically the same as the debug one with some alterations.
 // It is a placeholder for a proper reactor setup (probably a RUST descendant)
-/obj/machinery/power/ascent_reactor
+/obj/machinery/ascent_reactor
 	name = "mantid fusion stack"
 	desc = "A tall, gleaming assemblage of advanced alien machinery. It hums and crackles with restrained power."
 	icon = 'icons/obj/machines/power/fusion_core.dmi'
@@ -159,7 +159,7 @@ MANTIDIFY(/obj/item/chems/chem_disp_cartridge, "canister", "chemical storage")
 	var/output_power = 9000 KILOWATTS
 	var/image/field_image
 
-/obj/machinery/power/ascent_reactor/attack_hand(mob/user)
+/obj/machinery/ascent_reactor/attack_hand(mob/user)
 	if(!user.check_dexterity(DEXTERITY_COMPLEX_TOOLS, TRUE))
 		return ..()
 	if(ishuman(user))
@@ -175,7 +175,7 @@ MANTIDIFY(/obj/item/chems/chem_disp_cartridge, "canister", "chemical storage")
 	update_icon()
 	return TRUE
 
-/obj/machinery/power/ascent_reactor/on_update_icon()
+/obj/machinery/ascent_reactor/on_update_icon()
 	. = ..()
 
 	if(!field_image)
@@ -198,13 +198,13 @@ MANTIDIFY(/obj/item/chems/chem_disp_cartridge, "canister", "chemical storage")
 		set_light(0)
 		icon_state = "core0"
 
-/obj/machinery/power/ascent_reactor/Initialize()
+/obj/machinery/ascent_reactor/Initialize()
 	. = ..()
 	update_icon()
 
-/obj/machinery/power/ascent_reactor/Process()
+/obj/machinery/ascent_reactor/Process()
 	if(on)
-		add_avail(output_power)
+		generate_power(output_power)
 
 /obj/machinery/power/smes/buildable/power_shuttle/ascent
 	name = "mantid battery"

--- a/tools/map_migrations/5320_power_debug.txt
+++ b/tools/map_migrations/5320_power_debug.txt
@@ -1,0 +1,2 @@
+/obj/machinery/power/debug_items/@SUBTYPES : /obj/machinery/debug_items/@SUBTYPES{@OLD}
+/obj/machinery/power/ascent_reactor/@SUBTYPES : /obj/machinery/ascent_reactor/@SUBTYPES{@OLD}


### PR DESCRIPTION
## Description of changes
Split out of #5120.
Power debug objects are no longer a `/obj/machinery/power` subtype because, well, they don't need to be.

- [x] Map migration added

## Why and what will this PR improve
Unnecessary subtyping is unnecessary.

## Authorship
Me