### PR TITLE
Unify unary freezers/heaters under a shared type

### DIFF
--- a/code/game/objects/items/circuitboards/machinery/unary_atmos.dm
+++ b/code/game/objects/items/circuitboards/machinery/unary_atmos.dm
@@ -11,7 +11,7 @@
 
 /obj/item/stock_parts/circuitboard/unary_atmos/heater
 	name = "circuitboard (gas heating system)"
-	build_path = /obj/machinery/atmospherics/unary/heater
+	build_path = /obj/machinery/atmospherics/unary/temperature/heater
 	origin_tech = @'{"powerstorage":2,"engineering":1}'
 	req_components = list(
 							/obj/item/stack/cable_coil = 5,
@@ -20,7 +20,7 @@
 
 /obj/item/stock_parts/circuitboard/unary_atmos/cooler
 	name = "circuitboard (gas cooling system)"
-	build_path = /obj/machinery/atmospherics/unary/freezer
+	build_path = /obj/machinery/atmospherics/unary/temperature/freezer
 	origin_tech = @'{"magnets":2,"engineering":2}'
 	req_components = list(
 							/obj/item/stack/cable_coil = 2,

--- a/code/modules/atmospherics/components/unary/cold_sink.dm
+++ b/code/modules/atmospherics/components/unary/cold_sink.dm
@@ -23,14 +23,14 @@
 	return air_contents.temperature > set_temperature
 
 /obj/machinery/atmospherics/unary/temperature/freezer/modify_gas()
-	var/heat_transfer = max( -air_contents.get_thermal_energy_change(set_temperature - 5), 0 )
+	var/heat_transfer = min(air_contents.get_thermal_energy_change(set_temperature - 5), 0)
 
 	//Assume the heat is being pumped into the hull which is fixed at heatsink_temperature
 	//not /really/ proper thermodynamics but whatever
 	var/cop = performance_multiplier * air_contents.temperature/heatsink_temperature	//heatpump coefficient of performance from thermodynamics -> power used = heat_transfer/cop
 	heat_transfer = min(heat_transfer, cop * power_rating)	//limit heat transfer by available power
 
-	var/removed = -air_contents.add_thermal_energy(-heat_transfer)		//remove the heat
+	var/removed = -air_contents.add_thermal_energy(heat_transfer)		//remove the heat
 	if(debug)
 		visible_message("[src]: Removing [removed] W.")
 

--- a/code/modules/atmospherics/components/unary/cold_sink.dm
+++ b/code/modules/atmospherics/components/unary/cold_sink.dm
@@ -1,136 +1,42 @@
 //TODO: Put this under a common parent type with heaters to cut down on the copypasta
 #define FREEZER_PERF_MULT 2.5
 
-/obj/machinery/atmospherics/unary/freezer
+/obj/machinery/atmospherics/unary/temperature/freezer
 	name = "gas cooling system"
 	desc = "Cools gas when connected to a pipe network."
 	icon = 'icons/obj/Cryogenic2.dmi'
 	icon_state = "freezer_0"
-	layer = STRUCTURE_LAYER
-	density = TRUE
-	anchored = TRUE
-	use_power = POWER_USE_OFF
-	idle_power_usage = 5			// 5 Watts for thermostat related circuitry
-	base_type = /obj/machinery/atmospherics/unary/freezer
-	construct_state = /decl/machine_construction/default/panel_closed
-	uncreated_component_parts = null
-	stat_immune = 0
-
+	base_icon_state = "freezer"
+	base_type = /obj/machinery/atmospherics/unary/temperature/freezer
+	ui_title = "Gas Cooling System"
+	performance_multiplier = FREEZER_PERF_MULT
 	var/heatsink_temperature = T20C	// The constant temperature reservoir into which the freezer pumps heat. Probably the hull of the station or something.
-	var/internal_volume = 600		// L
 
-	var/max_power_rating = 20000	// Power rating when the usage is turned up to 100
-	var/power_setting = 100
-
-	var/set_temperature = T20C		// Thermostat
-	var/cooling = 0
-
-/obj/machinery/atmospherics/unary/freezer/on_update_icon()
-	if(LAZYLEN(nodes_to_networks))
-		if(use_power && cooling)
-			icon_state = "freezer_1"
-		else
-			icon_state = "freezer"
-	else
-		icon_state = "freezer_0"
-
-/obj/machinery/atmospherics/unary/freezer/interface_interact(mob/user)
-	ui_interact(user)
-	return TRUE
-
-/obj/machinery/atmospherics/unary/freezer/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null, var/force_open = 1)
-	// this is the data which will be sent to the ui
-	var/data[0]
-	data["on"] = use_power ? 1 : 0
-	data["gasPressure"] = round(air_contents.return_pressure())
-	data["gasTemperature"] = round(air_contents.temperature)
-	data["minGasTemperature"] = 0
-	data["maxGasTemperature"] = round(T20C+500)
-	data["targetGasTemperature"] = round(set_temperature)
-	data["powerSetting"] = power_setting
-
-	var/temp_class = "good"
+/obj/machinery/atmospherics/unary/temperature/freezer/get_temperature_class()
+	. = "good"
 	if(air_contents.temperature > (T0C - 20))
-		temp_class = "bad"
+		. = "bad"
 	else if(air_contents.temperature < (T0C - 20) && air_contents.temperature > (T0C - 100))
-		temp_class = "average"
-	data["gasTemperatureClass"] = temp_class
+		. = "average"
 
-	// update the ui if it exists, returns null if no ui is passed/found
-	ui = SSnano.try_update_ui(user, src, ui_key, ui, data, force_open)
-	if(!ui)
-		// the ui does not exist, so we'll create a new() one
-		// for a list of parameters and their descriptions see the code docs in \code\modules\nano\nanoui.dm
-		ui = new(user, src, ui_key, "freezer.tmpl", "Gas Cooling System", 440, 300)
-		// when the ui is first opened this is the data it will use
-		ui.set_initial_data(data)
-		// open the new ui window
-		ui.open()
-		// auto update every Master Controller tick
-		ui.set_auto_update(1)
+/obj/machinery/atmospherics/unary/temperature/freezer/should_modify_gas()
+	return air_contents.temperature > set_temperature
 
-/obj/machinery/atmospherics/unary/freezer/OnTopic(mob/user, href_list)
-	if((. = ..()))
-		return
-	if(href_list["toggleStatus"])
-		update_use_power(!use_power)
-		. = TOPIC_REFRESH
-	if(href_list["temp"])
-		var/amount = text2num(href_list["temp"])
-		set_temperature = clamp(set_temperature + amount, 0, 1000)
-		. = TOPIC_REFRESH
-	if(href_list["setPower"]) //setting power to 0 is redundant anyways
-		var/new_setting = clamp(text2num(href_list["setPower"]), 0, 100)
-		set_power_level(new_setting)
-		. = TOPIC_REFRESH
+/obj/machinery/atmospherics/unary/temperature/freezer/modify_gas()
+	var/heat_transfer = max( -air_contents.get_thermal_energy_change(set_temperature - 5), 0 )
 
-/obj/machinery/atmospherics/unary/freezer/Process()
-	..()
+	//Assume the heat is being pumped into the hull which is fixed at heatsink_temperature
+	//not /really/ proper thermodynamics but whatever
+	var/cop = performance_multiplier * air_contents.temperature/heatsink_temperature	//heatpump coefficient of performance from thermodynamics -> power used = heat_transfer/cop
+	heat_transfer = min(heat_transfer, cop * power_rating)	//limit heat transfer by available power
 
-	if(stat & (NOPOWER|BROKEN) || !use_power)
-		cooling = 0
-		update_icon()
-		return
-
-	if(LAZYLEN(nodes_to_networks) && air_contents.temperature > set_temperature)
-		cooling = 1
-
-		var/heat_transfer = max( -air_contents.get_thermal_energy_change(set_temperature - 5), 0 )
-
-		//Assume the heat is being pumped into the hull which is fixed at heatsink_temperature
-		//not /really/ proper thermodynamics but whatever
-		var/cop = FREEZER_PERF_MULT * air_contents.temperature/heatsink_temperature	//heatpump coefficient of performance from thermodynamics -> power used = heat_transfer/cop
-		heat_transfer = min(heat_transfer, cop * power_rating)	//limit heat transfer by available power
-
-		var/removed = -air_contents.add_thermal_energy(-heat_transfer)		//remove the heat
-		if(debug)
-			visible_message("[src]: Removing [removed] W.")
-
-		use_power_oneoff(power_rating)
-
-		update_networks()
-	else
-		cooling = 0
-
-	update_icon()
+	var/removed = -air_contents.add_thermal_energy(-heat_transfer)		//remove the heat
+	if(debug)
+		visible_message("[src]: Removing [removed] W.")
 
 //upgrading parts
-/obj/machinery/atmospherics/unary/freezer/RefreshParts()
+/obj/machinery/atmospherics/unary/temperature/freezer/RefreshParts()
 	..()
-	var/cap_rating = clamp(total_component_rating_of_type(/obj/item/stock_parts/capacitor), 0, 20)
 	var/manip_rating = clamp(total_component_rating_of_type(/obj/item/stock_parts/manipulator), 1, 10)
 	var/bin_rating = clamp(total_component_rating_of_type(/obj/item/stock_parts/matter_bin), 0, 10)
-
-	power_rating = initial(power_rating) * cap_rating / 2			//more powerful
 	heatsink_temperature = initial(heatsink_temperature) / ((manip_rating + bin_rating) / 2)	//more efficient
-	air_contents.total_volume = max(initial(internal_volume) - 200, 0) + 200 * bin_rating
-	set_power_level(power_setting)
-
-/obj/machinery/atmospherics/unary/freezer/proc/set_power_level(var/new_power_setting)
-	power_setting = new_power_setting
-	power_rating = max_power_rating * (power_setting/100)
-
-/obj/machinery/atmospherics/unary/freezer/get_examine_strings(mob/user, distance, infix, suffix)
-	. = ..()
-	if(panel_open)
-		. += "The maintenance hatch is open."

--- a/code/modules/atmospherics/components/unary/heat_source.dm
+++ b/code/modules/atmospherics/components/unary/heat_source.dm
@@ -14,7 +14,10 @@
 	return air_contents.temperature < set_temperature
 
 /obj/machinery/atmospherics/unary/temperature/heater/modify_gas()
-	air_contents.add_thermal_energy(power_rating * performance_multiplier)
+	// amount of heat needed to heat air_contents to set_temperature + 5
+	var/heat_transfer = max(air_contents.get_thermal_energy_change(set_temperature + 5), 0)
+	heat_transfer = min(heat_transfer, performance_multiplier * power_rating) // don't overshoot
+	air_contents.add_thermal_energy(heat_transfer)
 
 /obj/machinery/atmospherics/unary/temperature/heater/get_temperature_class()
 	. = "normal"

--- a/code/modules/atmospherics/components/unary/heat_source.dm
+++ b/code/modules/atmospherics/components/unary/heat_source.dm
@@ -1,123 +1,29 @@
 //TODO: Put this under a common parent type with freezers to cut down on the copypasta
 #define HEATER_PERF_MULT 2.5
 
-/obj/machinery/atmospherics/unary/heater
+/obj/machinery/atmospherics/unary/temperature/heater
 	name = "gas heating system"
 	desc = "Heats gas when connected to a pipe network."
 	icon = 'icons/obj/Cryogenic2.dmi'
 	icon_state = "heater_0"
-	layer = STRUCTURE_LAYER
-	density = TRUE
-	anchored = TRUE
-	use_power = POWER_USE_OFF
-	idle_power_usage = 5			//5 Watts for thermostat related circuitry
-	base_type = /obj/machinery/atmospherics/unary/heater
-	construct_state = /decl/machine_construction/default/panel_closed
-	uncreated_component_parts = null
-	stat_immune = 0
-	connect_types = CONNECT_TYPE_REGULAR | CONNECT_TYPE_FUEL
+	base_icon_state = "heater"
+	base_type = /obj/machinery/atmospherics/unary/temperature/heater
+	performance_multiplier = HEATER_PERF_MULT
 
-	var/max_temperature = T20C + 680
-	var/internal_volume = 600	//L
+/obj/machinery/atmospherics/unary/temperature/heater/should_modify_gas()
+	return air_contents.temperature < set_temperature
 
-	var/max_power_rating = 20000	//power rating when the usage is turned up to 100
-	var/power_setting = 100
+/obj/machinery/atmospherics/unary/temperature/heater/modify_gas()
+	air_contents.add_thermal_energy(power_rating * performance_multiplier)
 
-	var/set_temperature = T20C	//thermostat
-	var/heating = 0		//mainly for icon updates
-
-/obj/machinery/atmospherics/unary/heater/on_update_icon()
-	if(LAZYLEN(nodes_to_networks))
-		if(use_power && heating)
-			icon_state = "heater_1"
-		else
-			icon_state = "heater"
-	else
-		icon_state = "heater_0"
-
-/obj/machinery/atmospherics/unary/heater/Process()
-	..()
-
-	if(stat & (NOPOWER|BROKEN) || !use_power)
-		heating = 0
-		update_icon()
-		return
-
-	if(LAZYLEN(nodes_to_networks) && air_contents.total_moles && air_contents.temperature < set_temperature)
-		air_contents.add_thermal_energy(power_rating * HEATER_PERF_MULT)
-		use_power_oneoff(power_rating)
-
-		heating = 1
-		update_networks()
-	else
-		heating = 0
-
-	update_icon()
-
-/obj/machinery/atmospherics/unary/heater/interface_interact(mob/user)
-	ui_interact(user)
-	return TRUE
-
-/obj/machinery/atmospherics/unary/heater/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null, var/force_open = 1)
-	// this is the data which will be sent to the ui
-	var/data[0]
-	data["on"] = use_power ? 1 : 0
-	data["gasPressure"] = round(air_contents.return_pressure())
-	data["gasTemperature"] = round(air_contents.temperature)
-	data["minGasTemperature"] = 0
-	data["maxGasTemperature"] = round(max_temperature)
-	data["targetGasTemperature"] = round(set_temperature)
-	data["powerSetting"] = power_setting
-
-	var/temp_class = "normal"
+/obj/machinery/atmospherics/unary/temperature/heater/get_temperature_class()
+	. = "normal"
 	if(air_contents.temperature > (T20C+40))
