### PR TITLE
Replace direct uses of weld() with tool interactions

### DIFF
--- a/code/__defines/tools.dm
+++ b/code/__defines/tools.dm
@@ -100,3 +100,8 @@
 
 // Property for xenoarch.
 #define TOOL_PROP_EXCAVATION_DEPTH "excav_depth"
+
+// Tool use return value enums.
+#define TOOL_USE_FAILURE_NOMESSAGE -1
+#define TOOL_USE_FAILURE            0
+#define TOOL_USE_SUCCESS            1

--- a/code/datums/extensions/demolisher/welder.dm
+++ b/code/datums/extensions/demolisher/welder.dm
@@ -1,16 +1,19 @@
 /datum/extension/demolisher/welder
 	demolish_verb = "cutting through"
 	demolish_sound = 'sound/items/Welder.ogg'
-	expected_type = /obj/item/weldingtool
+	expected_type = /obj/item
 
 /datum/extension/demolisher/welder/try_demolish(mob/user, turf/wall/wall)
 	if(!(wall.get_material()?.removed_by_welder))
 		to_chat(user, SPAN_WARNING("\The [wall] is too delicate to be dismantled with \the [holder]; try a hammer or crowbar."))
 		return TRUE
-	var/obj/item/weldingtool/welder = holder
-	if(welder.weld(0,user))
-		return ..()
-	return TRUE
+	var/obj/item/welder = holder
+	var/decl/tool_archetype/welder_archetype = GET_DECL(TOOL_WELDER)
+	if(welder_archetype.can_use_tool(welder) != TOOL_USE_SUCCESS)
+		return TRUE
+	if(welder_archetype.handle_pre_interaction(welder) != TOOL_USE_SUCCESS)
+		return TRUE
+	return ..()
 
 /datum/extension/demolisher/welder/get_demolish_delay(turf/wall/wall)
 	return ..() * 0.7

--- a/code/game/machinery/_machines_base/machine_construction/frame.dm
+++ b/code/game/machinery/_machines_base/machine_construction/frame.dm
@@ -13,28 +13,20 @@
 
 /decl/machine_construction/frame/unwrenched/attackby(obj/item/used_item, mob/user, obj/machinery/machine)
 	if(IS_WRENCH(used_item))
-		playsound(machine.loc, 'sound/items/Ratchet.ogg', 50, 1)
-		if(do_after(user, 20, machine))
+		if(used_item.do_tool_interaction(TOOL_WRENCH, user, machine, 2 SECONDS))
 			TRANSFER_STATE(/decl/machine_construction/frame/wrenched)
 			to_chat(user, "<span class='notice'>You wrench \the [machine] into place.</span>")
 			machine.anchored = TRUE
 	if(IS_WELDER(used_item))
-		var/obj/item/weldingtool/welder = used_item
-		if(!welder.weld(0, user))
-			to_chat(user, "The welding tool must be on to complete this task.")
-			return TRUE
-		playsound(machine.loc, 'sound/items/Welder.ogg', 50, 1)
-		if(do_after(user, 20, machine))
-			if(!welder.isOn())
-				return TRUE
+		if(used_item.do_tool_interaction(TOOL_WELDER, user, machine, 2 SECONDS))
 			TRANSFER_STATE(/decl/machine_construction/default/deconstructed)
-			to_chat(user, "<span class='notice'>You deconstruct \the [machine].</span>")
+			to_chat(user, SPAN_NOTICE("You deconstruct \the [machine]."))
 			machine.dismantle()
 	return FALSE
 
 /decl/machine_construction/frame/unwrenched/mechanics_info()
 	. = list()
-	. += "Use a welder to break apart the frame."
+	. += "Use a welder to dismantle the frame."
 	. += "Use a wrench to secure the frame in place."
 
 /decl/machine_construction/frame/wrenched/state_is_valid(obj/machinery/constructable_frame/machine)
@@ -50,10 +42,8 @@
 
 /decl/machine_construction/frame/wrenched/attackby(obj/item/used_item, mob/user, obj/machinery/machine)
 	if(IS_WRENCH(used_item))
-		playsound(machine.loc, 'sound/items/Ratchet.ogg', 50, 1)
-		if(do_after(user, 20, machine))
+		if(used_item.do_tool_interaction(TOOL_WRENCH, user, machine, 2 SECONDS, "unfastening", "unfastening"))
 			TRANSFER_STATE(/decl/machine_construction/frame/unwrenched)
-			to_chat(user, "<span class='notice'>You unfasten \the [machine].</span>")
 			machine.anchored = FALSE
 		return TRUE
 	if(IS_COIL(used_item))
@@ -63,7 +53,7 @@
 			return TRUE
 		playsound(machine.loc, 'sound/items/Deconstruct.ogg', 50, 1)
 		to_chat(user, "<span class='notice'>You start to add cables to the frame.</span>")
-		if(do_after(user, 20, machine) && C.use(5))
+		if(do_after(user, 2 SECONDS, machine) && C.use(5))
 			TRANSFER_STATE(/decl/machine_construction/frame/awaiting_circuit)
 			to_chat(user, "<span class='notice'>You add cables to the frame.</span>")
 		return TRUE

--- a/code/game/machinery/_machines_base/machine_construction/pipe.dm
+++ b/code/game/machinery/_machines_base/machine_construction/pipe.dm
@@ -25,22 +25,13 @@
 // Same, but uses different tool.
 /decl/machine_construction/pipe/welder/deconstruct_transition(obj/item/used_item, mob/user, obj/machinery/machine)
 	if(IS_WELDER(used_item))
-		var/obj/item/weldingtool/welder = used_item
-		if(!welder.isOn())
-			return FALSE
-		if(!welder.weld(0,user))
-			return FALSE
 		var/fail = machine.cannot_transition_to(/decl/machine_construction/default/deconstructed, user)
 		if(istext(fail))
 			to_chat(user, fail)
 			return TRUE
 		if(fail != MCS_CHANGE)
 			return (fail == MCS_BLOCK)
-		to_chat(user, SPAN_NOTICE("You start welding \the [machine]."))
-		playsound(get_turf(machine), 'sound/items/Welder.ogg', 50, 1)
-		if(!do_after(user, 5 SECONDS, machine))
-			return TRUE
-		if(!welder.isOn())
+		if(!used_item.do_tool_interaction(TOOL_WELDER, user, machine, 5 SECONDS, fuel_expenditure = 0))
 			return TRUE
 		playsound(get_turf(machine), 'sound/items/Welder2.ogg', 50, 1)
 		TRANSFER_STATE(/decl/machine_construction/default/deconstructed)
@@ -49,4 +40,4 @@
 
 /decl/machine_construction/pipe/welder/mechanics_info()
 	. = list()
-	. += "Use a welder to deconstruct the machine"
+	. += "Use a welder to deconstruct the machine."

--- a/code/game/machinery/doors/_door.dm
+++ b/code/game/machinery/doors/_door.dm
@@ -291,16 +291,10 @@
 			to_chat(user, "<span class='warning'>\The [src] must be closed before you can repair it.</span>")
 			return TRUE
 
-		var/obj/item/weldingtool/welder = used_item
-		if(welder.weld(0,user))
-			to_chat(user, "<span class='notice'>You start to fix dents and weld \the [repairing] into place.</span>")
-			playsound(src, 'sound/items/Welder.ogg', 100, 1)
-			if(do_after(user, 5 * repairing.amount, src) && welder && welder.isOn())
-				to_chat(user, "<span class='notice'>You finish repairing the damage to \the [src].</span>")
-				current_health = clamp(current_health + repairing.amount*DOOR_REPAIR_AMOUNT,current_health, get_max_health())
-				update_icon()
-				qdel(repairing)
-				repairing = null
+		if(used_item.do_tool_interaction(TOOL_WELDER, user, src, 0.5 SECONDS * repairing.amount, "fixing dents and welding", "repairing the damage to"))
+			current_health = clamp(current_health + repairing.amount*DOOR_REPAIR_AMOUNT,current_health, get_max_health())
+			update_icon()
+			QDEL_NULL(repairing)
 		return TRUE
 
 	if(repairing && IS_CROWBAR(used_item))

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -632,6 +632,7 @@ About the new airlock wires panel:
 	var/cut_verb
 	var/cut_sound
 
+	// todo: should this use the demolisher extension?
 	if(IS_WELDER(item))
 		var/obj/item/weldingtool/welder = item
 		if(!welder.weld(0,user))

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -868,7 +868,8 @@ About the new airlock wires panel:
 		spark_at(da, amount=5, cardinal_only = TRUE)
 	else
 		da.anchored = TRUE
-	da.state = 1
+	// circuit is dumped onto the turf by parent call
+	da.wired = TRUE
 	da.created_name = name
 	da.update_icon()
 

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -634,8 +634,10 @@ About the new airlock wires panel:
 
 	// todo: should this use the demolisher extension?
 	if(IS_WELDER(item))
-		var/obj/item/weldingtool/welder = item
-		if(!welder.weld(0,user))
+		var/decl/tool_archetype/welder_archetype = GET_DECL(TOOL_WELDER)
+		if(welder_archetype.can_use_tool(item) != TOOL_USE_SUCCESS)
+			return FALSE
+		if(welder_archetype.handle_pre_interaction(item, user, 0) != TOOL_USE_SUCCESS)
 			return FALSE
 		cut_verb = "cutting"
 		cut_sound = 'sound/items/Welder.ogg'
