### PR TITLE
Add helper for internal pressure difference checks

### DIFF
--- a/code/game/objects/__objs.dm
+++ b/code/game/objects/__objs.dm
@@ -73,6 +73,23 @@
 /obj/return_air()
 	return loc?.return_air()
 
+/obj/proc/get_internal_pressure_difference()
+	var/datum/gas_mixture/int_air = return_air()
+	var/datum/gas_mixture/env_air = loc.return_air()
+	return int_air.return_pressure()-env_air.return_pressure()
+
+/// Return TRUE if the internal pressure difference is over `limit`.
+/obj/proc/check_internal_pressure_difference_over(limit)
+	var/datum/gas_mixture/int_air = return_air()
+	var/datum/gas_mixture/env_air = loc.return_air()
+	return (int_air.return_pressure()-env_air.return_pressure()) > limit
+
+/// Return TRUE if the internal pressure difference is under `limit`.
+/obj/proc/check_internal_pressure_difference_under(limit)
+	var/datum/gas_mixture/int_air = return_air()
+	var/datum/gas_mixture/env_air = loc.return_air()
+	return (int_air.return_pressure()-env_air.return_pressure()) < limit
+
 /obj/proc/updateUsrDialog()
 	if(in_use)
 		var/is_in_use = 0

--- a/code/modules/atmospherics/components/binary_devices/binary_atmos_base.dm
+++ b/code/modules/atmospherics/components/binary_devices/binary_atmos_base.dm
@@ -23,11 +23,7 @@
 		return air1
 
 /obj/machinery/atmospherics/binary/deconstruction_pressure_check()
-	var/datum/gas_mixture/int_air = return_air()
-	var/datum/gas_mixture/env_air = loc.return_air()
-	if ((int_air.return_pressure()-env_air.return_pressure()) > (2 ATM))
-		return FALSE
-	return TRUE
+	return !check_internal_pressure_difference_over(2 ATM)
 
 // Will only be used if you set the anchorable obj flag.
 /obj/machinery/atmospherics/binary/wrench_floor_bolts(mob/user, delay = 2 SECONDS, obj/item/tool)

--- a/code/modules/atmospherics/components/portables_connector.dm
+++ b/code/modules/atmospherics/components/portables_connector.dm
@@ -60,11 +60,7 @@
 			return list(connection.merged_mixture)
 
 /obj/machinery/atmospherics/portables_connector/deconstruction_pressure_check()
-	var/datum/gas_mixture/int_air = return_air()
-	var/datum/gas_mixture/env_air = loc.return_air()
-	if ((int_air.return_pressure()-env_air.return_pressure()) > (2 ATM))
-		return FALSE
-	return TRUE
+	return !check_internal_pressure_difference_over(2 ATM)
 
 /obj/machinery/atmospherics/portables_connector/cannot_transition_to(state_path, mob/user)
 	if(state_path == /decl/machine_construction/default/deconstructed)

--- a/code/modules/atmospherics/components/tvalve.dm
+++ b/code/modules/atmospherics/components/tvalve.dm
@@ -117,11 +117,7 @@
 	return null
 
 /obj/machinery/atmospherics/tvalve/deconstruction_pressure_check()
-	var/datum/gas_mixture/int_air = return_air()
-	var/datum/gas_mixture/env_air = loc.return_air()
-	if ((int_air.return_pressure()-env_air.return_pressure()) > (2 ATM))
-		return FALSE
-	return TRUE
+	return !check_internal_pressure_difference_over(2 ATM)
 
 /decl/public_access/public_variable/tvalve_state
 	expected_type = /obj/machinery/atmospherics/tvalve

--- a/code/modules/atmospherics/components/unary/heat_exchanger.dm
+++ b/code/modules/atmospherics/components/unary/heat_exchanger.dm
@@ -76,12 +76,7 @@
 		partner.update_networks()
 
 /obj/machinery/atmospherics/unary/heat_exchanger/deconstruction_pressure_check()
