### PR TITLE
Adding an Interact hotkey.

### DIFF
--- a/code/_helpers/cmp.dm
+++ b/code/_helpers/cmp.dm
@@ -98,6 +98,11 @@
 /proc/cmp_planelayer(atom/A, atom/B)
 	return (B.plane - A.plane) || (B.layer - A.layer)
 
+/proc/cmp_planelayer_interact_priority(atom/A, atom/B)
+	if(A.interaction_priority != B.interaction_priority)
+		return (B.interaction_priority - A.interaction_priority)
+	return (B.plane - A.plane) || (B.layer - A.layer)
+
 /proc/cmp_currency_denomination_des(var/datum/denomination/A, var/datum/denomination/B)
 	. = B.marked_value - A.marked_value
 

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -73,6 +73,9 @@
 	/// (DATUM) Similar to above, but largely used by /turf/wall, /obj/structure and /obj/item/stack/material
 	var/decl/material/reinf_material
 
+	/// (BOOLEAN) Set to TRUE to prioritise this atom when using the interact hotkey.
+	var/interaction_priority
+
 /atom/proc/get_max_health()
 	return max_health
 

--- a/code/game/machinery/_machines_base/machinery.dm
+++ b/code/game/machinery/_machines_base/machinery.dm
@@ -81,6 +81,7 @@ Class Procs:
 	)
 	temperature_sensitive = TRUE
 	abstract_type = /obj/machinery
+	interaction_priority = TRUE
 
 	var/stat = 0
 	var/waterproof = TRUE

--- a/code/game/machinery/doors/_door.dm
+++ b/code/game/machinery/doors/_door.dm
@@ -15,6 +15,7 @@
 	uncreated_component_parts = null
 	required_interaction_dexterity = DEXTERITY_SIMPLE_MACHINES
 	max_health = 300
+	interaction_priority = TRUE
 
 	var/can_open_manually = TRUE
 

--- a/code/game/objects/items/__item.dm
+++ b/code/game/objects/items/__item.dm
@@ -5,6 +5,7 @@
 	pass_flags = PASS_FLAG_TABLE
 	abstract_type = /obj/item
 	temperature_sensitive = TRUE
+	interaction_priority = TRUE
 
 	/// Set to prefix name with this string ('woven' for 'woven basket' etc)
 	var/name_prefix

--- a/code/game/objects/structures/doors/_door.dm
+++ b/code/game/objects/structures/doors/_door.dm
@@ -9,6 +9,7 @@
 	anchored              = TRUE
 	opacity               = TRUE
 	structure_flags       = STRUCTURE_FLAG_THROWN_DAMAGE
+	interaction_priority  = TRUE
 	var/has_window        = FALSE
 	var/changing_state    = FALSE
 	var/door_sound_volume = 25

--- a/code/game/objects/structures/fences/_fences.dm
+++ b/code/game/objects/structures/fences/_fences.dm
@@ -227,6 +227,7 @@
 	name = "fence gate"
 	desc = "Much like a regular door, but thinner."
 	icon_state = "door-closed"
+	interaction_priority   = TRUE
 
 /obj/structure/fence/door/can_install_lock()
 	return TRUE

--- a/code/game/objects/structures/inflatable.dm
+++ b/code/game/objects/structures/inflatable.dm
@@ -192,6 +192,7 @@
 	density = TRUE
 	anchored = TRUE
 	opacity = FALSE
+	interaction_priority = TRUE
 
 	icon_state = "door_closed"
 	undeploy_path = /obj/item/inflatable/door

--- a/code/modules/atmospherics/atmospherics.dm
+++ b/code/modules/atmospherics/atmospherics.dm
@@ -14,6 +14,7 @@ Pipelines + Other Objects -> Pipe network
 	idle_power_usage = 0
 	active_power_usage = 0
 	power_channel = ENVIRON
+	interaction_priority = null
 
 	var/power_rating //the maximum amount of power the machine can use to do work, affects how powerful the machine is, in Watts
 

--- a/code/modules/keybindings/binds/mob.dm
+++ b/code/modules/keybindings/binds/mob.dm
@@ -183,3 +183,30 @@
 /datum/keybinding/mob/minimal_hud/down(client/user)
 	user.mob.minimize_hud()
 	return TRUE
+
+/datum/keybinding/mob/interact
+	hotkey_keys = list("Enter")
+	name = "interact"
+	full_name = "Interact"
+	description = "Interact with the turf directly in front of you."
+
+/datum/keybinding/mob/interact/down(client/user)
+	user.mob.interact_with_facing()
+	return TRUE
+
+/mob/proc/interact_with_facing()
+
+	var/turf/facing = get_step(get_turf(src), dir)
+	if(!istype(facing) || !facing.simulated)
+		return
+
+	var/list/atoms = facing.get_contained_external_atoms()
+	// Move non-prioritised atoms to the end of the list (to avoid burning our hands on lights when trying to open a closet)
+	if(length(atoms) > 1)
+		atoms = sortTim(atoms, /proc/cmp_planelayer_interact_priority)
+	LAZYDISTINCTADD(atoms, facing) // Turf is always at the end of the list.
+
+	// Try to click something.
+	for(var/atom/clickable as anything in atoms)
+		if(clickable.invisibility <= see_invisible)
+			return clickable.Click()

--- a/code/modules/lights/light_fixture_base.dm
+++ b/code/modules/lights/light_fixture_base.dm
@@ -12,6 +12,7 @@
 	idle_power_usage = 2
 	active_power_usage = 20
 	power_channel = LIGHT //Lights are calc'd via area so they dont need to be in the machine list
+	interaction_priority = null
 
 	uncreated_component_parts = list(
 		/obj/item/stock_parts/power/apc


### PR DESCRIPTION
- Adds an Interact hotkey that attempts to click on the turf you are facing.
- Adds `interaction_priority` to mark atoms that we are most interested in interacting with (so that lights above airlocks do not block interacting with the airlock).