### PR TITLE
Fix gitignore not specifying repo root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,10 +6,10 @@
 *.lk
 *.backup
 *.before
-codex/
-data/
-dmdoc/
-cfg/
+/codex/
+/data/
+/dmdoc/
+/cfg/
 build_log.txt
 use_map
 stopserver
@@ -17,9 +17,9 @@ reboot_called
 atupdate
 
 # ignore config, but not subdirs
-!config/*/
-config/*
-sql/test_db
+/!config/*/
+/config/*
+/sql/test_db
 
 # misc OS garbage
 Thumbs.db
@@ -27,7 +27,7 @@ Thumbs.db:encryptable
 .DS_Store
 
 # vscode
-.vscode/*
+/.vscode/*
 *.code-workspace
 .history
 


### PR DESCRIPTION
the codex code folder was getting excluded. as far as i know, this is only needed for entries with `/` in it.