-	var/datum/gas_mixture/int_air = return_air()
-	var/datum/gas_mixture/env_air = loc.return_air()
-
-	if ((int_air.return_pressure()-env_air.return_pressure()) > (2 ATM))
-		return FALSE
-	return TRUE
+	return !check_internal_pressure_difference_over(2 ATM)
 
 /obj/machinery/atmospherics/unary/heat_exchanger/cannot_transition_to(state_path, mob/user)
 	if(state_path == /decl/machine_construction/default/deconstructed)

--- a/code/modules/atmospherics/components/unary/vent_pump.dm
+++ b/code/modules/atmospherics/components/unary/vent_pump.dm
@@ -341,9 +341,7 @@
 				break
 		if (hidden_pipe_check && isturf(T) && !T.is_plating())
 			return SPAN_WARNING("You must remove the plating first.")
-		var/datum/gas_mixture/int_air = return_air()
-		var/datum/gas_mixture/env_air = loc.return_air()
-		if ((int_air.return_pressure()-env_air.return_pressure()) > (2 ATM))
+		if (check_internal_pressure_difference_over(2 ATM))
 			return SPAN_WARNING("You cannot unwrench \the [src], it is too exerted due to internal pressure.")
 	return ..()
 

--- a/code/modules/atmospherics/components/unary/vent_scrubber.dm
+++ b/code/modules/atmospherics/components/unary/vent_scrubber.dm
@@ -197,9 +197,7 @@
 				break
 		if (hidden_pipe_check && isturf(T) && !T.is_plating())
 			return SPAN_WARNING("You must remove the plating first.")
-		var/datum/gas_mixture/int_air = return_air()
-		var/datum/gas_mixture/env_air = loc.return_air()
-		if ((int_air.return_pressure()-env_air.return_pressure()) > (2 ATM))
+		if (check_internal_pressure_difference_over(2 ATM))
 			return SPAN_WARNING("You cannot take this [src] apart, it too exerted due to internal pressure.")
 	return ..()
 

--- a/code/modules/atmospherics/components/valve.dm
+++ b/code/modules/atmospherics/components/valve.dm
@@ -113,11 +113,7 @@
 	return null
 
 /obj/machinery/atmospherics/valve/deconstruction_pressure_check()
-	var/datum/gas_mixture/int_air = return_air()
-	var/datum/gas_mixture/env_air = loc.return_air()
-	if ((int_air.return_pressure()-env_air.return_pressure()) > (2 ATM))
-		return FALSE
-	return TRUE
+	return !check_internal_pressure_difference_over(2 ATM)
 
 /obj/machinery/atmospherics/valve/get_examine_strings(mob/user, distance, infix, suffix)
 	. = ..()

--- a/code/modules/atmospherics/pipes.dm
+++ b/code/modules/atmospherics/pipes.dm
@@ -135,12 +135,8 @@
 	. = ..()
 
 /obj/machinery/atmospherics/pipe/deconstruction_pressure_check()
-	var/datum/gas_mixture/int_air = return_air()
-	var/datum/gas_mixture/env_air = loc.return_air()
-
-	if ((int_air.return_pressure()-env_air.return_pressure()) > (2 ATM))
-		return FALSE
-	return TRUE
+	// this uses !over instead of under so that it's <= instead of <
+	return !check_internal_pressure_difference_over(2 ATM)
 
 /obj/machinery/atmospherics/pipe/cannot_transition_to(state_path, mob/user)
 	if(state_path == /decl/machine_construction/default/deconstructed)


### PR DESCRIPTION
## Description of changes
Replaces this duplicated pattern with a helper (actually three helpers, only one is used). I thought about using the get_internal_pressure_difference method in the two other helpers but it's small and this is atmos code so avoiding extra proc call overhead might actually be worth it.

## Why and what will this PR improve
Reduces code duplication.