### PR TITLE
Make extensions use alists

### DIFF
--- a/code/__defines/lists.dm
+++ b/code/__defines/lists.dm
@@ -32,6 +32,14 @@
 // Reads L or an empty list if L is not a list.  Note: Does NOT assign, L may be an expression.
 #define SANITIZE_LIST(L) ( islist(L) ? L : list() )
 
+// The above but for alists. Prefixed with A_ because inserting "A" randomly in the name just made it confusing
+#define A_LAZYINITLIST(AL) if (!AL) { AL = alist(); }
+#define A_UNSETEMPTY(AL) if(!length(AL)) { AL = null; }
+#define A_LAZYREMOVE(AL, I) if(AL) { AL -= I; A_UNSETEMPTY(AL) }
+#define A_LAZYSET(AL, A, I) if(!AL) { AL = alist(); } AL[A] = I;
+#define A_LAZYCLEARLIST(AL) if(AL) { AL.Cut(); AL = null; }
+#define A_LAZYLEN(AL) length(AL)
+
 /// Passed into BINARY_INSERT to compare keys
 #define COMPARE_KEY __BIN_LIST[__BIN_MID]
 /// Passed into BINARY_INSERT to compare values

--- a/code/datums/datum.dm
+++ b/code/datums/datum.dm
@@ -42,10 +42,11 @@
 			qdel(timer)
 
 	if(extensions)
-		for(var/expansion_key in extensions)
-			var/list/extension = extensions[expansion_key]
+		var/list/extension_list
+		for(var/expansion_key, extension in extensions)
 			if(islist(extension))
-				extension.Cut()
+				extension_list = extension
+				extension_list.Cut()
 			else
 				qdel(extension)
 		extensions = null

--- a/code/datums/extensions/extensions.dm
+++ b/code/datums/extensions/extensions.dm
@@ -38,7 +38,8 @@
 	source.PopulateClone(src)
 
 /datum
-	var/list/datum/extension/extensions
+	/// A lazy alist() keyed by extension base type. Values are either a list of extension init arguments for lazy-loaded extensions, or an extension datum.
+	var/alist/extensions
 
 //Variadic - Additional positional arguments can be given. Named arguments might not work so well
 /proc/set_extension(var/datum/source, var/datum/extension/extension_type)
@@ -49,8 +50,7 @@
 		CRASH("Invalid base type: Expected /datum/extension, was [log_info_line(extension_base_type)]")
 	if(!ispath(extension_type, extension_base_type))
 		CRASH("Invalid extension type: Expected [extension_base_type], was [log_info_line(extension_type)]")
-	if(!source.extensions)
-		source.extensions = list()
+	A_LAZYINITLIST(source.extensions)
 	var/datum/extension/existing_extension = source.extensions[extension_base_type]
 	if(istype(existing_extension))
 		qdel(existing_extension)
@@ -115,7 +115,7 @@
 		return
 	if(!islist(source.extensions[base_type]))
 		qdel(source.extensions[base_type])
-	LAZYREMOVE(source.extensions, base_type)
+	A_LAZYREMOVE(source.extensions, base_type)
 
 ///Copy the extension instance on the 'source' and put it on the 'destination'.
 /proc/copy_extension(var/datum/source, var/datum/destination, var/base_type)


### PR DESCRIPTION
## Description of changes
`var/list/datum/extension/extensions` on `/datum` is now `var/alist/extensions`. no typehint because it's ambiguous whether it'd refer to the key or the value, if someone has a solution for indicating that without causing dreammaker to choke on it you're welcome to PR it to dreamchecker

## Why and what will this PR improve
memory savings and vaguely faster than normal associative lists.