-		temp_class = "bad"
-	data["gasTemperatureClass"] = temp_class
-
-	// update the ui if it exists, returns null if no ui is passed/found
-	ui = SSnano.try_update_ui(user, src, ui_key, ui, data, force_open)
-	if(!ui)
-		// the ui does not exist, so we'll create a new() one
-		// for a list of parameters and their descriptions see the code docs in \code\modules\nano\nanoui.dm
-		ui = new(user, src, ui_key, "freezer.tmpl", "Gas Heating System", 440, 300)
-		// when the ui is first opened this is the data it will use
-		ui.set_initial_data(data)
-		// open the new ui window
-		ui.open()
-		// auto update every Master Controller tick
-		ui.set_auto_update(1)
-
-/obj/machinery/atmospherics/unary/heater/OnTopic(mob/user, href_list)
-	if((. = ..()))
-		return
-	if(href_list["toggleStatus"])
-		update_use_power(!use_power)
-		. = TOPIC_REFRESH
-	if(href_list["temp"])
-		var/amount = text2num(href_list["temp"])
-		set_temperature = clamp(set_temperature + amount, 0, max_temperature)
-		. = TOPIC_REFRESH
-	if(href_list["setPower"]) //setting power to 0 is redundant anyways
-		var/new_setting = clamp(text2num(href_list["setPower"]), 0, 100)
-		set_power_level(new_setting)
-		. = TOPIC_REFRESH
+		. = "bad"
 
 //upgrading parts
-/obj/machinery/atmospherics/unary/heater/RefreshParts()
+/obj/machinery/atmospherics/unary/temperature/heater/RefreshParts()
 	..()
 	var/cap_rating = clamp(total_component_rating_of_type(/obj/item/stock_parts/capacitor), 1, 20)
 	var/bin_rating = clamp(total_component_rating_of_type(/obj/item/stock_parts/matter_bin), 0, 10)
-
-	max_power_rating = initial(max_power_rating) * cap_rating / 2
 	max_temperature = max(initial(max_temperature) - T20C, 0) * ((bin_rating * 4 + cap_rating) / 5) + T20C
-	air_contents.total_volume = max(initial(internal_volume) - 200, 0) + 200 * bin_rating
-	set_power_level(power_setting)
-
-/obj/machinery/atmospherics/unary/heater/proc/set_power_level(var/new_power_setting)
-	power_setting = new_power_setting
-	power_rating = max_power_rating * (power_setting/100)
-
-/obj/machinery/atmospherics/unary/heater/get_examine_strings(mob/user, distance, infix, suffix)
-	. = ..()
-	if(panel_open)
-		. += "The maintenance hatch is open."

--- a/code/modules/atmospherics/components/unary/temperature_base.dm
+++ b/code/modules/atmospherics/components/unary/temperature_base.dm
@@ -1,0 +1,122 @@
+/obj/machinery/atmospherics/unary/temperature
+	abstract_type = /obj/machinery/atmospherics/unary/temperature
+	name = "gas thermoregulation system"
+	desc = "This should not be visible."
+	icon = 'icons/obj/Cryogenic2.dmi'
+	icon_state = "heater_0"
+	layer = STRUCTURE_LAYER
+	density = TRUE
+	anchored = TRUE
+	use_power = POWER_USE_OFF
+	idle_power_usage = 5			//5 Watts for thermostat related circuitry
+	construct_state = /decl/machine_construction/default/panel_closed
+	uncreated_component_parts = null
+	stat_immune = 0
+	connect_types = CONNECT_TYPE_REGULAR | CONNECT_TYPE_FUEL
+	var/internal_volume = 600	//L
+	var/max_power_rating = 20000	//power rating when the usage is turned up to 100
+	var/power_setting = 100
+	var/set_temperature = T20C	//thermostat
+	var/is_modifying_gas = FALSE //mainly for icon updates
+	var/base_icon_state = "heater"
+	var/performance_multiplier = 1
+	var/max_temperature = T20C+500
+	var/ui_title = "Gas Thermoregulation System"
+
+/obj/machinery/atmospherics/unary/temperature/on_update_icon()
+	if(!LAZYLEN(nodes_to_networks))
+		icon_state = "[base_icon_state]_0"
+	else if(use_power && is_modifying_gas)
+		icon_state = "[base_icon_state]_1"
+	else
+		icon_state = base_icon_state
+
+// Modify air_contents in this proc.
+/obj/machinery/atmospherics/unary/temperature/proc/modify_gas()
+
+/obj/machinery/atmospherics/unary/temperature/proc/should_modify_gas()
+	return FALSE
+
+/obj/machinery/atmospherics/unary/temperature/Process()
+	..()
+
+	is_modifying_gas = FALSE
+	if(stat & (NOPOWER|BROKEN) || !use_power)
+		update_icon()
+		return
+
+	if(LAZYLEN(nodes_to_networks) && air_contents.total_moles && should_modify_gas())
+		modify_gas()
+		is_modifying_gas = TRUE
+		use_power_oneoff(power_rating)
+		update_networks()
+
+	update_icon()
+
+/obj/machinery/atmospherics/unary/temperature/interface_interact(mob/user)
+	ui_interact(user)
+	return TRUE
+
+/obj/machinery/atmospherics/unary/temperature/proc/get_temperature_class()
+	PROTECTED_PROC(TRUE)
+	return "normal"
+
+/obj/machinery/atmospherics/unary/temperature/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null, var/force_open = 1)
+	// this is the data which will be sent to the ui
+	var/data[0]
+	data["on"] = use_power ? 1 : 0
+	data["gasPressure"] = round(air_contents.return_pressure())
+	data["gasTemperature"] = round(air_contents.temperature)
+	data["minGasTemperature"] = 0
+	data["maxGasTemperature"] = round(max_temperature)
+	data["targetGasTemperature"] = round(set_temperature)
+	data["powerSetting"] = power_setting
+
+	data["gasTemperatureClass"] = get_temperature_class()
+
+	// update the ui if it exists, returns null if no ui is passed/found
+	ui = SSnano.try_update_ui(user, src, ui_key, ui, data, force_open)
+	if(!ui)
+		// the ui does not exist, so we'll create a new() one
+		// for a list of parameters and their descriptions see the code docs in \code\modules\nano\nanoui.dm
+		ui = new(user, src, ui_key, "freezer.tmpl", ui_title, 440, 300)
+		// when the ui is first opened this is the data it will use
+		ui.set_initial_data(data)
+		// open the new ui window
+		ui.open()
+		// auto update every Master Controller tick
+		ui.set_auto_update(1)
+
+/obj/machinery/atmospherics/unary/temperature/OnTopic(mob/user, href_list)
+	if((. = ..()))
+		return
+	if(href_list["toggleStatus"])
+		update_use_power(!use_power)
+		. = TOPIC_REFRESH
+	if(href_list["temp"])
+		var/amount = text2num(href_list["temp"])
+		set_temperature = clamp(set_temperature + amount, 0, max_temperature)
+		. = TOPIC_REFRESH
+	if(href_list["setPower"]) //setting power to 0 is redundant anyways
+		var/new_setting = clamp(text2num(href_list["setPower"]), 0, 100)
+		set_power_level(new_setting)
+		. = TOPIC_REFRESH
+
+//upgrading parts
+/obj/machinery/atmospherics/unary/temperature/RefreshParts()
+	..()
+	var/cap_rating = clamp(total_component_rating_of_type(/obj/item/stock_parts/capacitor), 1, 20)
+	var/bin_rating = clamp(total_component_rating_of_type(/obj/item/stock_parts/matter_bin), 0, 10)
+
+	max_power_rating = initial(max_power_rating) * cap_rating / 2
+	air_contents.total_volume = max(initial(internal_volume) - 200, 0) + 200 * bin_rating
+	set_power_level(power_setting)
+
+/obj/machinery/atmospherics/unary/temperature/proc/set_power_level(var/new_power_setting)
+	power_setting = new_power_setting
+	power_rating = max_power_rating * (power_setting/100)
+
+/obj/machinery/atmospherics/unary/temperature/get_examine_strings(mob/user, distance, infix, suffix)
+	. = ..()
+	if(panel_open)
+		. += "The maintenance hatch is open."

