### PR TITLE
Make global.overmap_sectors use an alist

### DIFF
--- a/code/_helpers/logging.dm
+++ b/code/_helpers/logging.dm
@@ -179,7 +179,7 @@ var/global/log_end= world.system_type == UNIX ? ascii2text(13) : ""
 	return "[..()] ([isnum(z) ? "[x],[y],[z]" : "0,0,0"])"
 
 /turf/get_log_info_line()
-	var/obj/effect/overmap/visitable/O = global.overmap_sectors[num2text(z)]
+	var/obj/effect/overmap/visitable/O = global.overmap_sectors[z]
 	if(istype(O))
 		return "[..()] ([x],[y],[z] - [O.name]) ([loc ? loc.type : "NULL"])"
 	else
@@ -188,7 +188,7 @@ var/global/log_end= world.system_type == UNIX ? ascii2text(13) : ""
 /atom/movable/get_log_info_line()
 	var/turf/t = get_turf(src)
 	if(t)
-		var/obj/effect/overmap/visitable/O = global.overmap_sectors[num2text(t.z)]
+		var/obj/effect/overmap/visitable/O = global.overmap_sectors[t.z]
 		if(istype(O))
 			return "[..()] ([t]) ([t.x],[t.y],[t.z] - [O.name]) ([t.type])"
 		return "[..()] ([t]) ([t.x],[t.y],[t.z]) ([t.type])"

--- a/code/_helpers/overmap.dm
+++ b/code/_helpers/overmap.dm
@@ -1,4 +1,4 @@
-var/global/list/overmap_sectors =  list()
+var/global/alist/overmap_sectors = alist()
 var/global/list/overmaps_by_name = list()
 var/global/list/overmaps_by_z =    list()
 

--- a/code/controllers/subsystems/shuttle.dm
+++ b/code/controllers/subsystems/shuttle.dm
@@ -80,7 +80,7 @@ SUBSYSTEM_DEF(shuttle)
 			try_add_landmark_tag(shuttle_landmark_tag, O)
 			landmarks_still_needed -= shuttle_landmark_tag
 		else if(istype(shuttle_landmark, /obj/effect/shuttle_landmark/automatic)) //These find their sector automatically
-			O = global.overmap_sectors[num2text(shuttle_landmark.z)]
+			O = global.overmap_sectors[shuttle_landmark.z]
 			O ? O.add_landmark(shuttle_landmark, shuttle_landmark.shuttle_restricted) : (landmarks_awaiting_sector += shuttle_landmark)
 
 /datum/controller/subsystem/shuttle/proc/unregister_landmark(shuttle_landmark_tag)

--- a/code/controllers/subsystems/skybox.dm
+++ b/code/controllers/subsystems/skybox.dm
@@ -104,7 +104,7 @@ SUBSYSTEM_DEF(skybox)
 /datum/controller/subsystem/skybox/proc/get_skybox(z)
 	if(!skybox_cache[num2text(z)])
 		skybox_cache[num2text(z)] = generate_skybox(z)
-		var/obj/effect/overmap/visitable/O = global.overmap_sectors[num2text(z)]
+		var/obj/effect/overmap/visitable/O = global.overmap_sectors[z]
 		if(istype(O))
 			for(var/zlevel in O.map_z)
 				skybox_cache["[zlevel]"] = skybox_cache[num2text(z)]
@@ -123,7 +123,7 @@ SUBSYSTEM_DEF(skybox)
 	res.overlays += base
 
 	if(use_overmap_details)
-		var/obj/effect/overmap/visitable/O = global.overmap_sectors[num2text(z)]
+		var/obj/effect/overmap/visitable/O = global.overmap_sectors[z]
 		if(istype(O))
 			var/image/overmap = image(skybox_icon)
 			overmap.overlays += O.generate_skybox()

--- a/code/controllers/subsystems/statistics.dm
+++ b/code/controllers/subsystems/statistics.dm
@@ -162,7 +162,7 @@ SUBSYSTEM_DEF(statistics)
 		death.brainloss = dead.get_damage(BRAIN)
 		death.oxyloss =   dead.get_damage(OXY)
 		death.using_map_name = global.using_map.full_name
