### PR TITLE
Fix harddels when atoms with storage undergo EarlyDestroy

### DIFF
--- a/code/game/atoms_init.dm
+++ b/code/game/atoms_init.dm
@@ -95,6 +95,8 @@
 
 // Called if an atom is deleted before it initializes. Only call Destroy in this if you know what you're doing.
 /atom/proc/EarlyDestroy(force = FALSE)
+	// since this is set up in New, we have to make sure it's cleared in EarlyDestroy too
+	QDEL_NULL(storage)
 	return QDEL_HINT_QUEUE
 
 


### PR DESCRIPTION
Fixes the hang that's causing Shaded Hills CI to fail on #4266. `storage` is created in `New()`, which means things undergoing EarlyDestroy need to make sure it's deleted too.