### PR TITLE
Remove unused and defunct code

### DIFF
--- a/code/_helpers/game.dm
+++ b/code/_helpers/game.dm
@@ -401,12 +401,6 @@
 		temps[direction] = rstats
 	return temps
 
-/proc/MinutesToTicks(var/minutes)
-	return SecondsToTicks(60 * minutes)
-
-/proc/SecondsToTicks(var/seconds)
-	return seconds * 10
-
 /proc/window_flash(var/client_or_usr)
 	if (!client_or_usr)
 		return

--- a/code/datums/mil_ranks.dm
+++ b/code/datums/mil_ranks.dm
@@ -69,11 +69,7 @@
  */
 /datum/mil_rank
 	var/name = "Unknown"
-	var/name_short // Abbreviation of the name. Should be null if the
-	                       // rank doesn't usually serve as a prefix to the individual's name.
-	var/list/accessory		//type of accesory that will be equipped by job code with this rank
-	var/sort_order = 0 // A numerical equivalent of the rank used to indicate its order when compared to other datums: eg e-1 = 1, o-1 = 11
-
-//Returns short designation (yes shorter than name_short), like E1, O3 etc.
-/datum/mil_rank/proc/grade()
-	return sort_order
+	/// Abbreviation of the name. Should be null if the rank doesn't usually serve as a prefix to the individual's name.
+	var/name_short
+	///type of accesory that will be equipped by job code with this rank
+	var/list/accessory

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -48,8 +48,6 @@ var/global/list/areas = list()
 	var/oneoff_light   =      0
 	var/oneoff_environ =      0
 	var/has_gravity =         TRUE
-	/// If FALSE, this area is unable to have its gravity overridden by a gravity generator. Used on /area/space.
-	var/can_have_gravity =    TRUE
 	var/air_doors_activated = FALSE
 
 	var/obj/machinery/apc/apc

--- a/code/game/machinery/_machines_base/machinery.dm
+++ b/code/game/machinery/_machines_base/machinery.dm
@@ -31,12 +31,6 @@ Class Variables:
    panel_open (num)
 	  Whether the panel is open
 
-   uid (num)
-	  Unique id of machine across all machines.
-
-   gl_uid (global num)
-	  Next uid value in sequence
-
    stat (bitflag)
 	  Machine status bit flags.
 	  Possible bit flags:
@@ -112,9 +106,7 @@ Class Procs:
 	var/list/uncreated_component_parts = list(/obj/item/stock_parts/power/apc)
 	/// null - no max. list(type part = number max).
 	var/list/maximum_component_parts = list(/obj/item/stock_parts = 10)
-	var/uid
 	var/panel_open = FALSE
-	var/static/gl_uid = 1
 	/// Can the machine be interacted with while de-powered.
 	var/interact_offline = FALSE
 	/// sound played on successful interface use

--- a/code/game/machinery/atmoalter/canister.dm
+++ b/code/game/machinery/atmoalter/canister.dm
@@ -139,7 +139,7 @@ EMPTY_CANISTER(hydrogen, /obj/machinery/portable_atmospherics/canister/hydrogen)
 	if(get_port())
 		add_overlay("can-connector")
 
-	var/tank_pressure = return_pressure()
+	var/tank_pressure = air_contents?.return_pressure()
 	if(tank_pressure < 10)
 		add_overlay("can-o0")
 	else if(tank_pressure < ONE_ATMOSPHERE)
@@ -205,18 +205,6 @@ EMPTY_CANISTER(hydrogen, /obj/machinery/portable_atmospherics/canister/hydrogen)
 	if(holding)
 		holding.update_icon()
 
-/obj/machinery/portable_atmospherics/canister/proc/return_temperature()
-	var/datum/gas_mixture/GM = return_air()
-	if(GM?.total_volume>0)
-		return GM.temperature
-	return 0
-
-/obj/machinery/portable_atmospherics/canister/proc/return_pressure()
-	var/datum/gas_mixture/GM = return_air()
-	if(GM?.total_volume>0)
-		return GM.return_pressure()
-	return 0
-
 /obj/machinery/portable_atmospherics/canister/bullet_act(var/obj/item/projectile/Proj)
 	if(!(Proj.atom_damage_type == BRUTE || Proj.atom_damage_type == BURN))
 		return
@@ -258,8 +246,8 @@ EMPTY_CANISTER(hydrogen, /obj/machinery/portable_atmospherics/canister/hydrogen)
 	data["name"] = name
 	data["canLabel"] = can_label ? 1 : 0
 	data["portConnected"] = get_port() ? 1 : 0
-	data["tankPressure"] = round(air_contents.return_pressure() ? air_contents.return_pressure() : 0)
-	data["releasePressure"] = round(release_pressure ? release_pressure : 0)
+	data["tankPressure"] = round(air_contents.return_pressure())
+	data["releasePressure"] = round(release_pressure)
 	data["minReleasePressure"] = round(0.1 ATM)
 	data["maxReleasePressure"] = round(10 ATM)
 	data["valveOpen"] = valve_open ? 1 : 0

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -175,11 +175,11 @@ About the new airlock wires panel:
 	return src.isWireCut(AIRLOCK_WIRE_BACKUP_POWER1) || src.isWireCut(AIRLOCK_WIRE_BACKUP_POWER2)
 
 /obj/machinery/door/airlock/proc/loseMainPower()
-	main_power_lost_until = mainPowerCablesCut() ? -1 : world.time + SecondsToTicks(60)
+	main_power_lost_until = mainPowerCablesCut() ? -1 : world.time + (1 MINUTE)
 
 	// If backup power is permanently disabled then activate in 10 seconds if possible, otherwise it's already enabled or a timer is already running
 	if(backup_power_lost_until == -1 && !backupPowerCablesCut())
-		backup_power_lost_until = world.time + SecondsToTicks(10)
+		backup_power_lost_until = world.time + (10 SECONDS)
 
 	// Disable electricity if required
 	if(electrified_until && isAllPowerLoss())
@@ -188,7 +188,7 @@ About the new airlock wires panel:
 	update_icon()
 
 /obj/machinery/door/airlock/proc/loseBackupPower()
-	backup_power_lost_until = backupPowerCablesCut() ? -1 : world.time + SecondsToTicks(60)
+	backup_power_lost_until = backupPowerCablesCut() ? -1 : world.time + (1 MINUTE)
 
 	// Disable electricity if required
 	if(electrified_until && isAllPowerLoss())
@@ -231,7 +231,7 @@ About the new airlock wires panel:
 		else
 			shockedby += text("\[[time_stamp()]\] - EMP)")
 		message = "The door is now electrified [duration == -1 ? "permanently" : "for [duration] second\s"]."
-		src.electrified_until = duration == -1 ? -1 : world.time + SecondsToTicks(duration)
+		src.electrified_until = duration == -1 ? -1 : world.time + (duration SECONDS)
 		. = 1
 
 	if(feedback && message)
@@ -939,8 +939,8 @@ About the new airlock wires panel:
 				if(AM.blocks_airlock())
 					if(world.time > next_beep_at)
 						playsound(src.loc, close_failure_blocked, 30, 0, -3)
-						next_beep_at = world.time + SecondsToTicks(10)
-					close_door_at = world.time + 6
+						next_beep_at = world.time + (10 SECONDS)
+					close_door_at = world.time + (0.6 SECONDS)
 					return FALSE
 
 	for(var/turf/turf in locs)
@@ -1082,7 +1082,7 @@ About the new airlock wires panel:
 		spawn(0)
 			open()
 	if(prob(40/severity))
-		var/duration = SecondsToTicks(30 / severity)
+		var/duration = (30 SECONDS) / severity
 		if(electrified_until > -1 && (duration + world.time) > electrified_until)
 			electrify(duration)
 	..()

--- a/code/game/objects/effects/overlays.dm
+++ b/code/game/objects/effects/overlays.dm
@@ -4,16 +4,6 @@
 /obj/effect/overlay/singularity_pull()
 	return
 
-/obj/effect/overlay/beam//Not actually a projectile, just an effect.
-	name="beam"
-	icon='icons/effects/beam.dmi'
-	icon_state= "b_beam"
-	var/tmp/atom/BeamSource
-
-/obj/effect/overlay/beam/Initialize()
-	. = ..()
-	QDEL_IN(src, 1 SECOND)
-
 /obj/effect/overlay/palmtree_r
 	name = "Palm tree"
 	icon = 'icons/misc/beach2.dmi'

--- a/code/game/objects/items/__item.dm
+++ b/code/game/objects/items/__item.dm
@@ -711,10 +711,6 @@
 	RAISE_EVENT(/decl/observ/mob_equipped, user, src, slot)
 	RAISE_EVENT(/decl/observ/item_equipped, src, user, slot)
 
-// As above but for items being equipped to an active module on a robot.
-/obj/item/proc/equipped_robot(var/mob/user)
-	return
-
 //the mob M is attempting to equip this item into the slot passed through as 'slot'. Return 1 if it can do this and 0 if it can't.
 //Set disable_warning to 1 if you wish it to not give you outputs.
 //Set ignore_equipped to 1 if you wish to ignore covering checks etc. when this item is already equipped.

--- a/code/game/objects/items/devices/gps.dm
+++ b/code/game/objects/items/devices/gps.dm
@@ -100,10 +100,6 @@ var/global/list/all_gps_units = list()
 		if(holder?.client && _compass)
 			holder.client.screen -= _compass
 
-/obj/item/gps/equipped_robot()
-	. = ..()
-	update_holder()
-
 /obj/item/gps/equipped()
 	. = ..()
 	update_holder()

--- a/code/modules/alarm/alarm.dm
+++ b/code/modules/alarm/alarm.dm
@@ -57,7 +57,7 @@
 		sources_assoc[source] = AS
 	// Currently only non-0 durations can be altered (normal alarms VS EMP blasts)
 	if(AS.duration)
-		duration = SecondsToTicks(duration)
+		duration = duration SECONDS
 		AS.duration = duration
 	AS.severity = severity
 

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -271,7 +271,7 @@
 	if(!(alarm.alarm_z() in SSmapping.get_connected_levels(my_z)))
 		return // Didn't actually hear it as far as we're concerned.
 	if(!next_alarm_notice)
-		next_alarm_notice = world.time + SecondsToTicks(10)
+		next_alarm_notice = world.time + (10 SECONDS)
 
 	var/list/alarms = queued_alarms[alarm_handler]
 	if(was_raised)

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -562,43 +562,6 @@ english_only - whether to use traditional english letters only (for use in NanoU
 /mob/proc/ssd_check()
 	return !client && !teleop && (last_ckey || !ai)
 
-/mob/proc/try_teleport(var/area/thearea)
-	if(istype(thearea, /list))
-		var/list/area_list = thearea
-		thearea = area_list[1]
-	var/list/L = list()
-	for(var/turf/T in get_area_turfs(thearea))
-		if(!T.density)
-			var/clear = 1
-			for(var/obj/O in T)
-				if(O.density)
-					clear = 0
-					break
-			if(clear)
-				L+=T
-
-	if(buckled)
-		buckled = null
-
-	var/attempt = null
-	var/success = 0
-	var/turf/end
-	var/candidates = L.Copy()
-	while(L.len)
-		attempt = pick(L)
-		success = Move(attempt)
-		if(!success)
-			L.Remove(attempt)
-		else
-			end = attempt
-			break
-
-	if(!success)
-		end = pick(candidates)
-		forceMove(end)
-
-	return end
-
 //Tries to find the mob's email.
 /proc/find_email(real_name)
 	for(var/mob/mob in global.living_mob_list_)

--- a/code/modules/sprite_accessories/tails/_accessory_tail.dm
+++ b/code/modules/sprite_accessories/tails/_accessory_tail.dm
@@ -35,8 +35,6 @@
 	color_blend          = ICON_MULTIPLY
 
 	var/icon_animation_states
-	var/hair_state
-	var/hair_blend = ICON_ADD
 
 /decl/sprite_accessory/tail/none
 	name                        = "Default Tail"


### PR DESCRIPTION
## Description of changes
Removes a bunch of unused or defunct code.

## Why and what will this PR improve
Dead code removal avoids footguns that can confuse people. These dead helpers can also promote bad practices if someone stumbles across and uses them.