### PR TITLE
Make stack recipe cache use an alist

### DIFF
--- a/code/modules/crafting/stack_recipes/_recipe_getter.dm
+++ b/code/modules/crafting/stack_recipes/_recipe_getter.dm
@@ -16,7 +16,6 @@
 /*
  * Recipe retrieval proc.
  */
-var/global/list/cached_recipes = list()
 /proc/get_stack_recipes(decl/material/mat, decl/material/reinf_mat, stack_type, tool_type, flat = FALSE)
 
 	// No recipes for holograms or fluids.
@@ -25,8 +24,9 @@ var/global/list/cached_recipes = list()
 
 	#ifndef UNIT_TEST // key creation is SLOW and in unit testing almost every call to this will be a cache fail
 	// Check if we've cached this before.
+	var/static/alist/cached_recipes = alist()
 	var/key = jointext(list((mat?.name || "base"), (reinf_mat?.name || "base"), (stack_type || "base"), (tool_type || "base")), "-")
-	. = global.cached_recipes[key]
+	. = cached_recipes[key]
 	#endif
 	if(!.)
 
@@ -49,5 +49,5 @@ var/global/list/cached_recipes = list()
 			for(var/group_name in grouped_recipes)
 				. += new /datum/stack_recipe_list(group_name, grouped_recipes[group_name])
 		#ifndef UNIT_TEST // associative list insertion is SLOW and in unit testing almost every call to this will be a cache fail
-		global.cached_recipes[key] = .
+		cached_recipes[key] = .
 		#endif


### PR DESCRIPTION
## Description of changes
Makes the stack recipe cache a static alist rather than a global list.

## Why and what will this PR improve
This will hopefully make `get_stack_recipes()` slightly faster by improving the key insertion and lookup.

## Authorship
Me