### PR TITLE
Add codex dump to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 *.lk
 *.backup
 *.before
+codex/
 data/
 dmdoc/
 cfg/


### PR DESCRIPTION
## Description of changes
Adds the codex dump directory to gitignore to avoid VSC crawling to a halt after over 7k files get created

## Why and what will this PR improve
It made my VSC sad