### PR TITLE
Open Turf Fix

### DIFF
--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -351,7 +351,7 @@
 			var/old_height     = old_turf.get_physical_height() + old_turf.reagents?.total_volume
 			var/current_height = get_physical_height() + reagents?.total_volume
 			if(abs(current_height - old_height) > FLUID_SHALLOW)
-				if(current_height > old_height)
+				if(current_height > old_height && !is_open() && !old_turf?.is_open()) // check is_open() due to open turf depth stuff.
 					return 0
 				if(istype(mover_mob) && MOVING_DELIBERATELY(mover_mob))
 					to_chat(mover_mob, SPAN_WARNING("You refrain from stepping over the edge; it looks like a steep drop down to \the [src]."))


### PR DESCRIPTION
## Description of changes
There's a bug where if you step onto a catwalk or ladder tile, to get back onto a normal floor tile you must pull yourself out, as if you were in a deep hole. This doesn't make a lot of sense, you would expect the catwalk to be roughly the same height as the floor. Turns out it's because you're technically standing on an open space tile whenever you stand on a catwalk or ladder tile.

## Why and what will this PR improve
You can now seamlessly walk through the ship without randomly being trapped on catwalks and ladders.

## Authorship
Me, myself, and Karl

## Changelog
:cl:
bugfix: You no longer need to physically pull yourself off of catwalks or ladder tiles.
/:cl: