### PR TITLE
Set category for Check Sky button

### DIFF
--- a/code/modules/multiz/movement.dm
+++ b/code/modules/multiz/movement.dm
@@ -323,6 +323,7 @@
 
 /mob/living/verb/check_sky()
 	set name = "Check Sky"
+	set category = "IC"
 	if(!client || is_physically_disabled() || !isturf(loc))
 		to_chat(src, SPAN_WARNING("You can't check the sky right now."))
 		return


### PR DESCRIPTION
Verbs without category are displayed in Commands tab.
I think this is an oversight and this verb should be in IC category.