### PR TITLE
Make the base law upload console an abstract type

### DIFF
--- a/code/game/machinery/computer/law.dm
+++ b/code/game/machinery/computer/law.dm
@@ -1,4 +1,5 @@
 /obj/machinery/computer/upload
+	abstract_type = /obj/machinery/computer/upload
 	name = "unused upload console"
 	icon_keyboard = "rd_key"
 	icon_screen = "command"


### PR DESCRIPTION
## Description of changes
`/obj/machinery/computer/upload` is now an abstract type.

## Why and what will this PR improve
It should never be mapped in or spawned, and this prevents that.

## Authorship
Me.