@@ -743,22 +745,13 @@ About the new airlock wires panel:
 		return
 
 	if(!repairing && IS_WELDER(used_item) && !operating && density)
-		var/obj/item/weldingtool/welder = used_item
-		if(!welder.weld(0,user))
-			to_chat(user, SPAN_NOTICE("Your [welder.name] doesn't have enough fuel."))
+		if(!used_item.do_tool_interaction(TOOL_WELDER, user, src, rand(3,5) SECONDS, suffix_message = welded ? ", unsealing it" : ", sealing it closed"))
 			return TRUE
-		playsound(src, 'sound/items/Welder.ogg', 50, 1)
-		user.visible_message(SPAN_WARNING("\The [user] begins welding \the [src] [welded ? "open" : "closed"]!"),
-							SPAN_NOTICE("You begin welding \the [src] [welded ? "open" : "closed"]."))
-		if(do_after(user, (rand(3,5)) SECONDS, src))
-			if(density && !operating && !repairing)
-				playsound(src, 'sound/items/Welder2.ogg', 50, 1)
-				welded = !welded
-				update_icon()
-				return TRUE
-		else
-			to_chat(user, SPAN_NOTICE("You must remain still to complete this task."))
+		if(!density || operating || repairing)
 			return TRUE
+		welded = !welded
+		update_icon()
+		return TRUE
 
 	else if(IS_WIRECUTTER(used_item) || IS_MULTITOOL(used_item) || istype(used_item, /obj/item/assembly/signaler))
 		return wires.Interact(user)

--- a/code/game/machinery/doors/blast_door.dm
+++ b/code/game/machinery/doors/blast_door.dm
@@ -223,9 +223,9 @@
 /obj/machinery/door/blast/dismantle()
 	var/obj/structure/door_assembly/da = ..()
 	. = da
-
+	// circuit is dumped onto the turf by parent call
 	da.anchored = TRUE
-	da.state = 1
+	da.wired = TRUE
 	da.created_name = name
 	da.update_icon()
 

--- a/code/game/machinery/doors/braces.dm
+++ b/code/game/machinery/doors/braces.dm
@@ -94,17 +94,14 @@
 		return TRUE
 
 	if(IS_WELDER(used_item))
-		var/obj/item/weldingtool/C = used_item
 		if(!is_damaged())
 			to_chat(user, "\The [src] does not require repairs.")
 			return TRUE
-		if(C.weld(0,user))
+		var/decl/tool_archetype/welder_archetype = GET_DECL(TOOL_WELDER)
+		if(welder_archetype.can_use_tool(used_item) == TOOL_USE_SUCCESS && welder_archetype.handle_pre_interaction(user, used_item, 0) == TOOL_USE_SUCCESS)
 			playsound(src, 'sound/items/Welder.ogg', 100, 1)
 			current_health = min(current_health + rand(20,30), get_max_health())
-			if(!is_damaged())
-				to_chat(user, "You repair some dents on \the [src]. It is in perfect condition now.")
-			else
-				to_chat(user, "You repair some dents on \the [src].")
+			to_chat(user, "You repair some dents on \the [src].[!is_damaged() ? "It is in perfect condition now." : ""]")
 		return TRUE
 	return ..()
 

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -222,19 +222,11 @@
 	if(operating)
 		return TRUE //Already doing something.
 	if(IS_WELDER(used_item) && !repairing)
-		var/obj/item/weldingtool/welder = used_item
-		if(welder.weld(0, user))
-			playsound(src, 'sound/items/Welder.ogg', 100, 1)
-			if(do_after(user, 2 SECONDS, src))
-				if(!welder.isOn()) return TRUE
-				blocked = !blocked
-				user.visible_message("<span class='danger'>\The [user] [blocked ? "welds" : "unwelds"] \the [src] with \a [welder].</span>",\
-				"You [blocked ? "weld" : "unweld"] \the [src] with \the [welder].",\
-				"You hear something being welded.")
-				playsound(src, 'sound/items/Welder.ogg', 100, 1)
-				update_icon()
-			else
-				to_chat(user, SPAN_WARNING("You must remain still to complete this task."))
+		if(used_item.do_tool_interaction(TOOL_WELDER, user, src, 2 SECONDS))
+			blocked = !blocked
+			update_icon()
+		else
+			to_chat(user, SPAN_WARNING("You must remain still to complete this task."))
 		return TRUE
 
 	if(blocked && IS_CROWBAR(used_item))

--- a/code/game/machinery/floor_light.dm
+++ b/code/game/machinery/floor_light.dm
@@ -39,15 +39,10 @@ var/global/list/floor_light_cache = list()
 		return TRUE
 
 	if(IS_WELDER(used_item) && (damaged || (stat & BROKEN)))
-		var/obj/item/weldingtool/welder = used_item
-		if(!welder.weld(0, user))
-			to_chat(user, SPAN_WARNING("\The [src] must be on to complete this task."))
+		if(!used_item.do_tool_interaction(TOOL_WELDER, user, src, 2 SECONDS, success_message = "repairing") || QDELETED(src))
 			return TRUE
-		playsound(src.loc, 'sound/items/Welder.ogg', 50, 1)
-		if(do_after(user, 20, src) && !QDELETED(src) && welder.isOn())
-			visible_message(SPAN_NOTICE("\The [user] has repaired \the [src]."))
-			set_broken(FALSE)
-			damaged = null
+		set_broken(FALSE)
+		damaged = null
 		return TRUE
 
 	if(IS_WRENCH(used_item))

--- a/code/game/machinery/self_destruct.dm
+++ b/code/game/machinery/self_destruct.dm
@@ -13,14 +13,8 @@
 	if(IS_WELDER(used_item))
 		if(!damaged)
 			return FALSE
-		user.visible_message("[user] begins to repair [src].", "You begin repairing [src].")
-		if(do_after(user, 100, src))
-			var/obj/item/weldingtool/w = used_item
-			if(w.weld(10))
-				damaged = 0
-				user.visible_message("[user] repairs [src].", "You repair [src].")
-			else
-				to_chat(user, "<span class='warning'>There is not enough fuel to repair [src].</span>")
+		if(used_item.do_tool_interaction(TOOL_WELDER, user, src, 10 SECONDS, "repairing", "repairing", fuel_expenditure = 10))
+			damaged = 0
 		return TRUE
 	if(istype(used_item, /obj/item/nuclear_cylinder))
 		if(damaged)
@@ -30,7 +24,7 @@
 			to_chat(user, "There is already a cylinder here.")
 			return TRUE
 		user.visible_message("[user] begins to carefully place [used_item] onto [src].", "You begin to carefully place [used_item] onto [src].")
-		if(do_after(user, 80, src) && user.try_unequip(used_item, src))
+		if(do_after(user, 8 SECONDS, src) && user.try_unequip(used_item, src))
 			cylinder = used_item
 			density = TRUE
 			user.visible_message("[user] places [used_item] onto [src].", "You place [used_item] onto [src].")
@@ -54,14 +48,14 @@
 				to_chat(user, "<span class='warning'>The self-destruct sequence is in progress, unable to disarm.</span>")
 				return
 			user.visible_message("[user] begins extracting [cylinder].", "You begin extracting [cylinder].")
-			if(do_after(user, 40, src))
+			if(do_after(user, 4 SECONDS, src))
 				user.visible_message("[user] extracts [cylinder].", "You extract [cylinder].")
 				armed = 0
 				density = TRUE
 				flick("unloading", src)
 		else if(!damaged)
 			user.visible_message("[user] begins to arm [cylinder].", "You begin to arm [cylinder].")
-			if(do_after(user, 40, src))
+			if(do_after(user, 4 SECONDS, src))
 				armed = 1
 				density = FALSE
 				user.visible_message("[user] arms [cylinder].", "You arm [cylinder].")
@@ -78,7 +72,7 @@
 		user.visible_message( \
 			SPAN_NOTICE("\The [user] beings to carefully pick up \the [cylinder]."), \
 			SPAN_NOTICE("You begin to carefully pick up \the [cylinder]."))
