### PR TITLE
Avoid queueing turfs for ambience during init

### DIFF
--- a/code/controllers/subsystems/ambience.dm
+++ b/code/controllers/subsystems/ambience.dm
@@ -4,11 +4,22 @@ SUBSYSTEM_DEF(ambience)
 	priority = SS_PRIORITY_LIGHTING
 	init_order = SS_INIT_LIGHTING
 	runlevels = RUNLEVEL_LOBBY | RUNLEVELS_DEFAULT // Copied from icon update subsystem.
-	flags = SS_NO_INIT
 	var/list/queued = list()
 
 /datum/controller/subsystem/ambience/stat_entry()
 	..("P:[length(queued)]")
+
+/datum/controller/subsystem/ambience/Initialize(start_timeofday)
+	for(var/datum/level_data/the_level as anything in SSmapping.levels_by_z)
+		// this may actually be faster than adding them to the queue. TBD.
+		for(var/turf/target_turf as anything in block(the_level.level_inner_min_x, the_level.level_inner_min_y, the_level.level_z, the_level.level_inner_max_x, the_level.level_inner_max_y, the_level.level_z))
+			if(target_turf.ambience_queued) // Somehow wound up queued, handle it then.
+				continue
+			if(!target_turf.simulated)
+				continue
+			target_turf.update_ambient_light_from_z_or_area()
+	// also flush the queue prior to roundstart
+	fire(no_mc_tick = TRUE)
 
 /datum/controller/subsystem/ambience/fire(resumed = FALSE, no_mc_tick = FALSE)
 	var/list/curr = queued

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -173,8 +173,9 @@ var/global/list/areas = list()
 
 	if(T.is_outside() != old_outside)
 		T.update_weather()
-		AMBIENCE_QUEUE_TURF(T)
-	else if(A.interior_ambient_light_modifier != old_area_ambience)
+		if(SSambience.initialized) // if not initialized, we'll loop over all turfs anyway
+			AMBIENCE_QUEUE_TURF(T)
+	else if(A.interior_ambient_light_modifier != old_area_ambience && SSambience.initialized)
 		AMBIENCE_QUEUE_TURF(T)
 
 /turf/proc/update_registrations_on_adjacent_area_change()

--- a/code/game/objects/structures/flora/tree.dm
+++ b/code/game/objects/structures/flora/tree.dm
@@ -37,7 +37,7 @@
 
 /obj/structure/flora/tree/Initialize(ml, _mat, _reinf_mat)
 	. = ..()
-	if(!ml && protects_against_weather)
+	if(!ml && protects_against_weather && SSambience.initialized)
 		for(var/turf/T as anything in RANGE_TURFS(src, 1))
 			AMBIENCE_QUEUE_TURF(T)
 
@@ -45,7 +45,7 @@
 /obj/structure/flora/tree/Destroy()
 	var/list/turfs_to_update = RANGE_TURFS(src, 1)
 	. = ..()
-	if(protects_against_weather)
+	if(protects_against_weather && SSambience.initialized)
 		for(var/turf/T in turfs_to_update)
 			AMBIENCE_QUEUE_TURF(T)
 

--- a/code/game/turfs/space/space.dm
+++ b/code/game/turfs/space/space.dm
@@ -25,7 +25,8 @@
 	atom_flags |= ATOM_FLAG_INITIALIZED
 	_earliest_type ||= type
 
-	AMBIENCE_QUEUE_TURF(src)
+	if(SSambience.initialized) // if not initialized, we'll loop over all turfs anyway
+		AMBIENCE_QUEUE_TURF(src)
 
 	//We might be an edge
 	if(y == world.maxy || forced_dirs & NORTH)

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -121,7 +121,8 @@
 	// we don't care about volume because turfs always create a maximum volume holder on reagent add.
 	FINALIZE_REAGENTS_SERDE(reagents)
 
-	AMBIENCE_QUEUE_TURF(src)
+	if(SSambience.initialized) // if not initialized, we'll loop over all turfs anyway
+		AMBIENCE_QUEUE_TURF(src)
 
 	if (opacity)
 		has_opaque_atom = TRUE
@@ -636,7 +637,8 @@
 	state_was_modified()
 	is_outside = new_outside
 	update_external_atmos_participation()
-	AMBIENCE_QUEUE_TURF(src)
+	if(SSambience.initialized) // if not initialized, we'll loop over all turfs anyway
+		AMBIENCE_QUEUE_TURF(src)
 
 	if(!skip_weather_update)
 		update_weather()

--- a/code/modules/multiz/level_data.dm
+++ b/code/modules/multiz/level_data.dm
@@ -906,7 +906,7 @@ INITIALIZE_IMMEDIATE(/obj/abstract/level_data_spawner)
 	return TRUE
 
 /datum/level_data/proc/update_turf_ambience()
-	if(SSatoms.atom_init_stage >= INITIALIZATION_INNEW_REGULAR)
+	if(SSambience.initialized) // our turfs will update themselves later anyway
 		for(var/turf/level_turf as anything in block(level_inner_min_x, level_inner_min_y, level_z, level_inner_max_x, level_inner_max_y, level_z))
 			level_turf.update_ambient_light_from_z_or_area() // AMBIENCE_QUEUE_TURF(level_turf) - seems to be less consistent
 			CHECK_TICK


### PR DESCRIPTION
## Description of changes
Instead of queueing turfs on SSambience during init, we loop over turfs in world instead.
Also, the SSambience queue is flushed during init now. I actually don't know why I added that given that nothing should be queueing during init...

## Why and what will this PR improve
In my local testing this provided a modest performance improvement, probably due to avoiding the creation of a huge list?? either way it also means ambience is set up prior to roundstart so there's no pop-in ambience issues where you start off in total darkness