### PR TITLE
Fix issues with traits in character setup

### DIFF
--- a/code/datums/traits/_traits.dm
+++ b/code/datums/traits/_traits.dm
@@ -106,6 +106,8 @@
 	var/available_at_map_tech = MAP_TECH_LEVEL_ANY
 	/// Whether or not a rejuvenation should apply this aspect.
 	var/reapply_on_rejuvenation = FALSE
+	/// Whether this trait should be copied and applied by mob snapshots.
+	var/is_heritable = TRUE
 	/// What species can select this trait in chargen?
 	var/list/permitted_species
 	/// What species cannot select this trait in chargen?

--- a/code/datums/traits/maluses/amputations.dm
+++ b/code/datums/traits/maluses/amputations.dm
@@ -3,6 +3,7 @@
 	category = "Missing Limbs"
 	abstract_type = /decl/trait/malus/amputation
 	reapply_on_rejuvenation = TRUE
+	is_heritable = FALSE
 	var/list/apply_to_limbs
 	var/list/ban_traits_relating_to_limbs
 

--- a/code/datums/traits/prosthetics/prosthetic_limbs.dm
+++ b/code/datums/traits/prosthetics/prosthetic_limbs.dm
@@ -6,6 +6,7 @@
 	available_at_map_tech = MAP_TECH_LEVEL_ANY // the base trait must be available so that wooden prostheses are available
 	abstract_type = /decl/trait/prosthetic_limb
 	reapply_on_rejuvenation = TRUE
+	is_heritable = FALSE
 	var/fullbody_synthetic_only = FALSE
 	var/replace_children = TRUE
 	var/check_bodytype

--- a/code/datums/traits/prosthetics/prosthetic_organs.dm
+++ b/code/datums/traits/prosthetics/prosthetic_organs.dm
@@ -5,6 +5,7 @@
 	available_at_map_tech = MAP_TECH_LEVEL_SPACE
 	category = "Prosthetic Organs"
 	reapply_on_rejuvenation = TRUE
+	is_heritable = FALSE
 	var/synthetic_bodytype_restricted = FALSE
 	var/apply_to_organ
 

--- a/code/modules/bodytype/_bodytype.dm
+++ b/code/modules/bodytype/_bodytype.dm
@@ -639,7 +639,7 @@ var/global/list/bodytypes_by_category = list()
 		set_extension(limb, /datum/extension/armor, natural_armour_values)
 
 //fully_replace: If true, all existing organs will be discarded. Useful when doing mob transformations, and not caring about the existing organs
-/decl/bodytype/proc/create_missing_organs(mob/living/human/H, fully_replace = FALSE)
+/decl/bodytype/proc/create_missing_organs(mob/living/human/H, fully_replace = FALSE, datum/mob_snapshot/snapshot_to_use = null)
 	if(fully_replace)
 		H.delete_organs()
 
@@ -659,8 +659,10 @@ var/global/list/bodytypes_by_category = list()
 				qdel(O)
 
 	//Create missing limbs
-	var/datum/mob_snapshot/supplied_data = H.get_mob_snapshot()
-	supplied_data.root_bodytype = src // This may not have been set on the target mob torso yet.
+	var/datum/mob_snapshot/supplied_data = snapshot_to_use
+	if(!supplied_data)
+		supplied_data = H.get_mob_snapshot()
+		supplied_data.root_bodytype = src // This may not have been set on the target mob torso yet.
 
 	for(var/limb_type in has_limbs)
 		if(GET_EXTERNAL_ORGAN(H, limb_type)) //Skip existing

--- a/code/modules/client/preference_setup/general/03_traits.dm
+++ b/code/modules/client/preference_setup/general/03_traits.dm
@@ -39,10 +39,18 @@
 	else
 		pref.prune_invalid_traits()
 
-/datum/category_item/player_setup_item/traits/apply_post_snapshot_preferences(mob/living/human/character, is_preview_copy = FALSE)
-	character.clear_extrinsic_traits()
+/datum/category_item/player_setup_item/traits/populate_mob_snapshot(datum/mob_snapshot/snapshot, is_preview_copy)
 	for(var/trait_type in pref.traits)
-		character.set_trait(trait_type, (pref.traits[trait_type] || TRAIT_LEVEL_EXISTS))
+		var/decl/trait/trait = GET_DECL(trait_type)
+		if(trait.is_heritable)
+			LAZYSET(snapshot.heritable_traits, trait_type, pref.traits[trait_type] || TRAIT_LEVEL_EXISTS)
+
+/datum/category_item/player_setup_item/traits/apply_post_snapshot_preferences(mob/living/human/character, is_preview_copy = FALSE)
+	// apply non-heritable traits now
+	for(var/trait_type in pref.traits)
+		var/decl/trait/trait = GET_DECL(trait_type)
+		if(!trait.is_heritable)
+			character.set_trait(trait_type, (pref.traits[trait_type] || TRAIT_LEVEL_EXISTS))
 
 /datum/category_item/player_setup_item/traits/save_character(datum/pref_record_writer/writer)
 	var/list/trait_ids = list()

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -309,6 +309,7 @@ var/global/list/time_prefs_fixed = list()
 	if(href_list["save"])
 		save_preferences()
 		save_character()
+		return TRUE // don't regenerate our preview, that's wasteful
 	else if(href_list["reload"])
 		load_preferences()
 		load_character()
@@ -325,6 +326,8 @@ var/global/list/time_prefs_fixed = list()
 		if(isnewplayer(client.mob))
 			var/mob/new_player/M = client.mob
 			M.show_lobby_menu()
+		update_setup_window(usr)
+		return TRUE // don't do a duplicate icon update
 
 	else if(href_list["resetslot"])
 		if(real_name != input("This will reset the current slot. Enter the character's full name to confirm."))
@@ -339,12 +342,15 @@ var/global/list/time_prefs_fixed = list()
 		equip_preview_mob ^= text2num(href_list["toggle_preview_value"])
 	else if(href_list["cycle_bg"])
 		bgstate = next_in_list(bgstate, global.using_map.char_preview_bgstate_options)
+		update_preview_icon(redress_mob = FALSE)
+		return TRUE
 	else
 		return FALSE
 
+	// this should get hit for reset, reload, load, slot change, and equipment preview toggle
 	update_preview_icon()
 	update_setup_window(usr)
-	return 1
+	return TRUE
 
 /datum/category_item/player_setup_item/records/character_info/apply_post_snapshot_preferences(mob/living/human/character, is_preview_copy = FALSE)
 	if(is_preview_copy)

--- a/code/modules/mob/living/human/human.dm
+++ b/code/modules/mob/living/human/human.dm
@@ -462,7 +462,7 @@
 /mob/proc/set_bodytype(var/decl/bodytype/new_bodytype)
 	return
 
-/mob/living/human/set_bodytype(var/decl/bodytype/new_bodytype)
+/mob/living/human/set_bodytype(var/decl/bodytype/new_bodytype, var/datum/mob_snapshot/snapshot_to_use = null)
 
 	var/decl/bodytype/old_bodytype = get_bodytype()
 	if(ispath(new_bodytype))
@@ -489,7 +489,7 @@
 //set_species should not handle the entirety of initing the mob, and should not trigger deep updates
 //It focuses on setting up species-related data, without force applying them uppon organs and the mob's appearance.
 // For transforming an existing mob, look at change_species()
-/mob/living/human/set_species(var/new_species_uid, var/new_bodytype = null)
+/mob/living/human/set_species(var/new_species_uid, var/new_bodytype = null, var/datum/mob_snapshot/snapshot_to_use = null)
 	if(!new_species_uid)
 		CRASH("set_species on mob '[src]' was passed a null species uid!")
 	var/decl/species/new_species = decls_repository.get_decl_by_id(new_species_uid)
@@ -518,7 +518,7 @@
 	//Handle bodytype
 	if(!new_bodytype)
 		new_bodytype = species.get_bodytype_by_pronouns(new_pronouns)
