### PR TITLE
Background helpers are now usable on /mob not /mob/living.

### DIFF
--- a/code/modules/mob/living/human/human.dm
+++ b/code/modules/mob/living/human/human.dm
@@ -894,20 +894,10 @@
 		if(!defer_language_update)
 			update_languages()
 
-/mob/living/proc/get_background_datum_by_flag(background_flag)
-	var/list/all_categories = global.using_map.get_background_categories()
-	for(var/cat_type in all_categories)
-		var/decl/background_category/background_cat = all_categories[cat_type]
-		if(background_cat.background_flags && (background_cat.background_flags & background_flag))
-			return get_background_datum(cat_type)
-
-/mob/living/proc/get_background_datum(cat_type)
-	return null
-
 /mob/living/human/get_background_datum(cat_type)
 	. = LAZYACCESS(background_info, cat_type)
 	if(!istype(., /decl/background_detail))
-		. = global.using_map.default_background_info[cat_type]
+		. = ..()
 		PRINT_STACK_TRACE("get_background_datum() tried to return a non-instance value for background category '[cat_type]' - full background list: [json_encode(background_info)] default species culture list: [json_encode(global.using_map.default_background_info)]")
 
 /mob/living/human/get_digestion_product()

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1603,3 +1603,13 @@ var/global/const/ACTION_DANGER_ALL = 2
 // Returns true if the mob is cloaked, otherwise false
 /mob/proc/is_cloaked()
 	return FALSE
+
+/mob/proc/get_background_datum_by_flag(background_flag)
+	var/list/all_categories = global.using_map.get_background_categories()
+	for(var/cat_type in all_categories)
+		var/decl/background_category/background_cat = all_categories[cat_type]
+		if(background_cat.background_flags && (background_cat.background_flags & background_flag))
+			return get_background_datum(cat_type)
+
+/mob/proc/get_background_datum(cat_type)
+	return global.using_map.default_background_info[cat_type]


### PR DESCRIPTION
Needed for downstream, but useful in general for making use of culture decls.