### PR TITLE
Garlic Oil now treats infections

### DIFF
--- a/code/modules/reagents/chems/chems_drinks.dm
+++ b/code/modules/reagents/chems/chems_drinks.dm
@@ -185,6 +185,7 @@
 	color = "#eeddcc"
 	uid = "chem_drink_garlic"
 	antibiotic_strength = 0.65
+	affect_blood_on_ingest = TRUE
 
 	glass_name = "garlic oil"
 	glass_desc = "A potion of guaranteed bad breath."


### PR DESCRIPTION
Adds `affect_blood_on_ingest = TRUE` to garlic oil, allowing it to be an antibiotic without requiring it to be injected.

<!-- !! PLEASE, READ THIS !! -->
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/NebulaSS13/Nebula/blob/dev/CONTRIBUTING.md -->
<!-- If you're opening a pull request which changes A LOT of icon/map files: -->
<!-- Add [IDB IGNORE] (to ignore icon file changes) or [MDB IGNORE] (to ignore map file changes) in the PR title. -->
<!-- These tags prevent huge diffs from overloading IconDiffBot and MapDiffBot. -->

## Description of changes
<!-- Describe the pull request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Garlic oil (`/decl/material/liquid/drink/juice/garlic`) from `code/modules/reagents/chems/chems_drinks.dm:180` now affects blood when ingested, allowing it to treat infections by drinking it, similar to normal Antibiotics.

## Why and what will this PR improve
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Medieval-era maps with no access to spacetech antibiotics had no way to treat an infected wound, which generally made infections a death sentence if the afflicted part was not or could not be amputated.

## Authorship
<!-- Describe original authors of changes to credit them. -->

## Changelog
:cl:
tweak: Garlic oil now affects blood on ingest, allowing its antibiotic property to function.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->