### PR TITLE
Various fixes/tweaks for unit tests.

### DIFF
--- a/code/modules/bodytype/_bodytype.dm
+++ b/code/modules/bodytype/_bodytype.dm
@@ -89,6 +89,8 @@ var/global/list/bodytypes_by_category = list()
 	var/z_flags              = 0
 	/// Amount to shift overlays when lying. TODO: check if this is still needed with KEEP_TOGETHER
 	var/list/prone_overlay_offset
+	/// Set to TRUE to skip unit testing as a primary bodytype in a human. Generally for partial prosthetic models.
+	var/skip_organ_validation = FALSE
 
 	/// Per-bodytype per-zone message strings, see /mob/proc/get_hug_zone_messages
 	var/list/default_hug_message
@@ -675,7 +677,7 @@ var/global/list/bodytypes_by_category = list()
 		var/organ_type = has_organ[organ_tag]
 		var/obj/item/organ/O = new organ_type(H, null, supplied_data)
 		if(organ_tag != O.organ_tag)
-			warning("[O.type] has a default organ tag \"[O.organ_tag]\" that differs from the species' organ tag \"[organ_tag]\". Updating organ_tag to match.")
+			warning("[O.type] has a default organ tag \"[O.organ_tag]\" that differs from the bodytype organ tag \"[organ_tag]\". Updating organ_tag to match.")
 			O.organ_tag = organ_tag
 		H.add_organ(O, GET_EXTERNAL_ORGAN(H, O.parent_organ), FALSE, FALSE, skip_health_update = TRUE)
 	H.update_health()

--- a/code/modules/codex/categories/_materials.dm
+++ b/code/modules/codex/categories/_materials.dm
@@ -22,6 +22,9 @@
 		var/list/reactant_values = list()
 		for(var/reactant_id in reaction.required_reagents)
 			var/decl/material/reactant = GET_DECL(reactant_id)
+			if(!istype(reactant))
+				log_error("Could not find /decl for [reactant_id], reaction type [reactiontype].")
+				continue
 			var/reactant_name = "<span codexlink='[reactant.codex_name || reactant.name] (substance)'>[reactant.name]</span>"
 			reactant_values += "[reaction.required_reagents[reactant_id]]u [reactant_name]"
 		mechanics_text += " [jointext(reactant_values, " + ")]"

--- a/code/modules/codex/categories/category_fusion_reaction.dm
+++ b/code/modules/codex/categories/category_fusion_reaction.dm
@@ -10,7 +10,15 @@
 			continue
 
 		var/decl/material/p_mat = GET_DECL(reaction.p_react)
+		if(!istype(p_mat))
+			log_error("Could not find /decl instance for [rtype]'s primary reactant [reaction.p_react || "NULL"].")
+			continue
+
 		var/decl/material/s_mat = GET_DECL(reaction.s_react)
+		if(!istype(s_mat))
+			log_error("Could not find /decl instance for [rtype]'s secondary reactant [reaction.s_react || "NULL"].")
+			continue
+
 		var/list/reaction_info = list()
 		reaction_info += "Fusion between [p_mat.name] and [s_mat.name] can be achieved with a plasma temperature of [T0C + reaction.minimum_reaction_temperature] Kelvin or higher."
 		reaction_info += "This reaction consumes [initial(reaction.energy_consumption)] heat unit\s and produces [reaction.energy_production] heat unit\s."

--- a/code/unit_tests/mob_tests.dm
+++ b/code/unit_tests/mob_tests.dm
@@ -24,6 +24,8 @@
 		T = locate(/turf/space)
 	var/datum/mob_snapshot/dummy_appearance = new
 	for(var/decl/bodytype/bodytype in decls_repository.get_decls_of_subtype_unassociated(/decl/bodytype))
+		if(bodytype.skip_organ_validation)
+			continue
 		var/decl/species/species = bodytype.get_user_species_for_validation()
 		if(!species)
 			continue
@@ -208,6 +210,7 @@
 	var/msg = "Damage taken: [ending_damage] out of [damage_amount] || expected: [expected_msg] \[Overall Health:[ending_health] (Initial: [initial_health]\]"
 
 	if(failure)
+		msg += " || species: [H.get_species()?.type || "NULL"] || bodytype: [H.get_bodytype()?.type || "NULL"]"
 		fail(msg)
 	else
 		pass(msg)
@@ -305,6 +308,8 @@
 	var/failed = FALSE
 	var/datum/mob_snapshot/dummy_appearance = new
 	for(var/decl/bodytype/bodytype in decls_repository.get_decls_of_subtype_unassociated(/decl/bodytype))
+		if(bodytype.skip_organ_validation)
+			continue
 		var/decl/species/species = bodytype.get_user_species_for_validation()
 		if(!species)
 			continue

--- a/code/unit_tests/organ_tests.dm
+++ b/code/unit_tests/organ_tests.dm
@@ -118,6 +118,8 @@
 	var/failcount = 0
 	var/datum/mob_snapshot/dummy_appearance = new
 	for(var/decl/bodytype/bodytype in decls_repository.get_decls_of_subtype_unassociated(/decl/bodytype))
+		if(bodytype.skip_organ_validation)
+			continue
 		var/decl/species/species = bodytype.get_user_species_for_validation()
 		if(!species)
 			continue
@@ -255,6 +257,8 @@
 	var/failcount = 0
 	var/datum/mob_snapshot/dummy_appearance = new
 	for(var/decl/bodytype/bodytype in decls_repository.get_decls_of_subtype_unassociated(/decl/bodytype))
+		if(bodytype.skip_organ_validation)
+			continue
 		var/decl/species/species = bodytype.get_user_species_for_validation()
 		if(!species)
 			continue

--- a/code/unit_tests/unique_tests.dm
+++ b/code/unit_tests/unique_tests.dm
@@ -181,9 +181,9 @@
 			continue
 		group_by(decls_by_uid, decl_instance.uid, decl_type)
 
-	var/number_of_issues = number_of_issues(decls_by_uid, "Language UIDs")
+	var/number_of_issues = number_of_issues(decls_by_uid, "/decl UIDs")
 	if(number_of_issues)
-		fail("[number_of_issues] issue\s with decl UIDs found.")
+		fail("[number_of_issues] issue\s with /decl UIDs found.")
 	else
 		pass("All decl UIDs are unique.")
 	return TRUE


### PR DESCRIPTION
- Allows bodytypes to skip organ validation (needed for bodytypes that don't implement a full set of organs, like specific prosthetic models).
- Makes category generation more explicit about failures in fusion reaction info.
- Fixes a copypaste error.