### PR TITLE
Fix passports spawning on the floor

### DIFF
--- a/maps/~mapsystem/maps.dm
+++ b/maps/~mapsystem/maps.dm
@@ -555,7 +555,7 @@ var/global/const/MAP_HAS_RANK   = 2		//Rank system, also toggleable
 	var/obj/item/passport/pass = new passport_type(get_turf(H))
 	if(istype(pass))
 		pass.set_info(H)
-	if(!H.equip_to_slot(pass, slot_in_wallet_str) && !H.equip_to_slot(pass, slot_in_backpack_str))
+	if(!H.equip_to_slot_if_possible(pass, slot_in_wallet_str, del_on_fail=FALSE, disable_warning=TRUE) && !H.equip_to_slot_if_possible(pass, slot_in_backpack_str, del_on_fail=FALSE, disable_warning=TRUE))
 		H.put_in_hands(pass)
 
 /datum/map/proc/populate_overmap_events()


### PR DESCRIPTION
## Description of changes
`equip_to_slot` would return TRUE even if it failed due to no backpack being equipped, but most outfits had backpacks so it was never noticed. The same happens with `slot_in_wallet_str`, but most outfits don't have wallets, so it would incorrectly return TRUE and not check the backpack or put it in your hands. This uses the correct proc to avoid that. It will also avoid it spawning on the floor if you have no backpack.

## Why and what will this PR improve
Passports will no longer spawn on the floor if you don't have a wallet.

## Authorship
Me.