### PR TITLE
Lighting: Corner Z-Bleed & Z-ambience rewrite

### DIFF
--- a/code/__defines/lighting.dm
+++ b/code/__defines/lighting.dm
@@ -25,6 +25,11 @@
 #define TURF_IS_AMBIENT_LIT_UNSAFE(T) (T:ambient_active)
 #define TURF_IS_AMBIENT_LIT(T) (isturf(T) && TURF_IS_AMBIENT_LIT_UNSAFE(T))
 
+// The relation of these is important.
+#define LIGHTING_CORNER_GENERATE_UP    1
+#define LIGHTING_CORNER_GENERATE_BOTH  0
+#define LIGHTING_CORNER_GENERATE_DOWN -1
+
 // If I were you I'd leave this alone.
 #define LIGHTING_BASE_MATRIX \
 	list            \

--- a/code/__defines/lighting.dm
+++ b/code/__defines/lighting.dm
@@ -25,7 +25,7 @@
 #define TURF_IS_AMBIENT_LIT_UNSAFE(T) (T:ambient_active)
 #define TURF_IS_AMBIENT_LIT(T) (isturf(T) && TURF_IS_AMBIENT_LIT_UNSAFE(T))
 
-// The relation of these is important.
+// These are centered around zero to simplify logic; 'up' is 'is greater than -1', 'down' is 'is less than 0'. 0 matches both conditions.
 #define LIGHTING_CORNER_GENERATE_UP    1
 #define LIGHTING_CORNER_GENERATE_BOTH  0
 #define LIGHTING_CORNER_GENERATE_DOWN -1

--- a/code/game/turfs/turf_changing.dm
+++ b/code/game/turfs/turf_changing.dm
@@ -152,7 +152,7 @@
 	var/new_z_opacity = z_flags & ZM_ALLOW_LIGHTING
 	if (new_z_opacity != old_z_opacity)
 		for (var/datum/lighting_corner/corn in corners)
-			corn.rebuild_ztraversal(!new_z_opacity)
+			corn.generate_z_connections()
 
 	var/tidlu = TURF_IS_DYNAMICALLY_LIT_UNSAFE(src)
 	if ((old_opacity != opacity) || (tidlu != old_dynamic_lighting) || force_lighting_update)

--- a/code/modules/lighting/ambient_turf.dm
+++ b/code/modules/lighting/ambient_turf.dm
@@ -18,7 +18,11 @@
 	ambient_light = isnull(color) ? ambient_light : color
 	ambient_light_multiplier = isnull(multiplier) ? ambient_light_multiplier : multiplier
 
-	update_ambient_light()
+	// If we haven't initialized our corners yet, do that instead to avoid ambience double-init.
+	if (!corners || !lighting_corners_initialised)
+		generate_missing_corners()
+	else
+		update_ambient_light()
 
 /// Replace one ambient light with another. This is effectively a delta update, but it can be used to pretend that our one channel is doing color blending.
 /turf/proc/replace_ambient_light(old_color, new_color, old_multiplier, new_multiplier = 0)
@@ -79,13 +83,12 @@
 	ambient_light_old_g += lg
 	ambient_light_old_b += lb
 
-	if (TURF_IS_DYNAMICALLY_LIT_UNSAFE(src))
-		if (!corners || !lighting_corners_initialised)
-			generate_missing_corners()
+	if (TURF_IS_DYNAMICALLY_LIT_UNSAFE(src) && (!corners || !lighting_corners_initialised))
+		generate_missing_corners()
 
-		// This list can contain nulls on things like space turfs -- they only have their neighbors' corners.
-		for (var/datum/lighting_corner/C in corners)
-			C.update_ambient_lumcount(lr, lg, lb, !update)
+	// This list can contain nulls on things like space turfs -- they only have their neighbors' corners.
+	for (var/datum/lighting_corner/C in corners)
+		C.update_ambient_lumcount(lr, lg, lb, !update)
 
 	if (!ambient_active)
 		SSlighting.total_ambient_turfs += 1