-		var/obj/effect/overmap/visitable/cell = global.overmap_sectors[num2text(dead.z)]
+		var/obj/effect/overmap/visitable/cell = global.overmap_sectors[dead.z]
 		death.overmap_location_name = cell?.name || "Unknown"
 		LAZYADD(deaths, death)
 

--- a/code/datums/helper_datums/teleport.dm
+++ b/code/datums/helper_datums/teleport.dm
@@ -25,7 +25,7 @@
 		return isAdminLevel(tz) || isStationLevel(tz) || isContactLevel(tz)
 
 	var/list/accessible_z_levels = SSmapping.get_connected_levels(oz)
-	var/obj/effect/overmap/sector = global.overmap_sectors[num2text(oz)]
+	var/obj/effect/overmap/sector = global.overmap_sectors[oz]
 	if(sector)
 
 		var/list/neighbors_to_add = list()

--- a/code/datums/trading/trade_hub_overmap.dm
+++ b/code/datums/trading/trade_hub_overmap.dm
@@ -66,7 +66,7 @@ var/global/list/trading_hub_names = list()
 
 /datum/trade_hub/overmap/is_accessible_from(var/turf/check)
 	if(istype(check))
-		var/obj/effect/overmap/customer = global.overmap_sectors[num2text(check.z)]
+		var/obj/effect/overmap/customer = global.overmap_sectors[check.z]
 		return customer && owner && get_turf(customer) == get_turf(owner)
 
 /datum/trade_hub/overmap/proc/update_hub(var/obj/effect/overmap/trade_hub/hub)

--- a/code/datums/uplink/services.dm
+++ b/code/datums/uplink/services.dm
@@ -86,7 +86,7 @@
 	if(state != AWAITING_ACTIVATION)
 		to_chat(user, "<span class='warning'>\The [src] won't activate again.</span>")
 		return
-	var/obj/effect/overmap/visitable/O = global.overmap_sectors[num2text(get_z(src))]
+	var/obj/effect/overmap/visitable/O = global.overmap_sectors[get_z(src)]
 	var/choice = alert(user, "This will only affect your current location[istype(O) ? " ([O])" : ""]. Proceed?","Confirmation", "Yes", "No")
 	if(choice != "Yes")
 		return

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -248,7 +248,7 @@
 	var/newz
 	if(prob(90))
 		var/list/possible_locations
-		var/obj/effect/overmap/visitable/O = global.overmap_sectors[num2text(z)]
+		var/obj/effect/overmap/visitable/O = global.overmap_sectors[z]
 		if(istype(O))
 			for(var/obj/effect/overmap/visitable/OO in range(O,2))
 				if((OO.sector_flags & OVERMAP_SECTOR_IN_SPACE) || istype(OO,/obj/effect/overmap/visitable/sector/planetoid))

--- a/code/game/machinery/hologram.dm
+++ b/code/game/machinery/hologram.dm
@@ -71,7 +71,7 @@ var/global/list/holopads = list()
 		holopad_id = A?.proper_name || "Unknown"
 
 	// For overmap sites, always tag the sector name so we have a unique discriminator for long range calls.
-	var/obj/effect/overmap/visitable/sector = global.overmap_sectors[num2text(z)]
+	var/obj/effect/overmap/visitable/sector = global.overmap_sectors[z]
 	if(sector)
 		holopad_id = "[sector.name] - [holopad_id]"
 
@@ -135,8 +135,8 @@ var/global/list/holopads = list()
 				var/list/zlevels_long = list()
 
 				if(holopadType == HOLOPAD_LONG_RANGE && length(reachable_overmaps))
-					for(var/zlevel in global.overmap_sectors)
-						var/obj/effect/overmap/visitable/O = global.overmap_sectors[zlevel]
+					for(var/zlevel, sector in global.overmap_sectors)
+						var/obj/effect/overmap/visitable/O = sector
 						if(!isnull(O) && (O.overmap_id in reachable_overmaps) && LAZYLEN(O.map_z))
 							zlevels_long |= O.map_z
 

--- a/code/game/objects/items/blueprints.dm
+++ b/code/game/objects/items/blueprints.dm
@@ -53,7 +53,7 @@
 
 	var/turf/T = get_turf(src)
 	if(istype(T) && length(global.using_map.overmap_ids))
