### PR TITLE
Reimplement air alarm remote_control variable

### DIFF
--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -37,7 +37,7 @@ var/global/list/areas = list()
 	/// Disables constructing or using APCs in this area.
 	var/always_unpowered =    FALSE
 
-	var/atmosalm =            0
+	var/atmosalm =            /obj/machinery/alarm::DANGER_NONE
 	var/power_equip =         1 // Status
 	var/power_light =         1
 	var/power_environ =       1
@@ -193,7 +193,7 @@ var/global/list/areas = list()
 	return cameras
 
 /area/proc/atmosalert(danger_level, var/alarm_source)
-	if (danger_level == 0)
+	if (danger_level == /obj/machinery/alarm::DANGER_NONE)
 		atmosphere_alarm.clearAlarm(src, alarm_source)
 	else
 		atmosphere_alarm.triggerAlarm(src, alarm_source, severity = danger_level)
@@ -204,10 +204,10 @@ var/global/list/areas = list()
 			danger_level = max(danger_level, AA.danger_level)
 
 	if(danger_level != atmosalm)
-		if (danger_level < 1 && atmosalm >= 1)
+		if (danger_level < /obj/machinery/alarm::DANGER_WARN && atmosalm >= /obj/machinery/alarm::DANGER_WARN)
 			//closing the doors on red and opening on green provides a bit of hysteresis that will hopefully prevent fire doors from opening and closing repeatedly due to noise
 			air_doors_open()
-		else if (danger_level >= 2 && atmosalm < 2)
+		else if (danger_level >= /obj/machinery/alarm::DANGER_DANGER && atmosalm < /obj/machinery/alarm::DANGER_DANGER)
 			air_doors_close()
 
 		atmosalm = danger_level

--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -65,15 +65,18 @@
 	directional_offset = @'{"NORTH":{"y":-21}, "SOUTH":{"y":21}, "EAST":{"x":-21}, "WEST":{"x":21}}'
 
 	var/alarm_id = null
-	var/breach_detection = 1 // Whether to use automatic breach detection or not
+	var/breach_detection = TRUE // Whether to use automatic breach detection or not
 	var/frequency = 1439
 	var/alarm_frequency = 1437
-	var/remote_control = 0
-	var/rcon_setting = 2
+	/// If TRUE, remote controllers like the atmos control computer can control the air alarm; if FALSE, they can only view it.
+	/// Typically auto-set by rcon_setting.
+	var/remote_control = FALSE
+	/// On RCON_AUTO, remote control is enabled when danger_level is DANGER_DANGER.
+	var/rcon_setting = RCON_AUTO
 	var/rcon_remote_override_access = list(access_ce)
-	var/locked = 1
-	var/aidisabled = 0
-	var/shorted = 0
+	var/locked = TRUE
+	var/aidisabled = FALSE
+	var/shorted = FALSE
 
 	var/mode = AALARM_MODE_SCRUBBING
 	var/screen = AALARM_SCREEN_MAIN
@@ -89,14 +92,17 @@
 	var/list/TLV = list() // stands for Threshold Limit Value, since it handles exposure amounts
 	var/list/trace_gas = list() //list of other gases that this air alarm is able to detect
 
-	var/danger_level = 0
-	var/pressure_dangerlevel = 0
-	var/oxygen_dangerlevel = 0
-	var/co2_dangerlevel = 0
-	var/temperature_dangerlevel = 0
-	var/other_dangerlevel = 0
+	var/const/DANGER_NONE   = 0
+	var/const/DANGER_WARN   = 1
+	var/const/DANGER_DANGER = 2 // danger, danger, circuits ready
+	var/danger_level = DANGER_NONE
+	var/pressure_dangerlevel = DANGER_NONE
+	var/oxygen_dangerlevel = DANGER_NONE
+	var/co2_dangerlevel = DANGER_NONE
+	var/temperature_dangerlevel = DANGER_NONE
+	var/other_dangerlevel = DANGER_NONE
 	var/environment_type = /decl/environment_data
-	var/report_danger_level = 1
+	var/report_danger_level = TRUE
 
 /obj/machinery/alarm/cold
 	target_temperature = T0C+4
@@ -215,14 +221,14 @@
 	//atmos computer remote controll stuff
 	switch(rcon_setting)
 		if(RCON_NO)
-			remote_control = 0
+			remote_control = FALSE
 		if(RCON_AUTO)
-			if(danger_level == 2)
-				remote_control = 1
+			if(danger_level == DANGER_DANGER)
+				remote_control = TRUE
 			else
-				remote_control = 0
+				remote_control = FALSE
 		if(RCON_YES)
-			remote_control = 1
+			remote_control = TRUE
 
 	return
 
@@ -318,10 +324,10 @@
 
 /obj/machinery/alarm/proc/get_danger_level(var/current_value, var/list/danger_levels)
 	if((current_value >= danger_levels[4] && danger_levels[4] > 0) || current_value <= danger_levels[1])
-		return 2
+		return DANGER_DANGER
 	if((current_value > danger_levels[3] && danger_levels[3] > 0) || current_value < danger_levels[2])
-		return 1
-	return 0
+		return DANGER_WARN
+	return DANGER_NONE
 
 /obj/machinery/alarm/on_update_icon()
 	// Broken or deconstructed states
@@ -477,7 +483,7 @@
 /obj/machinery/alarm/ui_interact(mob/user, ui_key = "main", datum/nanoui/ui = null, force_open = 1, var/master_ui = null, var/datum/topic_state/state = global.default_topic_state)
 	var/data[0]
 	var/remote_connection = istype(state, /datum/topic_state/remote)  // Remote connection means we're non-adjacent/connecting from another computer
-	var/remote_access = remote_connection && CanInteract(user, state) // Remote access means we also have the privilege to alter the air alarm.
+	var/remote_access = remote_control && remote_connection && CanInteract(user, state) // Remote access means we also have the privilege to alter the air alarm.
 
 	data["locked"] = locked && !issilicon(user)
 	data["remote_connection"] = remote_connection

--- a/code/modules/modular_computers/file_system/programs/engineering/atmos_control.dm
+++ b/code/modules/modular_computers/file_system/programs/engineering/atmos_control.dm
@@ -80,9 +80,9 @@
 				continue
 
 			var/danger_level = max(alarm.danger_level, alarm.alarm_area.atmosalm)
-			if(danger_level == 2)
+			if(danger_level == /obj/machinery/alarm::DANGER_DANGER)
 				alarmsAlert[++alarmsAlert.len] = list("name" = alarm_name, "ref"= "\ref[alarm]", "danger" = danger_level)
-			else if(danger_level == 1)
+			else if(danger_level == /obj/machinery/alarm::DANGER_WARN)
 				alarmsDanger[++alarmsDanger.len] = list("name" = alarm_name, "ref"= "\ref[alarm]", "danger" = danger_level)
 			else
 				alarms[++alarms.len] = list("name" = alarm_name, "ref"= "\ref[alarm]", "danger" = danger_level)


### PR DESCRIPTION
## Description of changes
Makes air alarm danger levels use constants rather than magic numbers.
Reimplements the `remote_control` variable for air alarms, which lets them be remotely controlled when `rcon_setting` is set to auto.

## Why and what will this PR improve
Improves code quality for air alarms and reimplements a defunct-yet-useful feature.