### PR TITLE
Real stable cooler

### DIFF
--- a/code/game/machinery/computer/law.dm
+++ b/code/game/machinery/computer/law.dm
@@ -1,4 +1,5 @@
 /obj/machinery/computer/upload
+	abstract_type = /obj/machinery/computer/upload
 	name = "unused upload console"
 	icon_keyboard = "rd_key"
 	icon_screen = "command"

--- a/code/game/objects/items/weapons/storage/secure.dm
+++ b/code/game/objects/items/weapons/storage/secure.dm
@@ -31,12 +31,12 @@
 
 /obj/item/secure_storage/Initialize(ml, material_key)
 	var/datum/extension/lockable/mylock = get_or_create_extension(src, lock_type)
-	events_repository.register(/decl/observ/lock_state_changed, mylock, src, /obj/item/secure_storage/proc/on_lock_state_changed)
+	events_repository.register(/decl/observ/lock_state_changed, mylock, src, PROC_REF(on_lock_state_changed))
 	. = ..()
 
 /obj/item/secure_storage/Destroy()
 	var/datum/extension/lockable/mylock = get_extension(src, lock_type)
-	events_repository.unregister(/decl/observ/lock_state_changed, mylock, src, /obj/item/secure_storage/proc/on_lock_state_changed)
+	events_repository.unregister(/decl/observ/lock_state_changed, mylock, src, PROC_REF(on_lock_state_changed))
 	. = ..()
 
 /obj/item/secure_storage/proc/on_lock_state_changed(datum/extension/lockable/L, old_locked, new_locked)

--- a/code/game/objects/structures/stool_bed_chair_nest_sofa/bedroll.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest_sofa/bedroll.dm
@@ -61,14 +61,14 @@
 
 /obj/structure/bed/bedroll/show_buckle_message(var/mob/buckled, var/mob/buckling)
 	if(buckled == buckling)
-		visible_message(
+		buckled.visible_message(
 			SPAN_NOTICE("\The [buckled] climbs into \the [src]."),
 			SPAN_NOTICE("You climb into \the [src]."),
 			SPAN_NOTICE("You hear a rustling sound.")
 		)
 	else
 		var/decl/pronouns/pronouns = buckled.get_pronouns()
-		visible_message(
+		buckled.visible_message(
 			SPAN_NOTICE("\The [buckled] [pronouns.is] bundled into \the [src] by \the [buckling]."),
 			SPAN_NOTICE("You are bundled into \the [src] by \the [buckling]."),
 			SPAN_NOTICE("You hear a rustling sound.")
@@ -76,13 +76,13 @@
 
 /obj/structure/bed/bedroll/show_unbuckle_message(var/mob/buckled, var/mob/buckling)
 	if(buckled == buckling)
-		visible_message(
+		buckled.visible_message(
 			SPAN_NOTICE("\The [buckled] climbs out of \the [src]."),
 			SPAN_NOTICE("You climb out of \the [src]."),
 			SPAN_NOTICE("You hear a rustling sound.")
 		)
 	else
-		visible_message(
+		buckled.visible_message(
 			SPAN_NOTICE("\The [buckled] was pulled out of \the [src] by \the [buckling]."),
 			SPAN_NOTICE("You were pulled out of \the [src] by \the [buckling]."),
 			SPAN_NOTICE("You hear a rustling sound.")

--- a/code/modules/augment/active/polytool.dm
+++ b/code/modules/augment/active/polytool.dm
@@ -14,9 +14,9 @@
 		var/obj/item/I = new path (src)
 		I.canremove = FALSE
 		items += I
-		events_repository.register(/decl/observ/moved, I, src, /obj/item/organ/internal/augment/active/polytool/proc/check_holding)
-		events_repository.register(/decl/observ/destroyed, I, src, /obj/item/organ/internal/augment/active/polytool/proc/check_holding)
-		events_repository.register(/decl/observ/item_unequipped, I, src, /obj/item/organ/internal/augment/active/polytool/proc/check_holding)
+		events_repository.register(/decl/observ/moved, I, src, PROC_REF(check_holding))
+		events_repository.register(/decl/observ/destroyed, I, src, PROC_REF(check_holding))
+		events_repository.register(/decl/observ/item_unequipped, I, src, PROC_REF(check_holding))
 
 /obj/item/organ/internal/augment/active/polytool/Destroy()
 	for(var/obj/item/item in items)

--- a/code/modules/augment/simple.dm
+++ b/code/modules/augment/simple.dm
@@ -12,9 +12,9 @@
 	holding.canremove = FALSE
 	if(!origin_tech)
 		origin_tech = holding.get_origin_tech()
-	events_repository.register(/decl/observ/moved, holding, src, /obj/item/organ/internal/augment/active/simple/proc/check_holding)
-	events_repository.register(/decl/observ/destroyed, holding, src, /obj/item/organ/internal/augment/active/simple/proc/check_holding)
-	events_repository.register(/decl/observ/item_unequipped, holding, src, /obj/item/organ/internal/augment/active/simple/proc/check_holding)
+	events_repository.register(/decl/observ/moved, holding, src, PROC_REF(check_holding))
+	events_repository.register(/decl/observ/destroyed, holding, src, PROC_REF(check_holding))
+	events_repository.register(/decl/observ/item_unequipped, holding, src, PROC_REF(check_holding))
 
 /obj/item/organ/internal/augment/active/simple/proc/check_holding()
 

--- a/code/modules/clothing/spacesuits/void/void.dm
+++ b/code/modules/clothing/spacesuits/void/void.dm
@@ -274,6 +274,17 @@ else if(##equipment_var) {\
 			playsound(loc, 'sound/items/Deconstruct.ogg', 50, 1)
 		return TRUE
 
+	if(istype(W,/obj/item/suit_cooling_unit))
+		if(user.get_equipped_slot_for_item(src) == slot_wear_suit_str)
+			to_chat(user, "<span class='warning'>You cannot modify \the [src] while it is being worn.</span>")
+		else if(tank)
+			to_chat(user, "\The [src] already has an airtank installed.")
+		else if(user.try_unequip(W, src))
+			to_chat(user, "You insert \the [W] into \the [src]'s storage compartment.")
+			tank = W
+			playsound(loc, 'sound/items/Deconstruct.ogg', 50, 1)
+		return TRUE
+
 	return ..()
 
 /obj/item/clothing/suit/space/void/attack_self() //sole purpose of existence is to toggle the helmet


### PR DESCRIPTION
<!-- !! PLEASE, READ THIS !! -->
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/NebulaSS13/Nebula/blob/dev/CONTRIBUTING.md -->
<!-- If you're opening a pull request which changes A LOT of icon/map files: -->
<!-- Add [IDB IGNORE] (to ignore icon file changes) or [MDB IGNORE] (to ignore map file changes) in the PR title. -->
<!-- These tags prevent huge diffs from overloading IconDiffBot and MapDiffBot. -->

## Description of changes
<!-- Describe the pull request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Git messed up my files and the index. had to make new branch. it should work this time. 
OK. I give up, git is broken. 
## Why and what will this PR improve
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Authorship
<!-- Describe original authors of changes to credit them. -->

## Changelog
:cl:
add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
bugfix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->