### PR TITLE
Fix reagent holders being cleared when ~0 units are transferred

### DIFF
--- a/code/modules/reagents/Chemistry-Holder.dm
+++ b/code/modules/reagents/Chemistry-Holder.dm
@@ -483,6 +483,8 @@ var/global/datum/reagents/sink/infinite_reagent_sink = new
 /// Removes up to [amount] of reagents from [src]. Returns actual amount removed.
 /datum/reagents/proc/remove_any(var/amount = 1, var/defer_update = FALSE, var/removed_phases = (MAT_PHASE_LIQUID | MAT_PHASE_SOLID), skip_reagents = null)
 
+	amount = CHEMS_QUANTIZE(amount)
+
 	if(amount <= 0)
 		return 0
 
@@ -518,8 +520,11 @@ var/global/datum/reagents/sink/infinite_reagent_sink = new
 	else
 		return 0
 
-	var/removing = clamp(CHEMS_QUANTIZE(amount), 0, total_volume) // not ideal but something is making total_volume become NaN
-	if(!removing || total_volume <= 0)
+	var/removing = clamp(amount, 0, total_volume) // not ideal but something is making total_volume become NaN
+	if(!removing)
+		return 0 // don't clear, we aren't removing any
+
+	if(total_volume <= removing) // we're removing everything
 		. = 0
 		clear_reagents()
 		return


### PR DESCRIPTION
## Description of changes
When an amount between 0 and `MINIMUM_CHEMICAL_VOLUME` (exclusive) is transferred, it would fail the first `amount <= 0` check and then succeed the `!removed` check due to rounding. This would cause transferring *approximately zero* reagents to nuke the reagents in a holder. This could even happen to someone's blood. I think it's more likely to happen for scavs because of the scaling of blood loss according to mob size (by `sqrt(mob_size/20)`, so around 0.55x for scavs).

## Why and what will this PR improve
Stops blood from vanishing.

## Authorship
Me. Scavs for reporting it.