### PR TITLE
Use ship-level burn/exhaust velocity helpers in delta-v calc

### DIFF
--- a/code/modules/overmap/ships/ship.dm
+++ b/code/modules/overmap/ships/ship.dm
@@ -121,9 +121,16 @@ var/global/const/OVERMAP_SPEED_CONSTANT = (1 SECOND)
 
 	..()
 
-/obj/effect/overmap/visitable/ship/proc/burn()
+/obj/effect/overmap/visitable/ship/proc/burn(partial_power)
+	partial_power = clamp(partial_power, 0, 1)
+	. = 0
 	for(var/datum/extension/ship_engine/E in engines)
-		. += E.burn()
+		. += E.burn(partial_power)
+
+/obj/effect/overmap/visitable/ship/proc/get_exhaust_velocity()
+	. = 0
+	for(var/datum/extension/ship_engine/E in engines)
+		. += E.get_exhaust_velocity()
 
 /obj/effect/overmap/visitable/ship/can_burn()
 	if(halted)

--- a/code/modules/overmap/ships/ship_physics.dm
+++ b/code/modules/overmap/ships/ship_physics.dm
@@ -4,10 +4,8 @@
 // to get a ship's total *possible* approxiamte delta v, use get_total_delta_v().
 // partial power is used with burn() in order to only do partial burns.
 /obj/effect/overmap/visitable/ship/get_delta_v(var/real_burn = FALSE, var/partial_power = 1)
-	var/total_exhaust_velocity = 0
 	partial_power = clamp(partial_power, 0, 1)
-	for(var/datum/extension/ship_engine/E in engines)
-		total_exhaust_velocity += real_burn ? E.burn(partial_power) : E.get_exhaust_velocity()
+	var/total_exhaust_velocity = real_burn ? burn(partial_power) : get_exhaust_velocity()
 	var/vessel_mass = get_vessel_mass()
 	// special note here
 	// get_instant_wet_mass() returns kg


### PR DESCRIPTION
## Description of changes
Replaces some ship physics code that directly poked at the engines list with a ship-level burn helper that abstracts over engines, in case someone wants to override or extend it on subtypes. Also promotes the `partial_power` variable to the ship-level burn proc, which was previously unused.

Similarly, a ship-level `get_exhaust_velocity()` now exists which does the same thing.

Needs testing.

## Why and what will this PR improve
More abstraction and encapsulation in ship physics code.