### PR TITLE
Make the keycard auth device use decls for event options

### DIFF
--- a/code/game/jobs/access.dm
+++ b/code/game/jobs/access.dm
@@ -66,7 +66,7 @@
 	if(!istype(supplied_access, /list))
 		return FALSE
 
-	if(maint_all_access)
+	if(global.using_map.maint_all_access) // todo: movable -> loc -> area -> map datum, to allow separate maps?
 		supplied_access = supplied_access.Copy()
 		supplied_access |= access_maint_tunnels
 

--- a/code/modules/security_levels/keycard_authentication.dm
+++ b/code/modules/security_levels/keycard_authentication.dm
@@ -65,6 +65,13 @@
 	interact(user)
 	return TRUE
 
+/obj/machinery/keycard_auth/proc/get_event_options(mob/user)
+	. = list()
+	for(var/decl/keycard_auth_event/event in global.decls_repository.get_decls_of_subtype_unassociated(/decl/keycard_auth_event))
+		if(!event.is_available(src, user))
+			continue
+		. += event.get_option(src, user)
+
 /obj/machinery/keycard_auth/interact(mob/user)
 	user.set_machine(src)
 
@@ -74,27 +81,12 @@
 	dat += "<br><hr><br>"
 
 	if(screen == 1)
-		dat += "Select an event to trigger:<ul>"
-
-		var/decl/security_state/security_state = GET_DECL(global.using_map.security_state)
-		if(security_state.current_security_level == security_state.severe_security_level)
-			dat += "<li>Cannot modify the alert level at this time: [security_state.severe_security_level.name] engaged.</li>"
-		else
-			if(security_state.current_security_level == security_state.high_security_level)
-				dat += "<li><A href='byond://?src=\ref[src];triggerevent=Revert alert'>Disengage [security_state.high_security_level.name]</A></li>"
-			else
-				dat += "<li><A href='byond://?src=\ref[src];triggerevent=Red alert'>Engage [security_state.high_security_level.name]</A></li>"
-
-		if(!get_config_value(/decl/config/toggle/ert_admin_call_only))
-			dat += "<li><A href='byond://?src=\ref[src];triggerevent=Emergency Response Team'>Emergency Response Team</A></li>"
-
-		dat += "<li><A href='byond://?src=\ref[src];triggerevent=Grant Emergency Maintenance Access'>Grant Emergency Maintenance Access</A></li>"
-		dat += "<li><A href='byond://?src=\ref[src];triggerevent=Revoke Emergency Maintenance Access'>Revoke Emergency Maintenance Access</A></li>"
-		dat += "<li><A href='byond://?src=\ref[src];triggerevent=Grant Nuclear Authorization Code'>Grant Nuclear Authorization Code</A></li>"
-		dat += "</ul>"
+		var/list/options = get_event_options(user)
+		dat += "Select an event to trigger:<ul><li>[options.Join("</li><li>")]</li></ul>"
 		show_browser(user, dat, "window=keycard_auth;size=500x250")
 	if(screen == 2)
-		dat += "Please swipe your card to authorize the following event: <b>[event]</b>"
+		var/decl/keycard_auth_event/real_event = global.decls_repository.get_decl_by_id(event)
+		dat += "Please swipe your card to authorize the following event: <b>[real_event.get_link_text()]</b>"
 		dat += "<p><A href='byond://?src=\ref[src];reset=1'>Back</A>"
 		show_browser(user, dat, "window=keycard_auth;size=500x250")
 	return
@@ -144,8 +136,10 @@
 /obj/machinery/keycard_auth/proc/broadcast_check()
 	if(confirmed)
 		confirmed = 0
+		var/decl/keycard_auth_event/real_event = global.decls_repository.get_decl_by_id(event)
+		var/cached_name = real_event.get_link_text() // because triggering the event can change the name
 		trigger_event(event)
-		log_and_message_admins("triggered and [key_name(event_confirmed_by)] confirmed event [event]", event_triggered_by || usr)
+		log_and_message_admins("triggered and [key_name(event_confirmed_by)] confirmed event [cached_name]", event_triggered_by || usr)
 	reset()
 
 /obj/machinery/keycard_auth/proc/receive_request(var/obj/machinery/keycard_auth/source, obj/item/card/id/ID)
@@ -166,45 +160,11 @@
 	busy = 0
 
 /obj/machinery/keycard_auth/proc/trigger_event()
