### PR TITLE
Skip some redundant mob icon updates

### DIFF
--- a/code/modules/bodytype/_bodytype.dm
+++ b/code/modules/bodytype/_bodytype.dm
@@ -712,7 +712,7 @@ var/global/list/bodytypes_by_category = list()
 	if(!istype(organ, /obj/item/organ/external))
 		return
 	var/obj/item/organ/external/limb = organ
-	for(var/bp_tag in has_organ)
+	for(var/bp_tag in has_organ) // make sure all organs that go inside this limb fit inside it
 		var/obj/item/organ/internal/I = has_organ[bp_tag]
 		if(initial(I.parent_organ) == organ.organ_tag)
 			limb.cavity_max_w_class = max(limb.cavity_max_w_class, get_resized_organ_w_class(initial(I.w_class)))

--- a/code/modules/mob/living/human/human.dm
+++ b/code/modules/mob/living/human/human.dm
@@ -456,10 +456,10 @@
 		custom_pain(msg,40,affecting = organ)
 	organ.take_damage(rand(1,3) + O.w_class, damage_flags = DAM_EDGE)
 
-/mob/proc/set_bodytype(var/decl/bodytype/new_bodytype)
+/mob/proc/set_bodytype(var/decl/bodytype/new_bodytype, skip_icon_updates = FALSE)
 	return
 
-/mob/living/human/set_bodytype(var/decl/bodytype/new_bodytype)
+/mob/living/human/set_bodytype(var/decl/bodytype/new_bodytype, skip_icon_updates = FALSE)
 
 	var/decl/bodytype/old_bodytype = get_bodytype()
 	if(ispath(new_bodytype))
@@ -475,18 +475,19 @@
 		old_bodytype.remove_abilities(src)
 	new_bodytype.grant_abilities(src)
 	apply_bodytype_appearance()
-	force_update_limbs()
-	update_hair()
-	update_eyes()
+	if(!skip_icon_updates)
+		force_update_limbs()
+		update_hair()
+		update_eyes()
 	return TRUE
 
-/mob/proc/set_species(var/new_species_uid, var/new_bodytype = null)
+/mob/proc/set_species(var/new_species_uid, var/new_bodytype = null, var/skip_icon_updates = FALSE)
 	return
 
 //set_species should not handle the entirety of initing the mob, and should not trigger deep updates
 //It focuses on setting up species-related data, without force applying them uppon organs and the mob's appearance.
 // For transforming an existing mob, look at change_species()
-/mob/living/human/set_species(var/new_species_uid, var/new_bodytype = null)
+/mob/living/human/set_species(var/new_species_uid, var/new_bodytype = null, var/skip_icon_updates = FALSE)
 	if(!new_species_uid)
 		CRASH("set_species on mob '[src]' was passed a null species uid!")
 	var/decl/species/new_species = decls_repository.get_decl_by_id(new_species_uid)
@@ -515,7 +516,7 @@
 	//Handle bodytype
 	if(!new_bodytype)
 		new_bodytype = species.get_bodytype_by_pronouns(new_pronouns)
-	set_bodytype(new_bodytype)
+	set_bodytype(new_bodytype, skip_icon_updates = skip_icon_updates)
 
 	available_maneuvers = species.maneuvers.Copy()
 
@@ -981,7 +982,7 @@
 	else if(!species_uid)
 		species_uid = global.using_map.default_species //Humans cannot exist without a species!
 
-	set_species(species_uid, supplied_appearance?.root_bodytype)
+	set_species(species_uid, supplied_appearance?.root_bodytype, skip_icon_updates = TRUE)
 	var/decl/bodytype/root_bodytype = get_bodytype() // root bodytype is set in set_species
 	ASSERT((!supplied_appearance?.root_bodytype) || (root_bodytype == supplied_appearance.root_bodytype))
 	if(!get_skin_colour())

--- a/code/modules/mob/living/human/human_appearance.dm
+++ b/code/modules/mob/living/human/human_appearance.dm
@@ -26,7 +26,7 @@
 	if(species?.uid == new_species)
 		return
 
-	set_species(new_species, new_bodytype)
+	set_species(new_species, new_bodytype, skip_icon_updates = TRUE)
 
 	//Handle spawning stuff
 	species.handle_pre_spawn(src)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -815,7 +815,7 @@ var/global/const/ACTION_DANGER_ALL = 2
 	reset_layer()
 
 	if(. || force_update)
-		update_icon()
+		queue_icon_update()
 		update_transform()
 
 /mob/proc/facedir(var/ndir)

--- a/code/modules/mob/mob_snapshot.dm
+++ b/code/modules/mob/mob_snapshot.dm
@@ -65,11 +65,11 @@
 
 	if(istype(root_species) && root_species != target.get_species())
 		if(istype(root_bodytype))
-			target.set_species(root_species.uid, root_bodytype)
+			target.set_species(root_species.uid, root_bodytype, skip_icon_updates = TRUE)
 		else
-			target.set_species(root_species.uid)
+			target.set_species(root_species.uid, skip_icon_updates = TRUE)
 	else if(istype(root_bodytype) && target.get_bodytype() != root_bodytype)
-		target.set_bodytype(root_bodytype)
+		target.set_bodytype(root_bodytype, skip_icon_updates = TRUE)
 
 	target.set_fingerprint(fingerprint)
 	target.set_unique_enzymes(unique_enzymes)
@@ -101,7 +101,7 @@
 	extra_limbs = null // can't reuse it!
 
 	for(var/obj/item/organ/organ in target.get_organs())
-		organ.copy_from_mob_snapshot(src)
+		organ.copy_from_mob_snapshot(src, skip_icon_update = TRUE)
 
 	for(var/decl/genetic_condition/condition as anything in genetic_conditions)
 		target.add_genetic_condition(condition.type)

--- a/code/modules/organs/external/_external.dm
+++ b/code/modules/organs/external/_external.dm
@@ -133,13 +133,14 @@
 	if(owner)
 		LAZYREMOVE(owner.bad_external_organs, src)
 
-/obj/item/organ/external/set_species(species_uid)
+/obj/item/organ/external/set_species(species_uid, skip_icon_update = FALSE)
 	_icon_cache_key = null
-	. = ..()
 	skin_blend = bodytype.limb_blend
-	update_icon()
+	. = ..()
+	if(!. && !skip_icon_update) // didn't update icon in parent
+		update_icon()
 
-/obj/item/organ/external/set_bodytype(decl/bodytype/new_bodytype, override_material = null, apply_to_internal_organs = TRUE)
+/obj/item/organ/external/set_bodytype(decl/bodytype/new_bodytype, override_material = null, skip_icon_update = FALSE, apply_to_internal_organs = TRUE)
 	_icon_cache_key = null
 	var/decl/bodytype/old_bodytype = bodytype
 	. = ..(new_bodytype, override_material)
@@ -148,7 +149,7 @@
 	if(.)
 		update_icon()
 
-/obj/item/organ/external/copy_from_mob_snapshot(datum/mob_snapshot/supplied_appearance)
+/obj/item/organ/external/copy_from_mob_snapshot(datum/mob_snapshot/supplied_appearance, skip_icon_update = FALSE)
 	_icon_cache_key = null
 	if(organ_tag in supplied_appearance?.sprite_accessories)
 		var/list/sprite_cats = supplied_appearance.sprite_accessories[organ_tag]

--- a/code/modules/organs/external/_external_icons.dm
+++ b/code/modules/organs/external/_external_icons.dm
@@ -127,22 +127,24 @@ var/global/list/organ_icon_cache = list()
 
 /obj/item/organ/external/proc/get_icon_cache_key_components()
 
-	. = list("[icon_state]_[species.uid]_[get_organ_appearance_bodytype()?.uid || "BAD_BODYTYPE"]_[render_alpha]_[icon]")
+	. = list(icon_state, species.uid, get_organ_appearance_bodytype()?.uid || "BAD_BODYTYPE", render_alpha, icon)
 
 	// Skeletons don't care about most icon appearance stuff.
 	if(limb_flags & ORGAN_FLAG_SKELETAL)
-		. += "_skeletal_[skin_blend]"
+		. += "skeletal"
+		. += skin_blend
 		return
 
 	if(status & ORGAN_DEAD)
-		. += "_dead"
-	. += "_tone_[skin_tone]_color_[skin_colour]_[skin_blend]"
+		. += "dead"
+	. += list("tone", skin_tone, "color", skin_colour, skin_blend)
 	for(var/accessory_category in _sprite_accessories)
 		var/list/draw_accessories = _sprite_accessories[accessory_category]
 		for(var/accessory in draw_accessories)
 			var/decl/sprite_accessory/accessory_decl = resolve_accessory_to_decl(accessory)
 			if(istype(accessory_decl) && !accessory_decl.sprite_overlay_layer)
-				. += "_[accessory]_[json_encode(draw_accessories[accessory])]"
+				. += accessory
+				. += json_encode(draw_accessories[accessory])
 
 /obj/item/organ/external/proc/clear_sprite_accessories(var/skip_update = FALSE)
 	if(!length(_sprite_accessories))
@@ -299,7 +301,7 @@ var/global/list/organ_icon_cache = list()
 	if(icon_state != next_state)
 		icon_state = next_state
 
-	_icon_cache_key = jointext(get_icon_cache_key_components(), null)
+	_icon_cache_key = jointext(get_icon_cache_key_components(), "_")
 	var/icon/mob_icon = global.organ_icon_cache[_icon_cache_key] || generate_mob_icon()
 	if(icon != mob_icon)
 		icon = mob_icon

