### PR TITLE
Fix unit tests stalling under load due to stoplag

### DIFF
--- a/code/_helpers/time.dm
+++ b/code/_helpers/time.dm
@@ -156,7 +156,12 @@ var/global/rollovercheck_last_timeofday = 0
 
 	if (!initial_delay)
 		initial_delay = world.tick_lag
-
+// Unit tests are not the normal environemnt. The mc can get absolutely thigh crushed, and sleeping procs running for ages is much more common
+// We don't want spurious hard deletes off this, so let's only sleep for the requested period of time here yeah?
+#ifdef UNIT_TEST
+	sleep(initial_delay)
+	return NONUNIT_CEILING(DS2TICKS(initial_delay), 1)
+#else
 	. = 0
 	var/i = DS2TICKS(initial_delay)
 	do
@@ -164,6 +169,7 @@ var/global/rollovercheck_last_timeofday = 0
 		sleep(i * world.tick_lag * DELTA_CALC)
 		i *= 2
 	while (TICK_USAGE > min(TICK_LIMIT_TO_RUN, Master.current_ticklimit))
+#endif
 
 #undef DELTA_CALC
 


### PR DESCRIPTION
## Description of changes
Adapted from https://github.com/tgstation/tgstation/pull/77868.

## Why and what will this PR improve
This is one potential cause of hard-to-replicate GC failures during unit tests, and moreover it just makes it take longer than it should (because the MC is often paused during unit tests, it can get hammered badly and exponentially increase the wait time). This will hopefully make unit tests more reliable.

## Authorship
LemonInTheDark at TG.