-	switch(event)
-		if("Red alert")
-			var/decl/security_state/security_state = GET_DECL(global.using_map.security_state)
-			security_state.stored_security_level = security_state.current_security_level
-			security_state.set_security_level(security_state.high_security_level)
-			SSstatistics.add_field("alert_keycard_auth_red",1)
-		if("Revert alert")
-			var/decl/security_state/security_state = GET_DECL(global.using_map.security_state)
-			security_state.set_security_level(security_state.stored_security_level)
-			SSstatistics.add_field("alert_keycard_revert_red",1)
-		if("Grant Emergency Maintenance Access")
-			global.using_map.make_maint_all_access()
-			SSstatistics.add_field("alert_keycard_auth_maintGrant",1)
-		if("Revoke Emergency Maintenance Access")
-			global.using_map.revoke_maint_all_access()
-			SSstatistics.add_field("alert_keycard_auth_maintRevoke",1)
-		if("Emergency Response Team")
-			if(is_ert_blocked())
-				visible_message(SPAN_WARNING("\The [src] blinks and displays a message: All emergency response teams are dispatched and can not be called at this time."), range=2)
-				return
-
-			trigger_armed_response_team(1)
-			SSstatistics.add_field("alert_keycard_auth_ert",1)
-		if("Grant Nuclear Authorization Code")
-			var/obj/machinery/nuclearbomb/nuke = locate(/obj/machinery/nuclearbomb/station) in SSmachines.machinery
-			if(nuke)
-				visible_message(SPAN_WARNING("\The [src] blinks and displays a message: The nuclear authorization code is [nuke.r_code]"), range=2)
-			else
-				visible_message(SPAN_WARNING("\The [src] blinks and displays a message: No self-destruct terminal found."), range=2)
-			SSstatistics.add_field("alert_keycard_auth_nukecode",1)
-
-/obj/machinery/keycard_auth/proc/is_ert_blocked()
-	if(get_config_value(/decl/config/toggle/ert_admin_call_only))
-		return TRUE
-	return SSticker.mode?.ert_disabled
+	var/decl/keycard_auth_event/the_event = decls_repository.get_decl_by_id(event)
+	if(the_event)
+		the_event.on_event(src)
 
 /obj/machinery/keycard_auth/update_directional_offset(force = FALSE)
 	if(!force && (!length(directional_offset) || !is_wall_mounted())) //Check if the thing is actually mapped onto a table or something
 		return
 	. = ..()
-
-var/global/maint_all_access = 0

--- a/code/modules/security_levels/keycard_authentication_events.dm
+++ b/code/modules/security_levels/keycard_authentication_events.dm
@@ -1,0 +1,96 @@
+/decl/keycard_auth_event
+	abstract_type = /decl/keycard_auth_event
+	decl_flags = DECL_FLAG_MANDATORY_UID
+	var/name = "Abstract Keycard Authentication Event"
+
+/decl/keycard_auth_event/proc/get_link_text(obj/machinery/keycard_auth/auth, mob/user)
+	return name
+
+/decl/keycard_auth_event/proc/is_available(obj/machinery/keycard_auth/auth, mob/user)
+	return TRUE
+
+/decl/keycard_auth_event/proc/get_option(obj/machinery/keycard_auth/auth, mob/user)
+	SHOULD_NOT_OVERRIDE(TRUE)
+	var/fail_reason = get_failure_reason(user)
+	if(fail_reason)
+		return fail_reason
+	return "<a href='byond://?src=\ref[auth];triggerevent=[uid]'>[get_link_text(auth, user)]</a>"
+
+/decl/keycard_auth_event/proc/get_failure_reason(obj/machinery/keycard_auth/auth, mob/user)
+	return
+
+/decl/keycard_auth_event/proc/on_event(obj/machinery/keycard_auth/auth)
+	return
+
+/decl/keycard_auth_event/high_security
+	name = "Toggle High Security Level"
+	uid = "keycard_event_toggle_high_security"
+
+/decl/keycard_auth_event/high_security/get_failure_reason(obj/machinery/keycard_auth/auth, mob/user)
+	var/decl/security_state/security_state = GET_DECL(global.using_map.security_state)
+	if(security_state.current_security_level == security_state.severe_security_level)
+		return "Cannot modify the alert level at this time: [security_state.severe_security_level.name] engaged."
+
+/decl/keycard_auth_event/high_security/get_link_text(obj/machinery/keycard_auth/auth, mob/user)
+	var/decl/security_state/security_state = GET_DECL(global.using_map.security_state)
+	if(security_state.current_security_level == security_state.high_security_level) // toggle!
+		return "Disengage [security_state.high_security_level.name]"
+	else
+		return "Engage [security_state.high_security_level.name]"
+
+/decl/keycard_auth_event/high_security/on_event(obj/machinery/keycard_auth/auth, mob/user)
+	var/decl/security_state/security_state = GET_DECL(global.using_map.security_state)
+	if(security_state.current_security_level == security_state.high_security_level)
+		security_state.set_security_level(security_state.stored_security_level)
+		SSstatistics.add_field("alert_keycard_revert_red",1)
+	else
+		security_state.stored_security_level = security_state.current_security_level
+		security_state.set_security_level(security_state.high_security_level)
+		SSstatistics.add_field("alert_keycard_auth_red",1)
+
+/decl/keycard_auth_event/call_ert
+	name = "Emergency Response Team"
+	uid = "keycard_event_call_ert"
+
+/decl/keycard_auth_event/call_ert/is_available(obj/machinery/keycard_auth/auth, mob/user)
+	if(get_config_value(/decl/config/toggle/ert_admin_call_only))
+		return FALSE
+	return TRUE
+
+/decl/keycard_auth_event/call_ert/on_event(obj/machinery/keycard_auth/auth)
+	if(!SSticker.mode || SSticker.mode.ert_disabled) // disabled by mode
+		auth.visible_message(SPAN_WARNING("\The [src] blinks and displays a message: All emergency response teams are dispatched and can not be called at this time."), range=2)
+		return
+
+	trigger_armed_response_team(1)
+	SSstatistics.add_field("alert_keycard_auth_ert",1)
+
+/decl/keycard_auth_event/maintenance_access
+	name = "Toggle Emergency Maintenance Access"
+	uid = "keycard_event_maintenance_access"
+
+/decl/keycard_auth_event/maintenance_access/get_link_text(obj/machinery/keycard_auth/auth, mob/user)
+	if(global.using_map.maint_all_access)
+		return "Revoke Emergency Maintenance Access"
+	else
+		return "Grant Emergency Maintenance Access"
+
+/decl/keycard_auth_event/maintenance_access/on_event(obj/machinery/keycard_auth/auth)
+	if(global.using_map.maint_all_access)
+		global.using_map.revoke_maint_all_access()
+		SSstatistics.add_field("alert_keycard_auth_maintRevoke",1)
+	else
+		global.using_map.make_maint_all_access()
+		SSstatistics.add_field("alert_keycard_auth_maintGrant",1)
+
+/decl/keycard_auth_event/nuke_code
+	name = "Grant Nuclear Authorization Code"
+	uid = "keycard_event_nuke_code"
+
+/decl/keycard_auth_event/nuke_code/on_event(obj/machinery/keycard_auth/auth)
+	var/obj/machinery/nuclearbomb/nuke = locate(/obj/machinery/nuclearbomb/station) in SSmachines.machinery
+	if(nuke)
+		auth.visible_message(SPAN_WARNING("\The [src] blinks and displays a message: The nuclear authorization code is [nuke.r_code]"), range=2)
+	else
+		auth.visible_message(SPAN_WARNING("\The [src] blinks and displays a message: No self-destruct terminal found."), range=2)
+	SSstatistics.add_field("alert_keycard_auth_nukecode",1)

--- a/maps/~mapsystem/maps.dm
+++ b/maps/~mapsystem/maps.dm
@@ -207,6 +207,9 @@ var/global/const/MAP_HAS_RANK   = 2		//Rank system, also toggleable
 
 	var/default_ui_style
 
+	/// Is maint currently all-access?
+	var/maint_all_access = FALSE
+
 /datum/map/New()
 	..()
 	default_ui_style ||= DEFAULT_UI_STYLE
@@ -475,11 +478,11 @@ var/global/const/MAP_HAS_RANK   = 2		//Rank system, also toggleable
 	return
 
 /datum/map/proc/make_maint_all_access(var/radstorm = 0)
-	maint_all_access = 1
+	maint_all_access = TRUE
 	priority_announcement.Announce("The maintenance access requirement has been revoked on all maintenance airlocks.", "Attention!")
 
 /datum/map/proc/revoke_maint_all_access(var/radstorm = 0)
-	maint_all_access = 0
+	maint_all_access = FALSE
 	priority_announcement.Announce("The maintenance access requirement has been readded on all maintenance airlocks.", "Attention!")
 
 /datum/map/proc/show_titlescreen(client/C)

--- a/nebula.dme
+++ b/nebula.dme
@@ -3748,6 +3748,7 @@
 #include "code\modules\security_levels\_security_level.dm"
 #include "code\modules\security_levels\alarm_appearance.dm"
 #include "code\modules\security_levels\keycard_authentication.dm"
+#include "code\modules\security_levels\keycard_authentication_events.dm"
 #include "code\modules\security_levels\security_levels.dm"
 #include "code\modules\security_levels\security_state.dm"
 #include "code\modules\shield_generators\floor_diffuser.dm"


### PR DESCRIPTION
<!-- !! PLEASE, READ THIS !! -->
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/NebulaSS13/Nebula/blob/dev/CONTRIBUTING.md -->
<!-- If you're opening a pull request which changes A LOT of icon/map files: -->
<!-- Add [IDB IGNORE] (to ignore icon file changes) or [MDB IGNORE] (to ignore map file changes) in the PR title. -->
<!-- These tags prevent huge diffs from overloading IconDiffBot and MapDiffBot. -->

## Description of changes
They aren't hardcoded anymore. Decls. Woo.
Also moves `maint_all_access` onto `/datum/map` in preparation for multi-map stuff, maybe...? Iunno.
todo: add priority so we can control ordering

- [x] Tested

## Why and what will this PR improve
allows modpacks to add their own entries

## Authorship
Me