--- a/code/modules/codex/entries/atmospherics.dm
+++ b/code/modules/codex/entries/atmospherics.dm
@@ -54,7 +54,7 @@
 
 //Freezers
 /datum/codex_entry/atmos_freezer
-	associated_paths = list(/obj/machinery/atmospherics/unary/freezer)
+	associated_paths = list(/obj/machinery/atmospherics/unary/temperature/freezer)
 	mechanics_text = "Cools down the gas of the pipe it is connected to.  It uses massive amounts of electricity while on. \
 	It can be upgraded by replacing the capacitors, manipulators, and matter bins.  It can be deconstructed by screwing the maintenance panel open with a \
 	screwdriver, and then using a crowbar."
@@ -63,7 +63,7 @@
 
 //Heaters
 /datum/codex_entry/atmos_heater
-	associated_paths = list(/obj/machinery/atmospherics/unary/heater)
+	associated_paths = list(/obj/machinery/atmospherics/unary/temperature/heater)
 	mechanics_text = "Heats up the gas of the pipe it is connected to.  It uses massive amounts of electricity while on. \
 	It can be upgraded by replacing the capacitors, manipulators, and matter bins.  It can be deconstructed by screwing the maintenance panel open with a \
 	screwdriver, and then using a crowbar."

--- a/maps/away/casino/casino.dmm
+++ b/maps/away/casino/casino.dmm
@@ -4575,7 +4575,7 @@
 /turf/floor/plating,
 /area/casino/casino_bow)
 "ne" = (
-/obj/machinery/atmospherics/unary/heater{
+/obj/machinery/atmospherics/unary/temperature/heater{
 	dir = 8
 	},
 /turf/floor/plating,

--- a/maps/away/errant_pisces/errant_pisces.dmm
+++ b/maps/away/errant_pisces/errant_pisces.dmm
@@ -260,7 +260,7 @@
 /turf/floor/plating,
 /area/errant_pisces/bow_starboard)
 "aJ" = (
-/obj/machinery/atmospherics/unary/heater{
+/obj/machinery/atmospherics/unary/temperature/heater{
 	dir = 1
 	},
 /turf/floor/plating,
@@ -286,7 +286,7 @@
 /turf/floor/plating,
 /area/errant_pisces/bow_port)
 "aN" = (
-/obj/machinery/atmospherics/unary/heater{
+/obj/machinery/atmospherics/unary/temperature/heater{
 	dir = 1
 	},
 /turf/floor/plating,

--- a/maps/away/unishi/unishi-2.dmm
+++ b/maps/away/unishi/unishi-2.dmm
@@ -1528,7 +1528,7 @@
 /area/unishi/hydro)
 "er" = (
 /obj/effect/vine,
-/obj/machinery/atmospherics/unary/freezer{
+/obj/machinery/atmospherics/unary/temperature/freezer{
 	dir = 8;
 	icon_state = "freezer"
 	},
@@ -1664,7 +1664,7 @@
 /area/unishi/hydro)
 "eJ" = (
 /obj/effect/vine,
-/obj/machinery/atmospherics/unary/heater{
+/obj/machinery/atmospherics/unary/temperature/heater{
 	dir = 8
 	},
 /turf/floor/tiled,

--- a/maps/away/yacht/yacht.dmm
+++ b/maps/away/yacht/yacht.dmm
@@ -1001,7 +1001,7 @@
 /turf/floor/plating,
 /area/yacht/engine)
 "di" = (
-/obj/machinery/atmospherics/unary/heater,
+/obj/machinery/atmospherics/unary/temperature/heater,
 /turf/floor/plating,
 /area/yacht/engine)
 "dj" = (
@@ -1009,7 +1009,7 @@
 /turf/floor/plating,
 /area/yacht/engine)
 "dk" = (
-/obj/machinery/atmospherics/unary/heater,
+/obj/machinery/atmospherics/unary/temperature/heater,
 /obj/effect/decal/cleanable/dirt/visible,
 /turf/floor/plating,
 /area/yacht/engine)
@@ -1100,7 +1100,7 @@
 /turf/floor/plating,
 /area/yacht/engine)
 "dw" = (
-/obj/machinery/atmospherics/unary/heater{
+/obj/machinery/atmospherics/unary/temperature/heater{
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt/visible,

--- a/maps/exodus/exodus-1.dmm
+++ b/maps/exodus/exodus-1.dmm
@@ -4285,13 +4285,13 @@
 /turf/floor/tiled/steel_grid,
 /area/exodus/engineering/atmos)
 "ln" = (
-/obj/machinery/atmospherics/unary/freezer{
+/obj/machinery/atmospherics/unary/temperature/freezer{
 	icon_state = "freezer"
 	},
 /turf/floor/tiled/steel_grid,
 /area/exodus/engineering/atmos)
 "lo" = (
-/obj/machinery/atmospherics/unary/heater{
+/obj/machinery/atmospherics/unary/temperature/heater{
 	icon_state = "heater"
 	},
 /turf/floor/tiled/steel_grid,

--- a/maps/exodus/exodus-2.dmm
+++ b/maps/exodus/exodus-2.dmm
@@ -42587,7 +42587,7 @@
 /turf/floor/tiled/white,
 /area/exodus/research)
 "bLl" = (
-/obj/machinery/atmospherics/unary/freezer{
+/obj/machinery/atmospherics/unary/temperature/freezer{
 	icon_state = "freezer"
 	},
 /obj/effect/floor_decal/corner/purple{
@@ -42665,7 +42665,7 @@
 /turf/floor/tiled/steel_grid,
 /area/exodus/maintenance/atmos_control)
 "bLv" = (
-/obj/machinery/atmospherics/unary/heater{
+/obj/machinery/atmospherics/unary/temperature/heater{
 	icon_state = "heater"
 	},
 /obj/effect/floor_decal/corner/purple{
@@ -47178,7 +47178,7 @@
 	pixel_x = -6;
 	pixel_y = 25
 	},
-/obj/machinery/atmospherics/unary/freezer{
+/obj/machinery/atmospherics/unary/temperature/freezer{
 	dir = 8;
 	icon_state = "freezer"
 	},

--- a/maps/ministation/ministation-0.dmm
+++ b/maps/ministation/ministation-0.dmm
@@ -3835,7 +3835,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/atmospherics/unary/freezer,
+/obj/machinery/atmospherics/unary/temperature/freezer,
 /turf/floor/tiled/techfloor,
 /area/ministation/atmospherics)
 "qL" = (

--- a/maps/ministation/ministation-2.dmm
+++ b/maps/ministation/ministation-2.dmm
@@ -3759,7 +3759,7 @@
 /turf/floor/plating,
 /area/ministation/bridge)
 "tT" = (
-/obj/machinery/atmospherics/unary/freezer{
+/obj/machinery/atmospherics/unary/temperature/freezer{
 	dir = 8;
 	set_temperature = 263
 	},
@@ -5996,7 +5996,7 @@
 /turf/floor/tiled/white,
 /area/ministation/science)
 "JY" = (
-/obj/machinery/atmospherics/unary/freezer,
+/obj/machinery/atmospherics/unary/temperature/freezer,
 /obj/structure/sign/warning/nosmoking_burned{
 	pixel_y = 32
 	},
@@ -6117,7 +6117,7 @@
 /turf/floor/tiled/white,
 /area/ministation/science)
 "LK" = (
-/obj/machinery/atmospherics/unary/freezer{
+/obj/machinery/atmospherics/unary/temperature/freezer{
 	set_temperature = 263
 	},
 /obj/machinery/light{

--- a/maps/random_ruins/exoplanet_ruins/playablecolony/colony.dmm
+++ b/maps/random_ruins/exoplanet_ruins/playablecolony/colony.dmm
@@ -1617,7 +1617,7 @@
 /turf/floor/tiled/techfloor,
 /area/map_template/colony)
 "dJ" = (
-/obj/machinery/atmospherics/unary/freezer{
+/obj/machinery/atmospherics/unary/temperature/freezer{
 	icon_state = "freezer"
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -3379,7 +3379,7 @@
 /turf/floor/lino,
 /area/map_template/colony/messhall)
 "gL" = (
-/obj/machinery/atmospherics/unary/heater{
+/obj/machinery/atmospherics/unary/temperature/heater{
 	dir = 1
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -5387,7 +5387,7 @@
 /turf/floor/tiled/techfloor,
 /area/map_template/colony)
 "kt" = (
-/obj/machinery/atmospherics/unary/freezer{
+/obj/machinery/atmospherics/unary/temperature/freezer{
 	dir = 8
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -6964,7 +6964,7 @@
 /turf/floor/concrete,
 /area/template_noop)
 "nr" = (
-/obj/machinery/atmospherics/unary/heater{
+/obj/machinery/atmospherics/unary/temperature/heater{
 	dir = 8
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,

--- a/nebula.dme
+++ b/nebula.dme
@@ -1795,6 +1795,7 @@
 #include "code\modules\atmospherics\components\unary\heat_source.dm"
 #include "code\modules\atmospherics\components\unary\outlet_injector.dm"
 #include "code\modules\atmospherics\components\unary\tank.dm"
+#include "code\modules\atmospherics\components\unary\temperature_base.dm"
 #include "code\modules\atmospherics\components\unary\thermal_plate.dm"
 #include "code\modules\atmospherics\components\unary\unary_base.dm"
 #include "code\modules\atmospherics\components\unary\vent_pump.dm"

--- a/tools/map_migrations/5281_freezer_heater.txt
+++ b/tools/map_migrations/5281_freezer_heater.txt
@@ -1,0 +1,2 @@
+/obj/machinery/atmospherics/unary/heater/@SUBTYPES : /obj/machinery/atmospherics/unary/temperature/heater{@OLD}
+/obj/machinery/atmospherics/unary/freezer/@SUBTYPES : /obj/machinery/atmospherics/unary/temperature/freezer{@OLD}


### PR DESCRIPTION
## Description of changes
Unifies `/obj/machinery/atmospherics/unary/freezer` and `/obj/machinery/atmospherics/unary/heater` under `/obj/machinery/atmospherics/unary/temperature` to reduce code duplication. Most of their code was identical already, so it only required minor changes.
- [x] Tested

## Why and what will this PR improve
Completes #5011.

## Authorship
Me