### PR TITLE
Fix missing length check in crew records code

### DIFF
--- a/code/modules/modular_computers/file_system/programs/generic/records.dm
+++ b/code/modules/modular_computers/file_system/programs/generic/records.dm
@@ -98,7 +98,7 @@
 			to_chat(usr, SPAN_WARNING("Network error."))
 			return
 		var/list/accesses = get_access(usr)
-		if(!network.get_mainframes_by_role(MF_ROLE_CREW_RECORDS, accesses))
+		if(!length(network.get_mainframes_by_role(MF_ROLE_CREW_RECORDS, accesses)))
 			to_chat(usr, SPAN_WARNING("You may not have access to generate new crew records, or there may not be a crew record mainframe active on the network."))
 			return
 		active_record = new/datum/computer_file/report/crew_record()


### PR DESCRIPTION
## Description of changes
`get_mainframes_by_role()` returns an empty list rather than null if there's no entries, because it is not a lazylist. It needs a length check rather than a null check or else it will always succeed.

## Why and what will this PR improve
Fix records being generated even without mainframes set to store records.

## Authorship
Me