### PR TITLE
Removing unused tallness var.

### DIFF
--- a/code/modules/backgrounds/citizenship/_citizenship.dm
+++ b/code/modules/backgrounds/citizenship/_citizenship.dm
@@ -1,18 +1,10 @@
 /decl/background_detail/citizenship
 	abstract_type = /decl/background_detail/citizenship
 	category = /decl/background_category/citizenship
-	var/ruling_body = "Other Faction"
-	var/capital
-	var/size_heading = "Systems"
-	var/size_value
-	var/founded
+	var/issuing_body
 
 /decl/background_detail/citizenship/get_text_details()
 	. = list()
-	if(!isnull(capital))
-		. += "<b>Capital:</b> [capital]."
-	if(!isnull(size_value) && !isnull(size_heading))
-		. += "<b>Extent:</b> [size_value] [size_heading]."
-	if(!isnull(founded))
-		. += "<b>Founded:</b> [founded]"
+	if(!isnull(issuing_body))
+		. += "<b>Issuing body:</b> [issuing_body]."
 	. += ..()

--- a/code/modules/backgrounds/citizenship/citizenship_other.dm
+++ b/code/modules/backgrounds/citizenship/citizenship_other.dm
@@ -13,7 +13,6 @@
 	uid = "stateless"
 	description = "You do not possess any kind of official citizenship."
 	economic_power = 0
-	capital = "None"
 
 /decl/background_detail/citizenship/synthetic
 	name = "Stateless Drone"

--- a/code/modules/maps/template_types/random_exoplanet/planetoid_data.dm
+++ b/code/modules/maps/template_types/random_exoplanet/planetoid_data.dm
@@ -16,8 +16,6 @@
 	var/width
 	///Preferred height for all the planet z-levels. Null means it's up to each z-levels. Not reliable for telling the height of the levels under this planet.
 	var/height
-	///Preferred amount of vertically connected z-levels for this planets. Null means it's up to each z-levels.
-	var/tallness = 1
 	///Topmost level data datum id of the root z stack (ID only, because this datum has an uncontrolled lifetime, and we don't want dangling refs)
 	var/topmost_level_id
 	///Level data id for the level that's considered to be the planet's surface. In other words, the topmost firm ground level of the root z stack.


### PR DESCRIPTION
- Removed unused/deprecated `tallness` var.
- Removed duplicate values for citizenship decl that make no sense and aren't really used, replaced with `issuing_body`.