### PR TITLE
Make random subset supplypacks use expected price instead of raw sum

### DIFF
--- a/code/datums/supplypacks/supplypack.dm
+++ b/code/datums/supplypacks/supplypack.dm
@@ -19,13 +19,16 @@ var/global/list/cargoprices = list()
 	. = ..() // make sure children are set up
 	if(is_category())
 		return // don't do any of this for categories
+	var/total_contained = 0
+	for(var/entry in contains)
+		total_contained += max(1, contains[entry])
 	if(!num_contained)
-		for(var/entry in contains)
-			num_contained += max(1, contains[entry])
+		num_contained = total_contained
 	if(isnull(cost))
 		cost = 0
 		for(var/entry in contains)
 			cost += atom_info_repository.get_combined_worth_for(entry) * max(1, contains[entry])
+		cost *= num_contained / total_contained // if you get a random selection, it costs the expected value rather than the total worth. gambling!
 		cost += containertype ? atom_info_repository.get_single_worth_for(containertype) : 0
 		cost = max(1, NONUNIT_CEILING((cost * WORTH_TO_SUPPLY_POINTS_CONSTANT * SSsupply.price_markup), WORTH_TO_SUPPLY_POINTS_ROUND_CONSTANT))
 	global.cargoprices[name] = cost


### PR DESCRIPTION
## Description of changes
Makes supplypacks that use `num_contained` to select a subset cost the expected price (average price times number of items) rather than the total price.

## Why and what will this PR improve
If you had something like a "Random MRE" supplypack that chose 1 out of 10 options, you'd have to pay, IMO, 10x too much; it'd act as if you were buying all 10. This fixes that while not breaking the economy.

## Authorship
Me

## Changelog
:cl:
balance: Certain supply packs that give a random selection are now priced more fairly.
/:cl: