### PR TITLE
Clean up unused/defunct message server code

### DIFF
--- a/code/game/machinery/message_server.dm
+++ b/code/game/machinery/message_server.dm
@@ -48,21 +48,9 @@ var/global/list/message_servers = list()
 	active_power_usage = 100
 
 	var/list/datum/data_rc_msg/rc_msgs = list()
-	var/active = 1
+	var/active = TRUE
 	var/power_failure = 0 // Reboot timer after power outage
 	var/decryptkey = "password"
-
-	/// Spam filtering stuff. Messages having theese tokens will be rejected by server. Case sensitive.
-	var/list/spamfilter = list(
-		"You have won",
-		"your prize",
-		"male enhancement",
-		"shitcurity",
-		"are happy to inform you",
-		"account number",
-		"enter your PIN"
-	)
-	var/spamfilter_limit = MESSAGE_SERVER_DEFAULT_SPAM_LIMIT	//Maximal amount of tokens
 
 	stat_immune = 0
 	uncreated_component_parts = null
@@ -80,7 +68,7 @@ var/global/list/message_servers = list()
 /obj/machinery/network/message_server/Process()
 	..()
 	if(active && (stat & (BROKEN|NOPOWER)))
-		active = 0
+		active = FALSE
 		power_failure = 10
 		update_icon()
 		return
@@ -88,7 +76,7 @@ var/global/list/message_servers = list()
 		return
 	else if(power_failure > 0)
 		if(!(--power_failure))
-			active = 1
+			active = TRUE
 			update_icon()
 
 /obj/machinery/network/message_server/proc/send_rc_message(var/recipient = "",var/sender = "",var/message = "",var/stamp = "", var/id_auth = "", var/priority = 1)
@@ -99,6 +87,8 @@ var/global/list/message_servers = list()
 	if (stamp)
 		authmsg += "[stamp]<br>"
 	. = FALSE
+	if(!active)
+		return // message suppressed but still saved on the message server
 
 	var/datum/extension/network_device/network_device = get_extension(src, /datum/extension/network_device)
 	var/datum/computer_network/network = network_device?.get_network()
@@ -129,21 +119,11 @@ var/global/list/message_servers = list()
 /obj/machinery/network/message_server/interface_interact(mob/user)
 	if(!CanInteract(user, DefaultTopicState()))
 		return FALSE
-	to_chat(user, "You toggle PDA message passing from [active ? "On" : "Off"] to [active ? "Off" : "On"]")
+	to_chat(user, "You toggle message passing from [active ? "On" : "Off"] to [active ? "Off" : "On"]")
 	active = !active
 	power_failure = 0
 	update_icon()
 	return TRUE
-
-/obj/machinery/network/message_server/attackby(obj/item/used_item, mob/user)
-	if (active && !(stat & (BROKEN|NOPOWER)) && (spamfilter_limit < MESSAGE_SERVER_DEFAULT_SPAM_LIMIT*2) && \
-		istype(used_item,/obj/item/stock_parts/circuitboard/message_monitor))
-		spamfilter_limit += round(MESSAGE_SERVER_DEFAULT_SPAM_LIMIT / 2)
-		qdel(used_item)
-		to_chat(user, "You install additional memory and processors into \the [src]. Its filtering capabilities been enhanced.")
-		return TRUE
-	else
-		return ..()
 
 /obj/machinery/network/message_server/on_update_icon()
 	icon_state = initial(icon_state)

--- a/code/game/machinery/requests_console.dm
+++ b/code/game/machinery/requests_console.dm
@@ -107,7 +107,7 @@ var/global/req_console_information = list()
 
 	data["message"] = message
 	data["recipient"] = recipient
-	data["priortiy"] = priority
+	data["priority"] = priority
 	data["msgStamped"] = msgStamped
 	data["msgVerified"] = msgVerified
 	data["announceAuth"] = announceAuth

--- a/code/modules/events/ion_storm.dm
+++ b/code/modules/events/ion_storm.dm
@@ -108,16 +108,6 @@
 		S.add_ion_law(law)
 		S.show_laws()
 
-	for(var/z in affecting_z)
-		var/obj/machinery/network/message_server/MS = get_message_server_for_z(z)
-		if(MS)
-			MS.spamfilter.Cut()
-			var/i
-			for (i = 1, i <= MS.spamfilter_limit, i++)
-				MS.spamfilter += pick("kitty","HONK","rev","malf","liberty","freedom","drugs", "[global.using_map.station_short]", \
-					"admin","ponies","heresy","meow","Pun Pun","monkey","Ian","moron","pizza","message","spam",\
-					"director", "Hello", "Hi!"," ","nuke","crate","dwarf","xeno")
-
 /datum/event/ionstorm/tick()
 	if(botEmagChance)
 		for(var/mob/living/bot/bot in global.living_mob_list_)

--- a/nano/templates/request_console.tmpl
+++ b/nano/templates/request_console.tmpl
@@ -66,7 +66,7 @@ Used In File(s): \code\game\machinery\requests_console.dm
 	<div class="item"><b>Message sent successfully.</b></div>
 	<div class="item">{{:helper.link('Continue', 'arrowthick-1-e', { 'setScreen' : 0 })}}</div>
 {{else data.screen == 5}}
-	<div class="item"><b>An Error occurred. Message not sent.</b></div>
+	<div class="item"><b>An error occurred and your message could not be sent. Retry in 30 seconds. If the issue persists, contact your system administrator for assistance.</b></div>
 	<div class="item">{{:helper.link('Continue', 'arrowthick-1-e', { 'setScreen' : 0 })}}</div>
 {{else data.screen == 6}}
 	<div class="statusDisplay" style="overflow: auto;">
@@ -104,9 +104,9 @@ Used In File(s): \code\game\machinery\requests_console.dm
 	</div>
 {{else}}
 	{{if data.newmessagepriority == 1}}
-		<div class="item"><font color='red'>There are new messages</font></div>
+		<div class="item"><font color='red'>There are new messages.</font></div>
 	{{else data.newmessagepriority == 2}}
-		<div class="item"><font color='red'><b>NEW PRIORITY MESSAGES</b></font></div>
+		<div class="item"><font color='red'><b>NEW PRIORITY MESSAGE!</b></font></div>
 	{{/if}}
 	<div class="item">{{:helper.link('View Messages', data.newmessagepriority ? 'mail-closed' : 'mail-open', { 'setScreen' : 6 })}}</div>
 	<br>


### PR DESCRIPTION
## Description of changes
Removes the spam filter which only existed for PDAs and doesn't function. It was also a lot of meme phrases and again, not really functional. Might be worth reimplementing from scratch for spam emails, maybe as a 'hazard' for having the PLEXUS extranet on, or a consequence of ""malware""?

The PDA message-passing toggle on the messaging server now applies to requests console messages.

The requests console UI has some slightly improved wording and a variable is now named "priority" instead of "priortiy".

## Why and what will this PR improve
Removes some defunct code.

## Authorship
Me

## Changelog
:cl:
tweak: Deactivating message passing on the message server now prevents requests console messages from being received. They will still be logged for admins and on the in-game message server console.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->