-		var/obj/effect/overmap/visitable/sector/S = global.overmap_sectors[num2text(T.z)]
+		var/obj/effect/overmap/visitable/sector/S = global.overmap_sectors[T.z]
 		if(!S) // The blueprints are useless now, but keep them around for fluff.
 			desc = "Some dusty old blueprints. The markings are old, and seem entirely irrelevant for your whereabouts."
 			return FALSE
@@ -75,14 +75,14 @@
 	icon_state = "blueprints2"
 
 /obj/item/blueprints/outpost/attack_self(mob/user)
-	var/obj/effect/overmap/visitable/sector/S = global.overmap_sectors[num2text(get_z(user))]
+	var/obj/effect/overmap/visitable/sector/S = global.overmap_sectors[get_z(user)]
 	area_prefix = S.name
 	. = ..()
 
 /obj/item/blueprints/outpost/set_valid_z_levels()
 	var/turf/T = get_turf(src)
 	if(istype(T) && length(global.using_map.overmap_ids))
-		var/obj/effect/overmap/visitable/sector/S = global.overmap_sectors[num2text(T.z)]
+		var/obj/effect/overmap/visitable/sector/S = global.overmap_sectors[T.z]
 		if(istype(S))
 			T = locate(1, 1, S.z)
 			var/area/overmap/map = T && get_area(T)
@@ -100,8 +100,8 @@
 
 /obj/item/blueprints/shuttle/set_valid_z_levels()
 	var/turf/T = get_turf(src)
-	if(istype(T) && length(global.using_map.overmap_ids) && global.overmap_sectors[num2text(T.z)])
-		var/obj/effect/overmap/visitable/ship/landable/S = global.overmap_sectors[num2text(T.z)]
+	if(istype(T) && length(global.using_map.overmap_ids) && global.overmap_sectors[T.z])
+		var/obj/effect/overmap/visitable/ship/landable/S = global.overmap_sectors[T.z]
 		if(isnull(shuttle_name))
 			shuttle_name = S.shuttle
 		update_linked_name(S, null, S.name)

--- a/code/modules/events/electrical_storm.dm
+++ b/code/modules/events/electrical_storm.dm
@@ -48,21 +48,21 @@
 
 	//See if shields can stop it first
 	var/overmap_only = TRUE
-	var/list/overmap_sectors = list()
+	var/list/event_overmap_sectors = list()
 	if(!length(affecting_z))
 		return
 
 	for(var/i in affecting_z)
-		var/obj/effect/overmap/visitable/sector = global.overmap_sectors[num2text(i)]
+		var/obj/effect/overmap/visitable/sector = global.overmap_sectors[i]
 		if(istype(sector))
-			overmap_sectors |= sector
+			event_overmap_sectors |= sector
 		else
 			overmap_only = FALSE
 			break
 
 	var/list/shields = list()
 	if(overmap_only)
-		for(var/obj/effect/overmap/visitable/sector as anything in overmap_sectors)
+		for(var/obj/effect/overmap/visitable/sector as anything in event_overmap_sectors)
 			var/list/sector_shields = sector.get_linked_machines_of_type(/obj/machinery/shield_generator)
 			if(length(sector_shields))
 				shields |= sector_shields

--- a/code/modules/events/event.dm
+++ b/code/modules/events/event.dm
@@ -165,5 +165,5 @@
 /datum/event/proc/location_name()
 	if(!length(global.using_map.overmap_ids))
 		return station_name()
-	var/obj/effect/overmap/visitable/O = global.overmap_sectors[num2text(pick(affecting_z))]
+	var/obj/effect/overmap/visitable/O = global.overmap_sectors[pick(affecting_z)]
 	return O?.name || "Unknown Location"

--- a/code/modules/holomap/holomap.dm
+++ b/code/modules/holomap/holomap.dm
@@ -232,7 +232,7 @@
 
 	//This is where the fun begins
 	if(length(global.using_map.overmap_ids))
-		var/obj/effect/overmap/visitable/O = global.overmap_sectors["[z]"]
+		var/obj/effect/overmap/visitable/O = global.overmap_sectors[z]
 
 		if(isAI)
 			T = get_turf(user.client.eye)