-		if(!do_after(user, 70, src) || !cylinder)
+		if(!do_after(user, 7 SECONDS, src) || !cylinder)
 			return TRUE
 		user.put_in_hands(cylinder)
 		user.visible_message( \

--- a/code/game/objects/effects/spiders.dm
+++ b/code/game/objects/effects/spiders.dm
@@ -44,9 +44,8 @@
 		damage += 5
 
 	if(IS_WELDER(used_item))
-		var/obj/item/weldingtool/welder = used_item
-
-		if(welder.weld(0, user))
+		var/decl/tool_archetype/welder_archetype = GET_DECL(TOOL_WELDER)
+		if(welder_archetype.can_use_tool(used_item) == TOOL_USE_SUCCESS && welder_archetype.handle_pre_interaction(user, used_item, 0) == TOOL_USE_SUCCESS)
 			damage = 15
 			playsound(loc, 'sound/items/Welder.ogg', 100, 1)
 

--- a/code/game/objects/items/circuitboards/circuitboard.dm
+++ b/code/game/objects/items/circuitboards/circuitboard.dm
@@ -29,8 +29,7 @@
 		return 1
 	return 0
 
-//Called when a computer is deconstructed to produce a circuitboard.
-//Only used by computers, as other machines store their circuitboard instance.
+//Called when a machine is deconstructed to produce a circuitboard.
 /obj/item/stock_parts/circuitboard/proc/deconstruct(var/obj/machinery/M)
 	if (istype(M, build_path))
 		return 1

--- a/code/game/objects/items/stacks/rods.dm
+++ b/code/game/objects/items/stacks/rods.dm
@@ -56,13 +56,17 @@
 			to_chat(user, SPAN_WARNING("You need at least two rods to do this."))
 			return TRUE
 
-		if(welder.weld(0,user))
-			visible_message(SPAN_NOTICE("\The [src] is fused together by \the [user] with \the [welder]."), 3, SPAN_NOTICE("You hear welding."), 2)
-			for(var/obj/item/stack/material/new_item in SSmaterials.create_object((material?.type || /decl/material/solid/metal/steel), usr.loc, 1))
-				new_item.add_to_stacks(usr)
-				if(user.is_holding_offhand(src))
-					user.put_in_hands(new_item)
-			use(2)
+		var/decl/tool_archetype/welder_archetype = GET_DECL(TOOL_WELDER)
+		if(welder_archetype.can_use_tool(used_item) != TOOL_USE_SUCCESS)
+			return TRUE
+		if(welder_archetype.handle_pre_interaction(user, used_item, 0) != TOOL_USE_SUCCESS)
+			return TRUE
+		visible_message(SPAN_NOTICE("\The [src] is fused together by \the [user] with \the [welder]."), 3, SPAN_NOTICE("You hear welding."), 2)
+		for(var/obj/item/stack/material/new_item in SSmaterials.create_object((material?.type || /decl/material/solid/metal/steel), usr.loc, 1))
+			new_item.add_to_stacks(usr)
+			if(user.is_holding_offhand(src))
+				user.put_in_hands(new_item)
+		use(2)
 		return TRUE
 
 	if (istype(used_item, /obj/item/stack/tape_roll/duct_tape))

--- a/code/game/objects/items/weapons/material/shards.dm
+++ b/code/game/objects/items/weapons/material/shards.dm
@@ -58,13 +58,16 @@
 
 /obj/item/shard/attackby(obj/item/used_item, mob/user)
 	if(IS_WELDER(used_item) && material.shard_can_repair)
-		var/obj/item/weldingtool/welder = used_item
-		if(welder.weld(0, user))
-			material.create_object(get_turf(src))
-			qdel(src)
+		var/decl/tool_archetype/welder_archetype = GET_DECL(TOOL_WELDER)
+		if(welder_archetype.can_use_tool(used_item) != TOOL_USE_SUCCESS)
 			return TRUE
-	if(istype(used_item, /obj/item/stack/cable_coil))
+		if(welder_archetype.handle_pre_interaction(user, used_item, 0) != TOOL_USE_SUCCESS)
+			return TRUE
+		material.create_object(get_turf(src))
+		qdel(src)
+		return TRUE
 
+	if(istype(used_item, /obj/item/stack/cable_coil))
 		if(!material || (material.shard_name in list(SHARD_SPLINTER, SHARD_SHRAPNEL)))
 			to_chat(user, SPAN_WARNING("\The [src] is not suitable for using as a shank."))
 			return TRUE

--- a/code/game/objects/structures/crates_lockers/closets/__closet.dm
+++ b/code/game/objects/structures/crates_lockers/closets/__closet.dm
@@ -265,9 +265,9 @@ var/global/list/closets = list()
 				receive_mouse_drop(grab.affecting, user)      //act like they were dragged onto the closet
 				return TRUE
 			if(IS_WELDER(used_item))
-				var/obj/item/weldingtool/welder = used_item
-				if(welder.weld(0,user))
-					slice_into_parts(welder, user)
+				var/decl/tool_archetype/welder_archetype = GET_DECL(TOOL_WELDER)
+				if(welder_archetype.can_use_tool(used_item) == TOOL_USE_SUCCESS && welder_archetype.handle_pre_interaction(user, used_item, 0) == TOOL_USE_SUCCESS)
+					slice_into_parts(used_item, user)
 					return TRUE
 			if(istype(used_item, /obj/item/gun/energy/plasmacutter))
 				var/obj/item/gun/energy/plasmacutter/cutter = used_item
@@ -315,10 +315,10 @@ var/global/list/closets = list()
 		return FALSE //Return false to get afterattack to be called
 
 	if(IS_WELDER(used_item) && (setup & CLOSET_CAN_BE_WELDED))
-		var/obj/item/weldingtool/welder = used_item
-		if(!welder.weld(0,user))
-			if(welder.isOn())
-				to_chat(user, SPAN_NOTICE("You need more welding fuel to complete this task."))
+		var/decl/tool_archetype/welder_archetype = GET_DECL(TOOL_WELDER)
+		if(welder_archetype.can_use_tool(used_item) != TOOL_USE_SUCCESS)
+			return TRUE
+		if(welder_archetype.handle_pre_interaction(user, used_item, 0) != TOOL_USE_SUCCESS)
 			return TRUE
 		welded = !welded
 		update_icon()
@@ -420,7 +420,7 @@ var/global/list/closets = list()
 
 	breakout = 1 //can't think of a better way to do this right now.
 	for(var/i in 1 to (6*breakout_time * 2)) //minutes * 6 * 5seconds * 2
-		if(!do_after(escapee, 50, incapacitation_flags = INCAPACITATION_DEFAULT & ~INCAPACITATION_RESTRAINED)) //5 seconds
+		if(!do_after(escapee, 5 SECONDS, incapacitation_flags = INCAPACITATION_DEFAULT & ~INCAPACITATION_RESTRAINED)) //5 seconds
 			breakout = 0
 			return FALSE
 		//Perform the same set of checks as above for weld and lock status to determine if there is even still a point in 'resisting'...

--- a/code/game/objects/structures/door_assembly.dm
+++ b/code/game/objects/structures/door_assembly.dm
@@ -8,9 +8,9 @@
 
 	material = /decl/material/solid/metal/steel
 	material_alteration = MAT_FLAG_ALTERATION_NAME
+	tool_interaction_flags = TOOL_INTERACTION_ANCHOR | TOOL_INTERACTION_WIRING
 
 	var/can_install_glass = TRUE
-	var/state = 0
 	var/base_name = "airlock assembly"
 	var/obj/item/stock_parts/circuitboard/airlock_electronics/electronics = null
 	var/airlock_type = /obj/machinery/door/airlock //the type path of the airlock once completed
@@ -25,19 +25,18 @@
 	var/width = 1 // For multi-tile doors
 
 /obj/structure/door_assembly/update_material_name(override_name)
-	var/modifier
-	switch (state)
-		if(0)
-			if(anchored)
-				modifier = "secured "
-		if(1)
-			modifier = "wired "
-		if(2)
-			modifier = "near-finished "
-	if(reinf_material)
-		SetName("[modifier][reinf_material.solid_name] window [base_name]")
+	if(electronics)
+		name_prefix = "near-finished"
+	else if(wired)
+		name_prefix = "wired"
+	else if(anchored)
+		name_prefix = "secured"
 	else
-		SetName("[modifier][base_name]")
+		name_prefix = null
+	if(reinf_material)
+		..("[reinf_material.solid_name] window [base_name]")
+	else
+		..("[base_name]")
 
 /obj/structure/door_assembly/window
 	reinf_material = /decl/material/solid/glass
@@ -69,24 +68,26 @@
 
 /obj/structure/door_assembly/get_examine_hints(mob/user, distance, infix, suffix)
 	. = ..() || list()
-	switch(state)
-		if(0)
-			LAZYADD(., "Use a wrench to [anchored ? "un" : ""]anchor it.")
-			if(!anchored)
-				if(can_install_glass)
-					if(reinf_material)
-						var/mat_name = reinf_material.solid_name || reinf_material.name
-						LAZYADD(., "Use a welder to remove the [mat_name] plating currently attached.")
-				else
-					LAZYADD(., "Use a welder to disassemble completely.")
-			else
-				LAZYADD(., "Use a cable coil to wire in preparation for electronics.")
-		if(1)
-			LAZYADD(., "Use a wirecutter to remove the wiring and expose the frame.")
-			LAZYADD(., "Insert electronics to proceed with construction.")
-		if(2)
-			LAZYADD(., "Use a crowbar to remove the electronics.")
+	if(electronics)
+		LAZYADD(., "Use a crowbar to remove the electronics.")
+		if(anchored)
 			LAZYADD(., "Use a screwdriver to complete assembly.")
+		else
+			LAZYADD(., "Use a wrench to anchor it.")
+	else if(!wired && !electronics)
+		LAZYADD(., "Use a wrench to [anchored ? "un" : ""]anchor it.")
+		if(!anchored)
+			if(can_install_glass)
+				if(reinf_material)
+					var/mat_name = reinf_material.solid_name || reinf_material.name
+					LAZYADD(., "Use a welder to remove the [mat_name] plating currently attached.")
+			else
+				LAZYADD(., "Use a welder to disassemble completely.")
+		else
+			LAZYADD(., "Use a cable coil to wire in preparation for electronics.")
+	else if(wired)
+		LAZYADD(., "Use a wirecutter to remove the wiring and expose the frame.")
+		LAZYADD(., "Insert electronics to proceed with construction.")
 
 /obj/structure/door_assembly/door_assembly_hatch
 	icon = 'icons/obj/doors/hatch/door.dmi'
@@ -144,6 +145,7 @@
 	airlock_type = /obj/machinery/door/blast/shutters
 
 /obj/structure/door_assembly/attackby(obj/item/used_item, mob/user)
+	var/const/window_sheets_used = 2
 
 	if(IS_PEN(used_item))
 		var/t = sanitize_safe(input(user, "Enter the name for the door.", src.name, src.created_name), MAX_NAME_LEN)
@@ -156,138 +158,81 @@
 		return TRUE
 
 	if(IS_WELDER(used_item) && (can_install_glass || !anchored))
-		var/obj/item/weldingtool/welder = used_item
-		if (welder.weld(0, user))
-			playsound(src.loc, 'sound/items/Welder2.ogg', 50, 1)
-			if(reinf_material)
-				var/mat_name = reinf_material.solid_name
-				user.visible_message("[user] welds the [mat_name] plating off the airlock assembly.", "You start to weld the [mat_name] plating off the airlock assembly.")
-				if(do_after(user, 4 SECONDS, src))
-					if(!welder.isOn())
-						return TRUE
-					to_chat(user, "<span class='notice'>You welded the [mat_name] plating off!</span>")
-					reinf_material.create_object(get_turf(src), 2)
-					reinf_material = null
-					update_icon()
-				return TRUE
-			if(!anchored)
-				user.visible_message("[user] dissassembles the airlock assembly.", "You start to dissassemble the airlock assembly.")
-				if(do_after(user, 4 SECONDS, src))
-					if(!welder.isOn())
-						return TRUE
-					to_chat(user, "<span class='notice'>You dissasembled the airlock assembly!</span>")
-					dismantle_structure(user)
-				return TRUE
-		else
-			to_chat(user, "<span class='notice'>You need more welding fuel.</span>")
-			return TRUE
-
-	if(IS_WRENCH(used_item) && state == 0)
-		playsound(src.loc, 'sound/items/Ratchet.ogg', 100, 1)
-		if(anchored)
-			user.visible_message("[user] begins unsecuring the airlock assembly from the floor.", "You begin unsecuring the airlock assembly from the floor.")
-		else
-			user.visible_message("[user] begins securing the airlock assembly to the floor.", "You begin securing the airlock assembly to the floor.")
-
-		if(do_after(user, 4 SECONDS, src))
-			if(QDELETED(src)) return TRUE
-			to_chat(user, "<span class='notice'>You [anchored? "un" : ""]secured the airlock assembly!</span>")
-			anchored = !anchored
-			update_icon()
-		return TRUE
-
-
-	else if(IS_COIL(used_item) && state == 0 && anchored)
-		var/obj/item/stack/cable_coil/C = used_item
-		if (C.get_amount() < 1)
-			to_chat(user, "<span class='warning'>You need one length of coil to wire the airlock assembly.</span>")
-			return TRUE
-		user.visible_message("[user] wires the airlock assembly.", "You start to wire the airlock assembly.")
-		if(do_after(user, 4 SECONDS, src) && state == 0 && anchored)
-			if (C.use(1))
-				src.state = 1
-				to_chat(user, "<span class='notice'>You wire the airlock.</span>")
+		if(reinf_material)
+			var/mat_name = reinf_material.solid_name
+			if(used_item.do_tool_interaction(TOOL_WELDER, user, src, 4 SECONDS, "welding the [mat_name] plating off", "welding the [mat_name] plating off"))
+				reinf_material.create_object(get_turf(src), window_sheets_used)
+				reinf_material = null
 				update_icon()
-		return TRUE
+				update_material_name()
+			return TRUE
+		if(!anchored && used_item.do_tool_interaction(TOOL_WELDER, user, src, 4 SECONDS, "disassembling", "disassembling"))
+			dismantle_structure(user)
+			return TRUE
 
-	else if(IS_WIRECUTTER(used_item) && state == 1 )
-		playsound(src.loc, 'sound/items/Wirecutter.ogg', 100, 1)
-		user.visible_message("[user] cuts the wires from the airlock assembly.", "You start to cut the wires from airlock assembly.")
-
-		if(do_after(user, 40,src))
-			if(QDELETED(src)) return TRUE
-			to_chat(user, "<span class='notice'>You cut the airlock wires!</span>")
-			new/obj/item/stack/cable_coil(src.loc, 1)
-			src.state = 0
-			update_icon()
-		return TRUE
-
-	else if(istype(used_item, /obj/item/stock_parts/circuitboard/airlock_electronics) && state == 1)
+	else if(istype(used_item, /obj/item/stock_parts/circuitboard/airlock_electronics) && wired && !electronics && anchored)
 		var/obj/item/stock_parts/circuitboard/airlock_electronics/E = used_item
 		if(!ispath(airlock_type, E.build_path))
 			return FALSE
 		playsound(src.loc, 'sound/items/Screwdriver.ogg', 100, 1)
-		user.visible_message("[user] installs the electronics into the airlock assembly.", "You start to install electronics into the airlock assembly.")
+		user.visible_message("[user] installs \the [E] into \the [src].", "You start to install \the [E] into \the [src].")
 
-		if(do_after(user, 40,src))
+		if(do_after(user, 4 SECONDS, src))
 			if(QDELETED(src)) return TRUE
 			if(!user.try_unequip(used_item, src))
 				return TRUE
 			to_chat(user, "<span class='notice'>You installed the airlock electronics!</span>")
-			src.state = 2
-			src.SetName("Near finished Airlock Assembly")
-			src.electronics = used_item
+			electronics = used_item
 			update_icon()
+			update_material_name()
 		return TRUE
 
-	else if(IS_CROWBAR(used_item) && state == 2 )
-		//This should never happen, but just in case I guess
-		if (!electronics)
-			to_chat(user, "<span class='notice'>There was nothing to remove.</span>")
-			src.state = 1
-			update_icon()
-			return TRUE
-
-		playsound(src.loc, 'sound/items/Crowbar.ogg', 100, 1)
-		user.visible_message("\The [user] starts removing the electronics from the airlock assembly.", "You start removing the electronics from the airlock assembly.")
-
-		if(do_after(user, 4 SECONDS, src))
-			if(QDELETED(src)) return TRUE
-			to_chat(user, "<span class='notice'>You removed the airlock electronics!</span>")
-			src.state = 1
-			src.SetName("Wired Airlock Assembly")
+	else if(IS_CROWBAR(used_item) && electronics && anchored)
+		if(used_item.do_tool_interaction(TOOL_CROWBAR, user, src, 4 SECONDS, "removing \the [electronics] from", "removing \the [electronics] from", check_skill = SKILL_ELECTRICAL))
+			if(QDELETED(src))
+				return TRUE
 			electronics.dropInto(loc)
 			electronics = null
 			update_icon()
+			update_material_name()
 		return TRUE
 
 	else if(istype(used_item, /obj/item/stack/material) && can_install_glass && !reinf_material)
-		var/obj/item/stack/material/S = used_item
-		var/decl/material/sheet_material = S.get_material()
-		if (S.get_amount() >= 2)
-			playsound(src.loc, 'sound/items/Crowbar.ogg', 100, 1)
-			user.visible_message("[user] adds [S.name] to the airlock assembly.", "You start to install [S.name] into the airlock assembly.")
+		var/obj/item/stack/material/stack_item = used_item
+		if (stack_item.can_use(window_sheets_used))
+			playsound(loc, 'sound/items/Crowbar.ogg', 100, 1)
+			var/stack_name = stack_item.get_string_for_amount(window_sheets_used)
+			user.visible_message("[user] adds [stack_name] to \the [src].", "You start to install [stack_name] into \the [src].")
 			if(do_after(user, 4 SECONDS, src) && can_install_glass && !reinf_material)
-				if (S.use(2))
-					reinf_material = sheet_material
-					to_chat(user, "<span class='notice'>You installed [reinf_material.solid_name] windows into the airlock assembly.</span>")
+				if (stack_item.use(window_sheets_used))
+					reinf_material = stack_item.get_material()
+					to_chat(user, "<span class='notice'>You finish installing [reinf_material.solid_name] windows into \the [src].</span>")
 					update_icon()
+					update_material_name()
 			return TRUE
 		return FALSE
 
-	else if(IS_SCREWDRIVER(used_item) && state == 2 )
-		playsound(src.loc, 'sound/items/Screwdriver.ogg', 100, 1)
+	else if(IS_SCREWDRIVER(used_item) && wired && electronics && anchored)
 		to_chat(user, "<span class='notice'>Now finishing the airlock.</span>")
-
-		if(do_after(user, 4 SECONDS, src))
-			if(QDELETED(src)) return TRUE
-			to_chat(user, "<span class='notice'>You finish the airlock!</span>")
+		if(used_item.do_tool_interaction(TOOL_SCREWDRIVER, user, src, 4 SECONDS))
+			if(QDELETED(src))
+				return TRUE
+			to_chat(user, SPAN_NOTICE("You finish the airlock!"))
 			var/obj/machinery/door/door = new airlock_type(get_turf(src), dir, FALSE, src)
 			door.construct_state.post_construct(door) // it eats the circuit inside Initialize
 			qdel(src)
 		return TRUE
 	else
 		return ..()
+
+/obj/structure/door_assembly/handle_default_wrench_attackby(mob/user, obj/item/wrench)
+	return !wired && !electronics && ..()
+
+/obj/structure/door_assembly/handle_default_cable_attackby(mob/user, obj/item/stack/cable_coil/coil)
+	return !wired && !electronics && ..()
+
+/obj/structure/door_assembly/handle_default_wirecutter_attackby(mob/user, obj/item/wirecutters)
+	return wired && !electronics && ..()
 
 /obj/structure/door_assembly/on_update_icon()
 	..()
@@ -303,10 +248,9 @@
 		add_overlay(filling_overlay)
 
 	var/image/panel_overlay
-	switch(state)
-		if(1)
-			panel_overlay = image(panel_icon, "construction0")
-		if(2)
-			panel_overlay = image(panel_icon, "construction1")
+	if(electronics)
+		panel_overlay = image(panel_icon, "construction1")
+	else if(wired)
+		panel_overlay = image(panel_icon, "construction0")
 	if(panel_overlay)
 		add_overlay(panel_overlay)

--- a/code/game/objects/structures/lattice.dm
+++ b/code/game/objects/structures/lattice.dm
@@ -64,15 +64,16 @@
 	to_chat(user, SPAN_NOTICE("Slicing lattice joints..."))
 	physically_destroyed()
 
+/obj/structure/lattice/handle_default_welder_attackby(mob/user, obj/item/weldingtool/welder)
+	if(welder.do_tool_interaction(TOOL_WELDER, user, src, 0))
+		deconstruct(user)
+		return TRUE
+	return FALSE
+
 /obj/structure/lattice/attackby(obj/item/used_item, mob/user)
 	if (istype(used_item, /obj/item/stack/tile))
 		var/turf/T = get_turf(src)
 		T.attackby(used_item, user) //BubbleWrap - hand this off to the underlying turf instead
-		return TRUE
-	if(IS_WELDER(used_item))
-		var/obj/item/weldingtool/welder = used_item
-		if(welder.weld(0, user))
-			deconstruct(user)
 		return TRUE
 	if(istype(used_item, /obj/item/gun/energy/plasmacutter))
 		var/obj/item/gun/energy/plasmacutter/cutter = used_item

--- a/code/game/turfs/floors/floor_attackby.dm
+++ b/code/game/turfs/floors/floor_attackby.dm
@@ -147,22 +147,16 @@
 				T.visible_message(SPAN_DANGER("The ceiling above has been pried off!"))
 		return TRUE
 
-	if(IS_WELDER(used_item))
-		var/obj/item/weldingtool/welder = used_item
-		if(welder.isOn() && is_plating() && welder.weld(0, user))
-			if(is_floor_damaged())
-				to_chat(user, SPAN_NOTICE("You fix some damage to \the [src]."))
-				playsound(src, 'sound/items/Welder.ogg', 80, 1)
+	if(IS_WELDER(used_item) && is_plating())
+		if(is_floor_damaged())
+			if(used_item.do_tool_interaction(TOOL_WELDER, user, src))
 				icon_state = "plating"
 				set_floor_burned(skip_update = TRUE)
 				set_floor_broken()
-			else
-				playsound(src, 'sound/items/Welder.ogg', 80, 1)
-				visible_message(SPAN_NOTICE("\The [user] has started melting \the [src]'s reinforcements!"))
-				if(do_after(user, 5 SECONDS) && welder.isOn() && welder_melt())
-					visible_message(SPAN_NOTICE("\The [user] has melted \the [src]'s reinforcements! It should now be possible to pry it off."))
-					playsound(src, 'sound/items/Welder.ogg', 80, 1)
-			return TRUE
+		else
+			if(used_item.do_tool_interaction(TOOL_WELDER, user, src, 5 SECONDS, "melting the reinforcements of") && welder_melt())
+				visible_message(SPAN_NOTICE("\The [user] has melted \the [src]'s reinforcements! It should now be possible to pry it off."))
+		return TRUE
 
 	if(istype(used_item, /obj/item/gun/energy/plasmacutter) && (is_plating()) && !is_floor_damaged())
 		var/obj/item/gun/energy/plasmacutter/cutter = used_item

--- a/code/game/turfs/walls/wall_attacks.dm
+++ b/code/game/turfs/walls/wall_attacks.dm
@@ -123,9 +123,9 @@
 			. = TRUE
 	if(locate(/obj/effect/overlay/wallrot) in src)
 		if(IS_WELDER(used_item))
-			var/obj/item/weldingtool/welder = used_item
-			if( welder.weld(0,user) )
-				to_chat(user, "<span class='notice'>You burn away the fungi with \the [welder].</span>")
+			var/decl/tool_archetype/welder_archetype = GET_DECL(TOOL_WELDER)
+			if(welder_archetype.can_use_tool(used_item) == TOOL_USE_SUCCESS && welder_archetype.handle_pre_interaction(user, used_item, 0) == TOOL_USE_SUCCESS)
+				to_chat(user, "<span class='notice'>You burn away the fungi with \the [used_item].</span>")
 				playsound(src, 'sound/items/Welder.ogg', 10, 1)
 				for(var/obj/effect/overlay/wallrot/WR in src)
 					qdel(WR)
@@ -136,17 +136,9 @@
 				to_chat(user, "<span class='notice'>\The [src] crumbles away under the force of your [used_item.name].</span>")
 				physically_destroyed()
 				return TRUE
-	var/turf/T = user.loc	//get user's location for delay checks
-	if(damage && istype(used_item, /obj/item/weldingtool))
-
-		var/obj/item/weldingtool/welder = used_item
-
-		if(welder.weld(0,user))
-			to_chat(user, "<span class='notice'>You start repairing the damage to [src].</span>")
-			playsound(src, 'sound/items/Welder.ogg', 100, 1)
-			if(do_after(user, max(5, damage / 5), src) && welder && welder.isOn())
-				to_chat(user, "<span class='notice'>You finish repairing the damage to [src].</span>")
-				take_damage(-damage)
+	if(damage && IS_WELDER(used_item))
+		if(used_item.do_tool_interaction(TOOL_WELDER, user, src, max(0.5, damage / 50) SECONDS, "repairing the damage to", "repairing the damage to"))
+			take_damage(-damage)
 		return TRUE
 
 	// Basic dismantling.
@@ -166,7 +158,7 @@
 					playsound(src, 'sound/items/Welder.ogg', 100, 1)
 					. = TRUE
 
-					if(!do_after(user, 60, src))
+					if(!do_after(user, 6 SECONDS, src))
 						return
 
 					to_chat(user, "<span class='notice'>You tear through the wall's support system and plating!</span>")
@@ -182,18 +174,16 @@
 					return TRUE
 			if(5)
 				if(IS_SCREWDRIVER(used_item))
-					to_chat(user, "<span class='notice'>You begin removing the support lines.</span>")
-					playsound(src, 'sound/items/Screwdriver.ogg', 100, 1)
-					. = TRUE
-					if(!do_after(user,40,src) || !istype(src, /turf/wall) || construction_stage != 5)
-						return
+					if(!used_item.do_tool_interaction(TOOL_SCREWDRIVER, user, src, 4 SECONDS, "removing the support lines from", "removing the support lines from"))
+						return TRUE // block further interactions
+					if(!istype(src, /turf/wall) || construction_stage != 5)
+						return TRUE // ditto
 					construction_stage = 4
 					update_icon()
-					to_chat(user, "<span class='notice'>You remove the support lines.</span>")
-					return
-				else if(istype(used_item,/obj/item/weldingtool))
-					var/obj/item/weldingtool/welder = used_item
-					if(welder.weld(0,user))
+					return TRUE
+				else if(IS_WELDER(used_item)) // why is this instant when every other repair action is timed
+					var/decl/tool_archetype/welder_archetype = GET_DECL(TOOL_WELDER)
+					if(welder_archetype.can_use_tool(used_item) == TOOL_USE_SUCCESS && welder_archetype.handle_pre_interaction(user, used_item, 0) == TOOL_USE_SUCCESS)
 						construction_stage = 6
 						update_icon()
 						to_chat(user, SPAN_NOTICE("You repair the outer grille."))
@@ -201,68 +191,66 @@
 			if(4)
 				var/cut_cover
 				if(istype(used_item,/obj/item/weldingtool))
-					var/obj/item/weldingtool/welder = used_item
-					if(welder.weld(0,user))
-						cut_cover=1
-					else
-						return
+					var/decl/tool_archetype/welder_archetype = GET_DECL(TOOL_WELDER)
+					if(welder_archetype.can_use_tool(used_item) != TOOL_USE_SUCCESS)
+						return TRUE
+					if(welder_archetype.handle_pre_interaction(user, used_item, 0) != TOOL_USE_SUCCESS)
+						return TRUE
+					cut_cover = TRUE
 				else if (used_item.is_special_cutting_tool())
 					if(istype(used_item, /obj/item/gun/energy/plasmacutter))
 						var/obj/item/gun/energy/plasmacutter/cutter = used_item
 						if(!cutter.slice(user))
-							return
-					cut_cover = 1
+							return TRUE
+					cut_cover = TRUE
 				if(cut_cover)
 					to_chat(user, "<span class='notice'>You begin slicing through the metal cover.</span>")
 					playsound(src, 'sound/items/Welder.ogg', 100, 1)
-					. = TRUE
-					if(!do_after(user, 60, src) || !istype(src, /turf/wall) || construction_stage != 4)
-						return
+					if(!do_after(user, 6 SECONDS, src) || !istype(src, /turf/wall) || construction_stage != 4)
+						return TRUE
 					construction_stage = 3
 					update_icon()
 					to_chat(user, "<span class='notice'>You press firmly on the cover, dislodging it.</span>")
-					return
+					return TRUE
 			if(3)
 				if(IS_CROWBAR(used_item))
-					to_chat(user, "<span class='notice'>You struggle to pry off the cover.</span>")
-					playsound(src, 'sound/items/Crowbar.ogg', 100, 1)
-					. = TRUE
-					if(!do_after(user,100,src) || !istype(src, /turf/wall) || construction_stage != 3)
-						return
+					if(!used_item.do_tool_interaction(TOOL_CROWBAR, user, src, 10 SECONDS, "struggling to pry the cover off of", "prying the cover off of"))
+						return TRUE
+					if(!istype(src, /turf/wall) || construction_stage != 3)
+						return TRUE
 					construction_stage = 2
 					update_icon()
-					to_chat(user, "<span class='notice'>You pry off the cover.</span>")
-					return
+					return TRUE
 			if(2)
 				if(IS_WRENCH(used_item))
-					to_chat(user, "<span class='notice'>You start loosening the anchoring bolts which secure the support rods to their frame.</span>")
-					playsound(src, 'sound/items/Ratchet.ogg', 100, 1)
-					. = TRUE
-					if(!do_after(user,40,src) || !istype(src, /turf/wall) || construction_stage != 2)
-						return
+					// what a mouthful
+					if(!used_item.do_tool_interaction(TOOL_WRENCH, user, src, 4 SECONDS, "loosening the anchoring bolts securing the support rods of", "removing the anchoring bolts of"))
+						return TRUE
+					if(!istype(src, /turf/wall) || construction_stage != 2)
+						return TRUE
 					construction_stage = 1
 					update_icon()
-					to_chat(user, "<span class='notice'>You remove the bolts anchoring the support rods.</span>")
-					return
+					return TRUE
 			if(1)
 				var/cut_cover
 				if(istype(used_item, /obj/item/weldingtool))
-					var/obj/item/weldingtool/welder = used_item
-					if( welder.weld(0,user) )
-						cut_cover=1
-					else
-						return
+					var/decl/tool_archetype/welder_archetype = GET_DECL(TOOL_WELDER)
+					if(welder_archetype.can_use_tool(used_item) != TOOL_USE_SUCCESS)
+						return TRUE
+					if(welder_archetype.handle_pre_interaction(user, used_item, 0) != TOOL_USE_SUCCESS)
+						return TRUE
+					cut_cover = TRUE
 				else if(used_item.is_special_cutting_tool())
 					if(istype(used_item, /obj/item/gun/energy/plasmacutter))
 						var/obj/item/gun/energy/plasmacutter/cutter = used_item
 						if(!cutter.slice(user))
-							return
-					cut_cover = 1
+							return TRUE
+					cut_cover = TRUE
 				if(cut_cover)
 					to_chat(user, "<span class='notice'>You begin slicing through the support rods.</span>")
 					playsound(src, 'sound/items/Welder.ogg', 100, 1)
 					. = TRUE
-					if(!do_after(user,70,src) || !istype(src, /turf/wall) || construction_stage != 1)
+					if(!do_after(user,7 SECONDS,src) || !istype(src, /turf/wall) || construction_stage != 1)
 						return
 					construction_stage = 0
 					update_icon()
@@ -270,14 +258,12 @@
 					return
 			if(0)
 				if(IS_CROWBAR(used_item))
-					to_chat(user, "<span class='notice'>You struggle to pry off the outer sheath.</span>")
-					playsound(src, 'sound/items/Crowbar.ogg', 100, 1)
-					. = TRUE
-					if(!do_after(user,100,src) || !istype(src, /turf/wall) || !user || !used_item || !T )	return
-					if(user.loc == T && user.get_active_held_item() == used_item )
-						to_chat(user, "<span class='notice'>You pry off the outer sheath.</span>")
-						dismantle_turf()
-					return
+					if(!used_item.do_tool_interaction(TOOL_CROWBAR, user, src, 10 SECONDS, "struggling to pry the outer sheath off of", "prying the outer sheath off of"))
+						return TRUE
+					if(!istype(src, /turf/wall) || construction_stage != 0)
+						return TRUE
+					dismantle_turf()
+					return TRUE
 
 	return FALSE
 

--- a/code/modules/atmospherics/components/unary/vent_pump.dm
+++ b/code/modules/atmospherics/components/unary/vent_pump.dm
@@ -280,38 +280,17 @@
 
 /obj/machinery/atmospherics/unary/vent_pump/attackby(obj/item/used_item, mob/user)
 	if(IS_WELDER(used_item))
+		if(!used_item.do_tool_interaction(TOOL_WELDER, user, src, 2 SECONDS, welded ? "unwelding" : "welding", welded ? "unwelding" : "welding"))
+			return TRUE
 
-		var/obj/item/weldingtool/welder = used_item
-
-		if(!welder.isOn())
-			to_chat(user, "<span class='notice'>The welding tool needs to be on to start this task.</span>")
-			return 1
-
-		if(!welder.weld(0,user))
-			to_chat(user, "<span class='warning'>You need more welding fuel to complete this task.</span>")
-			return 1
-
-		to_chat(user, "<span class='notice'>Now welding \the [src].</span>")
-		playsound(src, 'sound/items/Welder.ogg', 50, 1)
-
-		if(!do_after(user, 20, src))
-			to_chat(user, "<span class='notice'>You must remain close to finish this task.</span>")
-			return 1
-
-		if(!src)
-			return 1
-
-		if(!welder.isOn())
-			to_chat(user, "<span class='notice'>The welding tool needs to be on to finish this task.</span>")
-			return 1
+		if(QDELETED(src))
+			return TRUE
 
 		welded = !welded
 		update_icon()
 		playsound(src, 'sound/items/Welder2.ogg', 50, 1)
-		user.visible_message("<span class='notice'>\The [user] [welded ? "welds \the [src] shut" : "unwelds \the [src]"].</span>", \
-			"<span class='notice'>You [welded ? "weld \the [src] shut" : "unweld \the [src]"].</span>", \
-			"You hear welding.")
-		return 1
+		return TRUE
+
 	if(IS_MULTITOOL(used_item))
 		var/datum/browser/written_digital/popup = new(user, "Vent Configuration Utility", "[src] Configuration Panel", 600, 200)
 		popup.set_content(jointext(get_console_data(),"<br>"))

--- a/code/modules/atmospherics/components/unary/vent_scrubber.dm
+++ b/code/modules/atmospherics/components/unary/vent_scrubber.dm
@@ -202,39 +202,17 @@
 	return ..()
 
 /obj/machinery/atmospherics/unary/vent_scrubber/attackby(var/obj/item/used_item, var/mob/user)
-	if(istype(used_item, /obj/item/weldingtool))
+	if(IS_WELDER(used_item))
+		if(!used_item.do_tool_interaction(TOOL_WELDER, user, src, 2 SECONDS, welded ? "unwelding" : "welding", welded ? "unwelding" : "welding"))
+			return TRUE
 
-		var/obj/item/weldingtool/welder = used_item
-
-		if(!welder.isOn())
-			to_chat(user, "<span class='notice'>The welding tool needs to be on to start this task.</span>")
-			return 1
-
-		if(!welder.weld(0,user))
-			to_chat(user, "<span class='warning'>You need more welding fuel to complete this task.</span>")
-			return 1
-
-		to_chat(user, "<span class='notice'>Now welding \the [src].</span>")
-		playsound(src, 'sound/items/Welder.ogg', 50, 1)
-
-		if(!do_after(user, 20, src))
-			to_chat(user, "<span class='notice'>You must remain close to finish this task.</span>")
-			return 1
-
-		if(!src)
-			return 1
-
-		if(!welder.isOn())
-			to_chat(user, "<span class='notice'>The welding tool needs to be on to finish this task.</span>")
-			return 1
+		if(QDELETED(src))
+			return TRUE
 
 		welded = !welded
 		update_icon()
 		playsound(src, 'sound/items/Welder2.ogg', 50, 1)
-		user.visible_message("<span class='notice'>\The [user] [welded ? "welds \the [src] shut" : "unwelds \the [src]"].</span>", \
-			"<span class='notice'>You [welded ? "weld \the [src] shut" : "unweld \the [src]"].</span>", \
-			"You hear welding.")
-		return 1
+		return TRUE
 
 	return ..()
 

--- a/code/modules/crafting/slapcrafting/_crafting_stage.dm
+++ b/code/modules/crafting/slapcrafting/_crafting_stage.dm
@@ -125,9 +125,9 @@
 	var/obj/item/stack/material/M = thing
 	. = istype(M) && (!stack_material || M.material.type == stack_material) && ..()
 
-/decl/crafting_stage/welding/consume_crafting_resource(var/mob/user, var/obj/item/thing, var/obj/item/target)
-	var/obj/item/weldingtool/T = thing
-	. = istype(T) && T.weld(0, user) && T.isOn()
+/decl/crafting_stage/welding/consume_crafting_resource(var/mob/user, var/obj/item/used_item, var/obj/item/target)
+	var/decl/tool_archetype/welder_archetype = GET_DECL(TOOL_WELDER)
+	return welder_archetype.can_use_tool(used_item) == TOOL_USE_SUCCESS && welder_archetype.handle_pre_interaction(user, used_item, 0) == TOOL_USE_SUCCESS
 
 /decl/crafting_stage/welding
 	consume_completion_trigger = FALSE

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -448,14 +448,15 @@
 		if (!get_damage(BRUTE))
 			to_chat(user, "Nothing to fix here!")
 			return TRUE
-		var/obj/item/weldingtool/welder = used_item
-		if (welder.weld(0))
-			user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
-			heal_damage(BRUTE, 30)
-			add_fingerprint(user)
-			user.visible_message(SPAN_NOTICE("\The [user] has fixed some of the dents on \the [src]!"))
-		else
-			to_chat(user, "Need more welding fuel!")
+		var/decl/tool_archetype/welder_archetype = GET_DECL(TOOL_WELDER)
+		if(welder_archetype.can_use_tool(used_item) != TOOL_USE_SUCCESS)
+			return TRUE
+		if(welder_archetype.handle_pre_interaction(user, used_item, 0) != TOOL_USE_SUCCESS)
+			return TRUE
+		user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
+		heal_damage(BRUTE, 30)
+		add_fingerprint(user)
+		user.visible_message(SPAN_NOTICE("\The [user] has fixed some of the dents on \the [src]!"))
 		return TRUE
 
 	else if(istype(used_item, /obj/item/stack/cable_coil) && (wiresexposed || isdrone(src)))

--- a/code/modules/multiz/ladder.dm
+++ b/code/modules/multiz/ladder.dm
@@ -29,7 +29,7 @@
 	if(anchored != last_anchored)
 		find_connections()
 
-/obj/structure/ladder/handle_default_wrench_attackby()
+/obj/structure/ladder/handle_default_wrench_attackby(mob/user, obj/item/wrench)
 	var/last_anchored = anchored
 	. = ..()
 	if(anchored != last_anchored)

--- a/code/modules/recycling/disposal-construction.dm
+++ b/code/modules/recycling/disposal-construction.dm
@@ -17,33 +17,26 @@
 	var/constructed_path = /obj/structure/disposalpipe
 	var/built_icon_state
 
-/obj/structure/disposalconstruct/Initialize(mapload, var/P = null)
+/obj/structure/disposalconstruct/Initialize(mapload, var/obj/pipe = null)
 	. = ..(mapload)
-	if(P)
-		if(istype(P, /obj/structure/disposalpipe))//Unfortunately a necessary evil since some things are machines and other things are structures
-			var/obj/structure/disposalpipe/D = P
-			SetName(D.name)
-			desc = D.desc
-			icon = D.icon
-			built_icon_state = D.icon_state
-			anchored = D.anchored
-			set_density(D.density)
-			turn = D.turn
-			sort_type = D.sort_type
-			dpdir = D.dpdir
-			constructed_path = D.type
-			set_dir(D.dir) // Needs to be set after turn and possibly other state.
-		if(istype(P, /obj/machinery/disposal))
-			var/obj/machinery/disposal/D = P
-			SetName(D.name)
-			desc = D.desc
-			icon = D.icon
-			built_icon_state = D.icon_state
-			anchored = D.anchored
-			set_density(D.density)
-			turn = D.turn
-			constructed_path = D.base_type || D.type
-			set_dir(D.dir)
+	if(pipe)
+		SetName(pipe.name)
+		desc = pipe.desc
+		icon = pipe.icon
+		built_icon_state = pipe.icon_state
+		anchored = pipe.anchored
+		set_density(pipe.density)
+		constructed_path = pipe.type
+		if(istype(pipe, /obj/structure/disposalpipe))//Unfortunately a necessary evil since some things are machines and other things are structures
+			var/obj/structure/disposalpipe/disposalpipe = pipe
+			turn = disposalpipe.turn
+			sort_type = disposalpipe.sort_type
+			dpdir = disposalpipe.dpdir
+		if(istype(pipe, /obj/machinery/disposal))
+			var/obj/machinery/disposal/disposal = pipe
+			turn = disposal.turn
+			constructed_path = disposal.base_type || constructed_path
+		set_dir(pipe.dir) // Needs to be set after turn and possibly other state.
 	if(loc)
 		update_icon()
 	update_verbs()
@@ -128,7 +121,7 @@
 		to_chat(user, "You can only manipulate \the [src] if the plating is exposed.")
 		return TRUE
 
-	var/obj/structure/disposalpipe/CP = locate() in T
+	var/obj/structure/disposalpipe/pipe = locate() in T
 
 	if(IS_WRENCH(used_item))
 		if(anchored)
@@ -136,7 +129,7 @@
 			wrench_down(FALSE)
 			to_chat(user, "You detach \the [src] from the underfloor.")
 		else
-			if(!check_buildability(CP, user))
+			if(!check_buildability(pipe, user))
 				return TRUE
 			wrench_down(TRUE)
 			to_chat(user, "You attach \the [src] to the underfloor.")
@@ -144,36 +137,27 @@
 		update()
 		update_verbs()
 		return TRUE
-	else if(istype(used_item, /obj/item/weldingtool))
+	else if(IS_WELDER(used_item))
 		if(anchored)
-			var/obj/item/weldingtool/welder = used_item
-			if(welder.weld(0,user))
-				playsound(src.loc, 'sound/items/Welder2.ogg', 100, 1)
-				to_chat(user, "Welding \the [src] in place.")
-				if(do_after(user, 2 SECONDS, src))
-					if(!src || !welder.isOn()) return TRUE
-					to_chat(user, "\The [src] has been welded in place!")
-					build(CP)
-					qdel(src)
-					return TRUE
-				return TRUE
-			else
-				to_chat(user, "You need more welding fuel to complete this task.")
-				return TRUE
-		else
 			to_chat(user, "You need to attach it to the plating first!")
 			return TRUE
+		if(!used_item.do_tool_interaction(TOOL_WELDER, user, src, 2 SECONDS, suffix_message = ", attaching it to the floor"))
+			return TRUE
+		to_chat(user, "\The [src] has been welded in place!")
+		build(pipe)
+		qdel(src)
+		return TRUE
 	return TRUE
 
 /obj/structure/disposalconstruct/hides_under_flooring()
 	return anchored
 
-/obj/structure/disposalconstruct/proc/check_buildability(obj/structure/disposalpipe/CP, mob/user)
-	if(!CP)
+/obj/structure/disposalconstruct/proc/check_buildability(obj/structure/disposalpipe/pipe, mob/user)
+	if(!pipe)
 		return TRUE
-	var/pdir = CP.dpdir
-	if(istype(CP, /obj/structure/disposalpipe/broken))
-		pdir = CP.dir
+	var/pdir = pipe.dpdir
+	if(istype(pipe, /obj/structure/disposalpipe/broken))
+		pdir = pipe.dir
 	if(pdir & dpdir)
 		to_chat(user, "There is already a disposals pipe at that location.")
 		return FALSE
@@ -189,9 +173,9 @@
 		level = LEVEL_ABOVE_PLATING
 		set_density(1)
 
-/obj/structure/disposalconstruct/machine/check_buildability(obj/structure/disposalpipe/CP, mob/user)
-	if(CP) // There's something there
-		if(!istype(CP,/obj/structure/disposalpipe/trunk))
+/obj/structure/disposalconstruct/machine/check_buildability(obj/structure/disposalpipe/pipe, mob/user)
+	if(pipe) // There's something there
+		if(!istype(pipe,/obj/structure/disposalpipe/trunk))
 			to_chat(user, "\The [src] requires a trunk underneath it in order to work.")
 			return FALSE
 		return TRUE
@@ -200,14 +184,14 @@
 	return FALSE
 
 /obj/structure/disposalconstruct/proc/build()
-	var/obj/structure/disposalpipe/P = new constructed_path(loc)
-	transfer_fingerprints_to(P)
-	P.base_icon_state = built_icon_state
-	P.icon_state = built_icon_state
-	P.dpdir = dpdir
-	P.sort_type = sort_type
-	P.set_dir(dir)
-	P.on_build()
+	var/obj/structure/disposalpipe/pipe = new constructed_path(loc)
+	transfer_fingerprints_to(pipe)
+	pipe.base_icon_state = built_icon_state
+	pipe.icon_state = built_icon_state
+	pipe.dpdir = dpdir
+	pipe.sort_type = sort_type
+	pipe.set_dir(dir)
+	pipe.on_build()
 
 // Subtypes
 
@@ -227,7 +211,7 @@
 	set_density(1) // We don't want disposal bins or outlets to go density 0
 	update_icon()
 
-/obj/structure/disposalconstruct/machine/build(obj/structure/disposalpipe/CP)
+/obj/structure/disposalconstruct/machine/build(obj/structure/disposalpipe/pipe)
 	var/obj/machinery/disposal/machine = new constructed_path(get_turf(src), dir)
 	var/datum/extension/parts_stash/stash = get_extension(src, /datum/extension/parts_stash)
 	if(stash)
@@ -246,12 +230,12 @@
 /obj/structure/disposalconstruct/machine/outlet
 	constructed_path = /obj/structure/disposaloutlet
 
-/obj/structure/disposalconstruct/machine/outlet/build(obj/structure/disposalpipe/CP)
-	var/obj/structure/disposaloutlet/P = new constructed_path(loc)
-	transfer_fingerprints_to(P)
-	P.set_dir(dir)
-	var/obj/structure/disposalpipe/trunk/Trunk = CP
-	Trunk.linked = P
+/obj/structure/disposalconstruct/machine/outlet/build(obj/structure/disposalpipe/pipe)
+	var/obj/structure/disposaloutlet/outlet = new constructed_path(loc)
+	transfer_fingerprints_to(outlet)
+	outlet.set_dir(dir)
+	var/obj/structure/disposalpipe/trunk/trunk = pipe
+	trunk.linked = outlet
 
 /obj/structure/disposalconstruct/machine/chute
 	obj_flags = OBJ_FLAG_ROTATABLE

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -582,27 +582,18 @@ var/global/list/diversion_junctions = list()
 				return TRUE
 			else // This should be invalid?
 				return FALSE
-	else if(istype(used_item,/obj/item/weldingtool) && mode==1)
-		var/obj/item/weldingtool/welder = used_item
-		if(welder.weld(0,user))
-			playsound(src.loc, 'sound/items/Welder2.ogg', 100, 1)
-			to_chat(user, "You start slicing the floorweld off the disposal outlet.")
-			if(!do_after(user, 2 SECONDS, src))
-				to_chat(user, "You must remain still to deconstruct \the [src].")
-				return TRUE
-			if(QDELETED(src) || !welder.isOn())
-				return TRUE
-			to_chat(user, "You sliced the floorweld off the disposal outlet.")
-			var/obj/structure/disposalconstruct/machine/outlet/C = new (loc, src)
-			src.transfer_fingerprints_to(C)
-			C.anchored = TRUE
-			C.set_density(1)
-			C.update()
-			qdel(src)
+	else if(IS_WELDER(used_item) && mode==1)
+		if(!used_item.do_tool_interaction(TOOL_WELDER, user, src, 2 SECONDS, "slicing the floorweld off of", "slicing the floorweld off of"))
 			return TRUE
-		else
-			to_chat(user, "You need more welding fuel to complete this task.")
+		if(QDELETED(src))
 			return TRUE
+		var/obj/structure/disposalconstruct/machine/outlet/C = new (loc, src)
+		src.transfer_fingerprints_to(C)
+		C.anchored = TRUE
+		C.set_density(1)
+		C.update()
+		qdel(src)
+		return TRUE
 	else
 		return ..()
 

--- a/code/modules/recycling/disposalpipe.dm
+++ b/code/modules/recycling/disposalpipe.dm
@@ -201,27 +201,16 @@
 
 //attack by item
 //weldingtool: unfasten and convert to obj/disposalconstruct
-/obj/structure/disposalpipe/attackby(var/obj/item/used_item, var/mob/user)
-	if(!istype(used_item, /obj/item/weldingtool))
-		return ..()
+/obj/structure/disposalpipe/handle_default_welder_attackby(mob/user, obj/item/used_item)
 	if(!can_deconstruct())
 		return TRUE
-	src.add_fingerprint(user, 0, used_item)
-	var/obj/item/weldingtool/welder = used_item
-	if(welder.weld(0,user))
-		playsound(src.loc, 'sound/items/Welder2.ogg', 100, 1)
-		to_chat(user, "You begin slicing \the [src].")
-		if(!do_after(user, 3 SECONDS, src))
-			to_chat(user, "You must stay still while welding the pipe.")
-			return TRUE
-		if(!welder.isOn())
-			return TRUE
-		welded()
+	add_fingerprint(user, 0, used_item)
+	if(!used_item.do_tool_interaction(TOOL_WELDER, user, src, 3 SECONDS, "slicing"))
+		to_chat(user, "You must stay still while welding the pipe.")
 		return TRUE
-	to_chat(user, "You need more welding fuel to cut the pipe.")
-	return TRUE
+	welded()
 
-	// called when pipe is cut with welder
+// called when pipe is cut with welder
 /obj/structure/disposalpipe/proc/welded()
 	var/obj/structure/disposalconstruct/C = new (src.loc, src)
 	src.transfer_fingerprints_to(C)

--- a/code/modules/singularity/field_generator.dm
+++ b/code/modules/singularity/field_generator.dm
@@ -123,34 +123,19 @@ field_generator power level display
 				to_chat(user, "<span class='warning'> \The [src] needs to be unwelded from the floor.</span>")
 				return TRUE
 	else if(IS_WELDER(used_item))
-		var/obj/item/weldingtool/welder = used_item
 		switch(state)
 			if(0)
 				to_chat(user, "<span class='warning'>\The [src] needs to be wrenched to the floor.</span>")
 				return TRUE
 			if(1)
-				if (!welder.weld(0,user))
+				if(!used_item.do_tool_interaction(TOOL_WELDER, user, src, 2 SECONDS, suffix_message = ", attaching it to the floor"))
 					return TRUE
-				playsound(src.loc, 'sound/items/Welder2.ogg', 50, 1)
-				user.visible_message("[user.name] starts to weld \the [src] to the floor.", \
-					"You start to weld \the [src] to the floor.", \
-					"You hear welding.")
-				if (!do_after(user, 2 SECONDS, src))
-					return TRUE
-				if(!src || !welder.isOn()) return TRUE
 				state = 2
-				to_chat(user, "You weld the field generator to the floor.")
+				to_chat(user, "You weld \the [src] to the floor.")
 				return TRUE
 			if(2)
-				if (!welder.weld(0,user))
+				if(!used_item.do_tool_interaction(TOOL_WELDER, user, src, 2 SECONDS, "to cut free", suffix_message = ", detaching it from the floor"))
 					return TRUE
-				playsound(src.loc, 'sound/items/Welder2.ogg', 50, 1)
-				user.visible_message("[user.name] starts to cut \the [src] free from the floor.", \
-					"You start to cut \the [src] free from the floor.", \
-					"You hear welding.")
-				if (!do_after(user, 2 SECONDS, src))
-					return TRUE
-				if(!src || !welder.isOn()) return TRUE
 				state = 1
 				to_chat(user, "You cut \the [src] free from the floor.")
 				return TRUE

--- a/code/modules/tools/archetypes/_tool_defines.dm
+++ b/code/modules/tools/archetypes/_tool_defines.dm
@@ -1,3 +1,0 @@
-#define TOOL_USE_FAILURE_NOMESSAGE -1
-#define TOOL_USE_FAILURE            0
-#define TOOL_USE_SUCCESS            1

--- a/code/modules/tools/archetypes/tool_extension.dm
+++ b/code/modules/tools/archetypes/tool_extension.dm
@@ -84,9 +84,13 @@
 	if(check_result != TOOL_USE_SUCCESS)
 		return check_result
 
+	if(success_message) // jank: if we have a success message we show the prefix there, not here
+		prefix_message = null
+		suffix_message = null
+
 	user.visible_message(
-		SPAN_NOTICE("\The [user] begins [start_message || tool_archetype.tool_message] \the [target] with \the [tool]."),
-		SPAN_NOTICE("You begin [start_message || tool_archetype.tool_message] \the [target] with \the [tool].")
+		SPAN_NOTICE("\The [user] begins [prefix_message][start_message || tool_archetype.tool_message] \the [target] with \the [tool][suffix_message]."),
+		SPAN_NOTICE("You begin [prefix_message][start_message || tool_archetype.tool_message] \the [target] with \the [tool][suffix_message].")
 	)
 
 	var/datum/extension/tool/tool_data = get_extension(tool, /datum/extension/tool)

--- a/code/modules/tools/archetypes/tool_item.dm
+++ b/code/modules/tools/archetypes/tool_item.dm
@@ -57,8 +57,8 @@
 	if(. == TOOL_USE_SUCCESS)
 		if(success_message)
 			user.visible_message(
-				SPAN_NOTICE("\The [user] finishes [success_message] \the [target] with \the [src]."),
-				SPAN_NOTICE("You finish [success_message] \the [target] with \the [src].")
+				SPAN_NOTICE("\The [user] finishes [prefix_message][success_message] \the [target] with \the [src][suffix_message]."),
+				SPAN_NOTICE("You finish [prefix_message][success_message] \the [target] with \the [src][suffix_message].")
 			)
 		return TRUE
 

--- a/nebula.dme
+++ b/nebula.dme
@@ -3908,7 +3908,6 @@
 #include "code\modules\thermoelectric_generator\teg_circuits.dm"
 #include "code\modules\tools\tool.dm"
 #include "code\modules\tools\tool_serde.dm"
-#include "code\modules\tools\archetypes\_tool_defines.dm"
 #include "code\modules\tools\archetypes\tool_archetype.dm"
 #include "code\modules\tools\archetypes\tool_archetype_definition_pen.dm"
 #include "code\modules\tools\archetypes\tool_archetype_definitions.dm"


### PR DESCRIPTION
this one is a doozy
replaces a lot of direct uses of weld() with tool interactions, some others with just the welder tool archetype checks (mostly ones that had messages i couldn't convert, or other checks during/after)
also makes a few other interactions use tool interactions, mostly on airlocks i think

### entirely untested atm

i might split this up into easier to review PRs. not one commit each though that would be awful, more like atmos pipes and machines / disposals machines and pipes / airlocks + firedoors + door assemblies / closets / crafting step / demolisher extension / machine frames / airlock braces / rod + shard / lattice + plating / robots / field generator + spiderling + self-destruct.

emitters intentionally excluded, they are already covered by #5335