### PR TITLE
Fix issues with blood volume calculations

### DIFF
--- a/code/modules/mob/living/human/human_blood.dm
+++ b/code/modules/mob/living/human/human_blood.dm
@@ -185,8 +185,6 @@
 
 //Percentage of maximum blood volume, affected by the condition of circulation organs
 /mob/living/human/proc/get_blood_circulation()
-
-
 	var/obj/item/organ/internal/heart/heart = get_organ(BP_HEART, /obj/item/organ/internal/heart)
 	if(!heart)
 		return 0.25 * get_blood_volume()
@@ -210,8 +208,7 @@
 			if(PULSE_2FAST, PULSE_THREADY)
 				pulse_mod *= 1.25
 	blood_volume *= pulse_mod
-	if(current_posture.prone)
-		blood_volume *= 1.25
+	blood_volume *= current_posture.blood_volume_multiplier
 
 	var/min_efficiency = recent_pump ? 0.5 : 0.3
 	blood_volume *= max(min_efficiency, (1-(heart.get_organ_damage() / heart.max_damage)))
@@ -236,7 +233,8 @@
 	else
 		blood_volume = 100
 
-	var/blood_volume_mod = max(0, 1 - getOxyLossPercent()/(species.total_health/2))
+	// blood_volume_mod is 1 with no oxyloss, 0 at half species health (50%), and cannot go below 0
+	var/blood_volume_mod = max(0, (1 - getOxyLossFraction()*2))
 	var/oxygenated_mult = 0
 	switch(GET_CHEMICAL_EFFECT(src, CE_OXYGENATED))
 		if(1)
@@ -245,6 +243,6 @@
 			oxygenated_mult = 0.7
 		if(3)
 			oxygenated_mult = 0.9
-	blood_volume_mod = blood_volume_mod + oxygenated_mult - (blood_volume_mod * oxygenated_mult)
-	blood_volume = blood_volume * blood_volume_mod
-	return min(blood_volume, 100)
+	blood_volume_mod += oxygenated_mult * (1 - blood_volume_mod) // give us back a fraction of our missing oxygenation
+	blood_volume *= blood_volume_mod
+	return clamp(blood_volume, 0, 100)

--- a/code/modules/mob/living/human/human_damage.dm
+++ b/code/modules/mob/living/human/human_damage.dm
@@ -130,7 +130,10 @@
 	..()
 
 /mob/living/human/proc/getOxyLossPercent()
-	return (get_damage(OXY) / species.total_health) * 100
+	return getOxyLossFraction() * 100
+
+/mob/living/human/proc/getOxyLossFraction()
+	return (get_damage(OXY) / species.total_health)
 
 /mob/living/human/getOxyLoss()
 	if(need_breathe())

--- a/code/modules/posture/_posture.dm
+++ b/code/modules/posture/_posture.dm
@@ -14,6 +14,8 @@
 	var/selectable_type
 	/// String to use in Change Posture.
 	var/posture_change_message
+	/// Postural multiplier to effective blood circulation volume, a generalization of the old feature of 'laying down increases your effective blood volume'.
+	var/blood_volume_multiplier = 1
 
 /decl/posture/proc/can_be_selected_by(mob/mob)
 	return is_user_selectable

--- a/code/modules/posture/posture_subtypes.dm
+++ b/code/modules/posture/posture_subtypes.dm
@@ -9,6 +9,7 @@
 	prone = TRUE
 	posture_change_message = "lying down"
 	selectable_type = /decl/posture/lying/deliberate
+	blood_volume_multiplier = 1.25
 
 /decl/posture/lying/deliberate
 	name = "resting"
@@ -21,3 +22,4 @@
 	is_user_selectable = TRUE
 	deliberate = TRUE
 	prone = TRUE
+	blood_volume_multiplier = 1.1 // sitting is a little less intense than standing


### PR DESCRIPTION
## Description of changes
Cleans up blood circulation and volume calculations to make more sense (at least to me, which means it makes sense to 1 person rather than 0).
Replaces a hardcoded `current_posture.prone` check with a per-posture multiplier. Sitting now also gives a slight buff to circulating blood volume, a bit under half that of laying down.
Fixes a bug with the effect of oxyloss on blood volume. It was accidentally scaling inversely with the square of species total health, so higher max health mobs had a dramatically diminished effect. This is unintended judging from older revisions; the intended math is now used, which means it should scale correctly for all species regardless of health. This is one of several issues making yinglets downstream extra-sensitive to oxyloss currently.

## Why and what will this PR improve
Less hardcoded, easier to read, fixes a bug.

## Authorship
Me. Also the Nuclear Phase dev for rewriting it downstream and giving me a reason to check out our own code and clean it up.