--- a/code/modules/modular_computers/networking/device_types/_network_device.dm
+++ b/code/modules/modular_computers/networking/device_types/_network_device.dm
@@ -219,7 +219,7 @@
 	// Overmap isn't used, a modem alone provides internet connection.
 	if(!length(global.using_map.overmap_ids))
 		return TRUE
-	var/obj/effect/overmap/visitable/sector = global.overmap_sectors[num2text(get_z(holder))]
+	var/obj/effect/overmap/visitable/sector = global.overmap_sectors[get_z(holder)]
 	if(!istype(sector))
 		return
 	return sector.has_internet_connection(connecting_network)

--- a/code/modules/modular_computers/networking/machinery/telecomms.dm
+++ b/code/modules/modular_computers/networking/machinery/telecomms.dm
@@ -154,7 +154,7 @@ var/global/list/telecomms_hubs = list()
 
 	if(!send_overmap_object)
 		var/turf/T = get_turf(src)
-		send_overmap_object = istype(T) && global.overmap_sectors["[T.z]"]
+		send_overmap_object = istype(T) && global.overmap_sectors[T.z]
 
 	if(channel.secured)
 		encryption |= channel.secured
@@ -179,7 +179,7 @@ var/global/list/telecomms_hubs = list()
 
 		// If we're sending from an overmap object AND our overmap object transmits its identity AND it's different than the listener's
 		// then append the overmap object name to it, so they know where we're from
-		var/listener_overmap_object = istype(speaking_from) && global.overmap_sectors[num2text(speaking_from.z)]
+		var/listener_overmap_object = istype(speaking_from) && global.overmap_sectors[speaking_from.z]
 		var/send_overmap = send_overmap_object && send_overmap_object.ident_transmitter && send_overmap_object != listener_overmap_object
 		for(var/mob/listener as anything in radio.get_radio_listeners())
 			listeners[listener] = send_overmap
@@ -203,7 +203,7 @@ var/global/list/telecomms_hubs = list()
 		// Find the z-chunks we can chain the transmission to, which is our local chunk plus any overmap sites in range,
 		// assuming we have a functioning comms maser and the overmap site has a telecomms hub and comms antenna.
 		var/list/levels = SSmapping.get_connected_levels(z)
-		var/obj/effect/overmap/O = global.overmap_sectors["[z]"]
+		var/obj/effect/overmap/O = global.overmap_sectors[z]
 		for(var/obj/machinery/shipcomms/broadcaster/our_maser in O?.comms_masers)
 			levels |= our_maser.get_available_z_levels()
 

--- a/code/modules/multiz/level_data.dm
+++ b/code/modules/multiz/level_data.dm
@@ -605,7 +605,7 @@
 
 /datum/level_data/proc/get_display_name()
 	if(!name)
-		var/obj/effect/overmap/overmap_entity = global.overmap_sectors[num2text(level_z)]
+		var/obj/effect/overmap/overmap_entity = global.overmap_sectors[level_z]
 		if(overmap_entity?.name)
 			name = overmap_entity.name
 		else

--- a/code/modules/overmap/_overmap.dm
+++ b/code/modules/overmap/_overmap.dm
@@ -61,7 +61,7 @@
 	if (!T || !A)
 		return
 
-	var/obj/effect/overmap/visitable/M = global.overmap_sectors[num2text(T.z)]
+	var/obj/effect/overmap/visitable/M = global.overmap_sectors[T.z]
 	if (!M)
 		return
 

--- a/code/modules/overmap/contacts/contact_sensors.dm
+++ b/code/modules/overmap/contacts/contact_sensors.dm
@@ -74,7 +74,7 @@
 	// Find all sectors with a tracker on their z-level. Only works on ships when they are in space.
 	for(var/obj/item/ship_tracker/tracker in trackers)
 		if(tracker.enabled)
-			var/obj/effect/overmap/visitable/tracked_effect = global.overmap_sectors[num2text(get_z(tracker))]
+			var/obj/effect/overmap/visitable/tracked_effect = global.overmap_sectors[get_z(tracker)]
 			if(tracked_effect && istype(tracked_effect) && tracked_effect != linked && tracked_effect.requires_contact)
 				objects_in_current_view[tracked_effect] = TRUE
 				objects_in_view[tracked_effect] = 100

