### PR TITLE
Fixes rejuvenate not preserving skin color (Take Two)

### DIFF
--- a/code/modules/organs/external/_external.dm
+++ b/code/modules/organs/external/_external.dm
@@ -158,6 +158,8 @@
 
 /obj/item/organ/external/copy_from_mob_snapshot(datum/mob_snapshot/supplied_appearance)
 	_icon_cache_key = null
+	skin_colour = supplied_appearance.skin_color //match skin colors
+	skin_tone = supplied_appearance.skin_tone
 	if(organ_tag in supplied_appearance?.sprite_accessories)
 		var/list/sprite_cats = supplied_appearance.sprite_accessories[organ_tag]
 		for(var/category in sprite_cats)


### PR DESCRIPTION
## Description of changes
I noticed in testing that if you chop your arm off, and regrow it with the Rejuvenate verb (something I often find myself doing), the arm you grow back is inexplicably white, regardless of your character's actual skin color.
<img width="70" height="67" alt="image" src="https://github.com/user-attachments/assets/e52684aa-2cc2-4e42-b53e-ec2b8384ce3b" />

## Why and what will this PR improve
Now, if you regrow a limb, it will actually match your body, rather than looking like you stole someone else's arm. This is probably a good thing.

## Authorship
The one, the only, Karl Johansson

## Changelog
:cl: Karl Johansson
bugfix: Regrown limbs now match the skin color of the rest of your body
/:cl: