### PR TITLE
SSmapping: ZM Z-group regen fixes

### DIFF
--- a/code/controllers/subsystems/mapping.dm
+++ b/code/controllers/subsystems/mapping.dm
@@ -256,7 +256,7 @@ SUBSYSTEM_DEF(mapping)
 	planetoid_data_by_z.len = world.maxz
 	connected_z_cache.Cut()
 
-	SSzcopy.calculate_zstack_limits()
+	SSzcopy?.calculate_zstack_limits()
 
 	//Update SSWeather's indexed lists, if we can.
 	if(SSweather?.weather_by_z)

--- a/code/controllers/subsystems/mapping.dm
+++ b/code/controllers/subsystems/mapping.dm
@@ -256,20 +256,34 @@ SUBSYSTEM_DEF(mapping)
 	planetoid_data_by_z.len = world.maxz
 	connected_z_cache.Cut()
 
+	SSzcopy.calculate_zstack_limits()
+
 	//Update SSWeather's indexed lists, if we can.
 	if(SSweather?.weather_by_z)
 		SSweather.weather_by_z.len = world.maxz
+
+/// This is equivalent to calling `increment_world_z_size()` in a loop, but more efficient.
+/datum/controller/subsystem/mapping/proc/bulk_increment_world_z_size(num_z_levels, new_level_type, defer_setup = FALSE)
+	ASSERT(num_z_levels > 0)
+	var/old_max = world.maxz
+	world.maxz += num_z_levels
+
+	reindex_lists()
+
+	if (!new_level_type)
+		CRASH("Missing z-level data type for z[old_max] through z[old_max + num_z_levels]!")
+
+	for (var/i in 1 to num_z_levels)
+		var/datum/level_data/level = new new_level_type(old_max + i, defer_setup)
+		level.initialize_new_level()
 
 /datum/controller/subsystem/mapping/proc/increment_world_z_size(var/new_level_type, var/defer_setup = FALSE)
 
 	world.maxz++
 	reindex_lists()
 
-	if(SSzcopy.zlev_maximums.len)
-		SSzcopy.calculate_zstack_limits()
 	if(!new_level_type)
-		PRINT_STACK_TRACE("Missing z-level data type for z["[world.maxz]"]!")
-		return
+		CRASH("Missing z-level data type for z[world.maxz]!")
 
 	var/datum/level_data/level = new new_level_type(world.maxz, defer_setup)
 	level.initialize_new_level()

--- a/code/controllers/subsystems/zcopy.dm
+++ b/code/controllers/subsystems/zcopy.dm
@@ -168,7 +168,7 @@ SUBSYSTEM_DEF(zcopy)
 	// Flush the queue.
 	fire(FALSE, TRUE)
 
-// If you add a new Zlevel or change Z-connections, call this.
+/// (Re)generate Z-group information. You should run this every time world.maxz (or z-connections) change. ZM's behavior is undefined between resizing the world and calling this proc.
 /datum/controller/subsystem/zcopy/proc/calculate_zstack_limits()
 	zlev_maximums = new(world.maxz)
 	var/start_zlev = 1

--- a/code/modules/maps/reader.dm
+++ b/code/modules/maps/reader.dm
@@ -140,8 +140,10 @@ var/global/dmm_suite/preloader/_preloader = new
 			if(zexpansion && !measureOnly) // don't actually expand the world if we're only measuring bounds
 				if(cropMap)
 					continue
-				while(world.maxz < zcrd) //create new z_levels if needed.
-					SSmapping.increment_world_z_size(level_data_type)
+				var/desired_levels = zcrd - world.maxz
+				if (desired_levels > 0)	//create new z_levels if needed.
+					SSmapping.bulk_increment_world_z_size(level_data_type)
+
 			bounds[MAP_MINX] = min(bounds[MAP_MINX], clamp(xcrdStart, x_lower, x_upper))
 			bounds[MAP_MINZ] = min(bounds[MAP_MINZ], zcrd)
 			bounds[MAP_MAXZ] = max(bounds[MAP_MAXZ], zcrd)

--- a/code/modules/maps/reader.dm
+++ b/code/modules/maps/reader.dm
@@ -142,7 +142,7 @@ var/global/dmm_suite/preloader/_preloader = new
 					continue
 				var/desired_levels = zcrd - world.maxz
 				if (desired_levels > 0)	//create new z_levels if needed.
-					SSmapping.bulk_increment_world_z_size(level_data_type)
+					SSmapping.bulk_increment_world_z_size(desired_levels, level_data_type)
 
 			bounds[MAP_MINX] = min(bounds[MAP_MINX], clamp(xcrdStart, x_lower, x_upper))
 			bounds[MAP_MINZ] = min(bounds[MAP_MINZ], zcrd)

--- a/code/modules/multiz/map_data.dm
+++ b/code/modules/multiz/map_data.dm
@@ -18,8 +18,8 @@ INITIALIZE_IMMEDIATE(/obj/abstract/map_data)
 			z_levels.len = i
 		z_levels[i] = src
 
-	if (length(SSzcopy.zlev_maximums))
-		SSzcopy.calculate_zstack_limits()
+	SSzcopy.calculate_zstack_limits()
+
 	return ..()
 
 /obj/abstract/map_data/Destroy(forced)

--- a/code/modules/overmap/ships/landable.dm
+++ b/code/modules/overmap/ships/landable.dm
@@ -63,9 +63,10 @@
 // We autobuild our z levels.
 /obj/effect/overmap/visitable/ship/landable/find_z_levels()
 	if(!use_mapped_z_levels)
+		var/initial_z = world.maxz
+		SSmapping.bulk_increment_world_z_size(multiz + 1, level_type)
 		for(var/i = 0 to multiz)
-			SSmapping.increment_world_z_size(level_type)
-			map_z += world.maxz
+			map_z += initial_z + i + 1
 	else
 		..()
 


### PR DESCRIPTION
Mapping was being too conservative about (re)generating ZM's z-group lists, so things were interacting with ZM when it had stale z-group mappings.

For ref: redundant calls to `calculate_zstack_limits()` are safe, and it is not important that Z-Copy's init be what calls this (O7's Z-Copy doesn't even call it), it just needs to be run any time something affects the world size or z-connection mappings. Pretty much the only thing limiting how often you call it is that it prints the current z-groups to world.log every time it runs.