### PR TITLE
Fix small mobs taking forever to metabolize reagents out

### DIFF
--- a/code/modules/mob/living/life.dm
+++ b/code/modules/mob/living/life.dm
@@ -244,10 +244,14 @@
 					break
 			if(still_processing_reagent)
 				continue
-			var/dose = CHEM_DOSE(src, reagent) - reagent.metabolism*2
-			LAZYSET(_chem_doses, reagent, dose)
-			if(CHEM_DOSE(src, reagent) <= 0)
+			var/amount_removed = get_adjusted_metabolism(reagent.metabolism*2) // reagents metabolize out twice as fast as they metabolize in
+			if(!(reagent.flags & IGNORE_MOB_SIZE))
+				amount_removed *= (MOB_SIZE_MEDIUM/mob_size)
+			var/dose = CHEM_DOSE(src, reagent) - amount_removed
+			if(dose <= 0)
 				LAZYREMOVE(_chem_doses, reagent)
+			else
+				LAZYSET(_chem_doses, reagent, dose)
 	if(apply_chemical_effects())
 		update_health()
 


### PR DESCRIPTION
## Description of changes
Scales reagent removal from `_chem_doses` with mob size, to match them being scaled when added. This should mmmmmmaybe target stable?

## Why and what will this PR improve
This makes it so that carbon monoxide poisoning doesn't last 6.66x longer for yinglets on Scavstation. It would metabolize in 6.66x as fast as default, but metabolize out only at 2x default, meaning it had a ratio of 3.33:1 instead of 1:2. This is one of several issues making yinglets especially susceptible to carbon monoxide poisoning.

## Authorship
Me. Also Scavstation players for reporting the carbon monoxide issue in the first place.