### PR TITLE
Replace MIDNIGHT_ROLLOVER with (1 DAY) in REALTIMEOFDAY

### DIFF
--- a/code/__defines/_tick.dm
+++ b/code/__defines/_tick.dm
@@ -30,5 +30,5 @@
 
 //time of day but automatically adjusts to the server going into the next day within the same round.
 //for when you need a reliable time number that doesn't depend on byond time.
-#define REALTIMEOFDAY (world.timeofday + (MIDNIGHT_ROLLOVER * MIDNIGHT_ROLLOVER_CHECK))
+#define REALTIMEOFDAY (world.timeofday + ((1 DAY) * MIDNIGHT_ROLLOVER_CHECK))
 #define MIDNIGHT_ROLLOVER_CHECK ( global.rollovercheck_last_timeofday != world.timeofday ? update_midnight_rollover() : global.midnight_rollovers )

--- a/code/__defines/misc.dm
+++ b/code/__defines/misc.dm
@@ -184,8 +184,6 @@
 
 #define PIXEL_MULTIPLIER WORLD_ICON_SIZE/32
 
-#define MIDNIGHT_ROLLOVER		864000	//number of deciseconds in a day
-
 //Error handler defines
 #define ERROR_USEFUL_LEN 2
 


### PR DESCRIPTION
## Description of changes
Removes an unnecessary and confusing define and replaces it with `(1 DAY)`, which is equivalent but more readable.

## Why and what will this PR improve
Makes midnight rollover code marginally more readable.