### PR TITLE
Mark a bunch of areas as abstract, skip abstract areas in area usage test

### DIFF
--- a/code/game/area/area_abstract.dm
+++ b/code/game/area/area_abstract.dm
@@ -1,9 +1,11 @@
 /area/hallway
+	abstract_type = /area/hallway
 	name = "hallway"
 	holomap_color = HOLOMAP_AREACOLOR_HALLWAYS
 	area_start_lit = TRUE
 
 /area/maintenance
+	abstract_type = /area/maintenance
 	area_flags = AREA_FLAG_RAD_SHIELDED
 	sound_env = TUNNEL_ENCLOSED
 	turf_initializer = /decl/turf_initializer/maintenance
@@ -12,6 +14,7 @@
 	holomap_color = HOLOMAP_AREACOLOR_HALLWAYS
 
 /area/shuttle
+	abstract_type = /area/shuttle
 	requires_power = 0
 	sound_env = SMALL_ENCLOSED
 	base_turf = /turf/space
@@ -19,6 +22,10 @@
 	holomap_color = HOLOMAP_AREACOLOR_CREW
 
 /area/ship
+	abstract_type = /area/ship
 	name = "\improper Generic Ship"
 	ambience = list('sound/ambience/ambigen3.ogg','sound/ambience/ambigen4.ogg','sound/ambience/ambigen5.ogg','sound/ambience/ambigen6.ogg','sound/ambience/ambigen7.ogg','sound/ambience/ambigen8.ogg','sound/ambience/ambigen9.ogg','sound/ambience/ambigen10.ogg','sound/ambience/ambigen11.ogg','sound/ambience/ambigen12.ogg')
 	holomap_color = HOLOMAP_AREACOLOR_CREW
+
+/area/map_template
+	abstract_type = /area/map_template

--- a/code/modules/maps/template_types/random_exoplanet/random_planet_areas.dm
+++ b/code/modules/maps/template_types/random_exoplanet/random_planet_areas.dm
@@ -1,5 +1,6 @@
 ///Windy surface
 /area/exoplanet
