### PR TITLE
Shotgun icon fix

### DIFF
--- a/code/modules/projectiles/guns/projectile/shotgun.dm
+++ b/code/modules/projectiles/guns/projectile/shotgun.dm
@@ -24,6 +24,12 @@
 	else
 		icon_state = "[get_world_inventory_state()]-empty"
 
+/obj/item/gun/projectile/shotgun/pump/update_base_icon_state()
+	if(chambered)
+		icon_state = get_world_inventory_state()
+	else
+		icon_state = "[get_world_inventory_state()]-empty"
+
 /obj/item/gun/projectile/shotgun/pump/consume_next_projectile()
 	if(chambered)
 		return chambered.BB


### PR DESCRIPTION
## Description of changes
I noticed that pump action shotguns check for shells in the tube, not shells in the chamber when decided whether to display as empty. This doesn't reflect whether the shotgun is actually "loaded", as you can still have a shell in the chamber.

## Why and what will this PR improve
You can now tell if a shotgun is loaded by looking at it, rather than guessing on whether or not there's a shell in the chamber. This is better from a gameplay standpoint, more immersive, and more realistic.

## Authorship
It's me, Karl Johansson

## Changelog
:cl: Karl Johansson
bugfix: Fixes pump-action shotgun icons incorrectly displaying the state of the weapon
/:cl: