### PR TITLE
Inducer fix

### DIFF
--- a/code/game/objects/items/devices/inducer.dm
+++ b/code/game/objects/items/devices/inducer.dm
@@ -50,11 +50,11 @@
 	var/obj/item/cell/my_cell = get_cell()
 	var/datum/extension/loaded_cell/panel/cell_loaded = get_extension(src, /datum/extension/loaded_cell)
 
-	if(cell_loaded.has_tool_unload_interaction(W))
+	if(cell_loaded?.has_tool_unload_interaction(W))
 		return cell_loaded.try_unload(user, W)
 
 	else if(!istype(my_cell) && istype(W, /obj/item/cell))
-		return cell_loaded.try_load(user, W)
+		return cell_loaded?.try_load(user, W)
 
 	else if(CannotUse(user) || recharge(W, user))
 		return TRUE

--- a/code/game/objects/items/devices/inducer.dm
+++ b/code/game/objects/items/devices/inducer.dm
@@ -47,8 +47,18 @@
 	return FALSE
 
 /obj/item/inducer/attackby(obj/item/W, mob/user)
-	if(CannotUse(user) || recharge(W, user))
+	var/obj/item/cell/my_cell = get_cell()
+	var/datum/extension/loaded_cell/panel/cell_loaded = get_extension(src, /datum/extension/loaded_cell)
+
+	if(cell_loaded.has_tool_unload_interaction(W))
+		return cell_loaded.try_unload(user, W)
+
+	else if(!istype(my_cell) && istype(W, /obj/item/cell))
+		return cell_loaded.try_load(user, W)
+
+	else if(CannotUse(user) || recharge(W, user))
 		return TRUE
+
 	return ..()
 
 /obj/item/inducer/proc/recharge(atom/A, mob/user)


### PR DESCRIPTION
<!-- !! PLEASE, READ THIS !! -->
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/NebulaSS13/Nebula/blob/dev/CONTRIBUTING.md -->
<!-- If you're opening a pull request which changes A LOT of icon/map files: -->
<!-- Add [IDB IGNORE] (to ignore icon file changes) or [MDB IGNORE] (to ignore map file changes) in the PR title. -->
<!-- These tags prevent huge diffs from overloading IconDiffBot and MapDiffBot. -->

## Description of changes
<!-- Describe the pull request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Inducers (`/obj/item/inducer`) now check if an item being used on it is a tool to replace the power cell, or a replacement power cell, and handles them appropriately.  Previously, attempting to install a cell would erroneously try to charge the cell, which would cause an error because the inducer did not have a cell.

## Why and what will this PR improve
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Inducers can now have their cell removed and a fresh cell installed.  This makes them more than single-use items, like they were intended to be.

## Authorship
<!-- Describe original authors of changes to credit them. -->
Typhin

## Changelog
:cl:
bugfix: Inducers now allow a cell to be installed.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->