+	// not abstract, this can get instantiated
 	name = "\improper Planetary surface"
 	ambience = list(
 		'sound/effects/wind/wind_2_1.ogg',

--- a/code/modules/turbolift/turbolift_areas.dm
+++ b/code/modules/turbolift/turbolift_areas.dm
@@ -1,5 +1,6 @@
 // Used for creating the exchange areas.
 /area/turbolift
+	abstract_type = /area/turbolift
 	name = "\improper Turbolift"
 	base_turf = /turf/open
 	requires_power = FALSE

--- a/code/unit_tests/area_tests.dm
+++ b/code/unit_tests/area_tests.dm
@@ -82,7 +82,9 @@
 
 /datum/unit_test/areas_shall_be_used/start_test()
 	var/unused_areas = 0
-	for(var/area_type in subtypesof(/area))
+	for(var/area/area_type as anything in subtypesof(/area))
+		if(TYPE_IS_ABSTRACT(area_type))
+			continue
 		if(area_type in global.using_map.area_usage_test_exempted_areas)
 			continue
 		if(is_path_in_list(area_type, global.using_map.area_usage_test_exempted_root_areas))

--- a/code/unit_tests/~unit_test_types.dm
+++ b/code/unit_tests/~unit_test_types.dm
@@ -45,6 +45,9 @@
 /obj/unit_test/transparent
 	opacity = FALSE
 
+/area/test_area
+	abstract_type = /area/test_area
+
 /area/test_area/general
 	icon_state = "blue"
 

--- a/maps/away/derelict/derelict_areas.dm
+++ b/maps/away/derelict/derelict_areas.dm
@@ -1,3 +1,6 @@
+/area/derelict
+	abstract_type = /area/derelict
+
 /area/derelict/ship
 	name = "\improper Abandoned Ship"
 	icon_state = "yellow"

--- a/maps/away/errant_pisces/errant_pisces_areas.dm
+++ b/maps/away/errant_pisces/errant_pisces_areas.dm
@@ -1,4 +1,5 @@
 /area/errant_pisces
+	abstract_type = /area/errant_pisces
 	icon = 'maps/away/errant_pisces/icons/areas.dmi'
 
 /area/errant_pisces/bow_port

--- a/maps/away/liberia/liberia_areas.dm
+++ b/maps/away/liberia/liberia_areas.dm
@@ -1,4 +1,5 @@
 /area/liberia
+	abstract_type = /area/liberia
 	req_access = list(access_merchant)
 
 /area/liberia/dockinghall

--- a/maps/away/lost_supply_base/lost_supply_base_areas.dm
+++ b/maps/away/lost_supply_base/lost_supply_base_areas.dm
@@ -6,19 +6,15 @@
 /area/lost_supply_base/solar
 	name = "\improper Abandoned supply station solars control room"
 	icon_state = "lost_supply_base_solar"
-	icon = 'maps/away/lost_supply_base/lost_supply_base_sprites.dmi'
 
 /area/lost_supply_base/office
 	name = "\improper Abandoned supply station office"
 	icon_state = "lost_supply_base_office"
-	icon = 'maps/away/lost_supply_base/lost_supply_base_sprites.dmi'
 
 /area/lost_supply_base/supply
 	name = "\improper Abandoned supply station supplies room"
 	icon_state = "lost_supply_base_supply"
-	icon = 'maps/away/lost_supply_base/lost_supply_base_sprites.dmi'
 
 /area/lost_supply_base/common
 	name = "\improper Abandoned supply station common area"
 	icon_state = "lost_supply_base_common"
-	icon = 'maps/away/lost_supply_base/lost_supply_base_sprites.dmi'

--- a/maps/away/magshield/magshield_areas.dm
+++ b/maps/away/magshield/magshield_areas.dm
@@ -1,29 +1,27 @@
+/area/magshield
+	abstract_type = /area/magshield
+	icon = 'magshield_sprites.dmi'
+
 /area/magshield/south
 	name = "Orbital Station South Wing"
 	icon_state = "south"
-	icon = 'magshield_sprites.dmi'
 
 /area/magshield/north
 	name = "Orbital Station North Wing"
 	icon_state = "north"
-	icon = 'magshield_sprites.dmi'
 
 /area/magshield/east
 	name = "Orbital Station East Wing"
 	icon_state = "east"
-	icon = 'magshield_sprites.dmi'
 
 /area/magshield/west
 	name = "Orbital Station West Wing"
 	icon_state = "west"
-	icon = 'magshield_sprites.dmi'
 
 /area/magshield/engine
 	name = "Orbital Station Engine"
 	icon_state = "engine"
-	icon = 'magshield_sprites.dmi'
 
 /area/magshield/smes_storage
 	name = "Orbital Station SMES Battery Room"
 	icon_state = "smes_storage"
-	icon = 'magshield_sprites.dmi'

--- a/maps/away/mining/mining_areas.dm
+++ b/maps/away/mining/mining_areas.dm
@@ -1,5 +1,6 @@
 // GENERIC MINING AREAS
 /area/mine
+	abstract_type = /area/mine
 	icon_state = "mining"
 	ambience = list('sound/ambience/ambimine.ogg', 'sound/ambience/song_game.ogg')
 	sound_env = ASTEROID
@@ -15,9 +16,12 @@
 	icon_state = "unexplored"
 
 // OUTPOSTS
+/area/outpost
+	abstract_type = /area/outpost
+	icon_state = "dark"
+
 /area/outpost/abandoned
 	name = "Abandoned Outpost"
-	icon_state = "dark"
 
 /area/djstation
 	name = "\improper Listening Post"

--- a/maps/away/smugglers/smugglers_areas.dm
+++ b/maps/away/smugglers/smugglers_areas.dm
@@ -1,14 +1,15 @@
+/area/smugglers
+	abstract_type = /area/smugglers
+	icon = 'smugglers_sprites.dmi'
+
 /area/smugglers/base
 	name = "\improper Asteroid Base"
 	icon_state = "smgl_base"
-	icon = 'smugglers_sprites.dmi'
 
 /area/smugglers/office
 	name = "\improper Asteroid Base Office"
 	icon_state = "smgl_office"
-	icon = 'smugglers_sprites.dmi'
 
 /area/smugglers/dorms
 	name = "\improper Asteroid Base Rest Area"
 	icon_state = "smgl_dorms"
-	icon = 'smugglers_sprites.dmi'

--- a/maps/away/unishi/unishi_areas.dm
+++ b/maps/away/unishi/unishi_areas.dm
@@ -1,5 +1,6 @@
-/area/unishi/
-   icon = 'unishi.dmi'
+/area/unishi
+	abstract_type = /area/unishi
+	icon = 'unishi.dmi'
 
 /area/unishi/bridge
 	name = "\improper Bridge"

--- a/maps/away/yacht/yacht_areas.dm
+++ b/maps/away/yacht/yacht_areas.dm
@@ -1,12 +1,15 @@
+/area/yacht
+	abstract_type = /area/yacht
+	icon = 'yacht_icons.dmi'
+
 /area/yacht/bridge
 	name = "\improper Yacht Bridge"
 	icon_state = "bridge"
-	icon = 'yacht_icons.dmi'
+
 /area/yacht/living
 	name = "\improper Yacht Living"
 	icon_state = "living"
-	icon = 'yacht_icons.dmi'
+
 /area/yacht/engine
 	name = "\improper Yacht Engine"
 	icon_state = "engine"
-	icon = 'yacht_icons.dmi'

--- a/maps/example/example_areas.dm
+++ b/maps/example/example_areas.dm
@@ -1,4 +1,5 @@
 /area/example
+	abstract_type = /area/example
 	holomap_color = HOLOMAP_AREACOLOR_CREW
 
 /area/example/first
@@ -14,6 +15,7 @@
 	icon_state = "storage"
 
 /area/turbolift/example
+	abstract_type = /area/turbolift/example
 	name = "\improper Testing Site Elevator"
 	icon_state = "shuttle"
 	requires_power = FALSE

--- a/maps/exodus/exodus_areas.dm
+++ b/maps/exodus/exodus_areas.dm
@@ -11,6 +11,7 @@
 //Do not remove dots after comments
 
 /area/exodus
+	abstract_type = /area/exodus
 	secure = TRUE
 	holomap_color = HOLOMAP_AREACOLOR_CREW
 

--- a/maps/tradeship/tradeship_areas.dm
+++ b/maps/tradeship/tradeship_areas.dm
@@ -10,8 +10,6 @@
 /area/ship/trade
 	name = "\improper Tradeship"
 	ambience = list('sound/ambience/ambigen3.ogg','sound/ambience/ambigen4.ogg','sound/ambience/ambigen5.ogg','sound/ambience/ambigen6.ogg','sound/ambience/ambigen7.ogg','sound/ambience/ambigen8.ogg','sound/ambience/ambigen9.ogg','sound/ambience/ambigen10.ogg','sound/ambience/ambigen11.ogg','sound/ambience/ambigen12.ogg')
-
-/area/ship/trade
 	holomap_color = HOLOMAP_AREACOLOR_CREW
 
 /area/ship/trade/crew

--- a/maps/~mapsystem/maps_unit_testing.dm
+++ b/maps/~mapsystem/maps_unit_testing.dm
@@ -23,18 +23,13 @@
 
 	// These areas are used specifically by code and need to be broken out somehow
 	var/list/area_usage_test_exempted_areas = list(
-		/area/ship,
-		/area/hallway,
-		/area/maintenance,
 		/area/overmap,
-		/area/shuttle,
 		/area/template_noop
 	)
 
 	var/list/area_usage_test_exempted_root_areas = list(
 		/area/map_template,
 		/area/exoplanet,
-		/area/turbolift
 	)
 
 	var/list/area_purity_test_exempt_areas = list()

--- a/mods/content/corporate/away_sites/lar_maria/lar_maria_areas.dm
+++ b/mods/content/corporate/away_sites/lar_maria/lar_maria_areas.dm
@@ -1,4 +1,5 @@
 /area/lar_maria
+	abstract_type = /area/lar_maria
 	icon = 'mods/content/corporate/away_sites/lar_maria/lar_maria_sprites.dmi'
 
 /////////////////////////////Upper level areas

--- a/mods/content/fantasy/submaps/_submaps.dm
+++ b/mods/content/fantasy/submaps/_submaps.dm
@@ -47,6 +47,7 @@
 	area_flags = AREA_FLAG_EXTERNAL | AREA_FLAG_IS_BACKGROUND
 
 /area/fantasy/outside/point_of_interest
+	abstract_type = /area/fantasy/outside/point_of_interest
 	name = "Point Of Interest"
 	description = null
 	area_blurb_category = /area/fantasy/outside/point_of_interest

--- a/mods/content/government/away_sites/icarus/icarus_areas.dm
+++ b/mods/content/government/away_sites/icarus/icarus_areas.dm
@@ -1,4 +1,5 @@
 /area/icarus
+	abstract_type = /area/icarus
 	icon = 'mods/content/government/away_sites/icarus/icarus_sprites.dmi'
 
 /area/icarus/vessel


### PR DESCRIPTION
## Description of changes
Marks a bunch of abstract areas as abstract. Makes the area usage test skip abstract areas. Also makes it so only the base turbolift area is skipped, because the subtypes actually SHOULD be tested for.

## Why and what will this PR improve
Code cleanup, prevents use of abstract areas, also reshuffles vars so we actually take advantage of inheritance

## Authorship
Me