### PR TITLE
Replace inline parent with parent call in character info OnTopic

### DIFF
--- a/code/modules/client/preference_setup/records/01_character_info.dm
+++ b/code/modules/client/preference_setup/records/01_character_info.dm
@@ -61,3 +61,9 @@
 
 	if(. == TOPIC_REFRESH && istext(pref.comments_record_id) && length(pref.comments_record_id))
 		SScharacter_info.queue_to_save(pref.comments_record_id)
+
+/datum/category_item/player_setup_item/records/character_info/apply_post_snapshot_preferences(mob/living/human/character, is_preview_copy = FALSE)
+	if(is_preview_copy)
+		return
+	pref.validate_comments_record() // Make sure a record has been generated for this character.
+	character.comments_record_id = pref.comments_record_id

--- a/code/modules/client/preference_setup/records/01_character_info.dm
+++ b/code/modules/client/preference_setup/records/01_character_info.dm
@@ -31,11 +31,8 @@
 
 /datum/category_item/player_setup_item/records/character_info/OnTopic(var/href,var/list/href_list, var/mob/user)
 
-	if (record_key && href_list["set_record"])
-		var/new_record = sanitize(input(user,"Enter new [lowertext(name)] here.", CHARACTER_PREFERENCE_INPUT_TITLE, html_decode(pref.records[record_key])) as message|null, MAX_PAPER_MESSAGE_LEN, extra = 0)
-		if(!isnull(new_record) && !jobban_isbanned(user, "Records") && !jobban_isbanned(user, name) && CanUseTopic(user))
-			pref.records[record_key] = new_record
-		return TOPIC_REFRESH
+	if((. = ..())) // does nothing because it has no records_key
+		return
 
 	var/datum/character_information/comments = pref.comments_record_id && SScharacter_info.get_record(pref.comments_record_id, TRUE)
 	if(comments)

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -352,12 +352,6 @@ var/global/list/time_prefs_fixed = list()
 	update_setup_window(usr)
 	return TRUE
 
-/datum/category_item/player_setup_item/records/character_info/apply_post_snapshot_preferences(mob/living/human/character, is_preview_copy = FALSE)
-	if(is_preview_copy)
-		return
-	pref.validate_comments_record() // Make sure a record has been generated for this character.
-	character.comments_record_id = pref.comments_record_id
-
 /datum/preferences/proc/create_character_from_snapshot(spawn_turf)
 	// Sanitizing rather than saving as someone might still be editing.
 	player_setup.sanitize_setup()
@@ -367,7 +361,6 @@ var/global/list/time_prefs_fixed = list()
 	var/mob/living/human/character = new(spawn_turf, null, new_character_snapshot)
 	apply_post_snapshot_preferences(character, FALSE)
 	return character
-
 
 /datum/preferences/proc/copy_to(mob/living/human/character, is_preview_copy = FALSE)
 	apply_snapshot_to_mob(character, is_preview_copy) // this is effectively what create_character_from_snapshot does, but on an existing mob


### PR DESCRIPTION
## Description of changes
Removes duplicate dead code (never runs for charinfo because it has no records key) and replaces it with a parent call.

## Why and what will this PR improve
Duplicate code, dead code removal, etc. As far as I can tell this only uses the records subtype for organizational purposes.

## Authorship
Loaf wrote the original code, I just did this PR