### PR TITLE
Reduce code duplication in rig code

### DIFF
--- a/code/modules/clothing/spacesuits/rig/modules/vision.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/vision.dm
@@ -163,10 +163,14 @@
 	. = ..()
 	if(holder)
 		holder.visor = src
+		holder.verbs |= /obj/item/rig/proc/switch_vision_mode
+		holder.verbs |= /obj/item/rig/proc/toggle_vision
 
 /obj/item/rig_module/vision/removed()
 	if(holder)
 		holder.visor = null
+		holder.verbs -= /obj/item/rig/proc/switch_vision_mode
+		holder.verbs -= /obj/item/rig/proc/toggle_vision
 	. = ..()
 
 /obj/item/rig_module/vision/engage()

--- a/code/modules/clothing/spacesuits/rig/modules/vision.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/vision.dm
@@ -163,14 +163,16 @@
 	. = ..()
 	if(holder)
 		holder.visor = src
-		holder.verbs |= /obj/item/rig/proc/switch_vision_mode
 		holder.verbs |= /obj/item/rig/proc/toggle_vision
+		if(length(vision_modes) > 1) // don't add it if we have no modes to switch between
+			holder.verbs |= /obj/item/rig/proc/switch_vision_mode
 
 /obj/item/rig_module/vision/removed()
 	if(holder)
 		holder.visor = null
-		holder.verbs -= /obj/item/rig/proc/switch_vision_mode
 		holder.verbs -= /obj/item/rig/proc/toggle_vision
+		// let's always remove it, just in case.
+		holder.verbs -= /obj/item/rig/proc/switch_vision_mode
 	. = ..()
 
 /obj/item/rig_module/vision/engage()

--- a/code/modules/clothing/spacesuits/rig/rig_verbs.dm
+++ b/code/modules/clothing/spacesuits/rig/rig_verbs.dm
@@ -9,7 +9,7 @@
 	if(wearer && wearer.get_equipped_item(slot_back_str) == src)
 		ui_interact(usr)
 
-/obj/item/rig/verb/toggle_vision()
+/obj/item/rig/proc/toggle_vision()
 
 	set name = "Toggle Visor"
 	set desc = "Turns your rig visor off or on."
@@ -122,7 +122,7 @@
 
 	toggle_seals(wearer)
 
-/obj/item/rig/verb/switch_vision_mode()
+/obj/item/rig/proc/switch_vision_mode()
 
 	set name = "Switch Vision Mode"
 	set desc = "Switches between available vision modes."

--- a/code/modules/clothing/spacesuits/rig/rig_verbs.dm
+++ b/code/modules/clothing/spacesuits/rig/rig_verbs.dm
@@ -16,15 +16,7 @@
 	set category = "Hardsuit"
 	set src = usr.contents
 
-	if(!istype(wearer) || wearer.get_equipped_item(slot_back_str) != src)
-		to_chat(usr, "<span class='warning'>The hardsuit is not being worn.</span>")
-		return
-
-	if(!check_power_cost(usr))
-		return
-
-	if(canremove)
-		to_chat(usr, "<span class='warning'>The suit is not active.</span>")
+	if(!check_usable(usr))
 		return
 
 	if(!check_suit_access(usr))
@@ -106,14 +98,10 @@
 	set category = "Hardsuit"
 	set src = usr.contents
 
-	if(!istype(wearer) || wearer.get_equipped_item(slot_back_str) != src)
-		to_chat(usr, "<span class='warning'>The hardsuit is not being worn.</span>")
+	if(!check_usable(usr))
 		return
 
 	if(!check_suit_access(usr))
-		return
-
-	if(!check_power_cost(usr))
 		return
 
 	deploy(wearer)
@@ -141,14 +129,7 @@
 	set category = "Hardsuit"
 	set src = usr.contents
 
-	if(malfunction_check(usr))
-		return
-
-	if(!check_power_cost(usr, 0, 0, 0, 0))
-		return
-
-	if(canremove)
-		to_chat(usr, "<span class='warning'>The suit is not active.</span>")
+	if(!check_usable(usr))
 		return
 
 	if(!visor)
@@ -171,15 +152,7 @@
 	set category = "Hardsuit"
 	set src = usr.contents
 
-	if(malfunction_check(usr))
-		return
-
-	if(canremove)
-		to_chat(usr, "<span class='warning'>The suit is not active.</span>")
-		return
-
-	if(!istype(wearer) || wearer.get_equipped_item(slot_back_str) != src)
-		to_chat(usr, "<span class='warning'>The hardsuit is not being worn.</span>")
+	if(!check_usable(usr))
 		return
 
 	if(!speech)
@@ -188,6 +161,40 @@
 
 	speech.engage()
 
+/obj/item/rig/proc/check_usable(mob/user)
+	if(malfunction_check(user))
+		return FALSE
+
+	if(!check_power_cost(user))
+		return FALSE
+
+	if(canremove)
+		to_chat(user, SPAN_WARNING("The suit is not active."))
+		return FALSE
+
+	if(!istype(wearer) || wearer.get_equipped_item(slot_back_str) != src)
+		to_chat(user, SPAN_WARNING("The hardsuit is not being worn."))
+		return FALSE
+	return TRUE
+
+/obj/item/rig/proc/get_selectable_modules(mob/user)
+	. = list()
+	for(var/obj/item/rig_module/module in installed_modules)
+		if(module.selectable)
+			. |= module
+
+/obj/item/rig/proc/get_toggleable_modules(mob/user)
+	. = list()
+	for(var/obj/item/rig_module/module in installed_modules)
+		if(module.toggleable)
+			. |= module
+
+/obj/item/rig/proc/get_usable_modules(mob/user)
+	. = list()
+	for(var/obj/item/rig_module/module in installed_modules)
+		if(module.usable)
+			. |= module
+
 /obj/item/rig/verb/select_module()
 
 	set name = "Select Module"
@@ -195,24 +202,10 @@
 	set category = "Hardsuit"
 	set src = usr.contents
 
-	if(malfunction_check(usr))
+	if(!check_usable(usr))
 		return
 
-	if(!check_power_cost(usr, 0, 0, 0, 0))
-		return
-
-	if(canremove)
-		to_chat(usr, "<span class='warning'>The suit is not active.</span>")
-		return
-
-	if(!istype(wearer) || wearer.get_equipped_item(slot_back_str) != src)
-		to_chat(usr, "<span class='warning'>The hardsuit is not being worn.</span>")
-		return
-
-	var/list/selectable = list()
-	for(var/obj/item/rig_module/module in installed_modules)
-		if(module.selectable)
-			selectable |= module
+	var/list/selectable = get_selectable_modules()
 
 	var/obj/item/rig_module/module = input("Which module do you wish to select?") as null|anything in selectable
 
@@ -232,26 +225,12 @@
 	set category = "Hardsuit"
 	set src = usr.contents
 
-	if(malfunction_check(usr))
+	if(!check_usable(usr))
 		return
 
-	if(!check_power_cost(usr, 0, 0, 0, 0))
-		return
+	var/list/toggleable = get_toggleable_modules()
 
-	if(canremove)
-		to_chat(usr, "<span class='warning'>The suit is not active.</span>")
-		return
-
-	if(!istype(wearer) || wearer.get_equipped_item(slot_back_str) != src)
-		to_chat(usr, "<span class='warning'>The hardsuit is not being worn.</span>")
-		return
-
-	var/list/selectable = list()
-	for(var/obj/item/rig_module/module in installed_modules)
-		if(module.toggleable)
-			selectable |= module
-
-	var/obj/item/rig_module/module = input("Which module do you wish to toggle?") as null|anything in selectable
+	var/obj/item/rig_module/module = input("Which module do you wish to toggle?") as null|anything in toggleable
 
 	if(!istype(module))
 		return
@@ -270,24 +249,10 @@
 	set category = "Hardsuit"
 	set src = usr.contents
 
-	if(malfunction_check(usr))
+	if(!check_usable(usr))
 		return
 
-	if(canremove)
-		to_chat(usr, "<span class='warning'>The suit is not active.</span>")
-		return
-
-	if(!istype(wearer) || wearer.get_equipped_item(slot_back_str) != src)
-		to_chat(usr, "<span class='warning'>The hardsuit is not being worn.</span>")
-		return
-
-	if(!check_power_cost(usr, 0, 0, 0, 0))
-		return
-
-	var/list/selectable = list()
-	for(var/obj/item/rig_module/module in installed_modules)
-		if(module.usable)
-			selectable |= module
+	var/list/selectable = get_usable_modules()
 
 	var/obj/item/rig_module/module = input("Which module do you wish to engage?") as null|anything in selectable
 


### PR DESCRIPTION
## Description of changes
moves a bunch of repeated checks into a reusable helper
also the visor verbs are now gated behind having a visor. and the switch mode verb is gated behind having modes to switch to.

- [ ] tested

## Why and what will this PR improve
better code quality + removes the visor verbs when they don't apply.

## Authorship
Me

## Changelog
:cl:
tweak: The Toggle Visor and Switch Vision Mode verbs now only show up on rigs with applicable visors installed.
/:cl: