### PR TITLE
Fix combustion checks always returning true

### DIFF
--- a/code/modules/ZAS/Fire.dm
+++ b/code/modules/ZAS/Fire.dm
@@ -261,6 +261,7 @@ If it gains pressure too slowly, it may leak or just rupture instead of explodin
 				. |= HAS_FUEL
 			if(. == (HAS_OXIDIZER|HAS_FUEL))
 				return TRUE
+	return FALSE
 
 /datum/gas_mixture/proc/check_combustibility()
 	var/const/HAS_OXIDIZER = BITFLAG(0)
@@ -275,6 +276,7 @@ If it gains pressure too slowly, it may leak or just rupture instead of explodin
 				. |= HAS_FUEL
 			if(. == (HAS_OXIDIZER|HAS_FUEL))
 				return TRUE
+	return FALSE
 
 //returns a value between 0 and vsc.fire_firelevel_multiplier
 /datum/gas_mixture/proc/calculate_firelevel(total_fuel, total_oxidizers, reaction_limit, gas_volume)


### PR DESCRIPTION
## Description of changes
oops. basically i used `.` as an accumulator/temporary var and it wound up returning a truthy value

## Why and what will this PR improve
fixes stuff catching fire when there's no fuel

## Authorship
me for causing the bug and me for fixing it