--- a/code/modules/overmap/ftl_shunt/computer.dm
+++ b/code/modules/overmap/ftl_shunt/computer.dm
@@ -24,7 +24,7 @@
 /obj/machinery/computer/ship/ftl/proc/recalc_cost()
 	if(!linked_core)
 		return INFINITY
-	var/obj/effect/overmap/visitable/sector = global.overmap_sectors[num2text(z)]
+	var/obj/effect/overmap/visitable/sector = global.overmap_sectors[z]
 	if(!istype(sector))
 		return INFINITY
 	var/jump_dist = get_dist(linked, locate(linked_core.shunt_x, linked_core.shunt_y, sector.z))
@@ -35,7 +35,7 @@
 	if(!linked_core)
 		return INFINITY
 
-	var/obj/effect/overmap/visitable/sector = global.overmap_sectors[num2text(z)]
+	var/obj/effect/overmap/visitable/sector = global.overmap_sectors[z]
 	if(!istype(sector))
 		return INFINITY
 

--- a/code/modules/overmap/ftl_shunt/core.dm
+++ b/code/modules/overmap/ftl_shunt/core.dm
@@ -237,7 +237,7 @@
 	return FTL_START_CONFIRMED
 
 /obj/machinery/ftl_shunt/core/proc/calculate_jump_requirements()
-	var/obj/effect/overmap/visitable/site = global.overmap_sectors[num2text(z)]
+	var/obj/effect/overmap/visitable/site = global.overmap_sectors[z]
 	if(site)
 		var/shunt_distance
 		var/vessel_mass = ftl_computer.linked.get_vessel_mass()
@@ -274,7 +274,7 @@
 		cancel_shunt()
 		return //If for some reason we don't have fuel now, just return.
 
-	var/obj/effect/overmap/visitable/site = global.overmap_sectors[num2text(z)]
+	var/obj/effect/overmap/visitable/site = global.overmap_sectors[z]
 	if(site)
 		var/destination = locate(shunt_x, shunt_y, site.z)
 		var/jumpdist = get_dist(get_turf(ftl_computer.linked), destination)

--- a/code/modules/overmap/internet/internet_repeater.dm
+++ b/code/modules/overmap/internet/internet_repeater.dm
@@ -51,7 +51,7 @@ var/global/list/internet_repeaters = list()
 	var/data = list()
 	data["powered"] = (use_power == POWER_USE_ACTIVE)
 
-	var/obj/effect/overmap/visitable/sector = global.overmap_sectors[num2text(get_z(src))]
+	var/obj/effect/overmap/visitable/sector = global.overmap_sectors[get_z(src)]
 
 	if(sector)
 		var/list/internet_connections = sector.get_internet_connections()

--- a/code/modules/overmap/overmap_shuttle.dm
+++ b/code/modules/overmap/overmap_shuttle.dm
@@ -1,4 +1,4 @@
-#define waypoint_sector(waypoint) global.overmap_sectors[num2text(waypoint.z)]
+#define waypoint_sector(waypoint) global.overmap_sectors[waypoint.z]
 
 /datum/shuttle/autodock/overmap
 	warmup_time = 10

--- a/code/modules/overmap/radio_beacon.dm
+++ b/code/modules/overmap/radio_beacon.dm
@@ -46,7 +46,7 @@
 		to_chat(user, SPAN_NOTICE("You deactivate \the [src], cutting short it's radio broadcast."))
 		QDEL_NULL(signal)
 		return
-	var/obj/effect/overmap/visitable/O = global.overmap_sectors[num2text(get_z(src))]
+	var/obj/effect/overmap/visitable/O = global.overmap_sectors[get_z(src)]
 	if(!O)
 		to_chat(user, SPAN_WARNING("You cannot deploy \the [src] here."))
 		return

--- a/code/modules/overmap/sectors.dm
+++ b/code/modules/overmap/sectors.dm
@@ -131,7 +131,7 @@ var/global/list/known_overmap_sectors
 	var/datum/overmap/overmap = global.overmaps_by_z[num2text(z)]
 	if(istype(overmap))
 		for(var/zlevel in map_z)
