### PR TITLE
Implement magnetic gun ammo string

### DIFF
--- a/code/modules/projectiles/guns/magnetic/magnetic.dm
+++ b/code/modules/projectiles/guns/magnetic/magnetic.dm
@@ -83,9 +83,9 @@
 			if(mag.remaining)
 				add_overlay("[icon_state]_ammo")
 
-/obj/item/gun/magnetic/proc/show_ammo(var/mob/user)
+/obj/item/gun/magnetic/proc/get_ammo_string(mob/user, distance)
 	if(loaded)
-		to_chat(user, "<span class='notice'>It has \a [loaded] loaded.</span>")
+		return SPAN_NOTICE("It has \a [loaded] loaded.")
 
 /obj/item/gun/magnetic/get_examine_strings(mob/user, distance, infix, suffix)
 	. = ..()
@@ -97,6 +97,9 @@
 			. += SPAN_NOTICE("The capacitor charge indicator is [SPAN_ORANGE("amber")].")
 		else
 			. += SPAN_NOTICE("The capacitor charge indicator is [SPAN_GREEN("green")].")
+	var/ammo_string = get_ammo_string(user, distance)
+	if(ammo_string)
+		. += ammo_string
 
 /obj/item/gun/magnetic/attackby(var/obj/item/used_item, var/mob/user)
 

--- a/code/modules/projectiles/guns/magnetic/magnetic_railgun.dm
+++ b/code/modules/projectiles/guns/magnetic/magnetic_railgun.dm
@@ -33,12 +33,12 @@
 
 // Not going to check type repeatedly, if you code or varedit
 // load_type and get runtime errors, don't come crying to me.
-/obj/item/gun/magnetic/railgun/show_ammo(var/mob/user)
+/obj/item/gun/magnetic/railgun/get_ammo_string(mob/user, distance)
 	var/obj/item/rcd_ammo/ammo = loaded
 	if (ammo)
-		to_chat(user, "<span class='notice'>There are [ammo.remaining] shot\s remaining in \the [loaded].</span>")
+		return SPAN_NOTICE("There [ammo.remaining == 1 ? "is" : "are"] [ammo.remaining] shot\s remaining in \the [loaded].")
 	else
-		to_chat(user, "<span class='notice'>There is nothing loaded.</span>")
+		return SPAN_NOTICE("There is nothing loaded.")
 
 /obj/item/gun/magnetic/railgun/check_ammo()
 	var/obj/item/rcd_ammo/ammo = loaded

--- a/mods/species/ascent/items/guns.dm
+++ b/mods/species/ascent/items/guns.dm
@@ -60,9 +60,10 @@
 	if(isrobot(loc) || istype(loc, /obj/item/rig_module))
 		return loc.get_cell()
 
-/obj/item/gun/magnetic/railgun/flechette/ascent/show_ammo(var/mob/user)
+/obj/item/gun/magnetic/railgun/flechette/ascent/get_ammo_string(mob/user, distance)
 	var/obj/item/cell/cell = get_cell()
-	to_chat(user, "<span class='notice'>There are [cell ? floor(cell.charge/charge_per_shot) : 0] shot\s remaining.</span>")
+	var/shots_left = cell ? floor(cell.charge/charge_per_shot) : 0
+	return SPAN_NOTICE("There [shots_left == 1 ? "is" : "are"] [shots_left] shot\s remaining.")
 
 /obj/item/gun/magnetic/railgun/flechette/ascent/check_ammo()
 	var/obj/item/cell/cell = get_cell()


### PR DESCRIPTION
## Description of changes
Renames and implements `show_ammo()` on magnetic guns as an examine string.

## Why and what will this PR improve
Magnetic gun subtypes now show their loaded ammo on examine.