### PR TITLE
Fixes rejuvenate not preserving skin color

### DIFF
--- a/code/modules/bodytype/_bodytype.dm
+++ b/code/modules/bodytype/_bodytype.dm
@@ -668,6 +668,8 @@ var/global/list/bodytypes_by_category = list()
 		var/list/organ_data = has_limbs[limb_type]
 		var/limb_path = organ_data["path"]
 		var/obj/item/organ/external/E = new limb_path(H, null, supplied_data) //explicitly specify the dna and bodytype
+		E.skin_colour = supplied_data.skin_color //match skin colors
+		E.skin_tone = supplied_data.skin_tone
 		H.add_organ(E, GET_EXTERNAL_ORGAN(H, E.parent_organ), FALSE, FALSE, skip_health_update = TRUE)
 
 	//Create missing internal organs


### PR DESCRIPTION
## Description of changes
I noticed in testing that if you chop your arm off, and regrow it with the Rejuvenate verb (something I often find myself doing), the arm you grow back is inexplicably white, regardless of your character's actual skin color.
<img width="70" height="67" alt="image" src="https://github.com/user-attachments/assets/e52684aa-2cc2-4e42-b53e-ec2b8384ce3b" />

## Why and what will this PR improve
Now, if you regrow a limb, it will actually match your body, rather than looking like you stole someone else's arm. This is probably a good thing.

## Authorship
The one, the only, Karl Johansson

## Changelog
:cl: Karl Johansson
bugfix: Regrown limbs now match the skin color of the rest of your body
/:cl: