### PR TITLE
Fix turret control panels

### DIFF
--- a/code/game/machinery/turret_control.dm
+++ b/code/game/machinery/turret_control.dm
@@ -49,6 +49,10 @@
 	. = ..()
 
 /obj/machinery/turretid/Initialize()
+	. = ..()
+	return INITIALIZE_HINT_LATELOAD // Because areas initialize AFTER these!
+
+/obj/machinery/turretid/LateInitialize()
 	if(!control_area)
 		control_area = get_area(src)
 	else if(istext(control_area))
@@ -56,6 +60,8 @@
 			if(A.name && A.name==control_area)
 				control_area = A
 				break
+	else if(ispath(control_area))
+		control_area = locate(control_area) in global.areas
 
 	if(control_area)
 		var/area/A = control_area

--- a/code/modules/atmospherics/he_pipes.dm
+++ b/code/modules/atmospherics/he_pipes.dm
@@ -62,6 +62,7 @@
 	else
 		var/turf/turf = loc
 		var/datum/gas_mixture/pipe_air = return_air()
+		var/heat_radiated = FALSE
 		if(istype(loc, /turf/space))
 			parent.radiate_heat_to_space(surface, 1)
 		else if(istype(turf) && turf.simulated)
@@ -71,8 +72,13 @@
 				environment_temperature = pipe_turf.temperature
 			else
 				var/datum/gas_mixture/environment = pipe_turf.return_air()
+				if(environment.get_total_moles() == 0) // We're in a vacuum
+					if(loc.is_outside()) // But we're outside, so we're in space
+						parent.radiate_heat_to_space(surface, 0.5) // Radiate out at half efficiency
+					// Else, we're inside, no gas means no heat capacity.  Nothing to do, heat was dealt with either way
+					heat_radiated = TRUE // Skip temperature_interact() either way
 				environment_temperature = environment.temperature
-			if(abs(environment_temperature-pipe_air.temperature) > minimum_temperature_difference)
+			if(!heat_radiated && abs(environment_temperature-pipe_air.temperature) > minimum_temperature_difference)
 				parent.temperature_interact(pipe_turf, volume, thermal_conductivity)
 
 		if(buckled_mob)

--- a/maps/ministation/ministation-0.dmm
+++ b/maps/ministation/ministation-0.dmm
@@ -10255,7 +10255,7 @@
 	dir = 1
 	},
 /obj/machinery/turretid/stun{
-	control_area = "\improper AI Upload Chamber";
+	control_area = /area/ministation/ai_core;
 	id_tag = "aihome";
 	pixel_y = -24;
 	dir = 1
@@ -13371,7 +13371,6 @@
 /obj/machinery/turretid/stun{
 	name = "AI Upload turret control";
 	id_tag = "upload";
-	control_area = "\improper AI Upload Chamber";
 	pixel_y = -24;
 	dir = 1
 	},


### PR DESCRIPTION
<!-- !! PLEASE, READ THIS !! -->
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/NebulaSS13/Nebula/blob/dev/CONTRIBUTING.md -->
<!-- If you're opening a pull request which changes A LOT of icon/map files: -->
<!-- Add [IDB IGNORE] (to ignore icon file changes) or [MDB IGNORE] (to ignore map file changes) in the PR title. -->
<!-- These tags prevent huge diffs from overloading IconDiffBot and MapDiffBot. -->

## Description of changes
<!-- Describe the pull request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Fixes Turret Control Panels to initialize late, so it can search areas after they initialize and populate `global.areas`.
Previously, when trying to search by name, the search happened before areas ran their `Initialize()` and populated `global.areas`, so the search would fail.  Additionally, turret control panels can now specify an area by ID instead of by name, removing ambiguity and reducing maintenance.

## Why and what will this PR improve
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Turret control panels can now specify their control area in three ways:
* If `control_area` is null, it will take control of the area in which it resides.
* If `control_area` is a text string, such as `"\improper AI Core"`, it will search through areas until it finds an area whose name matches and take control of it.
* If `control_area` is a path to an area, such as `/area/ministation/ai_core`, it will get that area and take control of it.
Additionally, the turret control panels in Ministation's AI Satellite have been updated.  The Upload Chamber is set to null because it is already within that area, and the AI Core has been set to `/area/ministation/ai_core` rather than rely on a name string.

## Authorship
<!-- Describe original authors of changes to credit them. -->
Typhin

## Changelog
:cl:
add: Turret control panels can now specify their controlled area by path in addition to implicitly and by name.
bugfix: Turret control panels searching for an area by name works as intended now.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->