--- a/code/modules/organs/external/head.dm
+++ b/code/modules/organs/external/head.dm
@@ -94,7 +94,7 @@
 /obj/item/organ/external/head/get_agony_multiplier()
 	return (owner && owner.headcheck(organ_tag)) ? 1.50 : 1
 
-/obj/item/organ/external/head/set_bodytype(decl/bodytype/new_bodytype, override_material = null, apply_to_internal_organs = TRUE)
+/obj/item/organ/external/head/set_bodytype(decl/bodytype/new_bodytype, override_material = null, skip_icon_update = FALSE, apply_to_internal_organs = TRUE)
 	. = ..()
 	can_intake_reagents = !(bodytype.body_flags & BODY_FLAG_NO_EAT)
 
@@ -115,7 +115,7 @@
 
 /obj/item/organ/external/head/get_icon_cache_key_components()
 	. = ..()
-	. += "_eyes_[bodytype.eye_icon || "none"]_[get_eyes_organ()?.eye_colour || "none"]"
+	. += list("eyes", bodytype.eye_icon || "none", get_eyes_organ()?.eye_colour || "none")
 
 /obj/item/organ/external/head/generate_mob_icon()
 	var/icon/ret = ..()

--- a/code/modules/organs/internal/_internal.dm
+++ b/code/modules/organs/internal/_internal.dm
@@ -36,7 +36,7 @@
 	. = ..()
 	set_max_damage(absolute_max_damage)
 
-/obj/item/organ/internal/set_species(species_uid)
+/obj/item/organ/internal/set_species(species_uid, skip_icon_update = FALSE)
 	. = ..()
 	if(species.organs_icon)
 		icon = species.organs_icon

--- a/code/modules/organs/internal/brain.dm
+++ b/code/modules/organs/internal/brain.dm
@@ -45,7 +45,7 @@
 /obj/item/organ/internal/brain/getToxLoss()
 	return 0
 
-/obj/item/organ/internal/brain/set_species(species_uid)
+/obj/item/organ/internal/brain/set_species(species_uid, skip_icon_update = FALSE)
 	. = ..()
 	icon_state = "brain-prosthetic"
 	if(species)

--- a/code/modules/organs/internal/lungs.dm
+++ b/code/modules/organs/internal/lungs.dm
@@ -58,7 +58,7 @@
 /obj/item/organ/internal/lungs/proc/adjust_oxygen_deprivation(var/amount)
 	oxygen_deprivation = clamp(oxygen_deprivation + amount, 0, species.total_health)
 
-/obj/item/organ/internal/lungs/set_species(species_uid)
+/obj/item/organ/internal/lungs/set_species(species_uid, skip_icon_update = FALSE)
 	. = ..()
 	sync_breath_types()
 

--- a/code/modules/organs/internal/stomach.dm
+++ b/code/modules/organs/internal/stomach.dm
@@ -12,7 +12,7 @@
 	QDEL_NULL(ingested)
 	. = ..()
 
-/obj/item/organ/internal/stomach/set_species(species_uid)
+/obj/item/organ/internal/stomach/set_species(species_uid, skip_icon_update = FALSE)
 	if(species?.gluttonous)
 		verbs -= /obj/item/organ/internal/stomach/proc/throw_up
 	. = ..()

--- a/code/modules/organs/organ.dm
+++ b/code/modules/organs/organ.dm
@@ -119,9 +119,9 @@
 		log_debug("obj/item/organ/setup(): [src] had null bodytype, with an owner with null bodytype!")
 	bodytype = new_bodytype // used in later setup procs
 	if(supplied_appearance)
-		copy_from_mob_snapshot(supplied_appearance)
+		copy_from_mob_snapshot(supplied_appearance, skip_icon_update = !!owner) // if we have an owner then we expect them to update us later
 	else
-		set_species(owner?.get_species() || global.using_map.default_species)
+		set_species(owner?.get_species() || global.using_map.default_species, skip_icon_update = !!owner) // if we have an owner then we expect them to update us later
 
 // todo: make this redundant with matter shenanigans
 /obj/item/organ/populate_reagents()
@@ -131,7 +131,7 @@
 	if(reagent_to_add)
 		add_to_reagents(reagent_to_add, REAGENT_MAXIMUM_VOLUME(reagents))
 
-/obj/item/organ/proc/copy_from_mob_snapshot(var/datum/mob_snapshot/supplied_appearance)
+/obj/item/organ/proc/copy_from_mob_snapshot(var/datum/mob_snapshot/supplied_appearance, skip_icon_update = FALSE)
 	if(supplied_appearance != organ_appearance) // Hacky. Is this ever used? Do any organs ever have DNA set before setup_as_organic?
 		QDEL_NULL(organ_appearance)
 		organ_appearance = supplied_appearance.Clone()
@@ -139,11 +139,11 @@
 	if(species != organ_appearance.root_species)
 		if(organ_appearance.root_bodytype && organ_appearance.root_bodytype != bodytype)
 			bodytype = organ_appearance.root_bodytype // this lets us take advantage of set_bodytype being called in set_species
-		set_species(organ_appearance.root_species?.uid || global.using_map.default_species)
+		set_species(organ_appearance.root_species?.uid || global.using_map.default_species, skip_icon_update = skip_icon_update)
 	else if(organ_appearance.root_bodytype && organ_appearance.root_bodytype != bodytype)
-		set_bodytype(organ_appearance.root_bodytype)
+		set_bodytype(organ_appearance.root_bodytype, skip_icon_update = skip_icon_update)
 
-/obj/item/organ/proc/set_bodytype(decl/bodytype/new_bodytype, override_material = null, apply_to_internal_organs = TRUE)
+/obj/item/organ/proc/set_bodytype(decl/bodytype/new_bodytype, override_material = null, apply_to_internal_organs = TRUE, skip_icon_update = FALSE)
 	SHOULD_CALL_PARENT(TRUE)
 	if(isnull(new_bodytype))
 		PRINT_STACK_TRACE("Null bodytype passed to set_bodytype!")
@@ -183,7 +183,7 @@
 	absolute_max_damage = floor(ndamage)
 	max_damage = absolute_max_damage
 
-/obj/item/organ/proc/set_species(species_uid)
+/obj/item/organ/proc/set_species(species_uid, skip_icon_update = FALSE)
 	vital_to_owner = null // This generally indicates the owner mob is having species set, and this value may be invalidated.
 	if(istext(species_uid))
 		species = decls_repository.get_decl_by_id(species_uid)
@@ -193,7 +193,7 @@
 		species = decls_repository.get_decl_by_id(global.using_map.default_species)
 		PRINT_STACK_TRACE("Invalid species. Expected a valid species UID as string, was: [log_info_line(species_uid)]")
 
-	set_bodytype(bodytype || species.default_bodytype, override_material = material?.type)
+	. = set_bodytype(bodytype || species.default_bodytype, override_material = material?.type, skip_icon_update = skip_icon_update)
 
 	// Adjust limb health proportinate to total species health.
 	var/total_health_coefficient = scale_max_damage_to_species_health ? (species.total_health / DEFAULT_SPECIES_HEALTH) : 1

--- a/mods/species/drakes/species_bodytypes.dm
+++ b/mods/species/drakes/species_bodytypes.dm
@@ -325,8 +325,7 @@
 		TOOL_SHOVEL = TOOL_QUALITY_GOOD
 	))
 
-/obj/item/organ/external/hand/quadruped/grafadreka/set_bodytype(decl/bodytype/new_bodytype, override_material, apply_to_internal_organs)
-	override_material = /decl/material/solid/organic/bone
+/obj/item/organ/external/hand/quadruped/grafadreka/set_bodytype(decl/bodytype/new_bodytype, override_material = /decl/material/solid/organic/bone, skip_icon_update = FALSE, apply_to_internal_organs = TRUE)
 	. = ..()
 
 /obj/item/organ/external/hand/right/quadruped/grafadreka
@@ -345,8 +344,7 @@
 		TOOL_SHOVEL = TOOL_QUALITY_GOOD
 	))
 
-/obj/item/organ/external/hand/right/quadruped/grafadreka/set_bodytype(decl/bodytype/new_bodytype, override_material, apply_to_internal_organs)
-	override_material = /decl/material/solid/organic/bone
+/obj/item/organ/external/hand/right/quadruped/grafadreka/set_bodytype(decl/bodytype/new_bodytype, override_material = /decl/material/solid/organic/bone, skip_icon_update = FALSE, apply_to_internal_organs = TRUE)
 	. = ..()
 
 /obj/item/organ/external/head/gripper/grafadreka/get_natural_attacks()

--- a/mods/species/serpentid/mobs/bodyparts_serpentid.dm
+++ b/mods/species/serpentid/mobs/bodyparts_serpentid.dm
@@ -48,7 +48,7 @@
 	if(owner)
 		color = owner.get_eye_colour()
 
-/obj/item/organ/internal/eyes/insectoid/serpentid/copy_from_mob_snapshot(datum/mob_snapshot/supplied_appearance)
+/obj/item/organ/internal/eyes/insectoid/serpentid/copy_from_mob_snapshot(datum/mob_snapshot/supplied_appearance, skip_icon_update = FALSE)
 	. = ..()
 	color = supplied_appearance?.eye_color
 


### PR DESCRIPTION
## Description of changes
skips some redundant mob icon updates by threading through some skip update args. needs more thorough testing but it seemed fine at a glance

## Why and what will this PR improve
makes human mobs slightly less redundant update-wise