### PR TITLE
Prevent Garlic Oil from being poison

### DIFF
--- a/code/modules/reagents/chems/chems_drinks.dm
+++ b/code/modules/reagents/chems/chems_drinks.dm
@@ -18,7 +18,8 @@
 
 /decl/material/liquid/drink/affect_blood(var/mob/living/M, var/removed, var/datum/reagents/holder)
 	. = ..()
-	M.take_damage(removed, TOX) // Probably not a good idea; not very deadly though
+	if(!injectable_nutrition)
+		M.take_damage(removed, TOX) // Probably not a good idea; not very deadly though
 
 /decl/material/liquid/drink/affect_ingest(var/mob/living/M, var/removed, var/datum/reagents/holder)
 	. = ..()
@@ -181,11 +182,13 @@
 	name = "garlic oil"
 	lore_text = "A strong-smelling, pungent oil pressed from garlic cloves. It has some antibiotic properties, and can help with infections."
 	taste_description = "bad breath"
-	nutriment_factor = 1
+	nutriment_factor = 0.5 // Injectable Nutrition flag causes it to be digested twice
+	hydration_factor = 3 // Cut in half from 6 so double digestion gives normal amount
 	color = "#eeddcc"
 	uid = "chem_drink_garlic"
 	antibiotic_strength = 0.65
 	affect_blood_on_ingest = TRUE
+	injectable_nutrition = TRUE
 
 	glass_name = "garlic oil"
 	glass_desc = "A potion of guaranteed bad breath."


### PR DESCRIPTION
<!-- !! PLEASE, READ THIS !! -->
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/NebulaSS13/Nebula/blob/dev/CONTRIBUTING.md -->
<!-- If you're opening a pull request which changes A LOT of icon/map files: -->
<!-- Add [IDB IGNORE] (to ignore icon file changes) or [MDB IGNORE] (to ignore map file changes) in the PR title. -->
<!-- These tags prevent huge diffs from overloading IconDiffBot and MapDiffBot. -->

## Description of changes
<!-- Describe the pull request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Tags garlic oil as `injectable_nutrition`.  Because this causes `adjust_mob_nutrition()` to get called twice, nutriment/hydration factors are cut in half to compensate.

## Why and what will this PR improve
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Garlic Oil now can be used as an antibiotic without dealing 1.2 TOX damage per unit ingested (due to a food substance being present in the bloodstream).

## Authorship
<!-- Describe original authors of changes to credit them. -->

## Changelog
:cl:
tweak: Prevented Garlic Oil from dealing TOX damage
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->