### PR TITLE
Fix opacity issues with materials

### DIFF
--- a/code/modules/materials/definitions/liquids/materials_liquid_chemistry.dm
+++ b/code/modules/materials/definitions/liquids/materials_liquid_chemistry.dm
@@ -30,6 +30,7 @@
 	lore_text = "Lubricant is a substance introduced between two moving surfaces to reduce the friction and wear between them. giggity."
 	taste_description = "slime"
 	color = SYNTH_BLOOD_COLOR
+	opacity = 1.0 // liquid default is 0.5, we want oil to be fully opaque so the footsteps are too
 	value = 0.1
 	slipperiness = 80
 	exoplanet_rarity_gas = MAT_RARITY_EXOTIC

--- a/code/modules/materials/definitions/liquids/materials_liquid_toxins.dm
+++ b/code/modules/materials/definitions/liquids/materials_liquid_toxins.dm
@@ -227,6 +227,7 @@
 	taste_mult = 1.2
 	metabolism = REM * 0.25
 	exoplanet_rarity_gas = MAT_RARITY_NOWHERE
+	opacity = 1.0
 
 /decl/material/liquid/hair_remover
 	name = "hair remover"

--- a/code/modules/reagents/chems/chems_blood.dm
+++ b/code/modules/reagents/chems/chems_blood.dm
@@ -12,7 +12,7 @@
 	glass_desc = "Are you sure this is tomato juice?"
 	coated_adjective = "bloody"
 	value = 2.5
-	opacity = TRUE
+	opacity = 1.0
 	min_fluid_opacity = FLUID_MAX_ALPHA
 	max_fluid_opacity = 240
 	compost_value = 1 // yum

--- a/code/modules/reagents/chems/chems_blood.dm
+++ b/code/modules/reagents/chems/chems_blood.dm
@@ -89,3 +89,4 @@
 	value = 0
 	exoplanet_rarity_gas = MAT_RARITY_UNCOMMON
 	compost_value = 1 // yum
+	opacity = 1.0

--- a/code/modules/reagents/chems/chems_cleaner.dm
+++ b/code/modules/reagents/chems/chems_cleaner.dm
@@ -38,3 +38,4 @@
 	ignition_point   = 353
 	boiling_point    = 373
 	accelerant_value = 0.3
+	opacity          = 1.0 // liquid is opaque by default, but soap is solid (or maybe it should be like, mostly opaque? tbd)

--- a/code/modules/reagents/chems/chems_nutriment.dm
+++ b/code/modules/reagents/chems/chems_nutriment.dm
@@ -14,6 +14,7 @@
 	nutriment_factor = 10
 	affect_blood_on_ingest = 0
 	affect_blood_on_inhale = 0
+	opacity = 1.0 // liquids are half transparent by default; meat and etc should not be transparent
 
 	// Technically a room-temperature solid, but saves
 	// repathing it to /solid all over the codebase.
@@ -71,6 +72,7 @@
 	uid = "chem_nutriment_honey"
 	melting_point = 273
 	boiling_point = 373
+	opacity = 0.5
 
 /decl/material/liquid/nutriment/flour
 	name = "flour"
@@ -218,6 +220,7 @@
 	uid = "chem_nutriment_soysauce"
 	melting_point = 273
 	boiling_point = 373
+	opacity = 0.5
 
 /decl/material/liquid/nutriment/ketchup
 	name = "ketchup"
@@ -256,6 +259,7 @@
 	melting_point = 273
 	boiling_point = 373
 	allergen_flags = ALLERGEN_FRUIT | ALLERGEN_VEGETABLE // Is a tomato a fruit or a vegetable?
+	opacity = 0.9
 
 /decl/material/liquid/nutriment/garlicsauce
 	name = "garlic sauce"
@@ -269,6 +273,7 @@
 	melting_point = 273
 	boiling_point = 373
 	allergen_flags = ALLERGEN_VEGETABLE
+	opacity = 0.9
 
 /decl/material/liquid/nutriment/rice
 	name = "rice"
@@ -294,6 +299,7 @@
 	melting_point = 273
 	boiling_point = 373
 	allergen_flags = ALLERGEN_FRUIT
+	opacity = 0.7
 
 /decl/material/liquid/nutriment/sprinkles
 	name = "sprinkles"
@@ -329,6 +335,7 @@
 	uid = "chem_nutriment_vinegar"
 	melting_point = 273
 	boiling_point = 373
+	opacity = 0.5
 
 /decl/material/liquid/nutriment/mayo
 	name = "mayonnaise"
@@ -342,7 +349,7 @@
 	allergen_flags = ALLERGEN_EGG
 
 /decl/material/liquid/nutriment/yeast
-	name = "Yeast"
+	name = "yeast"
 	lore_text = "A collection of live fungal cultures, cultivated across history for use in fermentation and baking."
 	taste_description = "mustiness"
 	nutriment_factor = 1

--- a/code/modules/reagents/chems/chems_pigments.dm
+++ b/code/modules/reagents/chems/chems_pigments.dm
@@ -1,11 +1,12 @@
 /decl/material/liquid/pigment
 	name = "pigment"
-	lore_text = "Intensely coloured powder."
+	lore_text = "Intensely coloured powder." // then why is it a liquid?
 	taste_description = "the back of class"
 	color = "#888888"
 	overdose = 5
 	hidden_from_codex = TRUE
 	exoplanet_rarity_gas = MAT_RARITY_NOWHERE
+	opacity = 1.0
 	uid = "chem_pigment"
 
 /decl/material/liquid/pigment/red

--- a/mods/content/xenobiology/slime/slime_reagents.dm
+++ b/mods/content/xenobiology/slime/slime_reagents.dm
@@ -12,6 +12,7 @@
 	heating_message = "becomes clear."
 	color = "#cf3600"
 	metabolism = REM * 0.25
+	opacity = 0.7 // copied from cherry jelly
 	exoplanet_rarity_gas = MAT_RARITY_EXOTIC
 
 /decl/material/liquid/water/affect_touch(var/mob/living/victim, var/removed, var/datum/reagents/holder)


### PR DESCRIPTION
## Description of changes
- Oil (lubricant) is now opaque, which means oily footprints are back to being opaque.
- Soap is now opaque.
- Nutriment and most subtypes of it are now opaque.
- Vinegar, barbecue sauce, garlic sauce, cherry jelly, slime jelly, and soy sauce now have explicitly-set opacity levels.
- Tar is now opaque.
- Blood's opacity is now a float rather than a bool.
- Coagulated blood is now opaque.
- Pigment is now opaque.

Not opacity-related: Yeast is now called `yeast` instead of `Yeast` for parity with other materials.

## Why and what will this PR improve
fixes weird opacity levels on some materials