### PR TITLE
Fix Issue #5288 - crafting torch/splint with stick

### DIFF
--- a/code/game/objects/items/weapons/material/stick.dm
+++ b/code/game/objects/items/weapons/material/stick.dm
@@ -27,7 +27,7 @@
 	if(!sharp && (istype(used_item, /obj/item/stack/material/bolt) || istype(used_item, /obj/item/stack/material/bundle)))
 
 		var/choice = input(user, "Do you want to make a torch, or a splint?", "Stick Crafting") as null|anything in list("Torch", "Splint")
-		if(!choice || QDELETED(user) || user.get_active_held_item() != used_item || QDELETED(used_item) || !QDELETED(src) || (loc != user && !Adjacent(user)) || sharp)
+		if(!choice || QDELETED(user) || user.get_active_held_item() != used_item || QDELETED(used_item) || QDELETED(src) || (loc != user && !Adjacent(user)) || sharp)
 			return TRUE
 
 		var/obj/item/stack/material/cloth = used_item


### PR DESCRIPTION
Fixes the ability to craft torches/splints by using materials on sticks.

<!-- !! PLEASE, READ THIS !! -->
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/NebulaSS13/Nebula/blob/dev/CONTRIBUTING.md -->
<!-- If you're opening a pull request which changes A LOT of icon/map files: -->
<!-- Add [IDB IGNORE] (to ignore icon file changes) or [MDB IGNORE] (to ignore map file changes) in the PR title. -->
<!-- These tags prevent huge diffs from overloading IconDiffBot and MapDiffBot. -->

## Description of changes
<!-- Describe the pull request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Fixes the one-character issue in `code/game/objects/items/weapons/material/stick.dm:30` to allow crafting torches and splints to proceed correctly.

## Why and what will this PR improve
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Allows the crafting of torches and splints as intended.

## Authorship
<!-- Describe original authors of changes to credit them. -->
Typhin

## Changelog
:cl:
bugfix: fixed the conditional preventing crafting
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->