### PR TITLE
void suit accepts portable coolers into tank slot.

### DIFF
--- a/code/modules/clothing/spacesuits/void/void.dm
+++ b/code/modules/clothing/spacesuits/void/void.dm
@@ -274,14 +274,14 @@ else if(##equipment_var) {\
 			playsound(loc, 'sound/items/Deconstruct.ogg', 50, 1)
 		return TRUE
 
-	if(istype(W,/obj/item/suit_cooling_unit))
+	if(istype(used_item,/obj/item/suit_cooling_unit))
 		if(user.get_equipped_slot_for_item(src) == slot_wear_suit_str)
 			to_chat(user, "<span class='warning'>You cannot modify \the [src] while it is being worn.</span>")
 		else if(tank)
 			to_chat(user, "\The [src] already has an airtank installed.")
-		else if(user.try_unequip(W, src))
-			to_chat(user, "You insert \the [W] into \the [src]'s storage compartment.")
-			tank = W
+		else if(user.try_unequip(used_item, src))
+			to_chat(user, "You insert \the [used_item] into \the [src]'s storage compartment.")
+			tank = used_item
 			playsound(loc, 'sound/items/Deconstruct.ogg', 50, 1)
 		return TRUE
 	return ..()

--- a/code/modules/clothing/spacesuits/void/void.dm
+++ b/code/modules/clothing/spacesuits/void/void.dm
@@ -274,6 +274,16 @@ else if(##equipment_var) {\
 			playsound(loc, 'sound/items/Deconstruct.ogg', 50, 1)
 		return TRUE
 
+	if(istype(W,/obj/item/suit_cooling_unit))
+		if(user.get_equipped_slot_for_item(src) == slot_wear_suit_str)
+			to_chat(user, "<span class='warning'>You cannot modify \the [src] while it is being worn.</span>")
+		else if(tank)
+			to_chat(user, "\The [src] already has an airtank installed.")
+		else if(user.try_unequip(W, src))
+			to_chat(user, "You insert \the [W] into \the [src]'s storage compartment.")
+			tank = W
+			playsound(loc, 'sound/items/Deconstruct.ogg', 50, 1)
+		return TRUE
 	return ..()
 
 /obj/item/clothing/suit/space/void/attack_self() //sole purpose of existence is to toggle the helmet


### PR DESCRIPTION
<!-- !! PLEASE, READ THIS !! -->
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/NebulaSS13/Nebula/blob/dev/CONTRIBUTING.md -->
<!-- If you're opening a pull request which changes A LOT of icon/map files: -->
<!-- Add [IDB IGNORE] (to ignore icon file changes) or [MDB IGNORE] (to ignore map file changes) in the PR title. -->
<!-- These tags prevent huge diffs from overloading IconDiffBot and MapDiffBot. -->

## Description of changes
<!-- Describe the pull request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Added handling for adding portable cooler units to the voidsuit tank slot. It appears that a change of methods of handling suit storage about 10 years ago broke it and it has been broken since. It used to take flashlight and the cooler but now it can't. Added handling of attaching the cooling unit.
according to configuration still left in the file it should also take flashlight but I decided to leave that one as it was.
## Why and what will this PR improve
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
it could be helpful for synthetic characters. 
## Authorship
<!-- Describe original authors of changes to credit them. -->

## Changelog
:cl:
add: Added  handling of adding portable suit cooler to the suit tank slot. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->