--- a/code/modules/lighting/lighting_corner.dm
+++ b/code/modules/lighting/lighting_corner.dm
@@ -198,8 +198,8 @@ var/global/list/REVERSE_LIGHTING_CORNER_DIAGONAL = list(0, 0, 0, 0, 3, 4, 0, 0, 
 			Downward: check if self is ALLOW_LIGHTING and below
 
 		This corner will be shared by all four of its turfs, so it doesn't matter which condition passes.
-		The above/below corners should be created iff one of the masters is considered dynamically lit, including dynamic promotion. No other condition matters, and light is not
-			allowed to transmit through a static lit turf, even if it is marked as ZM_ALLOW_LIGHTING.
+		The above/below corners should be created if the master has a Z-connection and is ALLOW_LIGHTING, regardless of if it's actually dynamic. This allows light to shine
+			through Z-turfs that are themselves not dynamic.
 	*/
 
 	// BOTH is 0, so it's true for both conditions.
@@ -218,25 +218,25 @@ var/global/list/REVERSE_LIGHTING_CORNER_DIAGONAL = list(0, 0, 0, 0, 3, 4, 0, 0, 
 		It's just the same block of code repeated four times (for each master), plus the case of there now being no above corner, but previously having had one.
 		We also only initialize the one corner we need rather than all four since there's no benefit to initializing them all -- if a true light needs them, it'll make them itself.
 	*/
-	if      (t1 && (T = t1.above || GET_ABOVE(t1)) && (T.z_flags & ZM_ALLOW_LIGHTING) && TURF_IS_DYNAMICALLY_LIT_UNSAFE(T))
+	if      (t1 && (T = t1.above || GET_ABOVE(t1)) && (T.z_flags & ZM_ALLOW_LIGHTING))
 		if (!(above_corner = T.corners?[t1i]) && GOING_UP)
 			if (!T.corners)
 				T.corners = new(4)
 			T.corners[t1i] = new/datum/lighting_corner(T, LIGHTING_CORNER_DIAGONAL[t1i], t1i, LIGHTING_CORNER_GENERATE_UP)
 			above_corner = T.corners[t1i]
-	else if (t2 && (T = t2.above || GET_ABOVE(t2)) && (T.z_flags & ZM_ALLOW_LIGHTING) && TURF_IS_DYNAMICALLY_LIT_UNSAFE(T))
+	else if (t2 && (T = t2.above || GET_ABOVE(t2)) && (T.z_flags & ZM_ALLOW_LIGHTING))
 		if (!(above_corner = T.corners?[t2i]) && GOING_UP)
 			if (!T.corners)
 				T.corners = new(4)
 			T.corners[t2i] = new/datum/lighting_corner(T, LIGHTING_CORNER_DIAGONAL[t2i], t2i, LIGHTING_CORNER_GENERATE_UP)
 			above_corner = T.corners[t2i]
-	else if (t3 && (T = t3.above || GET_ABOVE(t3)) && (T.z_flags & ZM_ALLOW_LIGHTING) && TURF_IS_DYNAMICALLY_LIT_UNSAFE(T))
+	else if (t3 && (T = t3.above || GET_ABOVE(t3)) && (T.z_flags & ZM_ALLOW_LIGHTING))
 		if (!(above_corner = T.corners?[t3i]) && GOING_UP)
 			if (!T.corners)
 				T.corners = new(4)
 			T.corners[t3i] = new/datum/lighting_corner(T, LIGHTING_CORNER_DIAGONAL[t3i], t3i, LIGHTING_CORNER_GENERATE_UP)
 			above_corner = T.corners[t3i]
-	else if (t4 && (T = t4.above || GET_ABOVE(t4)) && (T.z_flags & ZM_ALLOW_LIGHTING) && TURF_IS_DYNAMICALLY_LIT_UNSAFE(T))
+	else if (t4 && (T = t4.above || GET_ABOVE(t4)) && (T.z_flags & ZM_ALLOW_LIGHTING))
 		if (!(above_corner = T.corners?[t4i]) && GOING_UP)
 			if (!T.corners)
 				T.corners = new(4)
@@ -280,25 +280,25 @@ var/global/list/REVERSE_LIGHTING_CORNER_DIAGONAL = list(0, 0, 0, 0, 3, 4, 0, 0, 
 					SSlighting.corner_queue += corn
 
 	// As above, so below. The ordering here is a bit different from the above block, check the comment at the top of this proc.
-	if      ((t1?.z_flags & ZM_ALLOW_LIGHTING) && (T = t1.below || GET_BELOW(t1)) && TURF_IS_DYNAMICALLY_LIT_UNSAFE(T))
+	if      ((t1?.z_flags & ZM_ALLOW_LIGHTING) && (T = t1.below || GET_BELOW(t1)))
 		if (!(below_corner = T.corners?[t1i]) && GOING_DOWN)
 			if (!T.corners)
 				T.corners = new(4)
 			T.corners[t1i] = new/datum/lighting_corner(T, LIGHTING_CORNER_DIAGONAL[t1i], t1i, LIGHTING_CORNER_GENERATE_DOWN)
 			below_corner = T.corners[t1i]
-	else if ((t2?.z_flags & ZM_ALLOW_LIGHTING) && (T = t2.below || GET_BELOW(t2)) && TURF_IS_DYNAMICALLY_LIT_UNSAFE(T))
+	else if ((t2?.z_flags & ZM_ALLOW_LIGHTING) && (T = t2.below || GET_BELOW(t2)))
 		if (!(below_corner = T.corners?[t2i]) && GOING_DOWN)
 			if (!T.corners)
 				T.corners = new(4)
 			T.corners[t2i] = new/datum/lighting_corner(T, LIGHTING_CORNER_DIAGONAL[t2i], t2i, LIGHTING_CORNER_GENERATE_DOWN)
 			below_corner = T.corners[t2i]
-	else if ((t3?.z_flags & ZM_ALLOW_LIGHTING) && (T = t3.below || GET_BELOW(t3)) && TURF_IS_DYNAMICALLY_LIT_UNSAFE(T))
+	else if ((t3?.z_flags & ZM_ALLOW_LIGHTING) && (T = t3.below || GET_BELOW(t3)))
 		if (!(below_corner = T.corners?[t3i]) && GOING_DOWN)
 			if (!T.corners)
 				T.corners = new(4)
 			T.corners[t3i] = new/datum/lighting_corner(T, LIGHTING_CORNER_DIAGONAL[t3i], t3i, LIGHTING_CORNER_GENERATE_DOWN)
 			below_corner = T.corners[t3i]
-	else if ((t4?.z_flags & ZM_ALLOW_LIGHTING) && (T = t4.below || GET_BELOW(t4)) && TURF_IS_DYNAMICALLY_LIT_UNSAFE(T))
+	else if ((t4?.z_flags & ZM_ALLOW_LIGHTING) && (T = t4.below || GET_BELOW(t4)))
 		if (!(below_corner = T.corners?[t4i]) && GOING_DOWN)
 			if (!T.corners)
 				T.corners = new(4)

--- a/code/modules/lighting/lighting_corner.dm
+++ b/code/modules/lighting/lighting_corner.dm
@@ -22,6 +22,11 @@ var/global/list/REVERSE_LIGHTING_CORNER_DIAGONAL = list(0, 0, 0, 0, 3, 4, 0, 0, 
 	var/turf/t4
 	var/t4i
 
+	/// If a connection for z-lights exists, the corner above us.
+	var/datum/lighting_corner/above_corner
+	/// If a connection for z-lights exists, the corner below us.
+	var/datum/lighting_corner/below_corner
+
 	var/list/datum/light_source/affecting // Light sources affecting us.
 	var/active                            = FALSE  // TRUE if one of our masters has dynamic lighting.
 
@@ -34,7 +39,7 @@ var/global/list/REVERSE_LIGHTING_CORNER_DIAGONAL = list(0, 0, 0, 0, 3, 4, 0, 0, 
 	var/self_g = 0
 	var/self_b = 0
 
-	// The intensity we're inheriting from the turf below us, if we're a Z-turf. This is a sum of all below turfs in the Z-stack.
+	// The intensity we're inheriting from the turfs below us, if we're a Z-turf. This is a sum of all below turfs.
 	var/below_r = 0
 	var/below_g = 0
 	var/below_b = 0
@@ -44,7 +49,7 @@ var/global/list/REVERSE_LIGHTING_CORNER_DIAGONAL = list(0, 0, 0, 0, 3, 4, 0, 0, 
 	var/ambient_g = 0
 	var/ambient_b = 0
 
-	// The turf above us' ambient
+	// The turf above us' ambient values.
 	var/above_ambient_r = 0
 	var/above_ambient_g = 0
 	var/above_ambient_b = 0
@@ -61,7 +66,7 @@ var/global/list/REVERSE_LIGHTING_CORNER_DIAGONAL = list(0, 0, 0, 0, 3, 4, 0, 0, 
 	var/cache_b  = 0
 	var/cache_mx = 0
 
-/datum/lighting_corner/New(turf/new_turf, diagonal, oi)
+/datum/lighting_corner/New(turf/new_turf, diagonal, oi, direction = LIGHTING_CORNER_GENERATE_BOTH)
 	SSlighting.total_lighting_corners += 1
 
 	var/has_ambience = FALSE
@@ -125,9 +130,10 @@ var/global/list/REVERSE_LIGHTING_CORNER_DIAGONAL = list(0, 0, 0, 0, 3, 4, 0, 0, 
 		if (TURF_IS_AMBIENT_LIT_UNSAFE(T))
 			has_ambience = TRUE
 
-	update_active()
 	if (has_ambience)
 		init_ambient()
+	generate_z_connections(direction)
+	update_active()
 
 #define OVERLAY_PRESENT(T) (T && T.lighting_overlay)
 
@@ -144,6 +150,7 @@ var/global/list/REVERSE_LIGHTING_CORNER_DIAGONAL = list(0, 0, 0, 0, 3, 4, 0, 0, 
 
 #define UPDATE_APPARENT(T, CH) T.apparent_##CH = T.self_##CH + T.below_##CH + T.ambient_##CH + T.above_ambient_##CH
 
+// Configure ambient lighting for *just* this corner. This deliberately does not handle Z-propagation, that's managed by generate_z_connections().
 /datum/lighting_corner/proc/init_ambient()
 	var/sum_r = 0
 	var/sum_g = 0
@@ -171,7 +178,182 @@ var/global/list/REVERSE_LIGHTING_CORNER_DIAGONAL = list(0, 0, 0, 0, 3, 4, 0, 0, 
 	sum_g /= 4
 	sum_b /= 4
 
-	update_ambient_lumcount(sum_r, sum_g, sum_b)
+	ambient_r += sum_r
+	ambient_g += sum_g
+	ambient_b += sum_b
+
+	UPDATE_APPARENT(src, r)
+	UPDATE_APPARENT(src, g)
+	UPDATE_APPARENT(src, b)
+
+	if (!needs_update)
+		needs_update = TRUE
+		SSlighting.corner_queue += src
+
+/datum/lighting_corner/proc/generate_z_connections(direction = LIGHTING_CORNER_GENERATE_BOTH)
+	/*
+		ZM_ALLOW_LIGHTING means that a z-turf is lighting-connected to the turf below it.
+		So:
+			Upward: check if above and above is ALLOW_LIGHTING
+			Downward: check if self is ALLOW_LIGHTING and below
+
+		This corner will be shared by all four of its turfs, so it doesn't matter which condition passes.
+		The above/below corners should be created iff one of the masters is considered dynamically lit, including dynamic promotion. No other condition matters, and light is not
+			allowed to transmit through a static lit turf, even if it is marked as ZM_ALLOW_LIGHTING.
+	*/
+
+	// BOTH is 0, so it's true for both conditions.
+	// Sometimes we need to only generate going upwards (or downwards); if this corner was created by another corner using this proc, then generating downward is invalid and causes infinite recursion.
+	// We still need to scan downward (or upward) to find the new connection in this case though.
+	#define GOING_UP (direction > LIGHTING_CORNER_GENERATE_DOWN)
+	#define GOING_DOWN (direction < LIGHTING_CORNER_GENERATE_UP)
+
+	var/turf/T
+
+	var/datum/lighting_corner/old_above_corner = above_corner
+	var/datum/lighting_corner/old_below_corner = below_corner
+
+	/*
+		This brick is responsible for finding the corner that's directly above us, and forcibly generating the corner if it doesn't exist yet.
+		It's just the same block of code repeated four times (for each master), plus the case of there now being no above corner, but previously having had one.
+		We also only initialize the one corner we need rather than all four since there's no benefit to initializing them all -- if a true light needs them, it'll make them itself.
+	*/
+	if      (t1 && (T = t1.above || GET_ABOVE(t1)) && (T.z_flags & ZM_ALLOW_LIGHTING) && TURF_IS_DYNAMICALLY_LIT_UNSAFE(T))
+		if (!(above_corner = T.corners?[t1i]) && GOING_UP)
+			if (!T.corners)
+				T.corners = new(4)
+			T.corners[t1i] = new/datum/lighting_corner(T, LIGHTING_CORNER_DIAGONAL[t1i], t1i, LIGHTING_CORNER_GENERATE_UP)
+			above_corner = T.corners[t1i]
+	else if (t2 && (T = t2.above || GET_ABOVE(t2)) && (T.z_flags & ZM_ALLOW_LIGHTING) && TURF_IS_DYNAMICALLY_LIT_UNSAFE(T))
+		if (!(above_corner = T.corners?[t2i]) && GOING_UP)
+			if (!T.corners)
+				T.corners = new(4)
+			T.corners[t2i] = new/datum/lighting_corner(T, LIGHTING_CORNER_DIAGONAL[t2i], t2i, LIGHTING_CORNER_GENERATE_UP)
+			above_corner = T.corners[t2i]
+	else if (t3 && (T = t3.above || GET_ABOVE(t3)) && (T.z_flags & ZM_ALLOW_LIGHTING) && TURF_IS_DYNAMICALLY_LIT_UNSAFE(T))
+		if (!(above_corner = T.corners?[t3i]) && GOING_UP)
+			if (!T.corners)
+				T.corners = new(4)
+			T.corners[t3i] = new/datum/lighting_corner(T, LIGHTING_CORNER_DIAGONAL[t3i], t3i, LIGHTING_CORNER_GENERATE_UP)
+			above_corner = T.corners[t3i]
+	else if (t4 && (T = t4.above || GET_ABOVE(t4)) && (T.z_flags & ZM_ALLOW_LIGHTING) && TURF_IS_DYNAMICALLY_LIT_UNSAFE(T))
+		if (!(above_corner = T.corners?[t4i]) && GOING_UP)
+			if (!T.corners)
+				T.corners = new(4)
+			T.corners[t4i] = new/datum/lighting_corner(T, LIGHTING_CORNER_DIAGONAL[t4i], t4i, LIGHTING_CORNER_GENERATE_UP)
+			above_corner = T.corners[t4i]
+	else if (above_corner)	// connected -> disconnected transition
+		/*
+			The corner directly above us contains the sum of the light that comes from us and everything below us, which is conveniently everything that we need to remove.
+			We iterate up through the stack removing only the above_corner's light contribution, as to not disturb light sourced from other turfs higher in the stack.
+		*/
+		for (var/datum/lighting_corner/corn = above_corner; corn; corn = corn.above_corner)
+			corn.below_r -= above_corner.below_r
+			corn.below_g -= above_corner.below_g
+			corn.below_b -= above_corner.below_b
+
+			UPDATE_APPARENT(corn, r)
+			UPDATE_APPARENT(corn, g)
+			UPDATE_APPARENT(corn, b)
+
+			if (!corn.needs_update)
+				corn.needs_update = TRUE
+				SSlighting.corner_queue += corn
+
+		above_corner.below_corner = null
+		above_corner = null
+
+	if (!old_above_corner && above_corner)	// disconnected -> connected transition
+		if (!(apparent_r == apparent_g == apparent_b == 0))
+			for (var/datum/lighting_corner/corn = above_corner; corn; corn = corn.above_corner)
+				// We can't just steal the precomputed value from the above like we can in the removal case: our effect on the turf above us is our own self-light plus the light below us.
+				corn.below_r += src.below_r + src.self_r
+				corn.below_g += src.below_g + src.self_g
+				corn.below_b += src.below_b + src.self_b
+
+				UPDATE_APPARENT(corn, r)
+				UPDATE_APPARENT(corn, g)
+				UPDATE_APPARENT(corn, b)
+
+				if (!corn.needs_update)
+					corn.needs_update = TRUE
+					SSlighting.corner_queue += corn
+
+	// As above, so below. The ordering here is a bit different from the above block, check the comment at the top of this proc.
+	if      ((t1?.z_flags & ZM_ALLOW_LIGHTING) && (T = t1.below || GET_BELOW(t1)) && TURF_IS_DYNAMICALLY_LIT_UNSAFE(T))
+		if (!(below_corner = T.corners?[t1i]) && GOING_DOWN)
+			if (!T.corners)
+				T.corners = new(4)
+			T.corners[t1i] = new/datum/lighting_corner(T, LIGHTING_CORNER_DIAGONAL[t1i], t1i, LIGHTING_CORNER_GENERATE_DOWN)
+			below_corner = T.corners[t1i]
+	else if ((t2?.z_flags & ZM_ALLOW_LIGHTING) && (T = t2.below || GET_BELOW(t2)) && TURF_IS_DYNAMICALLY_LIT_UNSAFE(T))
+		if (!(below_corner = T.corners?[t2i]) && GOING_DOWN)
+			if (!T.corners)
+				T.corners = new(4)
+			T.corners[t2i] = new/datum/lighting_corner(T, LIGHTING_CORNER_DIAGONAL[t2i], t2i, LIGHTING_CORNER_GENERATE_DOWN)
+			below_corner = T.corners[t2i]
+	else if ((t3?.z_flags & ZM_ALLOW_LIGHTING) && (T = t3.below || GET_BELOW(t3)) && TURF_IS_DYNAMICALLY_LIT_UNSAFE(T))
+		if (!(below_corner = T.corners?[t3i]) && GOING_DOWN)
+			if (!T.corners)
+				T.corners = new(4)
+			T.corners[t3i] = new/datum/lighting_corner(T, LIGHTING_CORNER_DIAGONAL[t3i], t3i, LIGHTING_CORNER_GENERATE_DOWN)
+			below_corner = T.corners[t3i]
+	else if ((t4?.z_flags & ZM_ALLOW_LIGHTING) && (T = t4.below || GET_BELOW(t4)) && TURF_IS_DYNAMICALLY_LIT_UNSAFE(T))
+		if (!(below_corner = T.corners?[t4i]) && GOING_DOWN)
+			if (!T.corners)
+				T.corners = new(4)
+			T.corners[t4i] = new/datum/lighting_corner(T, LIGHTING_CORNER_DIAGONAL[t4i], t4i, LIGHTING_CORNER_GENERATE_DOWN)
+			below_corner = T.corners[t4i]
+	else if (below_corner)	// connected -> disconnected transition
+		/*
+			Similar case to above, but not quite the same.
+			The corner below us' `above_ambient_*` var contins both our contributed light as well as turfs above us, so just subtract that instead of combining both vars manually.
+		*/
+		for (var/datum/lighting_corner/corn = below_corner; corn; corn = corn.below_corner)
+			corn.above_ambient_r -= below_corner.above_ambient_r
+			corn.above_ambient_g -= below_corner.above_ambient_g
+			corn.above_ambient_b -= below_corner.above_ambient_b
+
+			UPDATE_APPARENT(corn, r)
+			UPDATE_APPARENT(corn, g)
+			UPDATE_APPARENT(corn, b)
+
+			if (!corn.needs_update)
+				corn.needs_update = TRUE
+				SSlighting.corner_queue += corn
+
+		below_corner.above_corner = null
+		below_corner = null
+
+	if (!old_below_corner && below_corner)	// disconnected -> connected transition
+		// quick and dirty heuristic to avoid checking a bunch of different vars, it's still valid if we needlessly run this
+		if (!(apparent_r == apparent_g == apparent_b == 0))
+			for (var/datum/lighting_corner/corn = below_corner; corn; corn = corn.below_corner)
+				// As with above, we can't just steal the precomputed value from our neighbor. Our effect will be the sum effect of turfs above us, plus our effect.
+				corn.above_ambient_r += src.above_ambient_r + src.ambient_r
+				corn.above_ambient_g += src.above_ambient_g + src.ambient_g
+				corn.above_ambient_b += src.above_ambient_b + src.ambient_b
+
+				UPDATE_APPARENT(corn, r)
+				UPDATE_APPARENT(corn, g)
+				UPDATE_APPARENT(corn, b)
+
+				if (!corn.needs_update)
+					corn.needs_update = TRUE
+					SSlighting.corner_queue += corn
+
+	if (above_corner)
+		ASSERT(x == above_corner.x)
+		ASSERT(y == above_corner.y)
+		ASSERT(z == above_corner.z - 1)
+
+	if (below_corner)
+		ASSERT(x == below_corner.x)
+		ASSERT(y == below_corner.y)
+		ASSERT(z == below_corner.z + 1)
+
+#undef GOING_UP
+#undef GOING_DOWN
 
 // God that was a mess, now to do the rest of the corner code! Hooray!
 /datum/lighting_corner/proc/update_lumcount(delta_r, delta_g, delta_b, now = FALSE)
@@ -186,29 +368,19 @@ var/global/list/REVERSE_LIGHTING_CORNER_DIAGONAL = list(0, 0, 0, 0, 3, 4, 0, 0, 
 	UPDATE_APPARENT(src, g)
 	UPDATE_APPARENT(src, b)
 
-	var/turf/T
-	var/Ti
-	// Grab the first master that's a Z-turf, if one exists.
-	// The above var cannot be relied on due to init ordering, but we can use it if it is set.
-	if (t1 && (T = t1.above || GET_ABOVE(t1)) && (T.z_flags & ZM_ALLOW_LIGHTING))
-		Ti = t1i
-	else if (t2 && (T = t2.above || GET_ABOVE(t2)) && (T.z_flags & ZM_ALLOW_LIGHTING))
-		Ti = t2i
-	else if (t3 && (T = t3.above || GET_ABOVE(t3)) && (T.z_flags & ZM_ALLOW_LIGHTING))
-		Ti = t3i
-	else if (t4 && (T = t4.above || GET_ABOVE(t4)) && (T.z_flags & ZM_ALLOW_LIGHTING))
-		Ti = t4i
-	else	// Nothing above us that cares about below light.
-		T = null
+	for (var/datum/lighting_corner/corn = above_corner; corn; corn = corn.above_corner)
+		corn.below_r += delta_r
+		corn.below_g += delta_g
+		corn.below_b += delta_b
 
-	if (TURF_IS_DYNAMICALLY_LIT(T))
-		do
-			if (!T.corners || !T.corners[Ti])
-				T.generate_missing_corners()
+		UPDATE_APPARENT(corn, r)
+		UPDATE_APPARENT(corn, g)
+		UPDATE_APPARENT(corn, b)
 
-			// Above corners never get instant updates; they're less important, so better to avoid risk of lag.
-			T.corners[Ti].update_below_lumcount(delta_r, delta_g, delta_b)
-		while ((T = T.above) && (T.z_flags & ZM_ALLOW_LIGHTING))
+		// These are always queued, players are far less likely to notice these being a little behind.
+		if (!corn.needs_update)
+			corn.needs_update = TRUE
+			SSlighting.corner_queue += corn
 
 	// This needs to be down here instead of the above if so the lum values are properly updated.
 	if (needs_update)
@@ -220,25 +392,6 @@ var/global/list/REVERSE_LIGHTING_CORNER_DIAGONAL = list(0, 0, 0, 0, 3, 4, 0, 0, 
 		needs_update = TRUE
 		SSlighting.corner_queue += src
 
-/datum/lighting_corner/proc/update_below_lumcount(delta_r, delta_g, delta_b)
-	if (!(delta_r + delta_g + delta_b))
-		return
-
-	below_r += delta_r
-	below_g += delta_g
-	below_b += delta_b
-
-	UPDATE_APPARENT(src, r)
-	UPDATE_APPARENT(src, g)
-	UPDATE_APPARENT(src, b)
-
-	// This needs to be down here instead of the above if so the lum values are properly updated.
-	if (needs_update)
-		return
-
-	needs_update = TRUE
-	SSlighting.corner_queue += src
-
 /datum/lighting_corner/proc/update_ambient_lumcount(delta_r, delta_g, delta_b, skip_update = FALSE)
 
 	ambient_r += delta_r
@@ -249,46 +402,18 @@ var/global/list/REVERSE_LIGHTING_CORNER_DIAGONAL = list(0, 0, 0, 0, 3, 4, 0, 0, 
 	UPDATE_APPARENT(src, g)
 	UPDATE_APPARENT(src, b)
 
-	var/turf/T
-	var/Ti
+	for (var/datum/lighting_corner/corn = below_corner; corn; corn = corn.below_corner)
+		corn.above_ambient_r += delta_r
+		corn.above_ambient_g += delta_g
+		corn.above_ambient_b += delta_b
 
-	if (t1)
-		T = t1
-		Ti = t1i
-	else if (t2)
-		T = t2
-		Ti = t2i
-	else if (t3)
-		T = t3
-		Ti = t3i
-	else if (t4)
-		T = t4
-		Ti = t4i
-	else
-		// This should be impossible to reach -- how do we exist without at least one master turf?
-		CRASH("Corner has no masters!")
+		UPDATE_APPARENT(corn, r)
+		UPDATE_APPARENT(corn, g)
+		UPDATE_APPARENT(corn, b)
 
-	var/datum/lighting_corner/below = src
-
-	// We init before Z-Mimic, cannot rely on above/below.
-	while ((T = GET_BELOW(T)) && ((below.t1?.z_flags | below.t2?.z_flags | below.t3?.z_flags | below.t4?.z_flags) & ZM_ALLOW_LIGHTING) && TURF_IS_DYNAMICALLY_LIT_UNSAFE(T))
-		if (!T.corners || !T.corners[Ti])
-			T.generate_missing_corners()
-
-		ASSERT(T.corners?.len)
-
-		below = T.corners[Ti]
-		below.above_ambient_r += delta_r
-		below.above_ambient_g += delta_g
-		below.above_ambient_b += delta_b
-
-		UPDATE_APPARENT(below, r)
-		UPDATE_APPARENT(below, g)
-		UPDATE_APPARENT(below, b)
-
-		if (!skip_update && !below.needs_update)
-			below.needs_update = TRUE
-			SSlighting.corner_queue += below
+		if (!skip_update && !corn.needs_update)
+			corn.needs_update = TRUE
+			SSlighting.corner_queue += corn
 
 	if (needs_update || skip_update)
 		return
@@ -302,7 +427,7 @@ var/global/list/REVERSE_LIGHTING_CORNER_DIAGONAL = list(0, 0, 0, 0, 3, 4, 0, 0, 
 	var/lg = apparent_g
 	var/lb = apparent_b
 
-	// Cache these values a head of time so 4 individual lighting overlays don't all calculate them individually.
+	// Cache these values ahead of time so 4 individual lighting overlays don't all calculate them individually.
 	var/mx = max(lr, lg, lb) // Scale it so 1 is the strongest lum, if it is above 1.
 	. = 1 // factor
 	if (mx > 1)
@@ -330,75 +455,6 @@ var/global/list/REVERSE_LIGHTING_CORNER_DIAGONAL = list(0, 0, 0, 0, 3, 4, 0, 0, 
 			else if (!Ov.needs_update)
 				Ov.needs_update = TRUE
 				SSlighting.overlay_queue += Ov
-
-// This is called when our turf's downward Z-opacity changes.
-/datum/lighting_corner/proc/rebuild_ztraversal(new_opacity)
-	/*
-		If opacity transitions to off:
-		- Look down stack, removing below lights contributing to us
-		- Look up stack, updating turfs with our new below lighting value
-		If opacity transitions to on:
-		- Look down stack, add below contributors
-		- Look up stack, updating turfs with our new below lighting value
-	*/
-	below_r = below_g = below_b = 0
-	var/turf/T = null
-	var/datum/lighting_corner/Tcorn = src
-	var/Ti
-
-	if (!new_opacity)
-		for (;;)
-			if (Tcorn.t1 && (T = Tcorn.t1.below || GET_BELOW(Tcorn.t1)) && (T.above?.z_flags & ZM_ALLOW_LIGHTING))
-				Ti = Tcorn.t1i
-			else if (Tcorn.t2 && (T = Tcorn.t2.below || GET_BELOW(Tcorn.t2)) && (T.above?.z_flags & ZM_ALLOW_LIGHTING))
-				Ti = Tcorn.t2i
-			else if (Tcorn.t3 && (T = Tcorn.t3.below || GET_BELOW(Tcorn.t3)) && (T.above?.z_flags & ZM_ALLOW_LIGHTING))
-				Ti = Tcorn.t3i
-			else if (Tcorn.t4 && (T = Tcorn.t4.below || GET_BELOW(Tcorn.t4)) && (T.above?.z_flags & ZM_ALLOW_LIGHTING))
-				Ti = Tcorn.t4i
-			else	// Nothing above us that cares about below light.
-				break
-
-			Tcorn = T.corners[Ti]
-			below_r += Tcorn.apparent_r
-			below_g += Tcorn.apparent_g
-			below_b += Tcorn.apparent_b
-
-	UPDATE_APPARENT(src, r)
-	UPDATE_APPARENT(src, g)
-	UPDATE_APPARENT(src, b)
-
-	if (!needs_update)
-		needs_update = TRUE
-		SSlighting.corner_queue += src
-
-	T = null
-	Tcorn = src
-
-	for (;;)
-		if (Tcorn.t1 && (T = Tcorn.t1.above || GET_ABOVE(Tcorn.t1)) && (T.z_flags & ZM_ALLOW_LIGHTING))
-			Ti = Tcorn.t1i
-		else if (Tcorn.t2 && (T = Tcorn.t2.above || GET_ABOVE(Tcorn.t2)) && (T.z_flags & ZM_ALLOW_LIGHTING))
-			Ti = Tcorn.t2i
-		else if (Tcorn.t3 && (T = Tcorn.t3.above || GET_ABOVE(Tcorn.t3)) && (T.z_flags & ZM_ALLOW_LIGHTING))
-			Ti = Tcorn.t3i
-		else if (Tcorn.t4 && (T = Tcorn.t4.above || GET_ABOVE(Tcorn.t4)) && (T.z_flags & ZM_ALLOW_LIGHTING))
-			Ti = Tcorn.t4i
-		else	// Nothing above us that cares about below light.
-			break
-
-		Tcorn = T.corners[Ti]
-		Tcorn.below_r += apparent_r
-		Tcorn.below_g += apparent_g
-		Tcorn.below_b += apparent_b
-
-		UPDATE_APPARENT(Tcorn, r)
-		UPDATE_APPARENT(Tcorn, g)
-		UPDATE_APPARENT(Tcorn, b)
-
-		if (!Tcorn.needs_update)
-			Tcorn.needs_update = TRUE
-			SSlighting.corner_queue += Tcorn
 
 /datum/lighting_corner/Destroy(force = FALSE)
 	PRINT_STACK_TRACE("Someone [force ? "force-" : ""]deleted a lighting corner.")

--- a/code/modules/lighting/lighting_source.dm
+++ b/code/modules/lighting/lighting_source.dm
@@ -347,6 +347,7 @@
 	var/test_y
 
 	var/should_do_wedge = light_angle && !facing_opaque
+	var/is_dyn_or_adj
 
 	FOR_DVIEW(T, NONUNIT_CEILING(actual_range, 1), source_turf, 0) do
 		if (should_do_wedge)	// Directional lighting coordinate filter.
@@ -361,7 +362,7 @@
 		// These checks are inlined from generate_missing_corners. They must be kept (roughly) in sync. This one intentionally does not check for ambient turfs.
 		is_dyn_or_adj = TURF_IS_DYNAMICALLY_LIT_UNSAFE(T)
 		if (!is_dyn_or_adj)
-			for (var/turf/Tneigh as anything in RANGE_TURFS(1, T))
+			for (var/turf/Tneigh as anything in RANGE_TURFS(T, 1))
 				if (TURF_IS_DYNAMICALLY_LIT_UNSAFE(Tneigh))
 					is_dyn_or_adj = TRUE
 					break

--- a/code/modules/lighting/lighting_source.dm
+++ b/code/modules/lighting/lighting_source.dm
@@ -357,9 +357,17 @@
 			if ((DETERMINANT(limit_a_x, limit_a_y, test_x, test_y) > 0) || DETERMINANT(test_x, test_y, limit_b_x, limit_b_y) > 0)
 				continue
 
-		Tcorners = T.corners
+		// If we're shining a light from a static lit turf onto a dynamic lit one, we do actually want to create corners to light that turf.
 		// These checks are inlined from generate_missing_corners. They must be kept (roughly) in sync. This one intentionally does not check for ambient turfs.
-		if (TURF_IS_DYNAMICALLY_LIT_UNSAFE(T))
+		is_dyn_or_adj = TURF_IS_DYNAMICALLY_LIT_UNSAFE(T)
+		if (!is_dyn_or_adj)
+			for (var/turf/Tneigh as anything in RANGE_TURFS(1, T))
+				if (TURF_IS_DYNAMICALLY_LIT_UNSAFE(Tneigh))
+					is_dyn_or_adj = TRUE
+					break
+
+		Tcorners = T.corners
+		if (is_dyn_or_adj)
 			if (!T.lighting_corners_initialised)
 				T.lighting_corners_initialised = TRUE
 

--- a/code/modules/lighting/lighting_source.dm
+++ b/code/modules/lighting/lighting_source.dm
@@ -358,8 +358,8 @@
 				continue
 
 		Tcorners = T.corners
-		// These checks are inlined from generate_missing_corners. They must be kept in sync.
-		if (TURF_IS_DYNAMICALLY_LIT_UNSAFE(T) || T.light_source_solo || T.light_source_multi || (T.z_flags & ZM_ALLOW_LIGHTING))
+		// These checks are inlined from generate_missing_corners. They must be kept (roughly) in sync. This one intentionally does not check for ambient turfs.
+		if (TURF_IS_DYNAMICALLY_LIT_UNSAFE(T))
 			if (!T.lighting_corners_initialised)
 				T.lighting_corners_initialised = TRUE
 

--- a/code/modules/lighting/lighting_turf.dm
+++ b/code/modules/lighting/lighting_turf.dm
@@ -143,7 +143,14 @@
 // This is inlined in lighting_source.dm.
 // Update it too if you change this.
 /turf/proc/generate_missing_corners()
-	if (!TURF_IS_DYNAMICALLY_LIT_UNSAFE(src) && !ambient_light)
+	var/is_dyn = TURF_IS_DYNAMICALLY_LIT_UNSAFE(src) || ambient_light
+	if (!is_dyn)
+		for (var/turf/Tneigh as anything in RANGE_TURFS(1, src))
+			if (TURF_IS_DYNAMICALLY_LIT_UNSAFE(Tneigh))
+				is_dyn = TRUE
+				break
+
+	if (!is_dyn)
 		return
 
 	lighting_corners_initialised = TRUE

--- a/code/modules/lighting/lighting_turf.dm
+++ b/code/modules/lighting/lighting_turf.dm
@@ -143,8 +143,7 @@
 // This is inlined in lighting_source.dm.
 // Update it too if you change this.
 /turf/proc/generate_missing_corners()
-	// If a turf is dynamically lit, has a light source, or mimics lighting, it needs to have corners created.
-	if (!TURF_IS_DYNAMICALLY_LIT_UNSAFE(src) && !light_source_solo && !light_source_multi && !(z_flags & ZM_ALLOW_LIGHTING))
+	if (!TURF_IS_DYNAMICALLY_LIT_UNSAFE(src) && !ambient_light)
 		return
 
 	lighting_corners_initialised = TRUE

--- a/code/modules/lighting/lighting_turf.dm
+++ b/code/modules/lighting/lighting_turf.dm
@@ -145,7 +145,7 @@
 /turf/proc/generate_missing_corners()
 	var/is_dyn = TURF_IS_DYNAMICALLY_LIT_UNSAFE(src) || ambient_light
 	if (!is_dyn)
-		for (var/turf/Tneigh as anything in RANGE_TURFS(1, src))
+		for (var/turf/Tneigh as anything in RANGE_TURFS(src, 1))
 			if (TURF_IS_DYNAMICALLY_LIT_UNSAFE(Tneigh))
 				is_dyn = TRUE
 				break


### PR DESCRIPTION
I got tired of this logic breaking.

This version avoids piles of bespoke manual z-stack iteration with above/below references stored on the corner itself, built during corner init (and ChangeTurf). The stack will forcibly generate corners above/below it as required, but only the corner directly above/below rather than all corners on that master. It also supports delta updates for removing/adding connections.

Turf self-ambience init has also been moved: it now only initializes the turf it was directly applied to, with the general stack building logic handling propagation instead. This should avoid issues with double application of ambience during init.