### PR TITLE
Fix accessories vanishing when clothing moves, hoodie bugs

### DIFF
--- a/code/modules/clothing/_clothing.dm
+++ b/code/modules/clothing/_clothing.dm
@@ -219,12 +219,11 @@
 	if(should_use_combined_accessory_appearance())
 		var/image/I = get_mob_overlay(ismob(loc) ? loc : null, get_fallback_slot())
 		if(I?.icon) // Null or invisible overlay, we don't want to make our clothing invisible just because it has an accessory.
-			I.plane = plane
-			I.layer = layer
-			I.color = color
-			I.alpha = alpha
-			I.name  = name
-			appearance = I
+			icon = I.icon
+			icon_state = I.icon_state
+			underlays = I.underlays.Copy()
+			// we need to use the managed overlays system or else they will end up overwritten
+			set_overlays(I.overlays.Copy())
 			set_dir(SOUTH)
 			update_clothing_icon()
 			return

--- a/code/modules/clothing/suits/_suit_hood.dm
+++ b/code/modules/clothing/suits/_suit_hood.dm
@@ -16,9 +16,18 @@
 	if(. && istype(hood))
 		hood.set_color(new_color)
 
+// i don't think this needs to be a get_stored_inventory override instead since it should never be separated currently
+// but that may change in the future
+/obj/item/clothing/suit/get_contained_external_atoms()
+	. = ..()
+	if(istype(hood)) // this is considered a component rather than a contained item
+		. -= hood
+
 /obj/item/clothing/suit/Initialize()
 	if(ispath(hood))
-		hood = new hood(src)
+		hood = new hood(src, material)
+		if(paint_color)
+			hood.set_color(paint_color)
 	return ..()
 
 /obj/item/clothing/suit/Destroy()


### PR DESCRIPTION
## Description of changes
Accessory display no longer uses appearance copy, and instead sets icon, icon_state, underlays, and (managed) overlays. This will hopefully make it less brittle. This also means compile_overlays won't clobber the overlays.

## Why and what will this PR improve
Fixes #5199.
Fixes an issue where hoodie hoods had the wrong material and color, and showed up in the hoodie's storage.

## Authorship
Me