### PR TITLE
Optimize floor smoothing

### DIFF
--- a/code/game/turfs/flooring/_flooring.dm
+++ b/code/game/turfs/flooring/_flooring.dm
@@ -67,6 +67,8 @@ var/global/list/flooring_cache = list()
 	var/wall_smooth
 	/// How we smooth with space and openspace tiles
 	var/space_smooth
+	/// If we smooth with everything, we can skip a bunch of other smoothing checks. This is a bool and not an enum.
+	var/omni_smooth
 
 	/// same z flags used for turfs, i.e ZMIMIC_DEFAULT etc
 	var/z_flags
@@ -75,6 +77,7 @@ var/global/list/flooring_cache = list()
 
 	var/constructed = FALSE
 
+	var/has_corners = TRUE
 	var/has_internal_edges = FALSE
 	var/has_external_edges = FALSE
 	var/edge_state
@@ -127,6 +130,8 @@ var/global/list/flooring_cache = list()
 		space_smooth = default_smooth
 	if(isnull(floor_smooth))
 		floor_smooth = default_smooth
+	if(isnull(omni_smooth) && floor_smooth == wall_smooth && wall_smooth == space_smooth)
+		omni_smooth = (floor_smooth == SMOOTH_ALL) // bool, not enum
 
 /decl/flooring/validate()
 	. = ..()
@@ -197,37 +202,32 @@ var/global/list/flooring_cache = list()
 
 	if (icon_edge_layer != FLOOR_EDGE_NONE && (has_internal_edges || has_external_edges))
 		var/edge_layer = target.layer + icon_edge_layer
-		var/list/edge_overlays = list()
 		var/has_border = 0
 		for(var/step_dir in global.cardinal)
 			var/turf/T = get_step_resolving_mimic(target, step_dir)
-			if(!istype(T) || symmetric_test_link(target, T))
+			if(!istype(T) || test_link(T))
 				continue
 			has_border |= step_dir
-			if(icon_edge_layer != FLOOR_EDGE_NONE)
-				if(has_internal_edges)
-					edge_overlays += get_flooring_overlay("[icon]_[icon_base]-edge-[step_dir]", edge_state, step_dir, edge_layer = edge_layer)
-				if(has_external_edges && target.can_draw_edge_over(T))
-					edge_overlays += get_flooring_overlay("[icon]_[icon_base]-outer-edge-[step_dir]", outer_edge_state, step_dir, TRUE, edge_layer = edge_layer)
-
-		var/has_smooth = ~(has_border & (NORTH | SOUTH | EAST | WEST))
-		for(var/step_dir in global.cornerdirs)
-			var/turf/T = get_step_resolving_mimic(target, step_dir)
-			if(!istype(T) || symmetric_test_link(target, T))
-				continue
 			if(has_internal_edges)
-				if((has_smooth & step_dir) == step_dir)
-					edge_overlays += get_flooring_overlay("[icon]_[icon_base]-corner-[step_dir]", corner_state, step_dir, edge_layer = edge_layer)
-				else if((has_border & step_dir) == step_dir)
-					edge_overlays += get_flooring_overlay("[icon]_[icon_base]-edge-[step_dir]", edge_state, step_dir, edge_layer = edge_layer)
+				target.add_overlay(get_flooring_overlay("[icon]_[icon_base]-edge-[step_dir]", edge_state, step_dir, edge_layer = edge_layer))
 			if(has_external_edges && target.can_draw_edge_over(T))
-				if((has_smooth & step_dir) == step_dir)
-					edge_overlays += get_flooring_overlay("[icon]_[icon_base]-outer-corner-[step_dir]", outer_corner_state, step_dir, TRUE, edge_layer = edge_layer)
-				else if((has_border & step_dir) == step_dir)
-					edge_overlays += get_flooring_overlay("[icon]_[icon_base]-outer-edge-[step_dir]", outer_edge_state, step_dir, TRUE, edge_layer = edge_layer)
+				target.add_overlay(get_flooring_overlay("[icon]_[icon_base]-outer-edge-[step_dir]", outer_edge_state, step_dir, TRUE, edge_layer = edge_layer))
 
-		if(length(edge_overlays))
-			target.add_overlay(edge_overlays)
+		if(has_corners)
+			for(var/step_dir in global.cornerdirs)
+				var/turf/T = get_step_resolving_mimic(target, step_dir)
+				if(!istype(T) || test_link(T))
+					continue
+				if(has_internal_edges)
+					if((has_border & step_dir) == 0) // smooth
+						target.add_overlay(get_flooring_overlay("[icon]_[icon_base]-corner-[step_dir]", corner_state, step_dir, edge_layer = edge_layer))
+					else if((has_border & step_dir) == step_dir)
+						target.add_overlay(get_flooring_overlay("[icon]_[icon_base]-edge-[step_dir]", edge_state, step_dir, edge_layer = edge_layer))
+				if(has_external_edges)
+					if((has_border & step_dir) == 0 && target.can_draw_edge_over(T)) // smooth
+						target.add_overlay(get_flooring_overlay("[icon]_[icon_base]-outer-corner-[step_dir]", outer_corner_state, step_dir, TRUE, edge_layer = edge_layer))
+					else if((has_border & step_dir) == step_dir && target.can_draw_edge_over(T))
+						target.add_overlay(get_flooring_overlay("[icon]_[icon_base]-outer-edge-[step_dir]", outer_edge_state, step_dir, TRUE, edge_layer = edge_layer))
 
 	if(target.is_floor_broken())
 		target.add_overlay(get_damage_overlay(target._floor_broken))

--- a/code/game/turfs/flooring/flooring_mud.dm
+++ b/code/game/turfs/flooring/flooring_mud.dm
@@ -5,6 +5,7 @@
 	icon_base       = "mud"
 	color           = null // autoset from material
 	icon_edge_layer = FLOOR_EDGE_MUD
+	has_corners     = FALSE
 	footstep_type   = /decl/footsteps/mud
 	turf_flags      = TURF_FLAG_BACKGROUND | TURF_IS_HOLOMAP_PATH | TURF_FLAG_ABSORB_LIQUID
 	force_material  = /decl/material/solid/soil
@@ -39,6 +40,7 @@
 	icon            = 'icons/turf/flooring/seafloor.dmi'
 	icon_base       = "seafloor"
 	icon_edge_layer = FLOOR_EDGE_MUD
+	has_corners     = FALSE
 	footstep_type   = /decl/footsteps/mud
 	turf_flags      = TURF_FLAG_BACKGROUND | TURF_IS_HOLOMAP_PATH | TURF_FLAG_ABSORB_LIQUID
 	color           = "#ae9e66"
@@ -61,6 +63,7 @@
 	icon            = 'icons/turf/flooring/dirt.dmi'
 	icon_base       = "dirt"
 	icon_edge_layer = FLOOR_EDGE_DIRT
+	has_corners     = FALSE
 	color           = null // autoset from material
 	footstep_type   = /decl/footsteps/asteroid
 	turf_flags      = TURF_FLAG_BACKGROUND | TURF_IS_HOLOMAP_PATH | TURF_FLAG_ABSORB_LIQUID

--- a/code/game/turfs/flooring/flooring_natural.dm
+++ b/code/game/turfs/flooring/flooring_natural.dm
@@ -4,6 +4,7 @@
 	icon            = 'icons/turf/flooring/seafloor.dmi'
 	icon_base       = "seafloor"
 	icon_edge_layer = FLOOR_EDGE_SEAFLOOR
+	has_corners     = FALSE
 	turf_flags      = TURF_FLAG_BACKGROUND | TURF_IS_HOLOMAP_PATH | TURF_FLAG_ABSORB_LIQUID
 	force_material  = /decl/material/solid/sand
 	gender          = NEUTER
@@ -43,6 +44,7 @@
 	footstep_type   = /decl/footsteps/asteroid
 	turf_flags      = TURF_FLAG_BACKGROUND | TURF_IS_HOLOMAP_PATH
 	icon_edge_layer = FLOOR_EDGE_BARREN
+	has_corners     = FALSE
 	force_material  = /decl/material/solid/sand
 	growth_value    = 0.1
 	uid             = "floor_barren"
@@ -53,6 +55,7 @@
 	icon            = 'icons/turf/flooring/clay.dmi'
 	icon_base       = "clay"
 	icon_edge_layer = FLOOR_EDGE_CLAY
+	has_corners     = FALSE
 	footstep_type   = /decl/footsteps/mud
 	turf_flags      = TURF_FLAG_BACKGROUND | TURF_IS_HOLOMAP_PATH | TURF_FLAG_ABSORB_LIQUID
 	force_material  = /decl/material/solid/clay

--- a/code/game/turfs/flooring/flooring_path.dm
+++ b/code/game/turfs/flooring/flooring_path.dm
@@ -27,9 +27,10 @@
 	desc            = "A rustic cobblestone path."
 	icon_base       = "cobble"
 	icon_edge_layer = FLOOR_EDGE_PATH
+	has_corners     = FALSE
 	flooring_flags  = TURF_REMOVE_CROWBAR
-	has_base_range = 1
-	uid            = "floor_path_cobble"
+	has_base_range  = 1
+	uid             = "floor_path_cobble"
 
 /decl/flooring/path/running_bond
 	name           = "stone path"

--- a/code/game/turfs/flooring/flooring_rock.dm
+++ b/code/game/turfs/flooring/flooring_rock.dm
@@ -6,6 +6,7 @@
 	has_base_range  = null
 	color           = null
 	icon_edge_layer = FLOOR_EDGE_VOLCANIC
+	has_corners     = FALSE
 	gender          = NEUTER
 	uid             = "floor_reinf_shuttle_rock"
 

--- a/code/game/turfs/flooring/flooring_sand.dm
+++ b/code/game/turfs/flooring/flooring_sand.dm
@@ -29,6 +29,7 @@
 	icon_base       = "chlorine"
 	has_base_range  = 11
 	icon_edge_layer = FLOOR_EDGE_CHLORINE_SAND
+	has_corners     = FALSE
 	color           = "#d2e0b7"
 	dirt_color      = "#d2e0b7"
 	footstep_type   = /decl/footsteps/sand

--- a/code/game/turfs/flooring/flooring_snow.dm
+++ b/code/game/turfs/flooring/flooring_snow.dm
@@ -4,6 +4,7 @@
 	icon            = 'icons/turf/flooring/snow.dmi'
 	icon_base       = "snow"
 	icon_edge_layer = FLOOR_EDGE_SNOW
+	has_corners     = FALSE
 	flooring_flags  = TURF_REMOVE_SHOVEL
 	footstep_type   = /decl/footsteps/snow
 	has_base_range  = 13

--- a/code/game/turfs/floors/floor_icon.dm
+++ b/code/game/turfs/floors/floor_icon.dm
@@ -173,7 +173,9 @@
 		return TRUE
 	return FALSE
 
-/decl/flooring/proc/test_link(var/turf/origin, var/turf/opponent)
+/decl/flooring/proc/test_link(var/turf/opponent)
+	if(omni_smooth) // override EVERYTHING
+		return TRUE
 	// Just a normal floor
 	if (istype(opponent, /turf/floor))
 		if (floor_smooth == SMOOTH_ALL)
@@ -196,7 +198,7 @@
 		if (wall_smooth == SMOOTH_ALL && locate(/obj/structure/wall_frame) in opponent)
 			return TRUE
 	// Wall turf
-	else if(opponent.is_wall())
+	else if(opponent.is_wall()) // don't combine these so that we don't check if a wall is space just because we don't smooth with walls
 		if(wall_smooth == SMOOTH_ALL)
 			return TRUE
 	//If is_open is true, then it's space or openspace
@@ -204,6 +206,3 @@
 		if(space_smooth == SMOOTH_ALL)
 			return TRUE
 	return FALSE
-
-/decl/flooring/proc/symmetric_test_link(var/turf/A, var/turf/B)
-	return test_link(A, B) && test_link(B,A)


### PR DESCRIPTION
## Description of changes
makes init on shaded hills ~4-5 seconds faster, which is genuinely absurd. i did this through a few things:
1) if something has wall_smooth == SMOOTH_ALL, floor_smooth == SMOOTH_ALL, and space_smooth == SMOOTH_ALL, we just skip smoothing checks. this saves... a little time, not much tbh
2) disables diagonal turf checking for turfs without diagonal edge states. this saves a good bit, because it cuts it down from 8 symmetric_test_link calls to just 4.
3) removes `has_smooth` because it turns out we just don't need it, we can instead just check if both bits in `has_border` are 0 for the same effect.
4) ***removes symmetric_test_link, it never did anything but waste time.*** basically, test_link assumed src was the flooring for the origin turf and checked if the opponent turf had the same floor type. doing `&& test_link(B, A)` is not only nonsensical because src is still wrong, it also means it will always be true. in theory there are cases where we want to check symmetric smoothing, but this never did that properly, so it's fine to remove.
5) removes the origin argument from test_link, it just confused things.

## Why and what will this PR improve
saves several seconds of init on shaded hills, and simplifies the code.

## Authorship
Me