-			global.overmap_sectors[num2text(zlevel)] = src
+			global.overmap_sectors[zlevel] = src
 
 	SSmapping.player_levels |= map_z
 	if(!(sector_flags & OVERMAP_SECTOR_IN_SPACE))
@@ -149,7 +149,7 @@ var/global/list/known_overmap_sectors
 // Returns the /obj/effect/overmap/visitable to which the atom belongs based on localtion, or null
 /atom/proc/get_owning_overmap_object()
 	var/z = get_z(src)
-	var/initial_sector = global.overmap_sectors[num2text(z)]
+	var/initial_sector = global.overmap_sectors[z]
 	if(!initial_sector)
 		return
 

--- a/code/modules/overmap/ships/computers/comms.dm
+++ b/code/modules/overmap/ships/computers/comms.dm
@@ -120,7 +120,7 @@
 	var/turf/T = get_turf(src)
 	if(!T)
 		return
-	var/obj/effect/overmap/O = global.overmap_sectors["[z]"]
+	var/obj/effect/overmap/O = global.overmap_sectors[z]
 	if(!O)
 		return
 	if(stat & (BROKEN|NOPOWER))
@@ -140,7 +140,7 @@
 
 /obj/machinery/shipcomms/proc/get_nearby_entities()
 	. = list()
-	var/obj/effect/overmap/O = global.overmap_sectors["[z]"]
+	var/obj/effect/overmap/O = global.overmap_sectors[z]
 	if(!O)
 		return
 	var/turf/origin = get_turf(O)
@@ -173,7 +173,7 @@
 /obj/machinery/shipcomms/Destroy()
 	var/turf/T = get_turf(src)
 	if(istype(T))
-		var/obj/effect/overmap/O = global.overmap_sectors["[T.z]"]
+		var/obj/effect/overmap/O = global.overmap_sectors[T.z]
 		if(O)
 			unregister(O)
 	. = ..()
@@ -181,8 +181,8 @@
 /obj/machinery/shipcomms/update_power_on_move(atom/movable/mover, atom/old_loc, atom/new_loc)
 	..()
 	if(istype(old_loc) && old_loc != new_loc && (!istype(new_loc) || new_loc.z != old_loc.z))
-		var/obj/effect/overmap/lastsector = global.overmap_sectors["[old_loc.z]"]
-		var/obj/effect/overmap/currentsector = istype(new_loc) && global.overmap_sectors["[new_loc.z]"]
+		var/obj/effect/overmap/lastsector = global.overmap_sectors[old_loc.z]
+		var/obj/effect/overmap/currentsector = istype(new_loc) && global.overmap_sectors[new_loc.z]
 		if(istype(lastsector) && lastsector != currentsector)
 			unregister(lastsector.comms_masers)
 		refresh_overmap_registration()

--- a/code/modules/overmap/ships/computers/shuttle.dm
+++ b/code/modules/overmap/ships/computers/shuttle.dm
@@ -71,7 +71,7 @@
 		to_chat(user, SPAN_WARNING("The manual controls look hopelessly complex to you!"))
 
 /obj/machinery/computer/shuttle_control/explore/proc/start_landing(var/mob/user, var/datum/shuttle/autodock/overmap/shuttle)
-	var/obj/effect/overmap/visitable/current_sector = global.overmap_sectors[num2text(z)]
+	var/obj/effect/overmap/visitable/current_sector = global.overmap_sectors[z]
 	var/obj/effect/overmap/visitable/target_sector
 	if(current_sector && istype(current_sector))
 
@@ -110,7 +110,7 @@
 	var/mob/observer/eye/landing/landing_eye = eye_extension.extension_eye
 	var/turf/lz_turf = eye_extension.get_eye_turf()
 
-	var/obj/effect/overmap/visitable/sector = global.overmap_sectors[num2text(lz_turf.z)]
+	var/obj/effect/overmap/visitable/sector = global.overmap_sectors[lz_turf.z]
 	if(!sector.allow_free_landing())	// Additional safety check to ensure the sector permits landing.
 		to_chat(user, SPAN_WARNING("Invalid landing zone!"))
 		return

--- a/code/modules/overmap/ships/landable.dm
+++ b/code/modules/overmap/ships/landable.dm
@@ -53,7 +53,7 @@
 	if(!child_shuttle || !istype(child_shuttle))
 		return
 	if(child_shuttle.current_location.flags & SLANDMARK_FLAG_DISCONNECTED) // Keep an eye on the distance between the shuttle and the sector if we aren't fully docked.
-		var/obj/effect/overmap/visitable/ship/landable/encounter = global.overmap_sectors[num2text(child_shuttle.current_location.z)]
+		var/obj/effect/overmap/visitable/ship/landable/encounter = global.overmap_sectors[child_shuttle.current_location.z]
 		if((get_dist(src, encounter) > min(child_shuttle.range, 1))) // Some leeway so 0 range shuttles are still able to chase.
 			child_shuttle.attempt_force_move(landmark)
 		if(istype(encounter))
@@ -145,7 +145,7 @@
 	ADJUST_TAG_VAR(shuttle_name, map_hash)
 
 /obj/effect/shuttle_landmark/ship/Destroy()
-	var/obj/effect/overmap/visitable/ship/landable/ship = global.overmap_sectors[num2text(z)]
+	var/obj/effect/overmap/visitable/ship/landable/ship = global.overmap_sectors[z]
 	if(istype(ship) && ship.landmark == src)
 		ship.landmark = null
 	. = ..()
@@ -209,7 +209,7 @@
 	on_landing(from, into)
 
 /obj/effect/overmap/visitable/ship/landable/proc/on_landing(obj/effect/shuttle_landmark/from, obj/effect/shuttle_landmark/into)
-	var/obj/effect/overmap/visitable/target = global.overmap_sectors[num2text(into.z)]
+	var/obj/effect/overmap/visitable/target = global.overmap_sectors[into.z]
 	var/datum/shuttle/shuttle_datum = SSshuttle.shuttles[shuttle]
 	if(into.landmark_tag == shuttle_datum.motherdock) // If our motherdock is a landable ship, it won't be found properly here so we need to find it manually.
 		for(var/obj/effect/overmap/visitable/ship/landable/landable in SSshuttle.ships)
@@ -237,7 +237,7 @@
 			return "Docked with an unknown object."
 		if(SHIP_STATUS_ENCOUNTER)
 			var/datum/shuttle/autodock/overmap/child_shuttle = SSshuttle.shuttles[shuttle]
-			var/obj/effect/overmap/visitable/location = global.overmap_sectors[num2text(child_shuttle.current_location.z)]
+			var/obj/effect/overmap/visitable/location = global.overmap_sectors[child_shuttle.current_location.z]
 			return "Maneuvering nearby \the [location]."
 		if(SHIP_STATUS_TRANSIT)
 			return "Maneuvering under secondary thrust."

--- a/code/modules/power/solar.dm
+++ b/code/modules/power/solar.dm
@@ -194,7 +194,7 @@ var/global/list/solars_list = list()
 	// On planets, we take fewer steps because the light is mostly up
 	// Also, many planets barely have any spots with enough clear space around
 	if(isturf(loc))
-		var/obj/effect/overmap/visitable/sector/planetoid/E = overmap_sectors[num2text(loc.z)]
+		var/obj/effect/overmap/visitable/sector/planetoid/E = global.overmap_sectors[loc.z]
 		if(istype(E))
 			steps = 5
 

--- a/code/modules/shuttles/landmarks.dm
+++ b/code/modules/shuttles/landmarks.dm
@@ -56,7 +56,7 @@ var/global/list/shuttle_landmarks = list()
 	if(!istype(docking_controller))
 		log_error("Could not find docking controller for shuttle waypoint '[name]', docking tag was '[docking_tag]'.")
 
-	var/obj/effect/overmap/visitable/location = global.overmap_sectors[num2text(z)]
+	var/obj/effect/overmap/visitable/location = global.overmap_sectors[z]
 	if(location && location.docking_codes)
 		docking_controller.docking_codes = location.docking_codes
 
@@ -67,9 +67,9 @@ var/global/list/shuttle_landmarks = list()
 		ADJUST_TAG_VAR(docking_controller, map_hash)
 
 /obj/effect/shuttle_landmark/forceMove()
-	var/obj/effect/overmap/visitable/map_origin = global.overmap_sectors[num2text(z)]
+	var/obj/effect/overmap/visitable/map_origin = global.overmap_sectors[z]
 	. = ..()
-	var/obj/effect/overmap/visitable/map_destination = global.overmap_sectors[num2text(z)]
+	var/obj/effect/overmap/visitable/map_destination = global.overmap_sectors[z]
 	if(map_origin != map_destination)
 		if(map_origin)
 			map_origin.remove_landmark(src, shuttle_restricted)

--- a/code/modules/shuttles/shuttle_autodock.dm
+++ b/code/modules/shuttles/shuttle_autodock.dm
@@ -33,7 +33,7 @@
 	if(active_docking_controller)
 		set_docking_codes(active_docking_controller.docking_codes)
 	else if(current_location?.overmap_id)
-		var/obj/effect/overmap/visitable/location = global.overmap_sectors[num2text(current_location.z)]
+		var/obj/effect/overmap/visitable/location = global.overmap_sectors[current_location.z]
 		if(location && location.docking_codes)
 			set_docking_codes(location.docking_codes)
 	dock()

--- a/code/modules/submaps/_submap.dm
+++ b/code/modules/submaps/_submap.dm
@@ -45,7 +45,7 @@
 		qdel(src)
 		return
 
-	var/obj/effect/overmap/visitable/cell = global.overmap_sectors[num2text(associated_z)]
+	var/obj/effect/overmap/visitable/cell = global.overmap_sectors[associated_z]
 	if(istype(cell))
 		sync_cell(cell)
 

--- a/code/unit_tests/shuttle_tests.dm
+++ b/code/unit_tests/shuttle_tests.dm
@@ -4,8 +4,8 @@
 /datum/unit_test/generic_shuttle_landmarks_shall_not_appear_in_restricted_list/start_test()
 	var/fail = FALSE
 
-	for(var/sz in global.overmap_sectors)
-		var/obj/effect/overmap/visitable/sector = global.overmap_sectors[sz]
+	for(var/sz, sec in global.overmap_sectors)
+		var/obj/effect/overmap/visitable/sector = sec
 		if(!istype(sector))
 			continue
 		var/list/failures = list()

--- a/maps/exodus/exodus_setup.dm
+++ b/maps/exodus/exodus_setup.dm
@@ -13,8 +13,8 @@
 		welcome_text += "Time since last port visit:<br /><b>[rand(60,180)] days</b><br /><hr>"
 		welcome_text += "Scan results show the following points of interest:<br />"
 
-		for(var/zlevel in global.overmap_sectors)
-			var/obj/effect/overmap/visitable/O = global.overmap_sectors[zlevel]
+		for(var/zlevel, sector in global.overmap_sectors)
+			var/obj/effect/overmap/visitable/O = sector
 			if(O.name == exodus.name)
 				continue
 			if(istype(O, /obj/effect/overmap/visitable/ship/landable)) //Don't show shuttles

--- a/maps/tradeship/jobs/command.dm
+++ b/maps/tradeship/jobs/command.dm
@@ -27,8 +27,8 @@
 	global.using_map.station_short = ship
 	global.using_map.station_name = "Tradeship [ship]"
 
-	for(var/sz in global.overmap_sectors)
-		var/obj/effect/overmap/visitable/ship/tradeship/B = global.overmap_sectors[sz]
+	for(var/sz, sec in global.overmap_sectors)
+		var/obj/effect/overmap/visitable/ship/tradeship/B = sec
 		if(istype(B))
 			B.SetName(global.using_map.station_name)
 			command_announcement.Announce("Attention all hands on [global.using_map.station_name]! Thank you for your attention.", "Ship Re-Christened")


### PR DESCRIPTION
## Description of changes
Makes `global.overmap_sectors` use an alist, meaning we don't need to do `num2text` anymore.

## Why and what will this PR improve
Simplifies the code and hopefully makes it faster. However much faster it is, it's less than the noise from planet gen on tradeship, so...