### PR TITLE
Fix gun aiming accuracy bonus

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -75,7 +75,6 @@
 	var/selector_sound = 'sound/weapons/guns/selector.ogg'
 
 	//aiming system stuff
-	var/tmp/list/mob/living/aim_targets //List of who yer targeting.
 	var/tmp/last_safety_check = -INFINITY
 	var/safety_state = 1
 	var/has_safety = TRUE
@@ -490,7 +489,7 @@
 			disp_mod += 0.5
 
 		//accuracy bonus from aiming
-		if (aim_targets && (target in aim_targets))
+		if (user.aiming?.aiming_at == target)
 			//If you aim at someone beforehead, it'll hit more often.
 			//Kinda balanced by fact you need like 2 seconds to aim
 			//As opposed to no-delay pew pew

--- a/code/modules/projectiles/targeting/targeting_overlay.dm
+++ b/code/modules/projectiles/targeting/targeting_overlay.dm
@@ -76,6 +76,7 @@
 	to_chat(owner, aim_message)
 	if(aiming_at)
 		to_chat(aiming_at, "<span class='[use_span]'>You are [message].</span>")
+
 /obj/aiming_overlay/Process()
 	if(!owner)
 		qdel(src)


### PR DESCRIPTION
## Description of changes
`aim_targets` has been defunct for around 12 years, the proper way to check aim targeting is `aiming.aiming_at`.

## Why and what will this PR improve
Makes the accuracy bonus for aiming actually apply

## Authorship
Me

## Changelog
:cl:
bugfix: fixed aiming not giving an accuracy bonus
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->