### PR TITLE
Walls will be undamageable to certain weapons based on material.

### DIFF
--- a/code/game/turfs/walls/_wall.dm
+++ b/code/game/turfs/walls/_wall.dm
@@ -41,7 +41,6 @@ var/global/list/wall_fullblend_objects = list(
 	var/decl/material/reinf_material
 	var/decl/material/girder_material = /decl/material/solid/metal/steel
 	var/construction_stage
-	var/hitsound = 'sound/weapons/Genhit.ogg'
 	/// A list of connections to walls for each corner, used for icon generation. Can be converted to a list of dirs with corner_states_to_dirs().
 	var/list/wall_connections
 	/// A list of connections to non-walls for each corner, used for icon generation. Can be converted to a list of dirs with corner_states_to_dirs().
@@ -152,7 +151,7 @@ var/global/list/wall_fullblend_objects = list(
 	. = ..()
 	if(. && density && !ismob(AM))
 		var/tforce = AM.get_thrown_attack_force() * (TT.speed/THROWFORCE_SPEED_DIVISOR)
-		playsound(src, hitsound, tforce >= 15 ? 60 : 25, TRUE)
+		playsound(src, get_hit_sound(), tforce >= 15 ? 60 : 25, TRUE)
 		if(tforce > 0)
 			take_damage(tforce)
 
@@ -323,7 +322,7 @@ var/global/list/wall_fullblend_objects = list(
 	handle_melting()
 
 /turf/wall/proc/get_hit_sound()
-	return 'sound/effects/metalhit.ogg'
+	return material?.hitsound || 'sound/weapons/Genhit.ogg'
 
 // Mapped premade for false walls
 /turf/wall/false

--- a/code/game/turfs/walls/wall_attacks.dm
+++ b/code/game/turfs/walls/wall_attacks.dm
@@ -95,7 +95,7 @@
 
 	if (isnull(construction_stage) || !reinf_material)
 		to_chat(user, "<span class='notice'>You push \the [src], but nothing happens.</span>")
-		playsound(src, hitsound, 25, 1)
+		playsound(src, get_hit_sound(), 25, 1)
 		return TRUE
 
 /turf/wall/attack_hand(var/mob/user)
@@ -311,19 +311,19 @@
 	var/effective_force = round(force / material_divisor)
 	if(effective_force < damage_threshold)
 		visible_message(SPAN_DANGER("\The [user] has [pick(W.attack_verb)] \the [src] with \the [W], but it has no effect!"))
-		playsound(src, hitsound, 25, 1)
+		playsound(src, get_hit_sound(), 25, 1)
 		return TRUE
 	// Check for a glancing blow.
 	var/dam_prob = max(0, 100 - material.hardness + effective_force + W.armor_penetration)
 	if(!prob(dam_prob))
 		visible_message(SPAN_DANGER("\The [user] has [pick(W.attack_verb)] \the [src] with \the [W], but it bounced off!"))
-		playsound(src, hitsound, 25, 1)
+		playsound(src, get_hit_sound(), 25, 1)
 		if(user.skill_fail_prob(SKILL_HAULING, 40, SKILL_ADEPT))
 			SET_STATUS_MAX(user, STAT_WEAK, 2)
 			visible_message(SPAN_DANGER("\The [user] is knocked back by the force of the blow!"))
 		return TRUE
 
 	visible_message(SPAN_DANGER("\The [user] has [pick(W.attack_verb)] \the [src] with \the [W]!"))
-	playsound(src, hitsound, 50, 1)
+	playsound(src, get_hit_sound(), 50, 1)
 	take_damage(effective_force)
 	return TRUE

--- a/code/game/turfs/walls/wall_attacks.dm
+++ b/code/game/turfs/walls/wall_attacks.dm
@@ -303,25 +303,27 @@
 
 	user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
 	user.do_attack_animation(src)
+
+	var/damage_threshold = max(2, max(material.wall_damage_threshold, reinf_material?.wall_damage_threshold))
 	var/material_divisor = max(material.brute_armor, reinf_material?.brute_armor)
 	if(W.atom_damage_type == BURN)
 		material_divisor = max(material.burn_armor, reinf_material?.burn_armor)
 	var/effective_force = round(force / material_divisor)
-	if(effective_force < 2)
-		visible_message(SPAN_DANGER("\The [user] [pick(W.attack_verb)] \the [src] with \the [W], but it had no effect!"))
+	if(effective_force < damage_threshold)
+		visible_message(SPAN_DANGER("\The [user] has [pick(W.attack_verb)] \the [src] with \the [W], but it has no effect!"))
 		playsound(src, hitsound, 25, 1)
 		return TRUE
 	// Check for a glancing blow.
 	var/dam_prob = max(0, 100 - material.hardness + effective_force + W.armor_penetration)
 	if(!prob(dam_prob))
-		visible_message(SPAN_DANGER("\The [user] [pick(W.attack_verb)] \the [src] with \the [W], but it bounced off!"))
+		visible_message(SPAN_DANGER("\The [user] has [pick(W.attack_verb)] \the [src] with \the [W], but it bounced off!"))
 		playsound(src, hitsound, 25, 1)
 		if(user.skill_fail_prob(SKILL_HAULING, 40, SKILL_ADEPT))
 			SET_STATUS_MAX(user, STAT_WEAK, 2)
 			visible_message(SPAN_DANGER("\The [user] is knocked back by the force of the blow!"))
 		return TRUE
 
-	playsound(src, get_hit_sound(), 50, 1)
-	visible_message(SPAN_DANGER("\The [user] [pick(W.attack_verb)] \the [src] with \the [W]!"))
+	visible_message(SPAN_DANGER("\The [user] has [pick(W.attack_verb)] \the [src] with \the [W]!"))
+	playsound(src, hitsound, 50, 1)
 	take_damage(effective_force)
 	return TRUE

--- a/code/game/turfs/walls/wall_icon.dm
+++ b/code/game/turfs/walls/wall_icon.dm
@@ -11,7 +11,6 @@
 		material = get_default_material()
 	if(material)
 		explosion_resistance = material.explosion_resistance
-		hitsound = material.hitsound
 	if(reinf_material && reinf_material.explosion_resistance > explosion_resistance)
 		explosion_resistance = reinf_material.explosion_resistance
 	update_strings()

--- a/code/modules/materials/_materials.dm
+++ b/code/modules/materials/_materials.dm
@@ -362,6 +362,9 @@ INITIALIZE_IMMEDIATE(/obj/effect/gas_overlay)
 	/// If an item has a null paint_verb, it automatically sets it based on material.
 	var/paint_verb = "painted"
 
+	// Physical attacks against walls must beat this threshold to cause damage.
+	var/wall_damage_threshold = 2
+
 // Placeholders for light tiles and rglass.
 /decl/material/proc/reinforce(var/mob/user, var/obj/item/stack/material/used_stack, var/obj/item/stack/material/target_stack, var/use_sheets = 1)
 	if(!used_stack.can_use(use_sheets))

--- a/code/modules/materials/definitions/solids/materials_solid_alien.dm
+++ b/code/modules/materials/definitions/solids/materials_solid_alien.dm
@@ -12,6 +12,7 @@
 	default_solid_form = /obj/item/stack/material/cubes
 	exoplanet_rarity_plant = MAT_RARITY_EXOTIC
 	exoplanet_rarity_gas = MAT_RARITY_NOWHERE
+	wall_damage_threshold = 20
 
 /decl/material/solid/metal/aliumium/Initialize()
 	icon_base = 'icons/turf/walls/metal.dmi'

--- a/code/modules/materials/definitions/solids/materials_solid_exotic.dm
+++ b/code/modules/materials/definitions/solids/materials_solid_exotic.dm
@@ -30,6 +30,7 @@
 	default_solid_form = /obj/item/stack/material/segment
 	exoplanet_rarity_plant = MAT_RARITY_EXOTIC
 	exoplanet_rarity_gas = MAT_RARITY_NOWHERE
+	wall_damage_threshold = 20
 
 /decl/material/solid/exotic_matter
 	name = "exotic matter"
@@ -65,3 +66,4 @@
 	default_solid_form = /obj/item/stack/material/segment
 	exoplanet_rarity_plant = MAT_RARITY_EXOTIC
 	exoplanet_rarity_gas = MAT_RARITY_NOWHERE
+	wall_damage_threshold = 10

--- a/code/modules/materials/definitions/solids/materials_solid_fission.dm
+++ b/code/modules/materials/definitions/solids/materials_solid_fission.dm
@@ -27,7 +27,8 @@
 	fission_heat = 35000
 	fission_energy = 4000
 	neutron_absorption = 4
-	
+	wall_damage_threshold = 20
+
 
 /decl/material/solid/metal/neptunium // Np-237.
 	name = "neptunium"

--- a/code/modules/materials/definitions/solids/materials_solid_gemstones.dm
+++ b/code/modules/materials/definitions/solids/materials_solid_gemstones.dm
@@ -13,6 +13,7 @@
 	abstract_type = /decl/material/solid/gemstone
 	sound_manipulate = 'sound/foley/pebblespickup1.ogg'
 	sound_dropped = 'sound/foley/pebblesdrop1.ogg'
+	wall_damage_threshold = 10
 
 /decl/material/solid/gemstone/diamond
 	name = "diamond"

--- a/code/modules/materials/definitions/solids/materials_solid_ice.dm
+++ b/code/modules/materials/definitions/solids/materials_solid_ice.dm
@@ -20,6 +20,7 @@
 	heating_products       = list(
 		/decl/material/liquid/water = 1
 	)
+	wall_damage_threshold = 5
 
 /decl/material/solid/ice/Initialize()
 	liquid_name ||= "liquid [name]" // avoiding the 'molten ice' issue

--- a/code/modules/materials/definitions/solids/materials_solid_metal.dm
+++ b/code/modules/materials/definitions/solids/materials_solid_metal.dm
@@ -20,6 +20,7 @@
 	icon_reinf = 'icons/turf/walls/reinforced_metal.dmi'
 	exoplanet_rarity_gas = MAT_RARITY_NOWHERE
 	tensile_strength = 0.8 // metal wire is probably better than plastic?
+	wall_damage_threshold = 10
 
 /decl/material/solid/metal/uranium
 	name = "uranium"

--- a/code/modules/materials/definitions/solids/materials_solid_metal.dm
+++ b/code/modules/materials/definitions/solids/materials_solid_metal.dm
@@ -21,6 +21,7 @@
 	exoplanet_rarity_gas = MAT_RARITY_NOWHERE
 	tensile_strength = 0.8 // metal wire is probably better than plastic?
 	wall_damage_threshold = 10
+	hitsound = 'sound/effects/metalhit.ogg'
 
 /decl/material/solid/metal/uranium
 	name = "uranium"

--- a/code/modules/materials/definitions/solids/materials_solid_mineral.dm
+++ b/code/modules/materials/definitions/solids/materials_solid_mineral.dm
@@ -19,6 +19,7 @@
 	)
 	ore_type_value = ORE_NUCLEAR
 	ore_data_value = 3
+	wall_damage_threshold = 5
 
 /decl/material/solid/graphite
 	name = "graphite"

--- a/code/modules/materials/definitions/solids/materials_solid_mundane.dm
+++ b/code/modules/materials/definitions/solids/materials_solid_mundane.dm
@@ -24,3 +24,4 @@
 		/decl/material/gas/sulfur_dioxide    = 0.05,
 		/decl/material/gas/carbon_dioxide    = 0.05
 	)
+	wall_damage_threshold = 10

--- a/code/modules/materials/definitions/solids/materials_solid_organic.dm
+++ b/code/modules/materials/definitions/solids/materials_solid_organic.dm
@@ -12,6 +12,7 @@
 	bakes_into_at_temperature = T0C+500
 	bakes_into_material = /decl/material/solid/carbon
 */
+	wall_damage_threshold = 5
 
 /decl/material/solid/organic/plastic
 	name = "plastic"

--- a/code/modules/materials/definitions/solids/materials_solid_stone.dm
+++ b/code/modules/materials/definitions/solids/materials_solid_stone.dm
@@ -23,6 +23,7 @@
 	ore_result_amount = 4
 	sound_manipulate = 'sound/foley/rockscrape.ogg'
 	sound_dropped    = 'sound/foley/rockscrape.ogg'
+	wall_damage_threshold = 10
 
 /decl/material/solid/stone/sandstone
 	name = "sandstone"

--- a/code/modules/materials/definitions/solids/materials_solid_wood.dm
+++ b/code/modules/materials/definitions/solids/materials_solid_wood.dm
@@ -48,6 +48,7 @@
 	compost_value = 0.2
 	temperature_burn_milestone_material = /decl/material/solid/organic/wood
 	paint_verb = "stained"
+	wall_damage_threshold = 8
 
 // Wood is hard but can't really give it an edge.
 /decl/material/solid/organic/wood/can_hold_edge()


### PR DESCRIPTION
## Description of changes
Walls are undamageable to weapons under a threshold based on material. Pointing this to stable as it is a very small PR and I would like feedback from Scav.

## Why and what will this PR improve
Fixes  #4934.

## Authorship
I coded it, Nata suggested it.

## Changelog
:cl:
tweak: Walls can only be damaged by weapons with a high enough force, based on material. This does not impact dismantling walls, or shooting them.
/:cl: