### PR TITLE
Fix typo in ore image rotation matrix

### DIFF
--- a/code/modules/materials/stack_types/material_stack_ore.dm
+++ b/code/modules/materials/stack_types/material_stack_ore.dm
@@ -56,7 +56,7 @@
 			//Randomize the orientation and position of each ores in the image
 			var/matrix/M = matrix()
 			M.Translate(rand(-6, 6), rand(-6, 6))
-			M.Turn(pick(-72, -58, -45, -27.-5, 0, 0, 0, 0, 0, 27.5, 45, 58, 72))
+			M.Turn(pick(-72, -58, -45, -27.5, 0, 0, 0, 0, 0, 27.5, 45, 58, 72))
 			var/image/oreoverlay = image('icons/obj/materials/ore.dmi', IS)
 			oreoverlay.transform = M
 			scrapboard.overlays += oreoverlay


### PR DESCRIPTION
## Description of changes
Seems like someone was copy pasting values, quickly made a bunch negative and accidently made `27.5` to `-27.-5` instead.

Stumbled on this while working on a hobby DM parser/lexer, TIL BYOND lets you just write `0.`


## Changelog
:cl:
code: Fixed a rotation value for ore stacks
/:cl: