### PR TITLE
Implement salvage do_rotation var

### DIFF
--- a/code/modules/salvage/salvage.dm
+++ b/code/modules/salvage/salvage.dm
@@ -14,7 +14,8 @@
 	if(!ispath(salvaged_type, /obj/item))
 		return INITIALIZE_HINT_QDEL
 	// TODO: grab partial initial matter from the salvage type.
-	icon_rotation = rand(-45, 45)
+	if(do_rotation)
+		icon_rotation = rand(-45, 45)
 	name = "[pick("busted", "broken", "shattered", "scrapped")] [salvaged_type::name]"
 	w_class = salvaged_type::w_class
 


### PR DESCRIPTION
## Description of changes
Adds a check for the currently-unused `do_rotation` var in icon rotation.

## Why and what will this PR improve
Lets some salvage disable rotation by setting `do_rotation` to false.