-	set_bodytype(new_bodytype)
+	set_bodytype(new_bodytype, snapshot_to_use = snapshot_to_use)
 
 	available_maneuvers = species.maneuvers.Copy()
 
@@ -984,7 +984,7 @@
 	else if(!species_uid)
 		species_uid = global.using_map.default_species //Humans cannot exist without a species!
 
-	set_species(species_uid, supplied_appearance?.root_bodytype)
+	set_species(species_uid, supplied_appearance?.root_bodytype, snapshot_to_use = supplied_appearance)
 	var/decl/bodytype/root_bodytype = get_bodytype() // root bodytype is set in set_species
 	ASSERT((!supplied_appearance?.root_bodytype) || (root_bodytype == supplied_appearance.root_bodytype))
 	if(!get_skin_colour())

--- a/code/modules/mob/mob_snapshot.dm
+++ b/code/modules/mob/mob_snapshot.dm
@@ -16,6 +16,8 @@
 	var/list/genetic_conditions
 	/// Please find a better way to do this. This is done to add tails if we have the tail accessory selected...
 	var/list/extra_limbs
+	/// A list of trait levels to add. Should contain only 'heritable' traits... whatever that means.
+	var/list/heritable_traits
 
 /datum/mob_snapshot/New(mob/living/donor, genetic_info_only = FALSE)
 
@@ -73,6 +75,10 @@
 			target.set_species(root_species.uid)
 	else if(istype(root_bodytype) && target.get_bodytype() != root_bodytype)
 		target.set_bodytype(root_bodytype)
+
+	// we try to set traits as soon as possible after species set
+	for(var/target_trait in heritable_traits)
+		target.set_trait(target_trait, heritable_traits[target_trait])
 
 	target.set_fingerprint(fingerprint)
 	target.set_unique_enzymes(unique_enzymes)

--- a/code/modules/mob/new_player/preferences_setup.dm
+++ b/code/modules/mob/new_player/preferences_setup.dm
@@ -109,11 +109,12 @@
 		mannequin.update_icon()
 		mannequin.compile_overlays()
 
-/datum/preferences/proc/update_preview_icon()
+/datum/preferences/proc/update_preview_icon(redress_mob = TRUE)
 	var/mob/living/human/dummy/mannequin/mannequin = get_mannequin(client?.ckey)
 	if(mannequin)
-		mannequin.delete_inventory(TRUE)
-		dress_preview_mob(mannequin)
+		if(redress_mob)
+			mannequin.delete_inventory(TRUE)
+			dress_preview_mob(mannequin)
 		update_character_previews(mannequin)
 
 /datum/preferences/proc/get_random_name()

--- a/mods/content/biomods/ears_animal.dm
+++ b/mods/content/biomods/ears_animal.dm
@@ -19,7 +19,7 @@
 	icon_state = "fox"
 	uid        = "accessory_ears_fox"
 
-/decl/sprite_accessory/ears/biomods/antlers
+/decl/sprite_accessory/ears/biomods/animal/antlers
 	name       = "Antlers"
 	icon_state = "antlers"
 	uid        = "accessory_ears_antlers"


### PR DESCRIPTION
## Description of changes
'Heritable' traits (everything but amputations and prostheses) are now applied in character setup during the mob snapshot step rather than after the snapshot is applied. This means downstream (Pyrelight) doesn't run into issues with the traits not being set. It also makes sense for at least some traits to be copied in the snapshot; this just allows some granular control over which traits are included.

TODO: May need to make get_mob_snapshot copy heritable traits, this was mostly just done as a fix for the issues and not a full-fledged feature.

Also fixes some correctness issues with character creation: the supplied mob snapshot is now threaded all the way through setup_human -> create_missing_organs, which should avoid a bit more organ/limb churn.

Also-also avoids duplicate `update_preview_mob()` calls in `/datum/preferences/Topic()` and allows bgstate changes to skip re-dressing the mob.

Also-also-also makes antlers have the right typepath. No migration needed because of UIDs. Yay.

## Why and what will this PR improve
Fixes wyrdlings on Pyrelight not getting their ears.

## Authorship
Me for the fix, Loaf for pointing out the issue.