### PR TITLE
Improve material stratum picking for levels/planets

### DIFF
--- a/code/modules/geology/_strata.dm
+++ b/code/modules/geology/_strata.dm
@@ -3,15 +3,23 @@
 	var/list/base_materials
 	var/list/ores_sparse
 	var/list/ores_rich
-	var/default_strata_candidate = FALSE
+	var/const/STRATA_RANDOM_NEVER = 0
+	var/const/STRATA_RANDOM_PLANET = BITFLAG(0)
+	var/const/STRATA_RANDOM_LEVEL  = BITFLAG(1)
+	var/const/STRATA_RANDOM_ANY    = STRATA_RANDOM_PLANET | STRATA_RANDOM_LEVEL
+	var/default_strata_candidate = STRATA_RANDOM_NEVER
 	var/maximum_temperature = INFINITY
 
 /decl/strata/proc/is_valid_exoplanet_strata(var/datum/planetoid_data/planet)
+	if(!(default_strata_candidate & STRATA_RANDOM_PLANET))
+		return FALSE
 	if(istype(planet.atmosphere))
 		return planet.atmosphere.temperature <= maximum_temperature
 	return TCMB <= maximum_temperature
 
 /decl/strata/proc/is_valid_level_stratum(datum/level_data/level_data)
+	if(!(default_strata_candidate & STRATA_RANDOM_LEVEL))
+		return FALSE
 	var/temperature_to_check = istype(level_data.exterior_atmosphere) ? level_data.exterior_atmosphere.temperature : level_data.exterior_atmos_temp
 	return (temperature_to_check || TCMB) <= maximum_temperature
 

--- a/code/modules/geology/strata_igneous.dm
+++ b/code/modules/geology/strata_igneous.dm
@@ -1,12 +1,12 @@
 /decl/strata/igneous
 	name = "igneous rock"
 	base_materials = list(/decl/material/solid/stone/basalt)
-	default_strata_candidate = TRUE
+	default_strata_candidate = STRATA_RANDOM_ANY
 	ores_rich = list(
 		/decl/material/solid/gemstone/diamond,
 		/decl/material/solid/quartz,
 		/decl/material/solid/graphite,
-		/decl/material/solid/densegraphite,	
+		/decl/material/solid/densegraphite,
 		/decl/material/solid/metal/gold,
 		/decl/material/solid/quartz,
 		/decl/material/solid/metal/platinum,

--- a/code/modules/geology/strata_metamorphic.dm
+++ b/code/modules/geology/strata_metamorphic.dm
@@ -1,7 +1,7 @@
 /decl/strata/metamorphic
 	name = "metamorphic rock"
 	base_materials = list(/decl/material/solid/stone/marble)
-	default_strata_candidate = TRUE
+	default_strata_candidate = STRATA_RANDOM_ANY
 	ores_rich = list(
 		/decl/material/solid/quartz,
 		/decl/material/solid/graphite,

--- a/code/modules/geology/strata_permafrost.dm
+++ b/code/modules/geology/strata_permafrost.dm
@@ -18,4 +18,5 @@
 		/decl/material/solid/ice/hydrate/krypton,
 		/decl/material/solid/ice/hydrate/xenon,
 	)
+	default_strata_candidate = STRATA_RANDOM_PLANET
 	maximum_temperature = T0C

--- a/code/modules/geology/strata_sedimentary.dm
+++ b/code/modules/geology/strata_sedimentary.dm
@@ -1,7 +1,7 @@
 /decl/strata/sedimentary
 	name = "sedimentary rock"
 	base_materials = list(/decl/material/solid/stone/sandstone)
-	default_strata_candidate = TRUE
+	default_strata_candidate = STRATA_RANDOM_ANY
 	ores_rich = list(
 		/decl/material/solid/pitchblende,
 		/decl/material/solid/pyrite,

--- a/maps/shaded_hills/levels/strata.dm
+++ b/maps/shaded_hills/levels/strata.dm
@@ -2,7 +2,7 @@
 /decl/strata/shaded_hills
 	name = "mountainous rock"
 	base_materials = list(/decl/material/solid/stone/basalt)
-	default_strata_candidate = FALSE
+	default_strata_candidate = STRATA_RANDOM_NEVER // this is for a specific map
 	ores_sparse = list(
 		/decl/material/solid/quartz,
 		/decl/material/solid/graphite,


### PR DESCRIPTION
## Description of changes
Makes `default_strata_candidate` a bitflag rather than a boolean. `STRATA_RANDOM_PLANET` allows it to be rolled for an exoplanet, `STRATA_RANDOM_LEVEL` allows it to be rolled for non-planet level data, `STRATA_RANDOM_ANY` is a shorthand for both, and `STRATA_RANDOM_NEVER` forbids selecting it in random generation ever.
`default_strata_candidate` is now also... checked. Evidently it wasn't. Oops?

## Why and what will this PR improve
Permafrost and the Shaded Hills rock stratum will not randomly generate in inappropriate places

## Authorship
Me