### PR TITLE
Tweaks to the ability system and ability targeters.

### DIFF
--- a/code/datums/extensions/abilities/ability_button.dm
+++ b/code/datums/extensions/abilities/ability_button.dm
@@ -65,7 +65,7 @@
 /obj/screen/ability/button/handle_click(mob/user, params)
 	if(owning_handler.prepared_ability == ability)
 		owning_handler.cancel_prepared_ability()
-	else if(ability.use_ability(user, get_turf(user), owning_handler)) // tmp, needs better/multi-step target selection
+	else if(ability.use_ability(user, user, owning_handler)) // tmp, needs better/multi-step target selection
 		update_icon()
 		addtimer(CALLBACK(src, TYPE_PROC_REF(/atom, update_icon)), ability.get_cooldown_time(ability.get_metadata_for_user(user)) + 1)
 

--- a/code/datums/extensions/abilities/ability_decl.dm
+++ b/code/datums/extensions/abilities/ability_decl.dm
@@ -182,7 +182,7 @@
 
 	else
 		// Otherwise, just apply to the target directly.
-		apply_effect(user, target, metadata)
+		apply_ability_effect(user, target, metadata)
 
 	if(end_prep_on_cast && handler.prepared_ability == src)
 		handler.cancel_prepared_ability()
@@ -325,7 +325,7 @@
 
 	return TRUE
 
-/decl/ability/proc/apply_effect(mob/user, atom/hit_target, list/metadata, obj/item/projectile/ability/projectile)
+/decl/ability/proc/apply_ability_effect(mob/user, atom/hit_target, list/metadata, obj/item/projectile/ability/projectile)
 	SHOULD_CALL_PARENT(TRUE)
 	if(use_sound)
 		playsound(get_turf(user), use_sound, use_sound_volume, 1)
@@ -339,7 +339,7 @@
 		show_ability_cast_msg(user, targets, metadata)
 	while(length(targets))
 		var/target = targets[1]
-		apply_effect_to(user, target, metadata)
+		apply_ability_effect_to(user, target, metadata)
 		targets = prune_targets(user, target, targets, metadata)
 	finish_casting(user, hit_target, metadata)
 
@@ -366,7 +366,7 @@
 	ability_overlay.set_density(FALSE)
 	QDEL_IN(ability_overlay, overlay_lifespan)
 
-/decl/ability/proc/apply_effect_to(mob/user, atom/target, list/metadata)
+/decl/ability/proc/apply_ability_effect_to(mob/living/user, atom/target, list/metadata)
 	SHOULD_CALL_PARENT(TRUE)
 	SHOULD_NOT_SLEEP(TRUE)
 	apply_visuals(user, target, metadata)

--- a/code/datums/extensions/abilities/ability_handler.dm
+++ b/code/datums/extensions/abilities/ability_handler.dm
@@ -125,7 +125,7 @@
 		add_screen_element(category_toggle, "toggle", TRUE)
 		toggle_category_visibility(TRUE)
 
-/datum/ability_handler/proc/refresh_element_positioning(row = 1, col = 1)
+/datum/ability_handler/proc/refresh_element_positioning(row = 1, col = 0)
 	if(!LAZYLEN(screen_elements))
 		return 0
 	var/button_pos = col
@@ -134,14 +134,14 @@
 	for(var/ability in screen_elements)
 		var/obj/screen/element = screen_elements[ability]
 		if(istype(element, /obj/screen/ability/category))
-			element.screen_loc = "RIGHT-[col]:-4,TOP-[row]"
+			element.screen_loc = "RIGHT-[col]:-4,TOP-[row]:-24"
 		else if(!element.invisibility)
 			button_pos++
 			if((button_pos-col) > 5)
 				button_row++
 				.++
 				button_pos = col+1
-			element.screen_loc = "RIGHT-[button_pos]:-4,TOP-[button_row]"
+			element.screen_loc = "RIGHT-[button_pos]:-4,TOP-[button_row]:-24"
 
 /datum/ability_handler/proc/toggle_category_visibility(force_state)
 	showing_abilities = isnull(force_state) ? !showing_abilities : force_state

--- a/code/datums/extensions/abilities/ability_item.dm
+++ b/code/datums/extensions/abilities/ability_item.dm
@@ -54,8 +54,8 @@
 		// Fire a projectile if that is how this ability works.
 		ability.fire_projectile_at(user, target, metadata)
 	else
-		// Otherwise, apply to the target. Range checking etc. will be handled in apply_effect().
-		ability.apply_effect(user, target, metadata)
+		// Otherwise, apply to the target. Range checking etc. will be handled in apply_ability_effect().
+		ability.apply_ability_effect(user, target, metadata)
 
 	// Clean up our item if needed.
 	if(ability.item_end_on_cast)

--- a/code/datums/extensions/abilities/ability_projectile.dm
+++ b/code/datums/extensions/abilities/ability_projectile.dm
@@ -22,10 +22,10 @@
 
 /obj/item/projectile/ability/Bump(var/atom/A, forced=0)
 	if(loc && carried_ability && !expended)
-		carried_ability.apply_effect(owner, A, ability_metadata, src)
+		carried_ability.apply_ability_effect(owner, A, ability_metadata, src)
 	return TRUE
 
 /obj/item/projectile/ability/on_impact(var/atom/A)
 	if(loc && carried_ability && !expended)
-		carried_ability.apply_effect(owner, A, ability_metadata, src)
+		carried_ability.apply_ability_effect(owner, A, ability_metadata, src)
 	return TRUE

--- a/code/datums/extensions/abilities/ability_targeting.dm
+++ b/code/datums/extensions/abilities/ability_targeting.dm
@@ -72,19 +72,35 @@
 			return FALSE
 	return TRUE
 
+/decl/ability_targeting/target_self
+	target_turf = FALSE
+
+/decl/ability_targeting/target_self/validate_target(mob/user, atom/target, list/metadata, decl/ability/ability)
+	return target == user
+
+/decl/ability_targeting/target_self/get_affected(mob/user, atom/hit_target, list/metadata, decl/ability/ability, obj/item/projectile/ability/projectile)
+	return list(user)
+
 /decl/ability_targeting/clear_turf
 	ignore_dense_turfs = TRUE
 
 /decl/ability_targeting/clear_turf/validate_target(mob/user, atom/target, list/metadata, decl/ability/ability)
 	. = ..() && isturf(target)
 	if(.)
-		var/turf/target_turf = target
-		return !target_turf.contains_dense_objects(user)
+		var/turf/turf_to_target = target
+		return !turf_to_target.contains_dense_objects(user)
 
-/decl/ability_targeting/living_mob
-	target_turf               = FALSE
+/decl/ability_targeting/single_atom
+	target_turf = FALSE
+	user_is_immune = TRUE
 
-/decl/ability_targeting/living_mob/validate_target(mob/user, atom/target, list/metadata, decl/ability/ability)
+/decl/ability_targeting/single_atom/can_target_user
+	user_is_immune = FALSE
+
+/decl/ability_targeting/single_atom/get_affected(mob/user, atom/hit_target, list/metadata, decl/ability/ability, obj/item/projectile/ability/projectile)
+	return list(hit_target)
+
+/decl/ability_targeting/single_atom/living_mob/validate_target(mob/user, atom/target, list/metadata, decl/ability/ability)
 	. = ..() && isliving(target)
 	if(.)
 		var/mob/living/victim = target

--- a/mods/gamemodes/cult/abilities/construct.dm
+++ b/mods/gamemodes/cult/abilities/construct.dm
@@ -2,10 +2,9 @@
 /decl/ability/cult/construct
 	name                    = "Artificer"
 	desc                    = "This spell conjures a construct which may be controlled by shades."
-	target_selector         = /decl/ability_targeting/clear_turf
+	target_selector         = /decl/ability_targeting/clear_turf/construct
 	overlay_icon            = 'mods/gamemodes/cult/icons/effects.dmi'
 	overlay_icon_state      = "sparkles"
-	target_selector         = /decl/ability_targeting/clear_turf/construct
 	var/summon_type         = /obj/structure/constructshell
 
 /decl/ability_targeting/clear_turf/construct/validate_target(mob/user, atom/target, list/metadata, decl/ability/ability)
@@ -14,14 +13,14 @@
 		return FALSE
 	return ..() && !istype(target, cult_ability.summon_type) && !(locate(cult_ability.summon_type) in target)
 
-/decl/ability/cult/construct/apply_effect(mob/user, atom/hit_target, list/metadata, obj/item/projectile/ability/projectile)
+/decl/ability/cult/construct/apply_ability_effect(mob/user, atom/hit_target, list/metadata, obj/item/projectile/ability/projectile)
 	. = ..()
 	var/turf/target_turf = get_turf(hit_target)
 	if(istype(target_turf))
 		if(ispath(summon_type, /turf))
 			target_turf = target_turf.ChangeTurf(summon_type, TRUE, FALSE, TRUE, TRUE, FALSE)
 			if(target_turf) // We reapply effects as target no longer exists.
-				apply_effect_to(user, target_turf, metadata)
+				apply_ability_effect_to(user, target_turf, metadata)
 		else if(ispath(summon_type, /atom))
 			new summon_type(target_turf)
 
@@ -87,7 +86,7 @@
 		return TRUE
 	return FALSE
 
-/decl/ability/cult/construct/pylon/apply_effect(mob/user, atom/hit_target, list/metadata, obj/item/projectile/ability/projectile)
+/decl/ability/cult/construct/pylon/apply_ability_effect(mob/user, atom/hit_target, list/metadata, obj/item/projectile/ability/projectile)
 	for(var/obj/structure/cult/pylon/P in get_turf(hit_target))
 		if(P.isbroken)
 			P.repair(user)

--- a/mods/gamemodes/cult/abilities/harvest.dm
+++ b/mods/gamemodes/cult/abilities/harvest.dm
@@ -9,7 +9,7 @@
 	prepare_message_3p_str  = "Space around $USER$ begins to bubble and decay as a terrible vista begins to intrude..."
 	prepare_message_1p_str  = "You bore through space and time, seeking the essence of the Geometer of Blood."
 	fail_cast_1p_str        = "Reality reasserts itself, preventing your return to Nar-Sie."
-	target_selector         = /decl/ability_targeting/living_mob
+	target_selector         = /decl/ability_targeting/single_atom/living_mob
 
 /decl/ability/cult/construct/harvest/can_use_ability(mob/user, list/metadata, silent)
 	. = ..()
@@ -22,7 +22,7 @@
 			to_chat(user, SPAN_DANGER("You cannot sense the Geometer of Blood!"))
 			return FALSE
 
-/decl/ability/cult/construct/harvest/apply_effect(mob/user, atom/hit_target, list/metadata, obj/item/projectile/ability/projectile)
+/decl/ability/cult/construct/harvest/apply_ability_effect(mob/user, atom/hit_target, list/metadata, obj/item/projectile/ability/projectile)
 	..()
 	var/destination = null
 	for(var/obj/effect/narsie/N in global.narsie_list)


### PR DESCRIPTION
- Renames `apply_effect()` and `apply_effect_to()` to `apply_ability_effect()` and `apply_ability_effect_to()` to distinguish from other procs.
- Removes `get_turf()` in ability code preventing targeting non-turf atoms specifically.
- Adjusted ability list to sit flush with the right side of the screen, under z-level awareness element.
- Minor adjustments/fixes to targeters.