### PR TITLE
Optimize nanoui merge_templates (~1.5 seconds saved)

### DIFF
--- a/code/modules/client/asset_cache.dm
+++ b/code/modules/client/asset_cache.dm
@@ -221,12 +221,14 @@ var/global/template_file_name = "all_templates.json"
 /// Handles adding a directory's templates to the compiled templates list.
 /datum/asset/nanoui/proc/merge_templates(use_dir)
 	PRIVATE_PROC(TRUE)
+	var/static/regex/whitespace = new(@"[\n\t]+", "g")
 	var/list/templates = flist(use_dir)
 	for(var/filename in templates)
 		if(copytext(filename, length(filename)) != "/")
-			templates[filename] = replacetext(replacetext(file2text(use_dir + filename), "\n", ""), "\t", "")
+			templates[filename] = whitespace.Replace(file2text(use_dir + filename), "")
 		else
 			templates -= filename
+		CHECK_TICK
 	return templates
 
 /datum/asset/nanoui/send(client, uncommon)


### PR DESCRIPTION
## Description of changes
Optimizes the `merge_templates` proc by avoiding multiple replacetext calls (using regex replace instead). We also do CHECK_TICK so that it doesn't block things like user input, which is important given how late in init this is.

## Why and what will this PR improve
Slightly faster. This used to take 1.5 seconds and now it takes 0.05 seconds.
Latest dev on tradeship:
> Initialized Late Initialization subsystem within 1.48125 seconds!

This PR:
> Initialized Late Initialization subsystem within 0.05625 seconds!

Yeah, no, I thought I messed it up too somehow, but it works? UIs work fine.
<img width="342" height="466" alt="image" src="https://github.com/user-attachments/assets/6dba0633-8ecc-430b-8f93-f46d245c6a22" />


## Authorship
Me