### PR TITLE
Add UIDs to a lot of decl types

### DIFF
--- a/code/datums/ai_holo.dm
+++ b/code/datums/ai_holo.dm
@@ -3,6 +3,7 @@
 * bypass_colorize: if false, the hologram will be decolorized.
 */
 /decl/ai_holo
+	abstract_type = /decl/ai_holo
 	var/requires_malf = FALSE
 	var/icon = 'icons/mob/hologram.dmi'
 	var/icon_state = "icon_state"

--- a/code/datums/appearances/automatic/cardborg.dm
+++ b/code/datums/appearances/automatic/cardborg.dm
@@ -49,6 +49,7 @@
 			appearances[disguise.backpack_type] = disguise
 
 /decl/cardborg_appearance
+	abstract_type = /decl/cardborg_appearance
 	var/backpack_type
 	var/icon_state = ICON_STATE_WORLD
 	var/icon = 'icons/mob/robots/robot.dmi'

--- a/code/datums/colors/color_generator.dm
+++ b/code/datums/colors/color_generator.dm
@@ -1,4 +1,5 @@
 /decl/color_generator
+	abstract_type = /decl/color_generator
 	var/color = COLOR_WHITE
 	var/min_random_span = -25
 	var/max_random_span = 25

--- a/code/datums/communication/channel.dm
+++ b/code/datums/communication/channel.dm
@@ -1,6 +1,7 @@
 #define plain_key_name(A) key_name(A, highlight_special_characters = 0)
 
 /decl/communication_channel
+	abstract_type = /decl/communication_channel
 	var/name
 	var/config_setting
 	var/expected_communicator_type = /datum

--- a/code/datums/footsteps.dm
+++ b/code/datums/footsteps.dm
@@ -1,4 +1,5 @@
 /decl/footsteps
+	abstract_type = /decl/footsteps
 	var/list/footstep_sounds
 
 /decl/footsteps/catwalk

--- a/code/datums/genetics/genetic_conditions.dm
+++ b/code/datums/genetics/genetic_conditions.dm
@@ -1,4 +1,5 @@
 /decl/genetic_condition
+	abstract_type = /decl/genetic_condition
 	decl_flags = DECL_FLAG_MANDATORY_UID
 	/// Descriptive name, used in VV panel.
 	var/name

--- a/code/datums/genetics/genetic_conditions.dm
+++ b/code/datums/genetics/genetic_conditions.dm
@@ -1,4 +1,5 @@
 /decl/genetic_condition
+	decl_flags = DECL_FLAG_MANDATORY_UID
 	/// Descriptive name, used in VV panel.
 	var/name
 	/// Verb to be added or removed on activate/deactivate
@@ -50,73 +51,91 @@
 /decl/genetic_condition/superpower/no_breath
 	name               = "No Breathing"
 	activation_message = "You feel no need to breathe."
+	uid                = "genetic_condition_superpower_nobreath"
 
 /decl/genetic_condition/superpower/remoteview
 	name               = "Remote Viewing"
 	grant_verb         = /mob/living/human/proc/remoteobserve
 	activation_message = "Your mind expands."
+	uid                = "genetic_condition_superpower_remoteview"
 
 /decl/genetic_condition/superpower/running
 	name               = "Super Speed"
 	activation_message = "Your leg muscles pulsate."
+	uid                = "genetic_condition_superpower_running"
 
 /decl/genetic_condition/superpower/remotetalk
 	name               = "Telepathy"
 	grant_verb         = /mob/living/human/proc/remotesay
 	activation_message = "You expand your mind outwards."
+	uid                = "genetic_condition_superpower_remotetalk"
 
 /decl/genetic_condition/superpower/cold_resist
 	name               = "Cold Resistance"
 	underlay_state     = "fire_s"
 	activation_message = "Your body is filled with warmth."
+	uid                = "genetic_condition_superpower_cold_resist"
 
 /decl/genetic_condition/superpower/noprints
 	name               = "No Prints"
 	activation_message = "Your fingers feel numb."
+	uid                = "genetic_condition_superpower_noprints"
 
 /decl/genetic_condition/superpower/xray
 	name               = "X-Ray Vision"
 	activation_message = "The walls suddenly disappear."
+	uid                = "genetic_condition_superpower_xray"
 
 /decl/genetic_condition/superpower/space_resist
 	name               = "Space Resistance"
 	activation_message = "Your skin feels strange."
+	uid                = "genetic_condition_superpower_spaceresist"
 
 /decl/genetic_condition/disability
 	abstract_type      = /decl/genetic_condition/disability
 
 /decl/genetic_condition/disability/clumsy
 	name               = "Clumsy"
+	uid                = "genetic_condition_disability_clumsy"
 
 /decl/genetic_condition/disability/nearsighted
 	name               = "Nearsighted"
+	uid                = "genetic_condition_disability_nearsighted"
 
 /decl/genetic_condition/disability/epilepsy
 	name               = "Epilepsy"
+	uid                = "genetic_condition_disability_epilepsy"
 
 /decl/genetic_condition/disability/coughing
 	name               = "Coughing"
+	uid                = "genetic_condition_disability_coughing"
 
 /decl/genetic_condition/disability/tourettes
 	name               = "Tourettes"
+	uid                = "genetic_condition_disability_tourettes"
 
 /decl/genetic_condition/disability/nervous
 	name               = "Nervous"
+	uid                = "genetic_condition_disability_nervous"
 
 /decl/genetic_condition/disability/blinded
 	name               = "Blinded"
 	check_synthetic    = null
+	uid                = "genetic_condition_disability_blinded"
 
 /decl/genetic_condition/disability/muted
 	name               = "Mute"
 	check_synthetic    = null
+	uid                = "genetic_condition_disability_mute"
 
 /decl/genetic_condition/disability/deafened
 	name               = "Deafened"
 	check_synthetic    = null
+	uid                = "genetic_condition_disability_deafened"
 
 /decl/genetic_condition/husk
 	name               = "Husk"
+	uid                = "genetic_condition_husk"
 
 /decl/genetic_condition/husk/activate_condition(mob/living/M)
 	. = ..()

--- a/code/datums/hostility/hostility.dm
+++ b/code/datums/hostility/hostility.dm
@@ -1,4 +1,5 @@
 // A singleton useful for recycling hostility logic in things such as mobs or turrets.
+// intentionally NOT abstract
 /decl/hostility
 
 // Returns a value determining whether or not whatever is calling should attack the target.

--- a/code/datums/item_modifiers/item_modifier.dm
+++ b/code/datums/item_modifiers/item_modifier.dm
@@ -1,4 +1,5 @@
 /decl/item_modifier
+	abstract_type = /decl/item_modifier
 	var/name
 	var/list/type_setups
 

--- a/code/datums/licences/license.dm
+++ b/code/datums/licences/license.dm
@@ -1,4 +1,5 @@
 /decl/license
+	abstract_type = /decl/license
 	var/name
 	var/url
 	var/attribution_mandatory = TRUE

--- a/code/datums/mind/memory.dm
+++ b/code/datums/mind/memory.dm
@@ -122,6 +122,7 @@
 
 // General memory handling
 /decl/memory_options
+	abstract_type = /decl/memory_options
 	var/memory_type = /datum/memory
 
 /decl/memory_options/proc/validate_mind(var/datum/mind/target)

--- a/code/datums/move_intent/move_intent.dm
+++ b/code/datums/move_intent/move_intent.dm
@@ -6,6 +6,7 @@
 #define MOVE_INTENT_NEUTRAL    BITFLAG(3)
 
 /decl/move_intent
+	abstract_type = /decl/move_intent
 	var/name
 	var/flags = MOVE_INTENT_NONE
 	var/move_delay = 1

--- a/code/datums/observation/observation.dm
+++ b/code/datums/observation/observation.dm
@@ -57,6 +57,7 @@
 //		The first argument shall always be the event_source belonging to the event. Beyond that there are no restrictions.
 
 /decl/observ
+	abstract_type = /decl/observ
 	var/name = "Unnamed Event"                // The name of this event, used mainly for debug/VV purposes. The list of event managers can be reached through the "Debug Controller" verb, selecting the "Observation" entry.
 	var/expected_type = /datum                // The expected event source for this event. register() will CRASH() if it receives an unexpected type.
 	var/list/global_listeners = list()        // Associative list of instances that listen to all events of this type (as opposed to events belonging to a specific source) and the proc to call.

--- a/code/datums/outfits/equipment/backpacks.dm
+++ b/code/datums/outfits/equipment/backpacks.dm
@@ -53,6 +53,7 @@
 
 /* Code */
 /decl/backpack_outfit
+	abstract_type = /decl/backpack_outfit
 	var/flags
 	var/name
 	var/path

--- a/code/datums/state_machine/state.dm
+++ b/code/datums/state_machine/state.dm
@@ -1,6 +1,7 @@
 // An individual state, defined as a `/decl` to save memory.
 // On a directed graph, these would be the nodes themselves, connected to each other by unidirectional arrows.
 /decl/state
+	abstract_type = /decl/state
 	// Transition decl types, which get turned into refs to those types.
 	// Note that the order DOES matter, as decls earlier in the list have higher priority
 	// if more than one becomes 'open'.

--- a/code/datums/state_machine/transition.dm
+++ b/code/datums/state_machine/transition.dm
@@ -1,6 +1,7 @@
 // Used to connect `/decl/state`s together so the FSM knows what state to switch to, and on what conditions.
 // On a directed graph, these would be the arrows connecting the nodes representing states.
 /decl/state_transition
+	abstract_type = /decl/state_transition
 	var/list/from = null
 	var/decl/state/target = null
 

--- a/code/datums/traits/_traits.dm
+++ b/code/datums/traits/_traits.dm
@@ -84,6 +84,7 @@
 
 /decl/trait
 	abstract_type = /decl/trait
+	decl_flags = DECL_FLAG_MANDATORY_UID
 	/// String identifier.
 	var/name
 	/// Flavour text.

--- a/code/datums/traits/metabolically_inert.dm
+++ b/code/datums/traits/metabolically_inert.dm
@@ -1,3 +1,4 @@
 /decl/trait/metabolically_inert
 	name = "Metabolically Inert"
 	description = "For better or worse, there is little that this creature metabolizes."
+	uid = "trait_metabolically_inert"

--- a/code/datums/uplink/uplink_sources.dm
+++ b/code/datums/uplink/uplink_sources.dm
@@ -9,6 +9,7 @@ var/global/list/default_uplink_source_priority = list(
 )
 
 /decl/uplink_source
+	abstract_type = /decl/uplink_source
 	decl_flags = DECL_FLAG_MANDATORY_UID
 	var/name
 	var/desc

--- a/code/datums/uplink/uplink_sources.dm
+++ b/code/datums/uplink/uplink_sources.dm
@@ -9,6 +9,7 @@ var/global/list/default_uplink_source_priority = list(
 )
 
 /decl/uplink_source
+	decl_flags = DECL_FLAG_MANDATORY_UID
 	var/name
 	var/desc
 
@@ -17,6 +18,7 @@ var/global/list/default_uplink_source_priority = list(
 
 /decl/uplink_source/pda
 	name = "PDA"
+	uid = "uplink_pda"
 
 /decl/uplink_source/pda/Initialize()
 	desc = NO_GUARANTEE_NO_EXTRA_COST_DESC("a PDA")
@@ -48,6 +50,7 @@ var/global/list/default_uplink_source_priority = list(
 
 /decl/uplink_source/radio
 	name = "Radio"
+	uid = "uplink_radio"
 
 /decl/uplink_source/radio/Initialize()
 	desc = NO_GUARANTEE_NO_EXTRA_COST_DESC("a radio")
@@ -67,6 +70,7 @@ var/global/list/default_uplink_source_priority = list(
 /decl/uplink_source/implant
 	name = "Implant"
 	desc = "Teleports an uplink implant into your head. Costs 20% of the initial TC amount."
+	uid = "uplink_implant"
 
 /decl/uplink_source/implant/setup_uplink_source(var/mob/living/human/recipient, var/amount)
 	if(!istype(recipient))
@@ -82,6 +86,7 @@ var/global/list/default_uplink_source_priority = list(
 /decl/uplink_source/unit
 	name = "Uplink Unit"
 	desc = "Teleports an uplink unit to your location. Has 30% more TC."
+	uid = "uplink_unit"
 
 /decl/uplink_source/unit/setup_uplink_source(var/mob/M, var/amount)
 	var/obj/item/radio/uplink/U = new(M, M.mind, round(amount * 1.3))
@@ -90,6 +95,7 @@ var/global/list/default_uplink_source_priority = list(
 /decl/uplink_source/telecrystals
 	name = "Telecrystals"
 	desc = "Get your telecrystals in pure form, without the means to trade them for goods, Gives 150% of initial TC amount"
+	uid = "uplink_telecrystals"
 
 /decl/uplink_source/telecrystals/setup_uplink_source(var/mob/M, var/amount)
 	amount = round(amount * 1.5)

--- a/code/game/antagonist/antagonist.dm
+++ b/code/game/antagonist/antagonist.dm
@@ -1,5 +1,6 @@
 /decl/special_role
 	abstract_type = /decl/special_role
+	decl_flags = DECL_FLAG_MANDATORY_UID
 
 	// Text shown when becoming this antagonist.
 	var/list/restricted_jobs = 		list() // Jobs that cannot be this antagonist at roundstart (depending on config)

--- a/code/game/machinery/_machines_base/machine_construction/_construction.dm
+++ b/code/game/machinery/_machines_base/machine_construction/_construction.dm
@@ -26,6 +26,7 @@
 	return MCS_CHANGE
 
 /decl/machine_construction
+	abstract_type = /decl/machine_construction
 	var/needs_board  // Type of circuitboard expected, if any. Used in unit testing.
 	var/cannot_print // If false, unit testing will attempt to guarantee that the machine is buildable in-round. This inverts that behavior.
 	var/visible_components = TRUE // Whether user can see installed components on examine

--- a/code/game/machinery/_machines_base/machinery_public_vars.dm
+++ b/code/game/machinery/_machines_base/machinery_public_vars.dm
@@ -1,9 +1,11 @@
 /decl/public_access
+	abstract_type = /decl/public_access
 	decl_flags = DECL_FLAG_MANDATORY_UID
 	var/name
 	var/desc
 
 /decl/public_access/public_variable
+	abstract_type = /decl/public_access/public_variable
 	var/expected_type
 	var/can_write = FALSE
 	var/var_type = VAR_FORMAT_BOOLEAN // Reuses IC defines for better compatibility.
@@ -116,6 +118,7 @@ Public methods machines can expose. Pretty bare-bones; just wraps a proc and giv
 */
 
 /decl/public_access/public_method
+	abstract_type = /decl/public_access/public_method
 	var/call_proc
 	var/forward_args = FALSE
 

--- a/code/game/machinery/_machines_base/machinery_public_vars.dm
+++ b/code/game/machinery/_machines_base/machinery_public_vars.dm
@@ -1,4 +1,5 @@
 /decl/public_access
+	decl_flags = DECL_FLAG_MANDATORY_UID
 	var/name
 	var/desc
 

--- a/code/game/machinery/_machines_base/machinery_public_vars_common.dm
+++ b/code/game/machinery/_machines_base/machinery_public_vars_common.dm
@@ -12,6 +12,7 @@ Public vars at /obj/machinery level. Just because they are here does not mean th
 	desc = "The input toggle variable does not do anything by itself. This makes it useful for having receivers trigger transmitters. Can be toggled by a public method."
 	can_write = FALSE
 	has_updates = TRUE
+	uid = "public_var_machine_input_toggle"
 
 /decl/public_access/public_variable/input_toggle/access_var(obj/machinery/machine)
 	return machine.input_toggle
@@ -25,6 +26,7 @@ Public vars at /obj/machinery level. Just because they are here does not mean th
 	name = "toggle input"
 	desc = "Toggles the input toggle variable."
 	call_proc = TYPE_PROC_REF(/obj/machinery, toggle_input_toggle)
+	uid = "public_method_machine_toggle_input"
 
 /obj/machinery/proc/toggle_input_toggle()
 	var/decl/public_access/public_variable/variable = GET_DECL(/decl/public_access/public_variable/input_toggle)
@@ -37,6 +39,7 @@ Public vars at /obj/machinery level. Just because they are here does not mean th
 	can_write = FALSE
 	has_updates = FALSE
 	var_type = VAR_FORMAT_STRING
+	uid = "public_var_machine_area_id"
 
 /decl/public_access/public_variable/area_uid/access_var(obj/machinery/machine)
 	return machine.area_uid()
@@ -52,6 +55,7 @@ Public vars at /obj/machinery level. Just because they are here does not mean th
 	can_write = TRUE
 	has_updates = TRUE
 	var_type = VAR_FORMAT_STRING
+	uid = "public_var_machine_identifier"
 
 /decl/public_access/public_variable/identifier/access_var(obj/machinery/machine)
 	return machine.identifier
@@ -68,6 +72,7 @@ Public vars at /obj/machinery level. Just because they are here does not mean th
 	can_write = TRUE
 	has_updates = FALSE
 	var_type = VAR_FORMAT_NUMBER
+	uid = "public_var_machine_power_use"
 
 /decl/public_access/public_variable/use_power/access_var(obj/machinery/machine)
 	return machine.use_power
@@ -86,6 +91,7 @@ Public vars at /obj/machinery level. Just because they are here does not mean th
 	can_write = TRUE
 	has_updates = FALSE
 	var_type = VAR_FORMAT_STRING
+	uid = "public_var_machine_name"
 
 /decl/public_access/public_variable/name/access_var(obj/machinery/machine)
 	return machine.name
@@ -102,6 +108,7 @@ Public vars at /obj/machinery level. Just because they are here does not mean th
 	can_write = FALSE
 	has_updates = TRUE
 	var_type = VAR_FORMAT_LIST
+	uid = "public_var_machine_reagents"
 
 /decl/public_access/public_variable/reagents/access_var(obj/machinery/machine)
 	return istype(machine?.reagents) ? UNLINT(machine.reagents.reagent_data) : null
@@ -110,6 +117,7 @@ Public vars at /obj/machinery level. Just because they are here does not mean th
 	name = "reagents volumes"
 	desc = "Obtain the list of reagents and their volumes in the machine."
 	var_type = VAR_FORMAT_LIST
+	uid = "public_var_machine_reagent_volumes"
 
 /decl/public_access/public_variable/reagents/volumes/access_var(obj/machinery/machine)
 	return istype(machine?.reagents) ? UNLINT(REAGENT_VOLUMES(machine.reagents)) : null
@@ -118,6 +126,7 @@ Public vars at /obj/machinery level. Just because they are here does not mean th
 	name = "reagents free space"
 	desc = "Obtain the volume of free space left for reagents in the machine."
 	var_type = VAR_FORMAT_NUMBER
+	uid = "public_var_machine_reagents_free_space"
 
 /decl/public_access/public_variable/reagents/free_space/access_var(obj/machinery/machine)
 	return REAGENTS_FREE_SPACE(machine?.reagents)
@@ -126,6 +135,7 @@ Public vars at /obj/machinery level. Just because they are here does not mean th
 	name = "reagents total volume"
 	desc = "Obtain the total volume of reagents in the machine."
 	var_type = VAR_FORMAT_NUMBER
+	uid = "public_var_machine_reagents_total_volume"
 
 /decl/public_access/public_variable/reagents/total_volume/access_var(obj/machinery/machine)
 	return REAGENT_TOTAL_VOLUME(machine?.reagents)
@@ -134,6 +144,7 @@ Public vars at /obj/machinery level. Just because they are here does not mean th
 	name = "reagents maximum volume"
 	desc = "Obtain the maximum volume of reagents that can fit in the machine."
 	var_type = VAR_FORMAT_NUMBER
+	uid = "public_var_machine_reagents_maximum_volume"
 
 /decl/public_access/public_variable/reagents/maximum_volume/access_var(obj/machinery/machine)
 	return REAGENT_MAXIMUM_VOLUME(machine?.reagents)
@@ -142,6 +153,7 @@ Public vars at /obj/machinery level. Just because they are here does not mean th
 	name = "toggle power"
 	desc = "Turns the machine on or off."
 	call_proc = TYPE_PROC_REF(/obj/machinery, toggle_power)
+	uid = "public_method_machine_power_toggle"
 
 /obj/machinery/proc/toggle_power()
 	update_use_power(!use_power)
@@ -150,6 +162,7 @@ Public vars at /obj/machinery level. Just because they are here does not mean th
 	name = "refresh machine"
 	desc = "Attempts to refresh the machine's status. Implementation may vary."
 	call_proc = TYPE_PROC_REF(/obj/machinery, refresh)
+	uid = "public_var_machine_refresh"
 
 /obj/machinery/proc/refresh()
 	queue_icon_update()

--- a/code/game/machinery/_machines_base/stock_parts/stock_parts_presets.dm
+++ b/code/game/machinery/_machines_base/stock_parts/stock_parts_presets.dm
@@ -8,6 +8,7 @@ Do not work with lazy-initialized parts.
 	var/list/stock_part_presets  // Format: assotiative list of decl path -> number to apply.
 
 /decl/stock_part_preset
+	abstract_type = /decl/stock_part_preset
 	var/expected_part_type
 
 /decl/stock_part_preset/proc/apply(obj/machinery/machine, obj/item/stock_parts/part)

--- a/code/game/machinery/air_sensor.dm
+++ b/code/game/machinery/air_sensor.dm
@@ -37,6 +37,7 @@
 	can_write = FALSE
 	has_updates = FALSE
 	var_type = VAR_FORMAT_LIST
+	uid = "public_var_gas"
 
 /decl/public_access/public_variable/gas/access_var(obj/machinery/sensor)
 	var/datum/gas_mixture/air_sample = sensor.return_air()
@@ -59,6 +60,7 @@
 	can_write = FALSE
 	has_updates = FALSE
 	var_type = VAR_FORMAT_STRING
+	uid = "public_var_pressure"
 
 /decl/public_access/public_variable/pressure/access_var(obj/machinery/sensor)
 	var/datum/gas_mixture/air_sample = sensor.return_air()
@@ -71,6 +73,7 @@
 	can_write = FALSE
 	has_updates = FALSE
 	var_type = VAR_FORMAT_NUMBER
+	uid = "public_var_temperature"
 
 /decl/public_access/public_variable/temperature/access_var(obj/machinery/sensor)
 	var/datum/gas_mixture/air_sample = sensor.return_air()

--- a/code/game/machinery/buttons.dm
+++ b/code/game/machinery/buttons.dm
@@ -89,6 +89,7 @@
 	desc = "Toggled whenever the button is pressed."
 	can_write = FALSE
 	has_updates = TRUE
+	uid = "public_var_button_active"
 
 /decl/public_access/public_variable/button_active/access_var(obj/machinery/button/button)
 	return button.active
@@ -104,6 +105,7 @@
 	desc = "Toggled whenever the button is pressed. Inverse value of button toggle."
 	can_write = FALSE
 	has_updates = TRUE
+	uid = "public_var_button_active_inverse"
 
 /decl/public_access/public_variable/inv_button_active/access_var(obj/machinery/button/button)
 	return !button.active
@@ -121,6 +123,7 @@
 	can_write = TRUE
 	has_updates = FALSE
 	var_type = VAR_FORMAT_BOOLEAN
+	uid = "public_var_button_state"
 
 /decl/public_access/public_variable/button_state/access_var(obj/machinery/button/button)
 	return button.state

--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -357,12 +357,14 @@
 	name = "toggle camera"
 	desc = "Toggles camera on or off."
 	call_proc = TYPE_PROC_REF(/obj/machinery/camera, toggle_status)
+	uid = "public_method_camera_toggle"
 
 /decl/public_access/public_variable/camera_state
 	expected_type = /obj/machinery/camera
 	name = "camera status"
 	desc = "Status of the camera."
 	can_write = FALSE
+	uid = "public_var_camera_status"
 
 /decl/public_access/public_variable/camera_state/access_var(obj/machinery/camera/C)
 	return C.status ? "enabled" : "disabled"
@@ -372,6 +374,7 @@
 	name = "camera name"
 	desc = "Displayed name of the camera."
 	can_write = FALSE
+	uid = "public_var_camera_name"
 
 /decl/public_access/public_variable/camera_name/access_var(obj/machinery/camera/C)
 	var/datum/extension/network_device/camera/camera_device = get_extension(C, /datum/extension/network_device/)
@@ -382,6 +385,7 @@
 	name = "camera channels"
 	desc = "List of the channels this camera broadcasts on."
 	can_write = FALSE
+	uid = "public_var_camera_channels"
 
 /decl/public_access/public_variable/camera_channels/access_var(obj/machinery/camera/C)
 	return english_list(C.get_channels())

--- a/code/game/machinery/doors/_door.dm
+++ b/code/game/machinery/doors/_door.dm
@@ -606,19 +606,23 @@
 	name = "open door"
 	desc = "Opens the door if possible."
 	call_proc = TYPE_PROC_REF(/obj/machinery/door, open)
+	uid = "public_method_door_open"
 
 /decl/public_access/public_method/toggle_door
 	name = "toggle door"
 	desc = "Toggles whether the door is open or not, if possible."
 	call_proc = TYPE_PROC_REF(/obj/machinery/door, toggle)
+	uid = "public_method_door_toggle"
 
 /decl/public_access/public_method/toggle_door_to
 	name = "toggle door to"
 	desc = "Toggles the door, depending on the supplied argument, to open (if 1) or closed (if 0)."
 	call_proc = TYPE_PROC_REF(/obj/machinery/door, toggle)
 	forward_args = TRUE
+	uid = "public_method_door_set"
 
 /decl/public_access/public_method/close_door
 	name = "close door"
 	desc = "Closes the door if possible."
 	call_proc = TYPE_PROC_REF(/obj/machinery/door, close)
+	uid = "public_method_door_close"

--- a/code/game/machinery/doors/airlock_control.dm
+++ b/code/game/machinery/doors/airlock_control.dm
@@ -212,10 +212,13 @@
 		"pressure" = /decl/public_access/public_variable/airlock_pressure
 	)
 
-/decl/public_access/public_variable/set_airlock_cycling/airlock_sensor
-	expected_type = /obj/machinery/airlock_sensor
+/decl/public_access/public_variable/set_airlock_cycling
 	can_write     = TRUE
 	var_type      = VAR_FORMAT_BOOLEAN
+	abstract_type = /decl/public_access/public_variable/set_airlock_cycling
+
+/decl/public_access/public_variable/set_airlock_cycling/airlock_sensor
+	expected_type = /obj/machinery/airlock_sensor
 	uid           = "public_var_airlock_sensor_cycling"
 
 /decl/public_access/public_variable/set_airlock_cycling/airlock_sensor/access_var(obj/machinery/airlock_sensor/owner)
@@ -365,8 +368,6 @@
 //
 /decl/public_access/public_variable/set_airlock_cycling/access_button
 	expected_type = /obj/machinery/button/access
-	can_write     = TRUE
-	var_type      = VAR_FORMAT_BOOLEAN
 	uid           = "public_var_airlock_button_cycling"
 
 /decl/public_access/public_variable/set_airlock_cycling/access_button/access_var(obj/machinery/button/access/owner)

--- a/code/game/machinery/doors/airlock_control.dm
+++ b/code/game/machinery/doors/airlock_control.dm
@@ -57,16 +57,19 @@
 	name = "engage bolts"
 	desc = "Bolts the airlock, if possible."
 	call_proc = TYPE_PROC_REF(/obj/machinery/door/airlock, lock)
+	uid = "public_method_airlock_lock"
 
 /decl/public_access/public_method/airlock_unlock
 	name = "disengage bolts"
 	desc = "Unbolts the airlock, if possible."
 	call_proc = TYPE_PROC_REF(/obj/machinery/door/airlock, unlock)
+	uid = "public_method_airlock_unlock"
 
 /decl/public_access/public_method/airlock_toggle_bolts
 	name = "toggle bolts"
 	desc = "Toggles whether the airlock is bolted or not, if possible."
 	call_proc = TYPE_PROC_REF(/obj/machinery/door/airlock, toggle_lock)
+	uid = "public_method_airlock_bolts_toggle"
 
 /decl/public_access/public_variable/airlock_door_state
 	expected_type = /obj/machinery/door/airlock
@@ -75,6 +78,7 @@
 	can_write = FALSE
 	has_updates = FALSE
 	var_type = VAR_FORMAT_STRING
+	uid = "public_var_airlock_state"
 
 /decl/public_access/public_variable/airlock_door_state/access_var(obj/machinery/door/airlock/door)
 	return door.density ? "closed" : "open"
@@ -86,6 +90,7 @@
 	can_write = FALSE
 	has_updates = FALSE
 	var_type = VAR_FORMAT_STRING
+	uid = "public_var_airlock_bolt_state"
 
 /decl/public_access/public_variable/airlock_bolt_state/access_var(obj/machinery/door/airlock/door)
 	return door.locked ? "locked" : "unlocked"
@@ -191,6 +196,7 @@
 	can_write = FALSE
 	has_updates = TRUE
 	var_type = VAR_FORMAT_NUMBER
+	uid = "public_var_airlock_sensor_pressure"
 
 /decl/public_access/public_variable/airlock_pressure/access_var(obj/machinery/airlock_sensor/sensor)
 	return sensor.pressure
@@ -210,6 +216,7 @@
 	expected_type = /obj/machinery/airlock_sensor
 	can_write     = TRUE
 	var_type      = VAR_FORMAT_BOOLEAN
+	uid           = "public_var_airlock_sensor_cycling"
 
 /decl/public_access/public_variable/set_airlock_cycling/airlock_sensor/access_var(obj/machinery/airlock_sensor/owner)
 	return owner.master_cycling
@@ -360,6 +367,7 @@
 	expected_type = /obj/machinery/button/access
 	can_write     = TRUE
 	var_type      = VAR_FORMAT_BOOLEAN
+	uid           = "public_var_airlock_button_cycling"
 
 /decl/public_access/public_variable/set_airlock_cycling/access_button/access_var(obj/machinery/button/access/owner)
 	return owner.master_cycling
@@ -377,6 +385,7 @@
 	can_write = TRUE
 	has_updates = FALSE
 	var_type = VAR_FORMAT_STRING
+	uid = "public_var_airlock_button_command"
 
 /decl/public_access/public_variable/button_command/access_var(obj/machinery/button/access/button)
 	return button.command

--- a/code/game/machinery/doors/blast_door.dm
+++ b/code/game/machinery/doors/blast_door.dm
@@ -233,6 +233,7 @@
 	name = "delayed close door"
 	desc = "Closes the door if possible, after a short delay."
 	call_proc = TYPE_PROC_REF(/obj/machinery/door/blast, delayed_close)
+	uid = "public_method_blastdoor_close_delayed"
 
 /decl/stock_part_preset/radio/receiver/blast_door
 	frequency = BLAST_DOORS_FREQ

--- a/code/game/machinery/emitter.dm
+++ b/code/game/machinery/emitter.dm
@@ -180,6 +180,7 @@
 	name = "toggle emitter"
 	desc = "Toggles whether or not the emitter is active. It must be unlocked to work."
 	call_proc = TYPE_PROC_REF(/obj/machinery/emitter, activate)
+	uid = "public_method_emitter_toggle"
 
 /decl/public_access/public_variable/emitter_active
 	expected_type = /obj/machinery/emitter
@@ -187,6 +188,7 @@
 	desc = "Whether or not the emitter is firing."
 	can_write = FALSE
 	has_updates = FALSE
+	uid = "public_var_emitter_active"
 
 /decl/public_access/public_variable/emitter_active/access_var(obj/machinery/emitter/emitter)
 	return emitter.active
@@ -197,6 +199,7 @@
 	desc = "Whether or not the emitter is locked. Being locked prevents one from changing the active state."
 	can_write = FALSE
 	has_updates = FALSE
+	uid = "public_var_emitter_locked"
 
 /decl/public_access/public_variable/emitter_locked/access_var(obj/machinery/emitter/emitter)
 	return emitter.locked

--- a/code/game/machinery/flasher.dm
+++ b/code/game/machinery/flasher.dm
@@ -122,6 +122,7 @@
 	name = "flash"
 	desc = "Performs a flash, if possible."
 	call_proc = TYPE_PROC_REF(/obj/machinery/flasher, flash)
+	uid = "public_var_flasher_flash"
 
 /decl/stock_part_preset/radio/receiver/flasher
 	frequency = BUTTON_FREQ

--- a/code/game/machinery/holosign.dm
+++ b/code/game/machinery/holosign.dm
@@ -46,6 +46,7 @@
 	desc = "Whether or not the holosign is active."
 	can_write = FALSE
 	has_updates = FALSE
+	uid = "public_var_holosign_active"
 
 /decl/public_access/public_variable/holosign_on/access_var(obj/machinery/holosign/sign)
 	return sign.lit
@@ -54,6 +55,7 @@
 	name = "holosign toggle"
 	desc = "Toggle the holosign's active state."
 	call_proc = TYPE_PROC_REF(/obj/machinery/holosign, toggle)
+	uid = "public_method_holosign_toggle"
 
 /decl/stock_part_preset/radio/receiver/holosign
 	frequency = BUTTON_FREQ

--- a/code/game/machinery/igniter.dm
+++ b/code/game/machinery/igniter.dm
@@ -66,6 +66,7 @@
 	desc = "Whether or not the igniter is igniting."
 	can_write = FALSE
 	has_updates = FALSE
+	uid = "public_var_igniter_active"
 
 /decl/public_access/public_variable/igniter_on/access_var(obj/machinery/igniter/igniter)
 	return igniter.on
@@ -74,6 +75,7 @@
 	name = "igniter toggle"
 	desc = "Toggle the igniter on or off."
 	call_proc = TYPE_PROC_REF(/obj/machinery/igniter, toggle_igniter)
+	uid = "public_method_igniter_toggle"
 
 /decl/stock_part_preset/radio/receiver/igniter
 	frequency = BUTTON_FREQ
@@ -162,6 +164,7 @@
 	name = "spark"
 	desc = "Creates sparks to ignite nearby gases."
 	call_proc = TYPE_PROC_REF(/obj/machinery/sparker, create_sparks)
+	uid = "public_method_sparker_spark"
 
 /decl/stock_part_preset/radio/receiver/sparker
 	frequency = BUTTON_FREQ

--- a/code/game/machinery/mass_driver.dm
+++ b/code/game/machinery/mass_driver.dm
@@ -56,11 +56,13 @@
 	name = "launch"
 	desc = "Makes the mass driver launch immediately"
 	call_proc = TYPE_PROC_REF(/obj/machinery/mass_driver, drive)
+	uid = "public_method_massdriver_launch"
 
 /decl/public_access/public_method/driver_drive_delayed
 	name = "delayed launch"
 	desc = "Makes the mass driver launch after a short delay"
 	call_proc = TYPE_PROC_REF(/obj/machinery/mass_driver, delayed_drive)
+	uid = "public_method_massdriver_launch_delayed"
 
 /decl/stock_part_preset/radio/receiver/driver
 	frequency = BLAST_DOORS_FREQ

--- a/code/game/objects/structures/crates_lockers/closets/_closet_appearance_definitions.dm
+++ b/code/game/objects/structures/crates_lockers/closets/_closet_appearance_definitions.dm
@@ -3,6 +3,7 @@
 	. = ..(maploading)
 
 /decl/closet_appearance
+	// this is NOT abstract
 	var/color = COLOR_GRAY40
 	var/decals = list(
 		"upper_vent",

--- a/code/game/objects/structures/curtain_decls.dm
+++ b/code/game/objects/structures/curtain_decls.dm
@@ -2,10 +2,16 @@
 // Curtain types declaration
 //
 /decl/curtain_kind
+	abstract_type = /decl/curtain_kind
 	var/name = "curtain"
 	var/color = COLOR_WHITE
 	var/alpha = 255
-	var/material_key = /decl/material/solid/organic/plastic
+	var/material_key
+
+/decl/curtain_kind/validate()
+	. = ..()
+	if(isnull(material_key))
+		. += "no material key set"
 
 /decl/curtain_kind/proc/make_item(var/loc)
 	var/obj/item/curtain/C = new(loc)

--- a/code/modules/admin/view_variables/vv_set_handlers.dm
+++ b/code/modules/admin/view_variables/vv_set_handlers.dm
@@ -1,4 +1,5 @@
 /decl/vv_set_handler
+	abstract_type = /decl/vv_set_handler
 	var/handled_type
 	var/predicates
 	var/list/handled_vars

--- a/code/modules/atmospherics/atmos_primitives.dm
+++ b/code/modules/atmospherics/atmos_primitives.dm
@@ -478,6 +478,7 @@
 	can_write = FALSE
 	has_updates = FALSE
 	var_type = VAR_FORMAT_NUMBER
+	uid = "public_var_atmos_powerdraw"
 
 /decl/public_access/public_variable/power_draw/access_var(obj/machinery/atmospherics/machine)
 	return machine.last_power_draw
@@ -489,6 +490,7 @@
 	can_write = FALSE
 	has_updates = FALSE
 	var_type = VAR_FORMAT_NUMBER
+	uid = "public_var_atmos_flowrate"
 
 /decl/public_access/public_variable/flow_rate/access_var(obj/machinery/atmospherics/machine)
 	return machine.last_flow_rate

--- a/code/modules/atmospherics/components/binary_devices/passive_gate.dm
+++ b/code/modules/atmospherics/components/binary_devices/passive_gate.dm
@@ -197,6 +197,7 @@
 	can_write = TRUE
 	has_updates = FALSE
 	var_type = VAR_FORMAT_BOOLEAN
+	uid = "public_var_passive_gate_unlocked"
 
 /decl/public_access/public_variable/passive_gate_unlocked/access_var(obj/machinery/atmospherics/binary/passive_gate/machine)
 	return machine.unlocked
@@ -214,6 +215,7 @@
 	can_write = TRUE
 	has_updates = FALSE
 	var_type = VAR_FORMAT_NUMBER
+	uid = "public_var_passive_gate_flowrate"
 
 /decl/public_access/public_variable/passive_gate_flow_rate/access_var(obj/machinery/atmospherics/binary/passive_gate/machine)
 	return machine.set_flow_rate
@@ -231,6 +233,7 @@
 	can_write = TRUE
 	has_updates = FALSE
 	var_type = VAR_FORMAT_NUMBER
+	uid = "public_var_passive_gate_mode"
 
 /decl/public_access/public_variable/passive_gate_mode/access_var(obj/machinery/atmospherics/binary/passive_gate/machine)
 	return machine.regulate_mode
@@ -248,6 +251,7 @@
 	can_write = TRUE
 	has_updates = FALSE
 	var_type = VAR_FORMAT_NUMBER
+	uid = "public_var_passive_gate_target_pressure"
 
 /decl/public_access/public_variable/passive_gate_target_pressure/access_var(obj/machinery/atmospherics/binary/passive_gate/machine)
 	return machine.target_pressure
@@ -262,6 +266,7 @@
 	name = "toggle valve"
 	desc = "Open or close the valve."
 	call_proc = TYPE_PROC_REF(/obj/machinery/atmospherics/binary/passive_gate, toggle_unlocked)
+	uid = "public_method_passive_gate_toggle"
 
 /decl/stock_part_preset/radio/event_transmitter/passive_gate
 	frequency = PUMP_FREQ

--- a/code/modules/atmospherics/components/binary_devices/pump.dm
+++ b/code/modules/atmospherics/components/binary_devices/pump.dm
@@ -174,6 +174,7 @@ Thus, the two variables affect pump operation are set in New():
 	can_write = TRUE
 	has_updates = FALSE
 	var_type = VAR_FORMAT_NUMBER
+	uid = "public_var_pump_target_pressure"
 
 /decl/public_access/public_variable/pump_target_output/access_var(obj/machinery/atmospherics/binary/pump/machine)
 	return machine.target_pressure

--- a/code/modules/atmospherics/components/tvalve.dm
+++ b/code/modules/atmospherics/components/tvalve.dm
@@ -125,6 +125,7 @@
 	desc = "If true, the output is diverted to the side; if false, the output goes straight."
 	can_write = FALSE
 	has_updates = FALSE
+	uid = "public_var_tvalve_state"
 
 /decl/public_access/public_variable/tvalve_state/access_var(obj/machinery/atmospherics/tvalve/tvalve)
 	return tvalve.state
@@ -133,16 +134,19 @@
 	name = "valve go straight"
 	desc = "Sets the valve to send output straight."
 	call_proc = TYPE_PROC_REF(/obj/machinery/atmospherics/tvalve, go_straight)
+	uid = "public_method_tvalve_straight"
 
 /decl/public_access/public_method/tvalve_go_side
 	name = "valve go side"
 	desc = "Redirects output to the side."
 	call_proc = TYPE_PROC_REF(/obj/machinery/atmospherics/tvalve, go_to_side)
+	uid = "public_method_tvalve_side"
 
 /decl/public_access/public_method/tvalve_toggle
 	name = "valve toggle"
 	desc = "Toggles the output direction."
 	call_proc = TYPE_PROC_REF(/obj/machinery/atmospherics/tvalve, toggle)
+	uid = "public_method_tvalve_toggle"
 
 /decl/stock_part_preset/radio/receiver/tvalve
 	frequency = FUEL_FREQ

--- a/code/modules/atmospherics/components/unary/outlet_injector.dm
+++ b/code/modules/atmospherics/components/unary/outlet_injector.dm
@@ -137,11 +137,12 @@
 
 /decl/public_access/public_variable/volume_rate
 	expected_type = /obj/machinery/atmospherics/unary/outlet_injector
-	name = "volume_rate"
+	name = "volume rate"
 	desc = "The rate at which the machine pumps (a number)."
 	can_write = TRUE
 	has_updates = FALSE
 	var_type = VAR_FORMAT_NUMBER
+	uid = "public_var_outlet_injector_volume_rate"
 
 /decl/public_access/public_variable/volume_rate/access_var(obj/machinery/atmospherics/unary/outlet_injector/machine)
 	return machine.volume_rate
@@ -156,6 +157,7 @@
 	name = "inject"
 	desc = "Injects gas into its environment."
 	call_proc = TYPE_PROC_REF(/obj/machinery/atmospherics/unary/outlet_injector, inject)
+	uid = "public_method_outlet_injector_inject"
 
 /decl/stock_part_preset/radio/event_transmitter/outlet_injector
 	frequency = ATMOS_TANK_FREQ

--- a/code/modules/atmospherics/components/unary/vent_pump.dm
+++ b/code/modules/atmospherics/components/unary/vent_pump.dm
@@ -367,6 +367,7 @@
 	can_write = TRUE
 	has_updates = TRUE
 	var_type = VAR_FORMAT_STRING
+	uid = "public_var_vent_pump_dir"
 
 /decl/public_access/public_variable/pump_dir/access_var(obj/machinery/atmospherics/unary/vent_pump/machine)
 	return machine.pump_direction ? "release" : "siphon"
@@ -385,6 +386,7 @@
 	can_write = TRUE
 	has_updates = FALSE
 	var_type = VAR_FORMAT_ANY
+	uid = "public_var_vent_pump_checks"
 
 /decl/public_access/public_variable/pump_checks/access_var(obj/machinery/atmospherics/unary/vent_pump/machine)
 	return machine.pressure_checks
@@ -404,6 +406,7 @@
 	can_write = TRUE
 	has_updates = FALSE
 	var_type = VAR_FORMAT_ANY
+	uid = "public_var_vent_pump_bound_internal"
 
 /decl/public_access/public_variable/pressure_bound/access_var(obj/machinery/atmospherics/unary/vent_pump/machine)
 	return machine.internal_pressure_bound
@@ -423,6 +426,7 @@
 	expected_type = /obj/machinery/atmospherics/unary/vent_pump
 	name = "external pressure bound"
 	desc = "The bound on external pressure used in checks (a number). When writing, can be supplied the string keyword \"default\" instead."
+	uid = "public_var_vent_pump_bound_external"
 
 /decl/public_access/public_variable/pressure_bound/external/access_var(obj/machinery/atmospherics/unary/vent_pump/machine)
 	return machine.external_pressure_bound
@@ -439,11 +443,13 @@
 	name = "activate purge mode"
 	desc = "Activates purge mode, overriding pressure checks and removing air."
 	call_proc = TYPE_PROC_REF(/obj/machinery/atmospherics/unary/vent_pump, purge)
+	uid = "public_method_vent_pump_purge"
 
 /decl/public_access/public_method/toggle_pump_dir
 	name = "toggle pump direction"
 	desc = "Toggles the pump's direction, from release to siphon or vice versa."
 	call_proc = TYPE_PROC_REF(/obj/machinery/atmospherics/unary/vent_pump, toggle_pump_dir)
+	uid = "public_method_vent_pump_toggle_dir"
 
 /decl/stock_part_preset/radio/event_transmitter/vent_pump
 	frequency = PUMP_FREQ

--- a/code/modules/atmospherics/components/unary/vent_scrubber.dm
+++ b/code/modules/atmospherics/components/unary/vent_scrubber.dm
@@ -265,6 +265,7 @@
 	can_write = TRUE
 	has_updates = FALSE
 	var_type = VAR_FORMAT_STRING
+	uid = "public_var_vent_scrubber_mode"
 
 /decl/public_access/public_variable/scrubbing/access_var(obj/machinery/atmospherics/unary/vent_scrubber/machine)
 	return machine.scrubbing
@@ -285,6 +286,7 @@
 	can_write = TRUE
 	has_updates = FALSE
 	var_type = VAR_FORMAT_BOOLEAN
+	uid = "public_var_vent_scrubber_panic"
 
 /decl/public_access/public_variable/panic/access_var(obj/machinery/atmospherics/unary/vent_scrubber/machine)
 	return machine.panic
@@ -307,6 +309,7 @@
 	can_write = FALSE
 	has_updates = FALSE
 	var_type = VAR_FORMAT_LIST
+	uid = "public_var_vent_scrubber_scrubbing_gas"
 
 /decl/public_access/public_variable/scrubbing_gas/access_var(obj/machinery/atmospherics/unary/vent_scrubber/machine)
 	return machine.scrubbing_gas.Copy()
@@ -315,12 +318,14 @@
 	name = "toggle panic siphon"
 	desc = "Toggles the panic siphon function."
 	call_proc = TYPE_PROC_REF(/obj/machinery/atmospherics/unary/vent_scrubber, toggle_panic)
+	uid = "public_method_vent_scrubber_panic_toggle"
 
 /decl/public_access/public_method/set_scrub_gas
 	name = "set filter gases"
 	desc = "Given a list of gases, sets whether the gas is being scrubbed to the value of the gas in the list."
 	forward_args = TRUE
 	call_proc = TYPE_PROC_REF(/obj/machinery/atmospherics/unary/vent_scrubber, set_scrub_gas)
+	uid = "public_method_vent_scrubber_set_scrub_gas"
 
 /decl/stock_part_preset/radio/event_transmitter/vent_scrubber
 	frequency = PUMP_FREQ

--- a/code/modules/atmospherics/components/valve.dm
+++ b/code/modules/atmospherics/components/valve.dm
@@ -125,6 +125,7 @@
 	desc = "Whether or not the valve is open."
 	can_write = FALSE
 	has_updates = FALSE
+	uid = "public_var_valve_open"
 
 /decl/public_access/public_variable/valve_open/access_var(obj/machinery/atmospherics/valve/valve)
 	return valve.open
@@ -133,16 +134,19 @@
 	name = "open valve"
 	desc = "Sets the valve to open."
 	call_proc = TYPE_PROC_REF(/obj/machinery/atmospherics/valve, open)
+	uid = "public_method_valve_open"
 
 /decl/public_access/public_method/close_valve
 	name = "open valve"
 	desc = "Sets the valve to open."
 	call_proc = TYPE_PROC_REF(/obj/machinery/atmospherics/valve, close)
+	uid = "public_method_valve_close"
 
 /decl/public_access/public_method/toggle_valve
 	name = "toggle valve"
 	desc = "Toggles whether the valve is open or closed."
 	call_proc = TYPE_PROC_REF(/obj/machinery/atmospherics/valve, toggle)
+	uid = "public_method_valve_toggle"
 
 /obj/machinery/atmospherics/valve/digital		// can be controlled by AI
 	name = "digital valve"

--- a/code/modules/client/preference_setup/global/prefixes.dm
+++ b/code/modules/client/preference_setup/global/prefixes.dm
@@ -1,4 +1,5 @@
 /decl/prefix
+	abstract_type = /decl/prefix
 	decl_flags = DECL_FLAG_MANDATORY_UID
 	var/name
 	var/default_key

--- a/code/modules/client/preference_setup/global/prefixes.dm
+++ b/code/modules/client/preference_setup/global/prefixes.dm
@@ -1,4 +1,5 @@
 /decl/prefix
+	decl_flags = DECL_FLAG_MANDATORY_UID
 	var/name
 	var/default_key
 	var/is_locked = FALSE
@@ -6,24 +7,30 @@
 /decl/prefix/language
 	name = "Language"
 	default_key = ","
+	uid = "chat_prefix_language"
 
 /decl/prefix/radio_channel_selection
 	name = "Radio, channel selection"
 	default_key = ":"
 	is_locked = TRUE
+	uid = "chat_prefix_radio_channel"
 
 /decl/prefix/radio_main_channel
 	name = "Radio, main channel"
 	default_key = ";"
+	uid = "chat_prefix_radio_channel_main"
 
 /decl/prefix/audible_emote
 	name = "Emote, audible"
 	default_key = "!"
+	uid = "chat_prefix_emote_audible"
 
 /decl/prefix/visible_emote
 	name = "Emote, visible"
 	default_key = "^"
+	uid = "chat_prefix_emote_visible"
 
 /decl/prefix/custom_emote
 	name = "Emote, custom"
 	default_key = "*"
+	uid = "chat_prefix_emote_custom"

--- a/code/modules/client/preference_setup/loadout/lists/accessories.dm
+++ b/code/modules/client/preference_setup/loadout/lists/accessories.dm
@@ -1,5 +1,6 @@
 /decl/loadout_category/accessories
 	name = "Accessories"
+	uid = "loadout_category_accessories"
 
 /decl/loadout_option/accessory
 	category = /decl/loadout_category/accessories

--- a/code/modules/client/preference_setup/loadout/lists/clothing.dm
+++ b/code/modules/client/preference_setup/loadout/lists/clothing.dm
@@ -1,5 +1,6 @@
 /decl/loadout_category/clothing
 	name = "Clothing"
+	uid = "loadout_category_clothing"
 
 /decl/loadout_option/clothing
 	category = /decl/loadout_category/clothing

--- a/code/modules/client/preference_setup/loadout/lists/earwear.dm
+++ b/code/modules/client/preference_setup/loadout/lists/earwear.dm
@@ -1,5 +1,6 @@
 /decl/loadout_category/ears
 	name = "Earwear"
+	uid = "loadout_category_ears"
 
 // Stuff worn on the ears. Items here go in the "ears" sort_category but they must not use
 // the slot_r_ear_str or slot_l_ear_str as the slot, or else players will spawn with no headset.

--- a/code/modules/client/preference_setup/loadout/lists/eyegear.dm
+++ b/code/modules/client/preference_setup/loadout/lists/eyegear.dm
@@ -1,5 +1,6 @@
 /decl/loadout_category/eyes
 	name = "Eyewear"
+	uid = "loadout_category_eyes"
 
 /decl/loadout_option/eyes
 	category = /decl/loadout_category/eyes

--- a/code/modules/client/preference_setup/loadout/lists/footwear.dm
+++ b/code/modules/client/preference_setup/loadout/lists/footwear.dm
@@ -1,5 +1,6 @@
 /decl/loadout_category/feet
 	name = "Footwear"
+	uid = "loadout_category_feet"
 
 /decl/loadout_option/shoes
 	slot = slot_shoes_str

--- a/code/modules/client/preference_setup/loadout/lists/gloves.dm
+++ b/code/modules/client/preference_setup/loadout/lists/gloves.dm
@@ -1,5 +1,6 @@
 /decl/loadout_category/hands
 	name = "Handwear"
+	uid = "loadout_category_hands"
 
 /decl/loadout_option/gloves
 	cost = 2

--- a/code/modules/client/preference_setup/loadout/lists/headwear.dm
+++ b/code/modules/client/preference_setup/loadout/lists/headwear.dm
@@ -1,5 +1,6 @@
 /decl/loadout_category/head
 	name = "Headwear"
+	uid = "loadout_category_head"
 
 /decl/loadout_option/head
 	slot = slot_head_str

--- a/code/modules/client/preference_setup/loadout/lists/suits.dm
+++ b/code/modules/client/preference_setup/loadout/lists/suits.dm
@@ -1,5 +1,6 @@
 /decl/loadout_category/suit
 	name = "Suits"
+	uid = "loadout_category_suit"
 
 /decl/loadout_option/suit
 	slot = slot_wear_suit_str

--- a/code/modules/client/preference_setup/loadout/lists/uniforms.dm
+++ b/code/modules/client/preference_setup/loadout/lists/uniforms.dm
@@ -1,5 +1,6 @@
 /decl/loadout_category/uniform
 	name = "Uniform"
+	uid = "loadout_category_uniform"
 
 /decl/loadout_option/uniform
 	slot = slot_w_uniform_str

--- a/code/modules/client/preference_setup/loadout/lists/utility.dm
+++ b/code/modules/client/preference_setup/loadout/lists/utility.dm
@@ -1,5 +1,6 @@
 /decl/loadout_category/utility
 	name = "Utility"
+	uid = "loadout_category_utility"
 
 // "Useful" items - I'm guessing things that might be used at work?
 /decl/loadout_option/utility

--- a/code/modules/client/preference_setup/loadout/loadout.dm
+++ b/code/modules/client/preference_setup/loadout/loadout.dm
@@ -382,6 +382,8 @@
 	return ..()
 
 /decl/loadout_category
+	decl_flags = DECL_FLAG_MANDATORY_UID
+	uid = "loadout_category_miscellaneous"
 	var/name = "Miscellaneous"
 	var/max_selections = INFINITY
 	var/list/gear = list()

--- a/code/modules/codex/categories/_category.dm
+++ b/code/modules/codex/categories/_category.dm
@@ -1,4 +1,5 @@
 /decl/codex_category
+	abstract_type = /decl/codex_category
 	var/name = "Generic Category"
 	var/desc = "Some description for category's codex entry"
 	var/list/items = list()

--- a/code/modules/crafting/slapcrafting/_crafting_stage.dm
+++ b/code/modules/crafting/slapcrafting/_crafting_stage.dm
@@ -1,4 +1,5 @@
 /decl/crafting_stage
+	abstract_type = /decl/crafting_stage
 	var/descriptor = "undefined crafted item"
 	var/item_desc = "It's an unfinished item of some sort."
 	var/item_icon = 'icons/obj/crafting_icons.dmi'

--- a/code/modules/crafting/stack_recipes/_recipe.dm
+++ b/code/modules/crafting/stack_recipes/_recipe.dm
@@ -15,6 +15,7 @@
  */
 /decl/stack_recipe
 	abstract_type = /decl/stack_recipe
+	decl_flags = DECL_FLAG_MANDATORY_UID
 	/// Descriptive name, omitting any materials etc. Taken from product if null.
 	var/name
 	/// Descriptive name for multiple products, uses "[name]s" if null.

--- a/code/modules/crafting/stack_recipes/recipe_structures.dm
+++ b/code/modules/crafting/stack_recipes/recipe_structures.dm
@@ -7,3 +7,4 @@
 	required_material   = /decl/material/solid/metal/chromium
 	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
 	category            = "furniture"
+	uid                 = "stack_recipe_anomaly_container"

--- a/code/modules/crafting/stack_recipes/recipes_bricks.dm
+++ b/code/modules/crafting/stack_recipes/recipes_bricks.dm
@@ -14,12 +14,15 @@
 
 /decl/stack_recipe/bricks/cup
 	result_type                = /obj/item/chems/glass/handmade/cup
+	uid                        = "stack_recipe_brick_cup"
 
 /decl/stack_recipe/bricks/mug
 	result_type                = /obj/item/chems/glass/handmade/mug
+	uid                        = "stack_recipe_brick_mug"
 
 /decl/stack_recipe/bricks/bowl
 	result_type                = /obj/item/chems/glass/handmade/bowl
+	uid                        = "stack_recipe_brick_bowl"
 
 /decl/stack_recipe/bricks/fire_source
 	abstract_type              = /decl/stack_recipe/bricks/fire_source
@@ -41,12 +44,15 @@
 		/obj/item/stack/material/log,
 	)
 	difficulty                 = MAT_VALUE_EASY_DIY
+	uid                        = "stack_recipe_brick_firepit"
 
 /decl/stack_recipe/bricks/fire_source/kiln
 	result_type                = /obj/structure/fire_source/kiln
+	uid                        = "stack_recipe_brick_kiln"
 
 /decl/stack_recipe/bricks/fire_source/alembic
 	result_type                = /obj/structure/fire_source/heater
+	uid                        = "stack_recipe_brick_alembic"
 
 /decl/stack_recipe/bricks/furniture
 	abstract_type              = /decl/stack_recipe/bricks/furniture
@@ -59,71 +65,87 @@
 	name                       = "pillar, square"
 	result_type                = /obj/structure/pillar
 	category                   = "structures"
+	uid                        = "stack_recipe_brick_pillar_square"
 
 /decl/stack_recipe/bricks/furniture/pillar/narrow
 	name                       = "pillar, narrow"
 	result_type                = /obj/structure/pillar/narrow
+	uid                        = "stack_recipe_brick_pillar_narrow"
 
 /decl/stack_recipe/bricks/furniture/pillar/triad
 	name                       = "pillar, triad"
 	result_type                = /obj/structure/pillar/triad
+	uid                        = "stack_recipe_brick_pillar_triad"
 
 /decl/stack_recipe/bricks/furniture/pillar/round
 	name                       = "pillar, round"
 	result_type                = /obj/structure/pillar/round
+	uid                        = "stack_recipe_brick_pillar_round"
 
 /decl/stack_recipe/bricks/furniture/pillar/wide_round
 	name                       = "pillar, wide round"
 	result_type                = /obj/structure/pillar/wide
+	uid                        = "stack_recipe_brick_pillar_wide_round"
 
 /decl/stack_recipe/bricks/furniture/pillar/wide_square
 	name                       = "pillar, wide square"
-
 	result_type                = /obj/structure/pillar/wide/square
+	uid                        = "stack_recipe_brick_pillar_wide_square"
 
 /decl/stack_recipe/bricks/furniture/pillar/wide_inset
 	name                       = "pillar, wide inset"
 	result_type                = /obj/structure/pillar/wide/inset
+	uid                        = "stack_recipe_brick_wide_inset"
 
 /decl/stack_recipe/bricks/furniture/pillar/pedestal
 	name                       = "pedestal, square"
 	result_type                = /obj/structure/pedestal
+	uid                        = "stack_recipe_brick_pedestal_square"
 
 /decl/stack_recipe/bricks/furniture/pillar/pedestal_narrow
 	name                       = "pedestal, narrow"
 	result_type                = /obj/structure/pedestal/narrow
+	uid                        = "stack_recipe_brick_pedestal_narrow"
 
 /decl/stack_recipe/bricks/furniture/pillar/pedestal_triad
 	name                       = "pedestal, triad"
 	result_type                = /obj/structure/pedestal/triad
+	uid                        = "stack_recipe_brick_pedestal_triad"
 
 /decl/stack_recipe/bricks/furniture/pillar/pedestal_round
 	name                       = "pedestal, round"
 	result_type                = /obj/structure/pedestal/round
+	uid                        = "stack_recipe_brick_pedestal_round"
 
 /decl/stack_recipe/bricks/furniture/fence
 	result_type                = /obj/structure/fence/brick
 	difficulty                 = MAT_VALUE_NORMAL_DIY
+	uid                        = "stack_recipe_brick_fence"
 
 /decl/stack_recipe/bricks/furniture/fence_door
 	result_type                = /obj/structure/fence/door/brick
 	difficulty                 = MAT_VALUE_NORMAL_DIY
+	uid                        = "stack_recipe_brick_fence_door"
 
 /decl/stack_recipe/bricks/gravestone
 	result_type                = /obj/item/gravemarker/gravestone
 	difficulty                 = MAT_VALUE_NORMAL_DIY
+	uid                        = "stack_recipe_brick_gravestone"
 
 /decl/stack_recipe/bricks/fountain
 	result_type                = /obj/structure/fountain/mundane
 	one_per_turf               = TRUE
 	on_floor                   = TRUE
 	difficulty                 = MAT_VALUE_VERY_HARD_DIY
+	uid                        = "stack_recipe_brick_fountain"
 
 /decl/stack_recipe/bricks/fountain/well
 	result_type                = /obj/structure/reagent_dispensers/well
+	uid                        = "stack_recipe_brick_well"
 
 /decl/stack_recipe/bricks/fountain/wall
 	result_type                = /obj/structure/reagent_dispensers/well/wall_fountain
+	uid                        = "stack_recipe_brick_wall_fountain"
 
 /decl/stack_recipe/turfs/wall/brick
 	name                       = "brick wall"
@@ -131,23 +153,28 @@
 	craft_stack_types          = /obj/item/stack/material/brick
 	difficulty                 = MAT_VALUE_HARD_DIY
 	validation_material        = /decl/material/solid/stone/basalt
+	uid                        = "stack_recipe_brick_wall"
 
 /decl/stack_recipe/turfs/wall/brick/shutter
 	name                       = "shuttered brick wall"
 	result_type                = /turf/wall/brick/shutter
+	uid                        = "stack_recipe_brick_wall_shutter"
 
 /decl/stack_recipe/turfs/floor/brick
 	name                       = "cobblestone path"
 	result_type                = /turf/floor/path
 	craft_stack_types          = /obj/item/stack/material/brick
 	validation_material        = /decl/material/solid/stone/basalt
+	uid                        = "stack_recipe_brick_path_cobblestone"
 
 /decl/stack_recipe/turfs/floor/brick/herringbone
 	name                       = "herringbone path"
 	result_type                = /turf/floor/path/herringbone
 	difficulty                 = MAT_VALUE_HARD_DIY
+	uid                        = "stack_recipe_brick_path_herringbone"
 
 /decl/stack_recipe/turfs/floor/brick/running_bond
 	name                       = "running bond path"
 	result_type                = /turf/floor/path/running_bond
 	difficulty                 = MAT_VALUE_HARD_DIY
+	uid                        = "stack_recipe_brick_path_running_bond"

--- a/code/modules/crafting/stack_recipes/recipes_cardstock.dm
+++ b/code/modules/crafting/stack_recipes/recipes_cardstock.dm
@@ -7,48 +7,63 @@
 /decl/stack_recipe/cardstock/box
 	result_type       = /obj/item/box
 	category          = "cardstock boxes"
+	uid               = "stack_recipe_cardstock_box"
 
 /decl/stack_recipe/cardstock/box/large
 	result_type       = /obj/item/box/large
+	uid               = "stack_recipe_cardstock_box_large"
 
 /decl/stack_recipe/cardstock/box/donut
 	result_type       = /obj/item/box/fancy/donut/empty
+	uid               = "stack_recipe_cardstock_box_donut"
 
 /decl/stack_recipe/cardstock/box/egg
 	result_type       = /obj/item/box/fancy/egg_box/empty
+	uid               = "stack_recipe_cardstock_box_egg"
 
 /decl/stack_recipe/cardstock/box/light_tubes
 	result_type       = /obj/item/box/lights/tubes/empty
+	uid               = "stack_recipe_cardstock_box_tubes"
 
 /decl/stack_recipe/cardstock/box/light_bulbs
 	result_type       = /obj/item/box/lights/bulbs/empty
+	uid               = "stack_recipe_cardstock_box_bulbs"
 
 /decl/stack_recipe/cardstock/box/mouse_traps
 	result_type       = /obj/item/box/mousetraps/empty
+	uid               = "stack_recipe_cardstock_box_mousetraps"
 
 /decl/stack_recipe/cardstock/box/pizza
 	result_type       = /obj/item/pizzabox
+	uid               = "stack_recipe_cardstock_box_pizza"
 
 /decl/stack_recipe/cardstock/cardborg_suit
 	result_type       = /obj/item/clothing/suit/cardborg
 	difficulty        = MAT_VALUE_EASY_DIY
+	uid               = "stack_recipe_cardstock_cardborg_suit"
 
 /decl/stack_recipe/cardstock/cardborg_helmet
 	result_type       = /obj/item/clothing/head/cardborg
 	difficulty        = MAT_VALUE_EASY_DIY
+	uid               = "stack_recipe_cardstock_cardborg_helmet"
 
 /decl/stack_recipe/cardstock/folder
 	result_type       = /obj/item/folder
 	category          = "folders"
+	uid               = "stack_recipe_cardstock_folder"
 
 /decl/stack_recipe/cardstock/folder/yellow
 	result_type       = /obj/item/folder/yellow
+	uid               = "stack_recipe_cardstock_folder_yellow"
 
 /decl/stack_recipe/cardstock/folder/cyan
 	result_type       = /obj/item/folder/cyan
+	uid               = "stack_recipe_cardstock_folder_cyan"
 
 /decl/stack_recipe/cardstock/folder/red
 	result_type       = /obj/item/folder/red
+	uid               = "stack_recipe_cardstock_folder_red"
 
 /decl/stack_recipe/cardstock/folder/blue
 	result_type       = /obj/item/folder/blue
+	uid               = "stack_recipe_cardstock_folder_blue"

--- a/code/modules/crafting/stack_recipes/recipes_fodder.dm
+++ b/code/modules/crafting/stack_recipes/recipes_fodder.dm
@@ -8,6 +8,8 @@
 	difficulty                  = MAT_VALUE_EASY_DIY
 	recipe_skill                = SKILL_BOTANY
 	req_amount                  = 30 * SHEET_MATERIAL_AMOUNT // Arbitrary amount to make 20 food items.
+	uid                         = "stack_recipe_fodder_stack"
 
 /decl/stack_recipe/fodder/bale
 	result_type                 = /obj/structure/haystack/bale
+	uid                         = "stack_recipe_fodder_bale"

--- a/code/modules/crafting/stack_recipes/recipes_grass.dm
+++ b/code/modules/crafting/stack_recipes/recipes_grass.dm
@@ -13,39 +13,47 @@
 	return ..()
 
 /decl/stack_recipe/woven/rug
-	result_type                = /obj/structure/rug/crafted
-	one_per_turf               = TRUE
-	on_floor                   = TRUE
-	category                   = "furniture"
+	result_type                 = /obj/structure/rug/crafted
+	one_per_turf                = TRUE
+	on_floor                    = TRUE
+	category                    = "furniture"
+	uid                         = "stack_recipe_woven_rug"
 
 /decl/stack_recipe/woven/basket
-	result_type       = /obj/item/basket
+	result_type                 = /obj/item/basket
+	uid                         = "stack_recipe_woven_basket"
 
 /decl/stack_recipe/woven/large_basket
-	result_type       = /obj/item/basket/large
+	result_type                 = /obj/item/basket/large
+	uid                         = "stack_recipe_woven_basket_large"
 
 /decl/stack_recipe/woven/banner
-	result_type       = /obj/item/banner/woven
+	result_type                 = /obj/item/banner/woven
+	uid                         = "stack_recipe_woven_banner"
 
 /decl/stack_recipe/tile/woven
-	name              = "woven roof tile"
-	craft_stack_types = /obj/item/stack/material/bundle
-	required_material = /decl/material/solid/organic/plantmatter/grass/dry
-	result_type       = /obj/item/stack/tile/roof/woven
+	name                        = "woven roof tile"
+	craft_stack_types           = /obj/item/stack/material/bundle
+	required_material           = /decl/material/solid/organic/plantmatter/grass/dry
+	result_type                 = /obj/item/stack/tile/roof/woven
 	forbidden_craft_stack_types = null
+	uid                         = "stack_recipe_woven_roof_tile"
 
 /decl/stack_recipe/tile/woven/floor
-	name              = "woven floor tile"
-	result_type       = /obj/item/stack/tile/woven
+	name                        = "woven floor tile"
+	result_type                 = /obj/item/stack/tile/woven
+	uid                         = "stack_recipe_woven_floor_tile"
 
 /decl/stack_recipe/woven/bowstring
-	result_type       = /obj/item/bowstring
-	difficulty        = MAT_VALUE_VERY_HARD_DIY
+	result_type                 = /obj/item/bowstring
+	difficulty                  = MAT_VALUE_VERY_HARD_DIY
 	// TODO: cord
-	craft_stack_types = list(
+	craft_stack_types           = list(
 		/obj/item/stack/material/bundle,
 		/obj/item/stack/material/thread
 	)
+	uid                         = "stack_recipe_woven_bowstring"
 
 /decl/stack_recipe/woven/dummy
-	result_type = /obj/item/training_dummy/straw
+	result_type                 = /obj/item/training_dummy/straw
+	uid                         = "stack_recipe_woven_dummy"

--- a/code/modules/crafting/stack_recipes/recipes_hardness.dm
+++ b/code/modules/crafting/stack_recipes/recipes_hardness.dm
@@ -6,15 +6,19 @@
 /decl/stack_recipe/hardness/improvised_armour
 	result_type       = /obj/item/clothing/suit/armor/crafted
 	category          = "improvised armor"
+	uid               = "stack_recipe_improvised_suit"
 
 /decl/stack_recipe/hardness/improvised_armour/armguards
 	result_type       = /obj/item/clothing/gloves/armguards/craftable
+	uid               = "stack_recipe_improvised_armguards"
 
 /decl/stack_recipe/hardness/improvised_armour/legguards
 	result_type       = /obj/item/clothing/shoes/legguards/craftable
+	uid               = "stack_recipe_improvised_legguards"
 
 /decl/stack_recipe/hardness/improvised_armour/gauntlets
 	result_type       = /obj/item/clothing/gloves/thick/craftable
+	uid               = "stack_recipe_improvised_gauntlets"
 
 /decl/stack_recipe/hardness/utensils
 	abstract_type     = /decl/stack_recipe/hardness/utensils
@@ -22,25 +26,31 @@
 
 /decl/stack_recipe/hardness/utensils/fork
 	result_type       = /obj/item/utensil/fork
+	uid               = "stack_recipe_fork"
 
 /decl/stack_recipe/hardness/utensils/chopsticks
 	result_type       = /obj/item/utensil/chopsticks
+	uid               = "stack_recipe_chopsticks"
 
 /decl/stack_recipe/hardness/utensils/knife
 	result_type       = /obj/item/utensil/knife
 	difficulty        = MAT_VALUE_HARD_DIY
+	uid               = "stack_recipe_knife"
 
 /decl/stack_recipe/hardness/utensils/spoon
 	result_type       = /obj/item/utensil/spoon
+	uid               = "stack_recipe_spoon"
 
 /decl/stack_recipe/hardness/bell
 	result_type       = /obj/item/bell
 	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE // similar to boxes and bats, not thematically appropriate to low tech
+	uid               = "stack_recipe_bell"
 
 /decl/stack_recipe/hardness/blade
 	result_type       = /obj/item/butterflyblade
 	difficulty        = MAT_VALUE_NORMAL_DIY
 	category          = "weapons"
+	uid               = "stack_recipe_butterfly_blade"
 
 /decl/stack_recipe/hardness/urn
 	result_type       = /obj/item/urn
@@ -57,31 +67,38 @@
 		/obj/item/stack/material/slab,
 		/obj/item/stack/material/plank
 	)
+	uid               = "stack_recipe_urn"
 
 /decl/stack_recipe/hardness/drill_head
 	result_type       = /obj/item/drill_head
 	difficulty        = MAT_VALUE_EASY_DIY
 	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
+	uid               = "stack_recipe_drill_head"
 
 /decl/stack_recipe/hardness/baseball_bat
 	result_type       = /obj/item/baseball_bat
 	difficulty        = MAT_VALUE_HARD_DIY
 	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE // similar to boxes, not thematically appropriate to low tech
 	category          = "weapons"
+	uid               = "stack_recipe_baseball_bat"
 
 /decl/stack_recipe/hardness/ashtray
 	result_type       = /obj/item/ashtray
+	uid               = "stack_recipe_ashtray"
 
 /decl/stack_recipe/hardness/mortar
-	result_type = /obj/item/chems/glass/mortar
+	result_type       = /obj/item/chems/glass/mortar
+	uid               = "stack_recipe_mortar"
 
 /decl/stack_recipe/hardness/clipboard
 	result_type       = /obj/item/clipboard
 	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
+	uid               = "stack_recipe_clipboard"
 
 /decl/stack_recipe/hardness/cross
 	result_type       = /obj/item/cross
 	on_floor          = TRUE
+	uid               = "stack_recipe_cross"
 
 /decl/stack_recipe/hardness/surgical
 	abstract_type     = /decl/stack_recipe/hardness/surgical
@@ -91,18 +108,24 @@
 
 /decl/stack_recipe/hardness/surgical/retractor
 	result_type       = /obj/item/ancient_surgery/retractor
+	uid               = "stack_recipe_ancient_retractor"
 
 /decl/stack_recipe/hardness/surgical/cautery
 	result_type       = /obj/item/ancient_surgery/cautery
+	uid               = "stack_recipe_ancient_cautery"
 
 /decl/stack_recipe/hardness/surgical/bonesetter
 	result_type       = /obj/item/ancient_surgery/bonesetter
+	uid               = "stack_recipe_ancient_bonesetter"
 
 /decl/stack_recipe/hardness/surgical/scalpel
 	result_type       = /obj/item/ancient_surgery/scalpel
+	uid               = "stack_recipe_ancient_scalpel"
 
 /decl/stack_recipe/hardness/surgical/forceps
 	result_type       = /obj/item/ancient_surgery/forceps
+	uid               = "stack_recipe_ancient_forceps"
 
 /decl/stack_recipe/hardness/surgical/bonesaw
 	result_type       = /obj/item/ancient_surgery/bonesaw
+	uid               = "stack_recipe_ancient_bonesaw"

--- a/code/modules/crafting/stack_recipes/recipes_hardness_integrity.dm
+++ b/code/modules/crafting/stack_recipes/recipes_hardness_integrity.dm
@@ -4,15 +4,18 @@
 
 /decl/stack_recipe/hardness/integrity/sign
 	result_type        = /obj/item/banner/sign
+	uid                = "stack_recipe_sign"
 
 /decl/stack_recipe/hardness/integrity/buckler
 	result_type        = /obj/item/shield_base/buckler
 	difficulty         = MAT_VALUE_HARD_DIY
+	uid                = "stack_recipe_buckler_base"
 
 // TODO: forging
 /decl/stack_recipe/hardness/integrity/shield_fasteners
 	result_type        = /obj/item/shield_fasteners
 	difficulty         = MAT_VALUE_VERY_HARD_DIY
+	uid                = "stack_recipe_shield_fastener"
 
 /decl/stack_recipe/hardness/integrity/furniture
 	abstract_type      = /decl/stack_recipe/hardness/integrity/furniture
@@ -24,92 +27,119 @@
 /decl/stack_recipe/hardness/integrity/furniture/door
 	result_type        = /obj/structure/door
 	req_amount         = 5 * SHEET_MATERIAL_AMOUNT // Arbitrary value since doors return weird matter values.
+	uid                = "stack_recipe_door"
 
 /decl/stack_recipe/hardness/integrity/furniture/barricade
 	result_type        = /obj/structure/barricade
+	uid                = "stack_recipe_barricade"
 
 /decl/stack_recipe/hardness/integrity/furniture/banner_frame
 	result_type        = /obj/structure/banner_frame
+	uid                = "stack_recipe_banner_frame"
 
 /decl/stack_recipe/hardness/integrity/furniture/sign_hook
 	result_type        = /obj/structure/banner_frame/sign
+	uid                = "stack_recipe_sign_hook"
 
 /decl/stack_recipe/hardness/integrity/furniture/sign_hook/wall
 	result_type        = /obj/structure/banner_frame/sign/wall
+	uid                = "stack_recipe_sign_hook_wall"
 
 /decl/stack_recipe/hardness/integrity/furniture/coatrack
 	result_type        = /obj/structure/coatrack
+	uid                = "stack_recipe_coatrack"
 
 /decl/stack_recipe/hardness/integrity/furniture/stool
 	result_type        = /obj/item/stool
 	category           = "seating"
+	uid                = "stack_recipe_stool"
 
 /decl/stack_recipe/hardness/integrity/furniture/bar_stool
 	result_type        = /obj/item/stool/bar
 	category           = "seating"
+	uid                = "stack_recipe_stool_bar"
 
 /decl/stack_recipe/hardness/integrity/furniture/bench
 	result_type        = /obj/structure/chair/bench
 	category           = "seating"
+	uid                = "stack_recipe_bench"
 
 /decl/stack_recipe/hardness/integrity/furniture/bench/pew
 	result_type        = /obj/structure/chair/bench/pew
+	uid                = "stack_recipe_bench_pew"
 
 /decl/stack_recipe/hardness/integrity/furniture/bench/lounge
 	result_type        = /obj/structure/chair/bench/lounge
 	difficulty         = MAT_VALUE_VERY_HARD_DIY
+	uid                = "stack_recipe_bench_lounge"
 
 /decl/stack_recipe/hardness/integrity/furniture/closet
 	result_type        = /obj/structure/closet
+	uid                = "stack_recipe_closet"
 
 /decl/stack_recipe/hardness/integrity/furniture/tank_dispenser
 	result_type        = /obj/structure/tank_rack/empty
 	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
+	uid                = "stack_recipe_tank_dispenser"
 
 /decl/stack_recipe/hardness/integrity/furniture/coffin
 	result_type        = /obj/structure/closet/coffin
+	uid                = "stack_recipe_coffin"
 
 /decl/stack_recipe/hardness/integrity/furniture/chair
 	result_type        = /obj/structure/chair
 	category           = "seating"
+	uid                = "stack_recipe_chair"
 
 /decl/stack_recipe/hardness/integrity/furniture/chair/office
 	result_type        = /obj/structure/chair/office/comfy/unpadded
 	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
+	uid                = "stack_recipe_chair_office"
 
 /decl/stack_recipe/hardness/integrity/furniture/chair/comfy
 	result_type        = /obj/structure/chair/comfy/unpadded
+	uid                = "stack_recipe_chair_comfy"
 
 /decl/stack_recipe/hardness/integrity/furniture/chair/arm
 	result_type        = /obj/structure/chair/armchair/unpadded
+	uid                = "stack_recipe_chair_comfy_arm"
 
 /decl/stack_recipe/hardness/integrity/furniture/chair/roundedchair
 	result_type        = /obj/structure/chair/rounded
+	uid                = "stack_recipe_chair_rounded"
 
 /decl/stack_recipe/hardness/integrity/furniture/chair/backed
 	result_type        = /obj/structure/chair/backed
+	uid                = "stack_recipe_chair_backed"
 
 /decl/stack_recipe/hardness/integrity/furniture/chair/slatted
 	result_type        = /obj/structure/chair/slatted
+	uid                = "stack_recipe_chair_slatted"
 
 /decl/stack_recipe/hardness/integrity/furniture/drying_rack
 	result_type        = /obj/structure/drying_rack
+	uid                = "stack_recipe_drying_rack"
 
 /decl/stack_recipe/hardness/integrity/lock
 	result_type        = /obj/item/lock_construct
+	uid                = "stack_recipe_lock_construct"
 
 /decl/stack_recipe/hardness/integrity/lockpick
 	result_type        = /obj/item/lockpick
+	uid                = "stack_recipe_lockpick"
 
 /decl/stack_recipe/hardness/integrity/key
 	result_type        = /obj/item/key
+	uid                = "stack_recipe_key"
 
 /decl/stack_recipe/hardness/integrity/keyring
 	result_type        = /obj/item/keyring
+	uid                = "stack_recipe_keyring"
 
 /decl/stack_recipe/hardness/integrity/rod
 	result_type        = /obj/item/stack/material/rods
 	difficulty         = MAT_VALUE_NORMAL_DIY
+	uid                = "stack_recipe_rod"
 
 /decl/stack_recipe/hardness/integrity/nonflammable
 	abstract_type      = /decl/stack_recipe/hardness/integrity/nonflammable
@@ -123,8 +153,10 @@
 	result_type        = /obj/item/wall_sconce
 	difficulty         = MAT_VALUE_NORMAL_DIY
 	available_to_map_tech_level = MAP_TECH_LEVEL_MEDIEVAL
+	uid                = "stack_recipe_wall_sconce"
 
 /decl/stack_recipe/hardness/integrity/nonflammable/lantern
 	result_type        = /obj/item/flame/fuelled/lantern
 	difficulty         = MAT_VALUE_HARD_DIY
 	available_to_map_tech_level = MAP_TECH_LEVEL_MEDIEVAL
+	uid                = "stack_recipe_lantern"

--- a/code/modules/crafting/stack_recipes/recipes_items.dm
+++ b/code/modules/crafting/stack_recipes/recipes_items.dm
@@ -5,21 +5,25 @@
 	required_material = /decl/material/solid/metal/aluminium
 	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
 	category          = "weapons"
+	uid               = "stack_recipe_chem_grenade"
 
 /decl/stack_recipe/candle
 	result_type       = /obj/item/flame/candle/handmade
 	difficulty        = MAT_VALUE_EASY_DIY
 	required_material = /decl/material/solid/organic/wax
+	uid               = "stack_recipe_candle"
 
 /decl/stack_recipe/scroll
 	name              = "scroll"
 	result_type       = /obj/item/paper/scroll
 	required_material = /decl/material/solid/organic/paper
+	uid               = "stack_recipe_scroll"
 
 /decl/stack_recipe/paper_sheets
 	name              = "sheet of paper"
 	result_type       = /obj/item/paper
 	required_material = /decl/material/solid/organic/paper
+	uid               = "stack_recipe_paper_sheet"
 
 /decl/stack_recipe/paper_sheets/spawn_result(mob/user, location, amount, decl/material/mat, decl/material/reinf_mat, paint_color, spent_type, spent_amount = 1)
 	. = ..()
@@ -44,15 +48,19 @@
 /decl/stack_recipe/ring
 	result_type         = /obj/item/clothing/gloves/ring
 	validation_material = /decl/material/solid/metal/silver
+	uid                 = "stack_recipe_ring"
 
 /decl/stack_recipe/ring/thin
 	name                = "ring, thin"
 	result_type         = /obj/item/clothing/gloves/ring/thin
+	uid                 = "stack_recipe_ring_thin"
 
 /decl/stack_recipe/ring/thick
 	name                = "ring, thick"
 	result_type         = /obj/item/clothing/gloves/ring/thick
+	uid                 = "stack_recipe_ring_thick"
 
 /decl/stack_recipe/ring/split
 	name                = "ring, split"
 	result_type         = /obj/item/clothing/gloves/ring/split
+	uid                 = "stack_recipe_ring_split"

--- a/code/modules/crafting/stack_recipes/recipes_logs.dm
+++ b/code/modules/crafting/stack_recipes/recipes_logs.dm
@@ -7,6 +7,7 @@
 /decl/stack_recipe/logs/travois
 	result_type                 = /obj/structure/travois
 	difficulty                  = MAT_VALUE_EASY_DIY
+	uid                         = "stack_recipe_log_travois"
 
 /decl/stack_recipe/turfs/wall/logs
 	name                        = "log wall"
@@ -15,26 +16,31 @@
 	forbidden_craft_stack_types = /obj/item/stack/material/ore
 	validation_material         = /decl/material/solid/organic/wood/oak
 	difficulty                  = MAT_VALUE_HARD_DIY
+	uid                         = "stack_recipe_log_wall"
 
 /decl/stack_recipe/turfs/wall/logs/shutter
 	name                        = "shuttered log wall"
 	result_type                 = /turf/wall/log/shutter
+	uid                         = "stack_recipe_log_wall_shutter"
 
 /decl/stack_recipe/logs/wall_frame
 	result_type                 = /obj/structure/wall_frame/log
 	difficulty                  = MAT_VALUE_HARD_DIY
+	uid                         = "stack_recipe_log_wall_frame"
 
 /decl/stack_recipe/logs/furniture
-	abstract_type          = /decl/stack_recipe/logs/furniture
-	one_per_turf           = TRUE
-	on_floor               = TRUE
-	difficulty             = MAT_VALUE_HARD_DIY
-	category               = "furniture"
+	abstract_type               = /decl/stack_recipe/logs/furniture
+	one_per_turf                = TRUE
+	on_floor                    = TRUE
+	difficulty                  = MAT_VALUE_HARD_DIY
+	category                    = "furniture"
 
 /decl/stack_recipe/logs/furniture/fence
-	result_type            = /obj/structure/fence/palisade
-	difficulty             = MAT_VALUE_NORMAL_DIY
+	result_type                 = /obj/structure/fence/palisade
+	difficulty                  = MAT_VALUE_NORMAL_DIY
+	uid                         = "stack_recipe_log_palisade"
 
 /decl/stack_recipe/logs/furniture/fence_door
-	result_type            = /obj/structure/fence/door/palisade
-	difficulty             = MAT_VALUE_NORMAL_DIY
+	result_type                 = /obj/structure/fence/door/palisade
+	difficulty                  = MAT_VALUE_NORMAL_DIY
+	uid                         = "stack_recipe_log_palisade_door"

--- a/code/modules/crafting/stack_recipes/recipes_opacity.dm
+++ b/code/modules/crafting/stack_recipes/recipes_opacity.dm
@@ -16,6 +16,7 @@
 	one_per_turf         = TRUE
 	result_type          = /obj/structure/window
 	allow_multiple_craft = FALSE
+	uid                  = "stack_recipe_window_full"
 
 /decl/stack_recipe/opacity/fullwindow/can_make(mob/user)
 	. = ..()
@@ -36,6 +37,7 @@
 	result_type          = /obj/structure/window
 	one_per_turf         = FALSE
 	allow_multiple_craft = FALSE
+	uid                  = "stack_recipe_window_border"
 
 /decl/stack_recipe/opacity/borderwindow/can_make(mob/user)
 	. = ..()
@@ -54,6 +56,7 @@
 /decl/stack_recipe/opacity/windoor
 	result_type          = /obj/structure/windoor_assembly
 	allow_multiple_craft = FALSE
+	uid                  = "stack_recipe_window_door"
 
 /decl/stack_recipe/opacity/windoor/can_make(mob/user)
 	. = ..()

--- a/code/modules/crafting/stack_recipes/recipes_panels.dm
+++ b/code/modules/crafting/stack_recipes/recipes_panels.dm
@@ -7,10 +7,12 @@
 /decl/stack_recipe/panels/bag
 	result_type       = /obj/item/bag/flimsy
 	on_floor          = TRUE
+	uid               = "stack_recipe_panel_flimsy_bag"
 
 /decl/stack_recipe/panels/ivbag
 	result_type       = /obj/item/chems/ivbag
 	difficulty        = MAT_VALUE_HARD_DIY
+	uid               = "stack_recipe_panel_iv_bag"
 
 /decl/stack_recipe/panels/cartridge
 	difficulty        = MAT_VALUE_HARD_DIY
@@ -20,18 +22,22 @@
 /decl/stack_recipe/panels/cartridge/small
 	name              = "small dispenser cartridge"
 	result_type       = /obj/item/chems/chem_disp_cartridge/small
+	uid               = "stack_recipe_panel_dispenser_cartridge_small"
 
 /decl/stack_recipe/panels/cartridge/medium
 	name              = "medium dispenser cartridge"
 	result_type       = /obj/item/chems/chem_disp_cartridge/medium
+	uid               = "stack_recipe_panel_dispenser_cartridge_medium"
 
 /decl/stack_recipe/panels/cartridge/large
 	name              = "large dispenser cartridge"
 	result_type       = /obj/item/chems/chem_disp_cartridge
+	uid               = "stack_recipe_panel_dispenser_cartridge_large"
 
 /decl/stack_recipe/panels/hazard_cone
 	result_type       = /obj/item/caution/cone
 	on_floor          = TRUE
+	uid               = "stack_recipe_panel_caution_cone"
 
 /decl/stack_recipe/panels/furniture
 	abstract_type     = /decl/stack_recipe/panels/furniture
@@ -42,6 +48,8 @@
 
 /decl/stack_recipe/panels/furniture/crate
 	result_type       = /obj/structure/closet/crate/plastic
+	uid               = "stack_recipe_panel_crate"
 
 /decl/stack_recipe/panels/furniture/flaps
 	result_type       = /obj/structure/flaps
+	uid               = "stack_recipe_panel_flaps"

--- a/code/modules/crafting/stack_recipes/recipes_planks.dm
+++ b/code/modules/crafting/stack_recipes/recipes_planks.dm
@@ -5,72 +5,95 @@
 
 /decl/stack_recipe/planks/sandals
 	result_type            = /obj/item/clothing/shoes/sandal
+	uid                    = "stack_recipe_plank_sandals"
 
 /decl/stack_recipe/planks/crossbowframe
 	result_type            = /obj/item/crossbowframe
 	difficulty             = MAT_VALUE_VERY_HARD_DIY
 	category               = "weapons"
+	uid                    = "stack_recipe_plank_crossbowframe"
 
 /decl/stack_recipe/planks/zipgunframe
 	result_type            = /obj/item/zipgunframe
 	difficulty             = MAT_VALUE_VERY_HARD_DIY
 	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
 	category               = "weapons"
+	uid                    = "stack_recipe_plank_zipgunframe"
 
 /decl/stack_recipe/planks/coilgun
 	result_type            = /obj/item/coilgun_assembly
 	difficulty             = MAT_VALUE_VERY_HARD_DIY
 	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
+	uid                    = "stack_recipe_plank_coilgunassembly"
 
 /decl/stack_recipe/planks/stick
 	result_type            = /obj/item/stick
 	difficulty             = MAT_VALUE_EASY_DIY
+	uid                    = "stack_recipe_plank_stick"
 
 /decl/stack_recipe/planks/staff
 	result_type            = /obj/item/staff
 	difficulty             = MAT_VALUE_NORMAL_DIY
+	uid                    = "stack_recipe_plank_staff"
 
 /decl/stack_recipe/planks/cane
 	result_type            = /obj/item/cane
 	difficulty             = MAT_VALUE_NORMAL_DIY
+	uid                    = "stack_recipe_plank_cane"
 
 /decl/stack_recipe/planks/bucket
 	result_type            = /obj/item/chems/glass/bucket/wood
 	difficulty             = MAT_VALUE_EASY_DIY
+	uid                    = "stack_recipe_plank_bucket"
 
 /decl/stack_recipe/planks/bolt
 	result_type            = /obj/item/stack/material/bow_ammo/bolt
 	difficulty             = MAT_VALUE_EASY_DIY
+	uid                    = "stack_recipe_plank_bolt"
 
 /decl/stack_recipe/planks/arrow
 	result_type            = /obj/item/stack/material/bow_ammo/arrow
 	difficulty             = MAT_VALUE_HARD_DIY
+	uid                    = "stack_recipe_plank_arrow"
 
 /decl/stack_recipe/planks/bow
 	result_type            = /obj/item/gun/launcher/bow/crafted
 	difficulty             = MAT_VALUE_VERY_HARD_DIY
+	uid                    = "stack_recipe_plank_bow"
 
 /decl/stack_recipe/planks/bow/fancy
 	name                   = "decorated bow"
 	result_type            = /obj/item/gun/launcher/bow/fancy/crafted
+	uid                    = "stack_recipe_plank_bow_fancy"
 
 /decl/stack_recipe/planks/noticeboard
 	result_type            = /obj/structure/noticeboard
 	on_floor               = TRUE
 	difficulty             = MAT_VALUE_HARD_DIY
 	set_dir_on_spawn       = FALSE
+	uid                    = "stack_recipe_plank_noticeboard"
+
+/decl/stack_recipe/planks/noticeboard/spawn_result(mob/user, location, amount, decl/material/mat, decl/material/reinf_mat, paint_color, spent_type, spent_amount = 1)
+	. = ..()
+	if(user)
+		for(var/obj/structure/noticeboard/board in .)
+			board.set_dir(global.reverse_dir[user.dir])
 
 /decl/stack_recipe/planks/cup
 	result_type            = /obj/item/chems/glass/handmade/cup
+	uid                    = "stack_recipe_plank_handmade_cup"
 
 /decl/stack_recipe/planks/mug
 	result_type            = /obj/item/chems/glass/handmade/mug
+	uid                    = "stack_recipe_plank_handmade_mug"
 
 /decl/stack_recipe/planks/bowl
 	result_type            = /obj/item/chems/glass/handmade/bowl
+	uid                    = "stack_recipe_plank_handmade_bowl"
 
 /decl/stack_recipe/planks/buckler
 	result_type            = /obj/item/shield_base/buckler
+	uid                    = "stack_recipe_plank_buckler_base"
 
 /decl/stack_recipe/planks/fancy
 	abstract_type          = /decl/stack_recipe/planks/fancy
@@ -78,25 +101,24 @@
 
 /decl/stack_recipe/planks/fancy/decanter
 	result_type            = /obj/item/chems/glass/handmade/fancy/decanter
+	uid                    = "stack_recipe_plank_handmade_fancy_decanter"
 
 /decl/stack_recipe/planks/fancy/goblet
 	result_type            = /obj/item/chems/glass/handmade/fancy/goblet
+	uid                    = "stack_recipe_plank_handmade_fancy_goblet"
 
 /decl/stack_recipe/planks/fancy/bowl
 	result_type            = /obj/item/chems/glass/handmade/fancy/bowl
+	uid                    = "stack_recipe_plank_handmade_fancy_bowl"
 
 /decl/stack_recipe/planks/fancy/vase
 	result_type            = /obj/item/chems/glass/handmade/fancy/vase
+	uid                    = "stack_recipe_plank_handmade_fancy_vase"
 
 /decl/stack_recipe/planks/fancy/vase_fluted
 	name                   = "vase, fluted"
 	result_type            = /obj/item/chems/glass/handmade/fancy/vase/fluted
-
-/decl/stack_recipe/planks/noticeboard/spawn_result(mob/user, location, amount, decl/material/mat, decl/material/reinf_mat, paint_color, spent_type, spent_amount = 1)
-	. = ..()
-	if(user)
-		for(var/obj/structure/noticeboard/board in .)
-			board.set_dir(global.reverse_dir[user.dir])
+	uid                    = "stack_recipe_plank_handmade_fancy_vase_fluted"
 
 /decl/stack_recipe/planks/prosthetic
 	abstract_type          = /decl/stack_recipe/planks/prosthetic
@@ -114,27 +136,35 @@
 
 /decl/stack_recipe/planks/prosthetic/left_arm
 	result_type            = /obj/item/organ/external/arm
+	uid                    = "stack_recipe_plank_prosthetic_left_arm"
 
 /decl/stack_recipe/planks/prosthetic/right_arm
 	result_type            = /obj/item/organ/external/arm/right
+	uid                    = "stack_recipe_plank_prosthetic_right_arm"
 
 /decl/stack_recipe/planks/prosthetic/left_leg
 	result_type            = /obj/item/organ/external/leg
+	uid                    = "stack_recipe_plank_prosthetic_left_leg"
 
 /decl/stack_recipe/planks/prosthetic/right_leg
 	result_type            = /obj/item/organ/external/leg/right
+	uid                    = "stack_recipe_plank_prosthetic_right_leg"
 
 /decl/stack_recipe/planks/prosthetic/left_hand
 	result_type            = /obj/item/organ/external/hand
+	uid                    = "stack_recipe_plank_prosthetic_left_hand"
 
 /decl/stack_recipe/planks/prosthetic/right_hand
 	result_type            = /obj/item/organ/external/hand/right
+	uid                    = "stack_recipe_plank_prosthetic_right_hand"
 
 /decl/stack_recipe/planks/prosthetic/left_foot
 	result_type            = /obj/item/organ/external/foot
+	uid                    = "stack_recipe_plank_prosthetic_left_foot"
 
 /decl/stack_recipe/planks/prosthetic/right_foot
 	result_type            = /obj/item/organ/external/foot/right
+	uid                    = "stack_recipe_plank_prosthetic_right_foot"
 
 /decl/stack_recipe/planks/furniture
 	abstract_type          = /decl/stack_recipe/planks/furniture
@@ -144,115 +174,146 @@
 	category               = "furniture"
 
 /decl/stack_recipe/planks/furniture/simple_bed
-	result_type = /obj/structure/bed/simple/crafted
+	result_type            = /obj/structure/bed/simple/crafted
+	uid                    = "stack_recipe_plank_bed_simple"
 
 /decl/stack_recipe/planks/furniture/compost_bin
 	result_type            = /obj/structure/reagent_dispensers/compost_bin
+	uid                    = "stack_recipe_plank_compost_bin"
 
 /decl/stack_recipe/planks/furniture/filter_stand
 	result_type            = /obj/structure/filter_stand
+	uid                    = "stack_recipe_plank_filter_stand"
 
 /decl/stack_recipe/planks/furniture/produce_bin
 	result_type            = /obj/structure/produce_bin
+	uid                    = "stack_recipe_plank_produce_bin"
 
 /decl/stack_recipe/planks/furniture/coffin
 	result_type            = /obj/structure/closet/coffin/wooden
+	uid                    = "stack_recipe_plank_coffin"
 
 /decl/stack_recipe/planks/furniture/sofa
 	name                   = "sofa, middle"
 	result_type            = /obj/structure/bed/sofa/middle/unpadded
 	category               = "seating"
+	uid                    = "stack_recipe_plank_sofa_middle"
 
 /decl/stack_recipe/planks/furniture/sofa/left
 	name                   = "sofa, left"
 	result_type            = /obj/structure/bed/sofa/left/unpadded
+	uid                    = "stack_recipe_plank_sofa_left"
 
 /decl/stack_recipe/planks/furniture/sofa/right
 	name                   = "sofa, right"
 	result_type            = /obj/structure/bed/sofa/right/unpadded
+	uid                    = "stack_recipe_plank_sofa_right"
 
 /decl/stack_recipe/planks/furniture/bookcase
 	result_type            = /obj/structure/bookcase
+	uid                    = "stack_recipe_plank_bookcase"
 
 /decl/stack_recipe/planks/furniture/book_cart
 	result_type            = /obj/structure/bookcase/cart
+	uid                    = "stack_recipe_plank_bookcart"
 
 /decl/stack_recipe/planks/furniture/chair
 	result_type            = /obj/structure/chair/wood
 	category               = "seating"
+	uid                    = "stack_recipe_plank_chair"
 
 /decl/stack_recipe/planks/furniture/chair/fancy
 	result_type            = /obj/structure/chair/wood/wings
+	uid                    = "stack_recipe_plank_chair_fancy"
 
 /decl/stack_recipe/planks/furniture/chest
 	result_type            = /obj/structure/closet/crate/chest
+	uid                    = "stack_recipe_plank_chest"
 
 /decl/stack_recipe/planks/furniture/meathook
 	result_type            = /obj/structure/meat_hook
+	uid                    = "stack_recipe_plank_meathook"
 
 /decl/stack_recipe/planks/furniture/meathook/improvised
 	result_type            = /obj/structure/meat_hook/improvised
 	difficulty             = MAT_VALUE_EASY_DIY
+	uid                    = "stack_recipe_plank_meathook_improvised"
 
 /decl/stack_recipe/planks/furniture/spinning_wheel
 	result_type            = /obj/structure/working/spinning_wheel
 	difficulty             = MAT_VALUE_VERY_HARD_DIY
+	uid                    = "stack_recipe_plank_spinning_wheel"
 
 /decl/stack_recipe/planks/furniture/loom
 	result_type            = /obj/structure/working/loom
 	difficulty             = MAT_VALUE_VERY_HARD_DIY
+	uid                    = "stack_recipe_plank_loom"
 
 /decl/stack_recipe/planks/furniture/twisting_bench
 	result_type            = /obj/structure/working/spinning_wheel/twisting_bench
 	difficulty             = MAT_VALUE_VERY_HARD_DIY
+	uid                    = "stack_recipe_plank_twisting_bench"
 
 /decl/stack_recipe/planks/furniture/butter_churn
 	result_type            = /obj/structure/working/butter_churn
 	difficulty             = MAT_VALUE_HARD_DIY
+	uid                    = "stack_recipe_plank_butter_churn"
 
 /decl/stack_recipe/planks/furniture/cabinet
 	result_type            = /obj/structure/closet/cabinet/wooden
 	difficulty             = MAT_VALUE_HARD_DIY
+	uid                    = "stack_recipe_plank_cabinet"
 
 /decl/stack_recipe/planks/furniture/barrel
 	result_type            = /obj/structure/reagent_dispensers/barrel/crafted
 	difficulty             = MAT_VALUE_HARD_DIY
+	uid                    = "stack_recipe_plank_barrel"
 
 /decl/stack_recipe/planks/furniture/barrel/cask
 	result_type            = /obj/structure/reagent_dispensers/barrel/cask/crafted
+	uid                    = "stack_recipe_plank_cask"
 
 /decl/stack_recipe/planks/furniture/barrel/cask_rack
 	result_type            = /obj/structure/cask_rack
+	uid                    = "stack_recipe_plank_cask_rack"
 
 /decl/stack_recipe/planks/furniture/barrel/large_cask_rack
 	name                   = "cask rack, large"
 	result_type            = /obj/structure/cask_rack/large
+	uid                    = "stack_recipe_plank_cask_rack_large"
 
 /decl/stack_recipe/planks/furniture/table_frame
 	result_type            = /obj/structure/table/frame
 	category               = "furniture"
 	difficulty             = MAT_VALUE_HARD_DIY
+	uid                    = "stack_recipe_plank_table_frame"
 
 /decl/stack_recipe/planks/furniture/gravemarker
 	result_type            = /obj/item/gravemarker
 	difficulty             = MAT_VALUE_NORMAL_DIY
+	uid                    = "stack_recipe_plank_gravemarker"
 
 /decl/stack_recipe/planks/furniture/divider
 	result_type            = /obj/structure/divider
 	difficulty             = MAT_VALUE_HARD_DIY
+	uid                    = "stack_recipe_plank_divider"
 
 /decl/stack_recipe/planks/furniture/armor_stand
 	result_type            = /obj/structure/armor_stand
 	difficulty             = MAT_VALUE_NORMAL_DIY
+	uid                    = "stack_recipe_plank_armor_stand"
 
 /decl/stack_recipe/planks/furniture/target_stake
 	result_type            = /obj/structure/target_stake
 	difficulty             = MAT_VALUE_NORMAL_DIY
+	uid                    = "stack_recipe_plank_target_stake"
 
 /decl/stack_recipe/planks/furniture/fence
 	result_type            = /obj/structure/fence/plank
 	difficulty             = MAT_VALUE_NORMAL_DIY
+	uid                    = "stack_recipe_plank_fence"
 
 /decl/stack_recipe/planks/furniture/fence_door
 	result_type            = /obj/structure/fence/door/plank
 	difficulty             = MAT_VALUE_NORMAL_DIY
+	uid                    = "stack_recipe_plank_fence_door"

--- a/code/modules/crafting/stack_recipes/recipes_reinforced.dm
+++ b/code/modules/crafting/stack_recipes/recipes_reinforced.dm
@@ -11,13 +11,16 @@
 	on_floor          = FALSE
 	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
 	category          = "furniture"
+	uid               = "stack_recipe_reinforced_aicore"
 
 /decl/stack_recipe/reinforced/crate
 	result_type       = /obj/structure/closet/crate
 	category          = "furniture"
+	uid               = "stack_recipe_reinforced_crate"
 
 /decl/stack_recipe/reinforced/grip
 	result_type       = /obj/item/butterflyhandle
 	difficulty        = MAT_VALUE_NORMAL_DIY
 	one_per_turf      = FALSE
 	category          = "weapons"
+	uid               = "stack_recipe_reinforced_butterflyhandle"

--- a/code/modules/crafting/stack_recipes/recipes_rods.dm
+++ b/code/modules/crafting/stack_recipes/recipes_rods.dm
@@ -17,57 +17,69 @@
 	on_floor                    = FALSE
 	difficulty                  = MAT_VALUE_EASY_DIY
 	category                    = "items"
+	uid                         = "stack_recipe_rod_stick"
 
 /decl/stack_recipe/rods/stick/staff
 	result_type                 = /obj/item/staff
 	difficulty                  = MAT_VALUE_NORMAL_DIY
+	uid                         = "stack_recipe_rod_staff"
 
 /decl/stack_recipe/rods/stick/cane
 	result_type                 = /obj/item/cane
 	difficulty                  = MAT_VALUE_NORMAL_DIY
+	uid                         = "stack_recipe_rod_cane"
 
 /decl/stack_recipe/rods/railing
 	result_type                 = /obj/structure/railing
+	uid                         = "stack_recipe_rod_railing"
 
 /decl/stack_recipe/rods/ladder
 	result_type                 = /obj/structure/ladder
 	on_floor                    = FALSE
 	required_wall_support_value = 10
+	uid                         = "stack_recipe_rod_ladder"
 
 /decl/stack_recipe/rods/girder
 	result_type                 = /obj/structure/girder
 	required_wall_support_value = 10
 	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
+	uid                         = "stack_recipe_rod_girder"
 
 /decl/stack_recipe/rods/wall_frame
 	result_type                 = /obj/structure/wall_frame
 	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
+	uid                         = "stack_recipe_rod_wall_frame"
 
 /decl/stack_recipe/rods/table_frame
 	result_type                 = /obj/structure/table/frame
 	category                    = "furniture"
+	uid                         = "stack_recipe_rod_table_frame"
 
 /decl/stack_recipe/rods/rack
 	result_type                 = /obj/structure/rack
 	category                    = "furniture"
+	uid                         = "stack_recipe_rod_rack"
 
 /decl/stack_recipe/rods/butcher_hook
 	result_type                 = /obj/structure/meat_hook
 	one_per_turf                = TRUE
 	difficulty                  = MAT_VALUE_NORMAL_DIY
 	category                    = "furniture"
+	uid                         = "stack_recipe_rod_meat_hook"
 
 /decl/stack_recipe/rods/bed
 	result_type                 = /obj/structure/bed
 	required_integrity          = 50
 	required_min_hardness       = MAT_VALUE_FLEXIBLE + 10
 	category                    = "furniture"
+	uid                         = "stack_recipe_rod_bed"
 
 /decl/stack_recipe/rods/machine
 	result_type                 = /obj/machinery/constructable_frame/machine_frame
 	req_amount                  = 5 * SHEET_MATERIAL_AMOUNT // Arbitrary value since machines don't handle matter properly yet.
 	required_material           = /decl/material/solid/metal/steel
 	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
+	uid                         = "stack_recipe_rod_machineframe"
 
 /decl/stack_recipe/rods/machine/spawn_result(mob/user, location, amount, decl/material/mat, decl/material/reinf_mat, paint_color, spent_type, spent_amount = 1)
 	return ..(user, location, amount, null, null, paint_color, spent_type, spent_amount)
@@ -76,19 +88,22 @@
 	result_type                 = /obj/structure/grille
 	one_per_turf                = TRUE
 	difficulty                  = MAT_VALUE_NORMAL_DIY
+	uid                         = "stack_recipe_rod_grille"
 
 /decl/stack_recipe/rods/furniture
-	abstract_type          = /decl/stack_recipe/rods/furniture
-	one_per_turf           = TRUE
-	on_floor               = TRUE
-	difficulty             = MAT_VALUE_HARD_DIY
-	category               = "furniture"
+	abstract_type               = /decl/stack_recipe/rods/furniture
+	one_per_turf                = TRUE
+	on_floor                    = TRUE
+	difficulty                  = MAT_VALUE_HARD_DIY
+	category                    = "furniture"
 
 /decl/stack_recipe/rods/furniture/fence
-	result_type            = /obj/structure/fence/stick
-	difficulty             = MAT_VALUE_NORMAL_DIY
+	result_type                 = /obj/structure/fence/stick
+	difficulty                  = MAT_VALUE_NORMAL_DIY
+	uid                         = "stack_recipe_rod_fence"
 
 /decl/stack_recipe/rods/furniture/fence_door
-	result_type            = /obj/structure/fence/door/stick
-	difficulty             = MAT_VALUE_NORMAL_DIY
+	result_type                 = /obj/structure/fence/door/stick
+	difficulty                  = MAT_VALUE_NORMAL_DIY
+	uid                         = "stack_recipe_rod_fence_door"
 

--- a/code/modules/crafting/stack_recipes/recipes_soft.dm
+++ b/code/modules/crafting/stack_recipes/recipes_soft.dm
@@ -14,40 +14,45 @@
 
 /decl/stack_recipe/soft/teapot
 	result_type                 = /obj/item/chems/glass/handmade/teapot
+	uid                         = "stack_recipe_soft_handmade_teapot"
 
 /decl/stack_recipe/soft/cup
 	result_type                 = /obj/item/chems/glass/handmade/cup
+	uid                         = "stack_recipe_soft_handmade_cup"
 
 /decl/stack_recipe/soft/mug
 	result_type                 = /obj/item/chems/glass/handmade/mug
+	uid                         = "stack_recipe_soft_handmade_mug"
 
 /decl/stack_recipe/soft/vase
 	result_type                 = /obj/item/chems/glass/handmade/vase
+	uid                         = "stack_recipe_soft_handmade_vase"
 
 /decl/stack_recipe/soft/bowl
 	result_type                 = /obj/item/chems/glass/handmade/bowl
+	uid                         = "stack_recipe_soft_handmade_bowl"
 
 /decl/stack_recipe/soft/jar
 	result_type                 = /obj/item/chems/glass/handmade/jar
+	uid                         = "stack_recipe_soft_handmade_jar"
 
 /decl/stack_recipe/soft/bottle
 	result_type                 = /obj/item/chems/glass/handmade/bottle
+	uid                         = "stack_recipe_soft_handmade_bottle"
 
 /decl/stack_recipe/soft/bottle_wide
 	result_type                 = /obj/item/chems/glass/handmade/bottle/wide
+	uid                         = "stack_recipe_soft_handmade_bottle_wide"
 
 /decl/stack_recipe/soft/bottle_tall
 	result_type                 = /obj/item/chems/glass/handmade/bottle/tall
+	uid                         = "stack_recipe_soft_handmade_bottle_tall"
 
 /decl/stack_recipe/soft/stack
 	name                        = "brick"
 	name_plural                 = "bricks"
 	result_type                 = /obj/item/stack/material/brick
-
-/decl/stack_recipe/soft/bar
-	name                        = "bar"
-	name_plural                 = "bars"
-	result_type                 = /obj/item/stack/material/bar
+	uid                         = "stack_recipe_soft_stack_brick"
 
 /decl/stack_recipe/soft/stack/spawn_result(mob/user, location, amount, decl/material/mat, decl/material/reinf_mat, paint_color, spent_type, spent_amount = 1)
 	var/obj/item/stack/S = ..()
@@ -61,37 +66,45 @@
 	name                        = "bar"
 	name_plural                 = "bars"
 	result_type                 = /obj/item/stack/material/bar
-	result_type                 = /obj/item/stack/material/bar/wax
+	uid                         = "stack_recipe_soft_stack_bar"
 
 /decl/stack_recipe/soft/stack/large_lump
 	name                        = "large lump"
 	name_plural                 = "large lumps"
 	result_type                 = /obj/item/stack/material/lump/large
+	uid                         = "stack_recipe_soft_stack_lump_large"
 
 /decl/stack_recipe/soft/stack/small_lump
 	name                        = "small lump"
 	name_plural                 = "small lumps"
 	result_type                 = /obj/item/stack/material/lump
+	uid                         = "stack_recipe_soft_stack_lump_small"
 
 /decl/stack_recipe/soft/crucible
-	result_type = /obj/item/chems/crucible
+	result_type                 = /obj/item/chems/crucible
+	uid                         = "stack_recipe_soft_crucible"
 
 /decl/stack_recipe/soft/mould
-	name = "mould, blank"
-	result_type = /obj/item/chems/mould
-	category = "moulds"
+	name                        = "mould, blank"
+	result_type                 = /obj/item/chems/mould
+	category                    = "moulds"
+	uid                         = "stack_recipe_soft_mould_blank"
 
+// todo: remove since you can make a clay crucible to take an impression of?
 /decl/stack_recipe/soft/mould/crucible
 	name = "mould, crucible"
 	result_type = /obj/item/chems/mould/crucible
+	uid                         = "stack_recipe_soft_mould_crucible"
 
 /decl/stack_recipe/soft/mould/rod
 	name = "mould, rod"
 	result_type = /obj/item/chems/mould/rod
+	uid                         = "stack_recipe_soft_mould_rod"
 
 /decl/stack_recipe/soft/mould/ingot
 	name = "mould, ingot"
 	result_type = /obj/item/chems/mould/ingot
+	uid                         = "stack_recipe_soft_mould_ingot"
 
 /decl/stack_recipe/soft/sculpture
 	abstract_type               = /decl/stack_recipe/soft/sculpture
@@ -101,11 +114,14 @@
 
 /decl/stack_recipe/soft/sculpture/snowman
 	result_type                 = /obj/structure/snowman
+	uid                         = "stack_recipe_soft_sculpture_snowman"
 
 /decl/stack_recipe/soft/sculpture/snowspider
 	result_type                 = /obj/structure/snowman/spider
 	difficulty                  = MAT_VALUE_HARD_DIY
+	uid                         = "stack_recipe_soft_sculpture_snowspider"
 
 /decl/stack_recipe/soft/sculpture/snowbot
 	result_type                 = /obj/structure/snowman/bot
 	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
+	uid                         = "stack_recipe_soft_sculpture_nowbot"

--- a/code/modules/crafting/stack_recipes/recipes_stacks.dm
+++ b/code/modules/crafting/stack_recipes/recipes_stacks.dm
@@ -11,72 +11,88 @@
 /decl/stack_recipe/tile/wood/oak
 	result_type         = /obj/item/stack/tile/wood/oak
 	required_material   = /decl/material/solid/organic/wood/oak
+	uid                 = "stack_recipe_tile_wood_oak"
 
 /decl/stack_recipe/tile/wood/mahogany
 	result_type         = /obj/item/stack/tile/wood/mahogany
 	required_material   = /decl/material/solid/organic/wood/mahogany
+	uid                 = "stack_recipe_tile_wood_mahogany"
 
 /decl/stack_recipe/tile/wood/maple
 	result_type         = /obj/item/stack/tile/wood/maple
 	required_material   = /decl/material/solid/organic/wood/maple
+	uid                 = "stack_recipe_tile_wood_maple"
 
 /decl/stack_recipe/tile/wood/ebony
 	difficulty          = MAT_VALUE_VERY_HARD_DIY
 	result_type         = /obj/item/stack/tile/wood/ebony
 	required_material   = /decl/material/solid/organic/wood/ebony
+	uid                 = "stack_recipe_tile_wood_ebony"
 
 /decl/stack_recipe/tile/wood/walnut
 	result_type         = /obj/item/stack/tile/wood/walnut
 	required_material   = /decl/material/solid/organic/wood/walnut
+	uid                 = "stack_recipe_tile_wood_walnut"
 
 /decl/stack_recipe/tile/wood/oak/rough
 	crafting_extra_cost_factor = 2 // wasteful but easy
 	difficulty                 = MAT_VALUE_EASY_DIY
 	result_type                = /obj/item/stack/tile/wood/rough/oak
+	uid                        = "stack_recipe_tile_wood_oak_rough"
 
 /decl/stack_recipe/tile/wood/mahogany/rough
 	crafting_extra_cost_factor = 2
 	difficulty                 = MAT_VALUE_EASY_DIY
 	result_type                = /obj/item/stack/tile/wood/rough/mahogany
+	uid                        = "stack_recipe_tile_wood_mahogany_rough"
 
 /decl/stack_recipe/tile/wood/maple/rough
 	crafting_extra_cost_factor = 2
 	difficulty                 = MAT_VALUE_EASY_DIY
 	result_type                = /obj/item/stack/tile/wood/rough/maple
+	uid                        = "stack_recipe_tile_wood_maple_rough"
 
 /decl/stack_recipe/tile/wood/ebony/rough
 	crafting_extra_cost_factor = 2
 	difficulty                 = MAT_VALUE_HARD_DIY
 	result_type                = /obj/item/stack/tile/wood/rough/ebony
+	uid                        = "stack_recipe_tile_wood_ebony_rough"
 
 /decl/stack_recipe/tile/wood/walnut/rough
 	crafting_extra_cost_factor = 2
 	difficulty                 = MAT_VALUE_EASY_DIY
 	result_type                = /obj/item/stack/tile/wood/rough/walnut
+	uid                        = "stack_recipe_tile_wood_walnut_rough"
 
 /decl/stack_recipe/tile/wood/oak_laminate
 	result_type         = /obj/item/stack/tile/wood/laminate/oak
 	required_material   = /decl/material/solid/organic/wood/chipboard
+	uid                 = "stack_recipe_tile_wood_laminate_oak"
 
 /decl/stack_recipe/tile/wood/mahogany_laminate
 	result_type         = /obj/item/stack/tile/wood/laminate/mahogany
 	required_material   = /decl/material/solid/organic/wood/chipboard/mahogany
+	uid                 = "stack_recipe_tile_wood_laminate_mahogany"
 
 /decl/stack_recipe/tile/wood/maple_laminate
 	result_type         = /obj/item/stack/tile/wood/laminate/maple
 	required_material   = /decl/material/solid/organic/wood/chipboard/maple
+	uid                 = "stack_recipe_tile_wood_laminate_maple"
 
 /decl/stack_recipe/tile/wood/ebony_laminate
 	result_type         = /obj/item/stack/tile/wood/laminate/ebony
 	required_material   = /decl/material/solid/organic/wood/chipboard/ebony
+	uid                 = "stack_recipe_tile_wood_laminate_ebony"
 
 /decl/stack_recipe/tile/wood/walnut_laminate
 	result_type         = /obj/item/stack/tile/wood/walnut
 	required_material   = /decl/material/solid/organic/wood/chipboard/walnut
+	uid                 = "stack_recipe_tile_wood_laminate_walnut"
 
 /decl/stack_recipe/tile/wood/yew_laminate
 	result_type         = /obj/item/stack/tile/wood/laminate/yew
 	required_material   = /decl/material/solid/organic/wood/chipboard/yew
+	uid                 = "stack_recipe_tile_wood_laminate_yew"
 
 /decl/stack_recipe/tile/steel
 	abstract_type     = /decl/stack_recipe/tile/steel
@@ -85,36 +101,47 @@
 
 /decl/stack_recipe/tile/steel/floor
 	result_type       = /obj/item/stack/tile/floor
+	uid               = "stack_recipe_tile_steel_floor"
 
 /decl/stack_recipe/tile/steel/roof
 	result_type       = /obj/item/stack/tile/roof
+	uid               = "stack_recipe_tile_steel_roof"
 
 /decl/stack_recipe/tile/steel/mono
 	result_type       = /obj/item/stack/tile/mono
+	uid               = "stack_recipe_tile_steel_mono"
 
 /decl/stack_recipe/tile/steel/mono_dark
 	result_type       = /obj/item/stack/tile/mono/dark
+	uid               = "stack_recipe_tile_steel_mono_dark"
 
 /decl/stack_recipe/tile/steel/grid
 	result_type       = /obj/item/stack/tile/grid
+	uid               = "stack_recipe_tile_steel_grid"
 
 /decl/stack_recipe/tile/steel/ridged
 	result_type       = /obj/item/stack/tile/ridge
+	uid               = "stack_recipe_tile_steel_ridge"
 
 /decl/stack_recipe/tile/steel/tech_grey
 	result_type       = /obj/item/stack/tile/techgrey
+	uid               = "stack_recipe_tile_steel_tech_grey"
 
 /decl/stack_recipe/tile/steel/tech_grid
 	result_type       = /obj/item/stack/tile/techgrid
+	uid               = "stack_recipe_tile_steel_tech_grid"
 
 /decl/stack_recipe/tile/steel/tech_maint
 	result_type       = /obj/item/stack/tile/techmaint
+	uid               = "stack_recipe_tile_steel_tech_maint"
 
 /decl/stack_recipe/tile/steel/dark
 	result_type       = /obj/item/stack/tile/floor_dark
+	uid               = "stack_recipe_tile_steel_dark"
 
 /decl/stack_recipe/tile/steel/pool
 	result_type       = /obj/item/stack/tile/pool
+	uid               = "stack_recipe_tile_steel_pool"
 
 /decl/stack_recipe/tile/panels
 	abstract_type = /decl/stack_recipe/tile/panels
@@ -124,6 +151,8 @@
 
 /decl/stack_recipe/tile/panels/floor
 	result_type       = /obj/item/stack/tile/floor_white
+	uid               = "stack_recipe_tile_panel_floor_white"
 
 /decl/stack_recipe/tile/panels/freezer
 	result_type       = /obj/item/stack/tile/floor_freezer
+	uid               = "stack_recipe_tile_panel_floor_freezer"

--- a/code/modules/crafting/stack_recipes/recipes_steel.dm
+++ b/code/modules/crafting/stack_recipes/recipes_steel.dm
@@ -7,38 +7,47 @@
 /decl/stack_recipe/steel/apc
 	result_type       = /obj/item/frame/apc
 	difficulty        = MAT_VALUE_HARD_DIY
+	uid               = "stack_recipe_steel_apc_frame"
 
 /decl/stack_recipe/steel/air_alarm
 	result_type       = /obj/item/frame/air_alarm
 	difficulty        = MAT_VALUE_HARD_DIY
+	uid               = "stack_recipe_steel_air_alarm_frame"
 
 /decl/stack_recipe/steel/fire_alarm
 	result_type       = /obj/item/frame/fire_alarm
 	difficulty        = MAT_VALUE_HARD_DIY
+	uid               = "stack_recipe_steel_fire_alarm_frame"
 
 /decl/stack_recipe/steel/light
 	result_type       = /obj/item/frame/light
 	difficulty        = MAT_VALUE_HARD_DIY
+	uid               = "stack_recipe_steel_light_fixture"
 
 /decl/stack_recipe/steel/light_small
 	result_type       = /obj/item/frame/light/small
 	difficulty        = MAT_VALUE_HARD_DIY
+	uid               = "stack_recipe_steel_light_fixture_small"
 
 /decl/stack_recipe/steel/light_switch
 	result_type       = /obj/item/frame/button/light_switch
 	difficulty        = MAT_VALUE_HARD_DIY
+	uid               = "stack_recipe_steel_light_switch_frame"
 
 /decl/stack_recipe/steel/light_switch/windowtint
 	result_type       = /obj/item/frame/button/light_switch/windowtint
 	difficulty        = MAT_VALUE_HARD_DIY
+	uid               = "stack_recipe_steel_windowtint_switch_frame"
 
 /decl/stack_recipe/grenade/steel
 	required_material = /decl/material/solid/metal/steel
+	uid               = "stack_recipe_steel_chem_grenade"
 
 /decl/stack_recipe/steel/cannon
 	result_type       = /obj/item/cannonframe
 	difficulty        = MAT_VALUE_VERY_HARD_DIY
 	category          = "weapons"
+	uid               = "stack_recipe_steel_cannonframe"
 
 /decl/stack_recipe/steel/furniture
 	abstract_type     = /decl/stack_recipe/steel/furniture
@@ -50,6 +59,7 @@
 /decl/stack_recipe/steel/furniture/computerframe
 	result_type       = /obj/machinery/constructable_frame/computerframe
 	req_amount        = 5 * SHEET_MATERIAL_AMOUNT // Arbitrary value since machines don't handle matter properly yet.
+	uid               = "stack_recipe_steel_computerframe"
 
 /decl/stack_recipe/steel/furniture/computerframe/spawn_result(mob/user, location, amount, decl/material/mat, decl/material/reinf_mat, paint_color, spent_type, spent_amount = 1)
 	return ..(user, location, amount, null, null)
@@ -61,58 +71,73 @@
 
 /decl/stack_recipe/steel/furniture/door_assembly/standard
 	result_type       = /obj/structure/door_assembly
+	uid               = "stack_recipe_steel_doorassembly_standard"
 
 /decl/stack_recipe/steel/furniture/door_assembly/airtight
 	name              = "airtight hatch assembly"
 	result_type       = /obj/structure/door_assembly/door_assembly_hatch
+	uid               = "stack_recipe_steel_doorassembly_hatch"
 
 /decl/stack_recipe/steel/furniture/door_assembly/highsec
 	name              = "high security airlock assembly"
 	result_type       = /obj/structure/door_assembly/door_assembly_highsecurity
+	uid               = "stack_recipe_steel_doorassembly_highsec"
 
 /decl/stack_recipe/steel/furniture/door_assembly/ext
 	name              = "exterior airlock assembly"
 	result_type       = /obj/structure/door_assembly/door_assembly_ext
+	uid               = "stack_recipe_steel_doorassembly_ext"
 
 /decl/stack_recipe/steel/furniture/door_assembly/firedoor
 	name              = "emergency shutter assembly"
 	result_type       = /obj/structure/firedoor_assembly
+	uid               = "stack_recipe_steel_doorassembly_firedoor"
 
 /decl/stack_recipe/steel/furniture/door_assembly/firedoor/border
 	name              = "unidirectional emergency shutter assembly"
 	result_type       = /obj/structure/firedoor_assembly/border
 	one_per_turf      = FALSE
+	uid               = "stack_recipe_steel_doorassembly_firedoor_border"
 
 /decl/stack_recipe/steel/furniture/door_assembly/double
 	name              = "double airlock assembly"
 	result_type       = /obj/structure/door_assembly/double
+	uid               = "stack_recipe_steel_doorassembly_double"
 
 /decl/stack_recipe/steel/furniture/door_assembly/blast
 	name              = "blast door assembly"
 	result_type       = /obj/structure/door_assembly/blast
+	uid               = "stack_recipe_steel_doorassembly_blast"
 
 /decl/stack_recipe/steel/furniture/door_assembly/shutter
 	name              = "shutter assembly"
 	result_type       = /obj/structure/door_assembly/blast/shutter
+	uid               = "stack_recipe_steel_doorassembly_shutter"
 
 /decl/stack_recipe/steel/furniture/door_assembly/morgue
 	name              = "morgue door assembly"
 	result_type       = /obj/structure/door_assembly/blast/morgue
+	uid               = "stack_recipe_steel_doorassembly_morgue"
 
 /decl/stack_recipe/steel/furniture/canister
 	result_type       = /obj/machinery/portable_atmospherics/canister
 	req_amount        = 5 * SHEET_MATERIAL_AMOUNT // Arbitrary value since machines don't handle matter properly yet.
+	uid               = "stack_recipe_steel_canister"
 
 /decl/stack_recipe/steel/furniture/tank
 	result_type       = /obj/item/pipe/tank
+	uid               = "stack_recipe_steel_tank"
 
 /decl/stack_recipe/steel/furniture/drill_brace
 	result_type       = /obj/structure/drill_brace
+	uid               = "stack_recipe_steel_drill_brace"
 
 /decl/stack_recipe/steel/furniture/armor_stand
 	result_type       = /obj/structure/armor_stand
 	difficulty        = MAT_VALUE_NORMAL_DIY
+	uid               = "stack_recipe_steel_armor_stand"
 
 /decl/stack_recipe/steel/furniture/target_stake
 	result_type       = /obj/structure/target_stake
 	difficulty        = MAT_VALUE_NORMAL_DIY
+	uid               = "stack_recipe_steel_target_stake"

--- a/code/modules/crafting/stack_recipes/recipes_textiles.dm
+++ b/code/modules/crafting/stack_recipes/recipes_textiles.dm
@@ -13,10 +13,12 @@
 	one_per_turf               = TRUE
 	on_floor                   = TRUE
 	category                   = "furniture"
+	uid                        = "stack_recipe_textile_rug"
 
 /decl/stack_recipe/textiles/cloak
 	result_type                = /obj/item/clothing/suit/cloak/hide
 	category                   = "clothing"
+	uid                        = "stack_recipe_textile_cloak"
 
 /decl/stack_recipe/textiles/banner
 	name                       = "banner"
@@ -24,41 +26,50 @@
 	category                   = "furniture"
 	crafting_extra_cost_factor = 1.1 // less material is lost because it's relatively simple
 	difficulty                 = MAT_VALUE_NORMAL_DIY // Slightly easier than making actual clothing.
+	uid                        = "stack_recipe_textile_banner"
 
 /decl/stack_recipe/textiles/banner/forked
 	name                       = "banner, forked"
 	result_type                = /obj/item/banner/forked
+	uid                        = "stack_recipe_textile_banner_forked"
 
 /decl/stack_recipe/textiles/banner/pointed
 	name                       = "banner, pointed"
 	result_type                = /obj/item/banner/pointed
+	uid                        = "stack_recipe_textile_banner_pointed"
 
 /decl/stack_recipe/textiles/banner/rounded
 	name                       = "banner, rounded"
 	result_type                = /obj/item/banner/rounded
+	uid                        = "stack_recipe_textile_banner_rounded"
 
 /decl/stack_recipe/textiles/banner/square
 	name                       = "banner, square"
 	result_type                = /obj/item/banner/square
+	uid                        = "stack_recipe_textile_banner_square"
 
 /decl/stack_recipe/textiles/banner/tasselled
 	name                       = "banner, tasselled"
 	result_type                = /obj/item/banner/tasselled
+	uid                        = "stack_recipe_textile_banner_tasselled"
 
 /decl/stack_recipe/textiles/sack
 	result_type                = /obj/item/bag/sack
 	category                   = "storage"
 	crafting_extra_cost_factor = 1.1 // less material is lost because it's relatively simple
 	difficulty                 = MAT_VALUE_NORMAL_DIY // Slightly easier than making actual clothing.
+	uid                        = "stack_recipe_textile_sack"
 
 /decl/stack_recipe/textiles/bandolier
 	result_type           = /obj/item/clothing/webbing/bandolier/crafted
 	category              = "storage"
+	uid                   = "stack_recipe_textile_bandolier"
 
 /decl/stack_recipe/textiles/headband
 	result_type           = /obj/item/clothing/head/headband
 	crafting_extra_cost_factor = 1.2 // less material is lost because it's relatively simple
 	category              = "clothing"
+	uid                   = "stack_recipe_textile_headband"
 
 
 /decl/stack_recipe/textiles/leather
@@ -66,44 +77,55 @@
 	validation_material   = /decl/material/solid/organic/leather
 	craft_stack_types     = /obj/item/stack/material/skin
 	category              = "clothing"
+	uid                   = "stack_recipe_textile_leather_"
 
 /decl/stack_recipe/textiles/leather/bedroll
 	result_type           = /obj/item/bedroll
 	difficulty            = MAT_VALUE_NORMAL_DIY // Slightly easier than making clothing.
 	category              = "bedding"
+	uid                   = "stack_recipe_textile_leather_bedroll"
 
 /decl/stack_recipe/textiles/leather/shoes
 	result_type           = /obj/item/clothing/shoes/craftable
+	uid                   = "stack_recipe_textile_leather_shoes"
 
 /decl/stack_recipe/textiles/leather/boots
 	result_type           = /obj/item/clothing/shoes/craftable/boots
+	uid                   = "stack_recipe_textile_leather_boots"
 
 /decl/stack_recipe/textiles/leather/coat
 	result_type           = /obj/item/clothing/suit/leathercoat
+	uid                   = "stack_recipe_textile_leather_coat"
 
 /decl/stack_recipe/textiles/leather/gloves
 	result_type           = /obj/item/clothing/gloves/thick
+	uid                   = "stack_recipe_textile_leather_gloves"
 
 /decl/stack_recipe/textiles/leather/sling
 	result_type                = /obj/item/gun/launcher/bow/sling
 	crafting_extra_cost_factor = 1.1 // less material is lost because it's relatively simple
 	difficulty                 = MAT_VALUE_NORMAL_DIY // Slightly easier than making clothing.
+	uid                        = "stack_recipe_textile_leather_sling"
 
 /decl/stack_recipe/textiles/leather/sack
 	result_type                = /obj/item/bag/sack
 	difficulty                 = MAT_VALUE_HARD_DIY
+	uid                        = "stack_recipe_textile_leather_sack"
 
 /decl/stack_recipe/textiles/leather/backpack
 	result_type                = /obj/item/backpack/crafted/backpack
 	difficulty                 = MAT_VALUE_VERY_HARD_DIY
+	uid                        = "stack_recipe_textile_leather_backpack"
 
 /decl/stack_recipe/textiles/leather/backpack/haversack
 	result_type                = /obj/item/backpack/crafted
+	uid                        = "stack_recipe_textile_leather_haversack"
 
 /decl/stack_recipe/textiles/leather/waterskin
 	result_type           = /obj/item/chems/glass/waterskin/crafted
 	required_material     = /decl/material/solid/organic/leather
 	category              = null
+	uid                   = "stack_recipe_textile_leather_waterskin"
 
 /decl/stack_recipe/textiles/cloth
 	abstract_type         = /decl/stack_recipe/textiles/cloth
@@ -115,31 +137,38 @@
 	result_type           = /obj/item/chems/filter
 	difficulty            = MAT_VALUE_EASY_DIY // see above comment
 	category              = "utility"
+	uid                   = "stack_recipe_textile_cloth_filter"
 
 /decl/stack_recipe/textiles/cloth/bandana
 	result_type           = /obj/item/clothing/mask/bandana/colourable
 	difficulty            = MAT_VALUE_EASY_DIY // see above comment
 	crafting_extra_cost_factor = 1 // basically just a rag
+	uid                   = "stack_recipe_textile_cloth_bandana"
 
 /decl/stack_recipe/textiles/cloth/gloves
 	result_type           = /obj/item/clothing/gloves
+	uid                   = "stack_recipe_textile_cloth_gloves"
 
 /decl/stack_recipe/textiles/cloth/robe
 	result_type           = /obj/item/clothing/suit/robe
+	uid                   = "stack_recipe_textile_cloth_robe"
 
 /decl/stack_recipe/textiles/cloth/poncho
 	result_type           = /obj/item/clothing/suit/poncho/colored
+	uid                   = "stack_recipe_textile_cloth_poncho"
 
 /decl/stack_recipe/textiles/cloth/bedding
 	result_type                = /obj/item/bedsheet
 	crafting_extra_cost_factor = 1.1 // less material is lost because it's relatively simple
 	category                   = "bedding"
+	uid                        = "stack_recipe_textile_cloth_bedsheet"
 
 /decl/stack_recipe/textiles/cloth/bandages
 	result_type                = /obj/item/stack/medical/bandage/crafted
 	difficulty                 = MAT_VALUE_EASY_DIY
 	crafting_extra_cost_factor = 1.1 // it's not that much more complicated than making a rag, but you probably want to at least tidy up the edges
 	category                   = "medical"
+	uid                        = "stack_recipe_textile_cloth_bandage"
 
 /decl/stack_recipe/textiles/fur
 	abstract_type         = /decl/stack_recipe/textiles/fur
@@ -151,6 +180,7 @@
 	crafting_extra_cost_factor = 1.1 // you're basically just trimming the edges and cleaning the pelt
 	result_type                = /obj/item/bedsheet/furs
 	category                   = "bedding"
+	uid                        = "stack_recipe_textile_fur_bedding"
 
 /decl/stack_recipe/textiles/surgical_sutures
 	result_type                 = /obj/item/ancient_surgery/sutures
@@ -159,8 +189,10 @@
 	crafting_extra_cost_factor  = 1 // no overall material loss, you're just prepping the thread
 	category                    = "medical"
 	available_to_map_tech_level = MAP_TECH_LEVEL_MEDIEVAL
+	uid                         = "stack_recipe_textile_sutures"
 
 /decl/stack_recipe/textiles/rag
-	result_type = /obj/item/chems/rag
+	result_type                = /obj/item/chems/rag
 	crafting_extra_cost_factor = 1 // whatever you produce is going to be a rag, there's no wastage
-	difficulty = MAT_VALUE_TRIVIAL_DIY
+	difficulty                 = MAT_VALUE_TRIVIAL_DIY
+	uid                        = "stack_recipe_textile_rag"

--- a/code/modules/departments/department.dm
+++ b/code/modules/departments/department.dm
@@ -2,11 +2,12 @@
 	. = b.display_priority - a.display_priority
 
 /decl/department
+	// this isn't abstract because it's used as a fallback
 	var/name
 	var/noun = "department"
 	var/noun_adj = "departmental"
 	var/announce_channel = "Common" // The Channel for spawn annoncement. Leave as common if unsure. The channel will be selected based of the first deparment listed in a jobs .department_types
-	var/list/goals = list() 
+	var/list/goals = list()
 	var/min_goals = 1
 	var/max_goals = 2
 	var/colour = "#808080"

--- a/code/modules/economy/worth_currency.dm
+++ b/code/modules/economy/worth_currency.dm
@@ -129,9 +129,11 @@
 /decl/stack_recipe/coin/credits
 	name = "two credit coin"
 	currency = /decl/currency/credits
+	uid = "stack_recipe_coin_credit_two"
 
 /decl/stack_recipe/coin/credits/one
 	name = "one credit coin"
+	uid = "stack_recipe_coin_credit_one"
 
 /datum/denomination/coin/mid
 	state = "coin_medium"
@@ -155,12 +157,15 @@
 /decl/stack_recipe/coin/trader
 	currency = /decl/currency/trader
 	name = "ten scrip coin"
+	uid = "stack_recipe_coin_scrip_ten"
 
 /decl/stack_recipe/coin/trader/mid
 	name = "five scrip coin"
+	uid = "stack_recipe_coin_scrip_five"
 
 /decl/stack_recipe/coin/trader/small
 	name = "one scrip coin"
+	uid = "stack_recipe_coin_scrip_one"
 
 /decl/currency/scav
 	name = "scavbucks"
@@ -171,12 +176,15 @@
 /datum/denomination/trash
 	name = "wiggly string"
 	state = "string"
+
 /datum/denomination/trash/bone
 	name = "pointy bone"
 	state = "bone"
+
 /datum/denomination/trash/rock
 	name = "neat rock"
 	state = "rock"
+
 /datum/denomination/trash/shell
 	name = "tasty shell"
 	state = "shell"

--- a/code/modules/fusion/fusion_reactions.dm
+++ b/code/modules/fusion/fusion_reactions.dm
@@ -1,6 +1,7 @@
 #define FUSION_PROCESSING_TIME_MULT 2 // SSmachines.wait / (1 SECOND) - previous values were intended for SSobj 1-second wait.
 
 /decl/fusion_reaction
+	abstract_type = /decl/fusion_reaction
 	var/p_react // Primary reactant.
 	var/s_react // Secondary reactant.
 	var/minimum_energy_level = 1

--- a/code/modules/genetics/plants/_gene_plant.dm
+++ b/code/modules/genetics/plants/_gene_plant.dm
@@ -1,5 +1,6 @@
 /decl/plant_gene
 	abstract_type   = /decl/plant_gene
+	decl_flags = DECL_FLAG_MANDATORY_UID
 	//expected_source = /datum/seed
 	//expected_target = /datum/seed
 	/// Set to a randomized gene mask in Initialize().

--- a/code/modules/genetics/plants/gene_atmosphere.dm
+++ b/code/modules/genetics/plants/gene_atmosphere.dm
@@ -5,6 +5,7 @@
 		TRAIT_LOWKPA_TOLERANCE,
 		TRAIT_HIGHKPA_TOLERANCE
 	)
+	uid = "plant_gene_atmosphere"
 
 /decl/plant_gene/atmosphere/mutate(datum/seed/seed, turf/location)
 	if(prob(60))

--- a/code/modules/genetics/plants/gene_biochemistry.dm
+++ b/code/modules/genetics/plants/gene_biochemistry.dm
@@ -7,6 +7,7 @@
 		TRAIT_YIELD,
 		TRAIT_ENDURANCE
 	)
+	uid = "plant_gene_biochemistry"
 
 /decl/plant_gene/biochemistry/mutate(datum/seed/seed)
 	seed.set_trait(TRAIT_POTENCY, seed.get_trait(TRAIT_POTENCY)+rand(-20,20),200, 0)

--- a/code/modules/genetics/plants/gene_diet.dm
+++ b/code/modules/genetics/plants/gene_diet.dm
@@ -6,6 +6,7 @@
 		TRAIT_NUTRIENT_CONSUMPTION,
 		TRAIT_WATER_CONSUMPTION
 	)
+	uid = "plant_gene_diet"
 
 /decl/plant_gene/diet/mutate(datum/seed/seed, turf/location)
 	if(prob(60))

--- a/code/modules/genetics/plants/gene_environment.dm
+++ b/code/modules/genetics/plants/gene_environment.dm
@@ -5,6 +5,7 @@
 		TRAIT_IDEAL_LIGHT,
 		TRAIT_LIGHT_TOLERANCE
 	)
+	uid = "plant_gene_environment"
 
 /decl/plant_gene/environment/mutate(datum/seed/seed, turf/location)
 	if(prob(60))

--- a/code/modules/genetics/plants/gene_fruit.dm
+++ b/code/modules/genetics/plants/gene_fruit.dm
@@ -6,6 +6,7 @@
 		TRAIT_FLESH_COLOUR,
 		TRAIT_JUICY
 	)
+	uid = "plant_gene_fruit"
 
 /decl/plant_gene/fruit/mutate(datum/seed/seed, turf/location)
 	if(prob(65))

--- a/code/modules/genetics/plants/gene_hardiness.dm
+++ b/code/modules/genetics/plants/gene_hardiness.dm
@@ -6,6 +6,7 @@
 		TRAIT_WEED_TOLERANCE,
 		TRAIT_ENDURANCE
 	)
+	uid = "plant_gene_hardiness"
 
 /decl/plant_gene/hardiness/mutate(datum/seed/seed, turf/location)
 	if(prob(60))

--- a/code/modules/genetics/plants/gene_metabolism.dm
+++ b/code/modules/genetics/plants/gene_metabolism.dm
@@ -5,6 +5,7 @@
 		TRAIT_REQUIRES_WATER,
 		TRAIT_ALTER_TEMP
 	)
+	uid = "plant_gene_metabolism"
 
 /decl/plant_gene/metabolism/mutate(datum/seed/seed, turf/location)
 	if(prob(65))

--- a/code/modules/genetics/plants/gene_output.dm
+++ b/code/modules/genetics/plants/gene_output.dm
@@ -4,6 +4,7 @@
 		TRAIT_PRODUCES_POWER,
 		TRAIT_BIOLUM
 	)
+	uid = "plant_gene_output"
 
 /decl/plant_gene/output/mutate(datum/seed/seed, turf/location)
 	if(prob(50))

--- a/code/modules/genetics/plants/gene_pigment.dm
+++ b/code/modules/genetics/plants/gene_pigment.dm
@@ -6,3 +6,4 @@
 		TRAIT_BIOLUM_COLOUR,
 		TRAIT_LEAVES_COLOUR
 	)
+	uid = "plant_gene_pigment"

--- a/code/modules/genetics/plants/gene_special.dm
+++ b/code/modules/genetics/plants/gene_special.dm
@@ -3,6 +3,7 @@
 	associated_traits = list(
 		TRAIT_TELEPORTING
 	)
+	uid = "plant_gene_special"
 
 /decl/plant_gene/special/mutate(datum/seed/seed, atom/location)
 	if(prob(65))

--- a/code/modules/genetics/plants/gene_structure.dm
+++ b/code/modules/genetics/plants/gene_structure.dm
@@ -6,3 +6,4 @@
 		TRAIT_HARVEST_REPEAT,
 		TRAIT_LARGE
 	)
+	uid = "plant_gene_structure"

--- a/code/modules/genetics/plants/gene_vigour.dm
+++ b/code/modules/genetics/plants/gene_vigour.dm
@@ -6,6 +6,7 @@
 		TRAIT_YIELD,
 		TRAIT_SPREAD
 	)
+	uid = "plant_gene_vigour"
 
 /decl/plant_gene/vigour/mutate(datum/seed/seed, atom/location)
 	if(prob(65))

--- a/code/modules/geology/_strata.dm
+++ b/code/modules/geology/_strata.dm
@@ -1,4 +1,5 @@
 /decl/strata
+	abstract_type = /decl/strata
 	var/name
 	var/list/base_materials
 	var/list/ores_sparse

--- a/code/modules/ghosttrap/trap.dm
+++ b/code/modules/ghosttrap/trap.dm
@@ -1,5 +1,6 @@
 // This system is used to grab a ghost from observers with the required preferences and lack of bans set.
 /decl/ghosttrap
+	abstract_type = /decl/ghosttrap
 	var/name
 	var/minutes_since_death = 0     // If non-zero the ghost must have been dead for this many minutes to be allowed to spawn
 	var/list/ban_checks

--- a/code/modules/mob/grab/grab_datum.dm
+++ b/code/modules/mob/grab/grab_datum.dm
@@ -1,4 +1,5 @@
 /decl/grab
+	abstract_type = /decl/grab
 	var/name                    = "generic grab"
 	/// Whether or not the grabbed person can move out of the grab
 	var/stop_move               = 0

--- a/code/modules/modular_computers/networking/device_types/acl.dm
+++ b/code/modules/modular_computers/networking/device_types/acl.dm
@@ -112,15 +112,18 @@
 	desc = "Adds a new group with the passed name. A parent group can be passed to add a child group."
 	call_proc = TYPE_PROC_REF(/datum/extension/network_device/acl, add_group)
 	forward_args = TRUE
+	uid = "public_method_acl_group_add"
 
 /decl/public_access/public_method/remove_group
 	name = "Remove group"
 	desc = "Removes a group with the passed name. A parent group can be passed to remove a child group of that parent."
 	call_proc = TYPE_PROC_REF(/datum/extension/network_device/acl, remove_group)
 	forward_args = TRUE
+	uid = "public_method_acl_group_remove"
 
 /decl/public_access/public_method/list_groups
 	name = "List groups"
 	desc = "Lists groups on the group access controller. A parent group can be passed list children of that parent group."
 	call_proc = TYPE_PROC_REF(/datum/extension/network_device/acl, get_group_listing)
 	forward_args = TRUE
+	uid = "public_method_acl_group_list"

--- a/code/modules/organs/external/diagnostics.dm
+++ b/code/modules/organs/external/diagnostics.dm
@@ -178,6 +178,7 @@
 	return sounds
 
 /decl/diagnostic_sign
+	abstract_type = /decl/diagnostic_sign
 	var/name = "Some symptom"
 	var/descriptor
 	var/explanation

--- a/code/modules/overmap/events/event.dm
+++ b/code/modules/overmap/events/event.dm
@@ -253,6 +253,7 @@
 
 //These now are basically only used to spawn hazards. Will be useful when we need to spawn group of moving hazards
 /decl/overmap_event
+	abstract_type = /decl/overmap_event
 	var/name = "map event"
 	var/radius = 2
 	var/count = 6

--- a/code/modules/paperwork/faxmachine.dm
+++ b/code/modules/paperwork/faxmachine.dm
@@ -622,6 +622,7 @@ var/global/list/adminfaxes     = list()	//cache for faxes that have been sent to
 	desc = "Sends the specified document over to the specified network tag."
 	call_proc = TYPE_PROC_REF(/obj/machinery/faxmachine, receive_fax)
 	forward_args = TRUE
+	uid = "public_method_fax_receive_message"
 
 ////////////////////////////////////////////////////////////////////////////////////////
 // Admin Faxes Handling

--- a/code/modules/projectiles/guns/energy/capacitor.dm
+++ b/code/modules/projectiles/guns/energy/capacitor.dm
@@ -1,6 +1,7 @@
 var/global/list/laser_wavelengths
 
 /decl/laser_wavelength
+	abstract_type = /decl/laser_wavelength
 	var/name
 	var/color
 	var/light_color

--- a/code/modules/projectiles/guns/projectile/random_pistol.dm
+++ b/code/modules/projectiles/guns/projectile/random_pistol.dm
@@ -59,6 +59,7 @@
 	safety.pixel_x = safety_offset[base_state][1]
 	safety.pixel_y = safety_offset[base_state][2]
 	return safety
+
 /decl/gun_look/cover
 	icon =  'icons/obj/guns/random_pistol/looks/cover.dmi'
 	ammo_offset = list(

--- a/code/modules/reagents/chems/random/random_effects.dm
+++ b/code/modules/reagents/chems/random/random_effects.dm
@@ -3,6 +3,7 @@
 #define RANDOM_CHEM_EFFECT_FLOAT 3
 
 /decl/random_chem_effect
+	abstract_type = /decl/random_chem_effect
 	var/minimum = 0
 	var/maximum = 1
 	var/mode = RANDOM_CHEM_EFFECT_TRUE

--- a/code/modules/research/research_fields.dm
+++ b/code/modules/research/research_fields.dm
@@ -1,4 +1,5 @@
 /decl/research_field
+	abstract_type = /decl/research_field
 	var/name
 	var/desc
 	var/id

--- a/code/modules/scent/_scent.dm
+++ b/code/modules/scent/_scent.dm
@@ -2,6 +2,7 @@
 Scent intensity
 *****/
 /decl/scent_intensity
+	abstract_type = /decl/scent_intensity
 	var/cooldown = 5 MINUTES
 	var/intensity = 1
 

--- a/code/modules/scent/scent_decls.dm
+++ b/code/modules/scent/scent_decls.dm
@@ -1,4 +1,5 @@
 /decl/scent_type
+	abstract_type = /decl/scent_type
 	var/color
 	var/scent //this is for the desc, the actual scent goes in the datum
 	var/scent_datum

--- a/code/modules/security_levels/_security_level.dm
+++ b/code/modules/security_levels/_security_level.dm
@@ -1,4 +1,5 @@
 /decl/security_level
+	decl_flags = DECL_FLAG_MANDATORY_UID
 	var/icon = 'icons/misc/security_state.dmi'
 	var/name
 

--- a/code/modules/security_levels/security_levels.dm
+++ b/code/modules/security_levels/security_levels.dm
@@ -32,6 +32,7 @@
 
 /decl/security_level/default/code_green
 	name = "code green"
+	uid = "security_level_green"
 
 	light_range = 2
 	light_power = 1
@@ -47,6 +48,7 @@
 
 /decl/security_level/default/code_blue
 	name = "code blue"
+	uid = "security_level_blue"
 
 	light_range = 2
 	light_power = 1
@@ -61,6 +63,7 @@
 
 /decl/security_level/default/code_red
 	name = "code red"
+	uid = "security_level_red"
 
 	light_range = 4
 	light_power = 2
@@ -75,6 +78,7 @@
 
 /decl/security_level/default/code_delta
 	name = "code delta"
+	uid = "security_level_delta"
 
 	light_range = 4
 	light_power = 2
@@ -101,5 +105,6 @@
 /// A dummy security level with no effects.
 /decl/security_level/none
 	name = "none"
+	uid = "security_level_none"
 	// Since currently we're required to have an alarm_appearance, we just use a blank one.
 	alarm_appearance = /datum/alarm_appearance

--- a/code/modules/status_conditions/_status_condition.dm
+++ b/code/modules/status_conditions/_status_condition.dm
@@ -3,6 +3,7 @@ var/global/list/status_marker_holders = list()
 // Check code/modules/mob/mob_status.dm code/modules/mob/living/living_status.dm
 // for the procs that check/set/process these status conditions.
 /decl/status_condition
+	abstract_type = /decl/status_condition
 	var/name
 	var/check_flags = 0
 	var/list/victim_data

--- a/code/modules/submaps/submap_archetype.dm
+++ b/code/modules/submaps/submap_archetype.dm
@@ -1,4 +1,5 @@
 /decl/submap_archetype
+	abstract_type = /decl/submap_archetype
 	// TODO: use UID instead of name for pref saving.
 	var/name = "generic ship archetype"
 	var/list/whitelisted_species = list()

--- a/code/modules/tools/components/recipes.dm
+++ b/code/modules/tools/components/recipes.dm
@@ -21,9 +21,11 @@
 
 /decl/stack_recipe/tool/handle/long
 	result_type                 = /obj/item/tool_component/handle/long
+	uid                         = "stack_recipe_tool_handle_long"
 
 /decl/stack_recipe/tool/handle/short
 	result_type                 = /obj/item/tool_component/handle/short
+	uid                         = "stack_recipe_tool_handle_short"
 
 /decl/stack_recipe/tool/head
 	abstract_type               = /decl/stack_recipe/tool/head
@@ -31,15 +33,19 @@
 
 /decl/stack_recipe/tool/head/hammer
 	result_type                 = /obj/item/tool_component/head/hammer
+	uid                         = "stack_recipe_tool_head_hammer"
 
 /decl/stack_recipe/tool/head/hoe
 	result_type                 = /obj/item/tool_component/head/hoe
+	uid                         = "stack_recipe_tool_head_hoe"
 
 /decl/stack_recipe/tool/head/shovel
 	result_type                 = /obj/item/tool_component/head/shovel
+	uid                         = "stack_recipe_tool_head_shovel"
 
 /decl/stack_recipe/tool/head/handaxe
 	result_type                 = /obj/item/tool_component/head/handaxe
+	uid                         = "stack_recipe_tool_head_handaxe"
 
 /decl/stack_recipe/tool/head/sledgehammer
 	difficulty                  = MAT_VALUE_VERY_HARD_DIY
@@ -48,6 +54,7 @@
 		/obj/item/stack/material/ore,
 		/obj/item/stack/material/lump
 	)
+	uid                         = "stack_recipe_tool_head_sledgehammer"
 
 /decl/stack_recipe/tool/head/pickaxe
 	difficulty                  = MAT_VALUE_VERY_HARD_DIY
@@ -56,3 +63,4 @@
 		/obj/item/stack/material/ore,
 		/obj/item/stack/material/lump
 	)
+	uid                         = "stack_recipe_tool_head_pickaxe"

--- a/code/modules/webhooks/_webhook.dm
+++ b/code/modules/webhooks/_webhook.dm
@@ -1,4 +1,5 @@
 /decl/webhook
+	abstract_type = /decl/webhook
 	var/id
 	var/list/urls
 	var/list/mentions

--- a/code/modules/xenoarcheaology/artifacts/artifact_appearance.dm
+++ b/code/modules/xenoarcheaology/artifacts/artifact_appearance.dm
@@ -3,12 +3,15 @@
 
 /decl/artifact_appearance
 	var/name = "alien artifact"
+
 /decl/artifact_appearance/proc/apply_to(obj/structure/artifact/A)
 	A.SetName(name)
 	adjust_desc(A)
 	adjust_icon(A)
 	A.update_icon()
+
 /decl/artifact_appearance/proc/adjust_desc(obj/structure/artifact/A)
+
 /decl/artifact_appearance/proc/adjust_icon(obj/structure/artifact/A)
 	var/icon_num = rand(0, 6)
 	A.base_icon = "ano[icon_num]"
@@ -17,8 +20,10 @@
 
 /decl/artifact_appearance/vents
 	name = "alien artifact"
+
 /decl/artifact_appearance/vents/adjust_desc(obj/structure/artifact/A)
 	A.desc = "A large alien device, there appear to be some kind of vents in the side."
+
 /decl/artifact_appearance/vents/adjust_icon(obj/structure/artifact/A)
 	A.base_icon = "ano10"
 
@@ -26,21 +31,25 @@
 
 /decl/artifact_appearance/computer
 	name = "alien computer"
+
 /decl/artifact_appearance/computer/adjust_desc(obj/structure/artifact/A)
 	A.desc = "It is covered in strange markings."
+
 /decl/artifact_appearance/computer/adjust_icon(obj/structure/artifact/A)
 	A.base_icon = "ano9"
-	
+
 // Sealed pod
 
 /decl/artifact_appearance/pod
 	name = "sealed alien pod"
+
 /decl/artifact_appearance/pod/adjust_icon(obj/structure/artifact/A)
 	A.base_icon = "ano11"
 
 // Crystals
 /decl/artifact_appearance/crystal
 	name = "large crystal"
+
 /decl/artifact_appearance/crystal/adjust_desc(obj/structure/artifact/A)
 	A.desc = pick(
 		"It shines faintly as it catches the light.",
@@ -48,5 +57,6 @@
 		"It seems to draw you inward as you look it at.",
 		"Something twinkles faintly as you look at it.",
 		"It's mesmerizing to behold.")
+
 /decl/artifact_appearance/crystal/adjust_icon(obj/structure/artifact/A)
 	A.base_icon = "ano[pick(7,8)]"

--- a/mods/_modpack.dm
+++ b/mods/_modpack.dm
@@ -1,4 +1,5 @@
 /decl/modpack
+	abstract_type = /decl/modpack
 	/// A string name for the modpack. Used for looking up other modpacks in init.
 	var/name
 	/// A string desc for the modpack. Can be used for modpack verb list as description.

--- a/mods/content/actors.dm
+++ b/mods/content/actors.dm
@@ -20,6 +20,7 @@
 	default_outfit = /decl/outfit/actor
 	default_access = list()
 	id_title = "Actor"
+	uid = "special_role_actor"
 
 /obj/abstract/landmark/actor_spawn
 	name = "ActorSpawn"

--- a/mods/content/augments/augment_loadout.dm
+++ b/mods/content/augments/augment_loadout.dm
@@ -1,5 +1,6 @@
 /decl/loadout_category/augmentation
 	name = "Augmentations"
+	uid = "loadout_category_augmentation"
 
 /decl/loadout_option/augmentation
 	category = /decl/loadout_category/augmentation

--- a/mods/content/beekeeping/recipes.dm
+++ b/mods/content/beekeeping/recipes.dm
@@ -1,5 +1,7 @@
 /decl/stack_recipe/planks/furniture/apiary
 	result_type = /obj/structure/apiary
+	uid         = "stack_recipe_plank_apiary"
 
 /decl/stack_recipe/planks/beehive_frame
 	result_type = /obj/item/hive_frame/crafted
+	uid         = "stack_recipe_plank_beehive_frame"

--- a/mods/content/blacksmithy/anvil.dm
+++ b/mods/content/blacksmithy/anvil.dm
@@ -130,6 +130,7 @@
 	material            = /decl/material/solid/metal/steel
 	max_health          = 500
 
-/decl/stack_recipe/steel/furniture
+/decl/stack_recipe/steel/furniture/anvil
 	result_type       = /obj/structure/anvil/improvised
 	difficulty        = MAT_VALUE_HARD_DIY
+	uid               = "stack_recipe_steel_anvil_improvised"

--- a/mods/content/blacksmithy/barrel_rim.dm
+++ b/mods/content/blacksmithy/barrel_rim.dm
@@ -11,6 +11,7 @@
 	one_per_turf = FALSE
 	on_floor     = FALSE
 	category     = "items"
+	uid          = "stack_recipe_stick_barrel_rim"
 
 /obj/structure/reagent_dispensers/barrel
 	// Skill used for coopery.

--- a/mods/content/corporate/datum/antagonists/commando.dm
+++ b/mods/content/corporate/datum/antagonists/commando.dm
@@ -12,6 +12,7 @@
 	default_access = list(access_mercenary)
 	rig_type = /obj/item/rig/merc
 	id_title = "Commando"
+	uid = "special_role_deathsquad_mercenary"
 
 /decl/outfit/mercenary_commando
 	name =    "Special Role - Mercenary Commando"

--- a/mods/content/corporate/datum/antagonists/deathsquad.dm
+++ b/mods/content/corporate/datum/antagonists/deathsquad.dm
@@ -20,6 +20,7 @@
 	faction = "deathsquad"
 	default_outfit = /decl/outfit/commando
 	id_title = "Asset Protection"
+	uid = "special_role_deathsquad"
 	var/deployed = 0
 
 /decl/special_role/deathsquad/attempt_spawn()

--- a/mods/content/fantasy/datum/currencies.dm
+++ b/mods/content/fantasy/datum/currencies.dm
@@ -46,9 +46,12 @@
 /decl/stack_recipe/coin/imperial
 	currency = /decl/currency/imperial
 	name = "\improper Imperial crown"
+	uid = "stack_recipe_coin_imperial_crown"
 
 /decl/stack_recipe/coin/imperial/quin
 	name = "\improper Imperial quincrown"
+	uid = "stack_recipe_coin_imperial_quincrown"
 
 /decl/stack_recipe/coin/imperial/huge
 	name = "\improper Imperial crown regalis"
+	uid = "stack_recipe_coin_imperial_regalis"

--- a/mods/content/fantasy/items/clothing/_loadout.dm
+++ b/mods/content/fantasy/items/clothing/_loadout.dm
@@ -3,6 +3,7 @@
 
 /decl/loadout_category/fantasy/clothing
 	name = "Clothing"
+	uid = "loadout_category_fantasy_clothing"
 
 /decl/loadout_option/fantasy
 	abstract_type = /decl/loadout_option/fantasy
@@ -215,6 +216,7 @@
 
 /decl/loadout_category/fantasy/utility
 	name = "Utility"
+	uid = "loadout_category_fantasy_utility"
 
 /decl/loadout_option/fantasy/utility
 	abstract_type = /decl/loadout_option/fantasy/utility

--- a/mods/content/fantasy/items/clothing/_recipes.dm
+++ b/mods/content/fantasy/items/clothing/_recipes.dm
@@ -1,23 +1,29 @@
 /decl/stack_recipe/textiles/jerkin
 	result_type = /obj/item/clothing/shirt/crafted
 	category    = "clothing"
+	uid         = "stack_recipe_textile_jerkin"
 
 /decl/stack_recipe/textiles/gown
-	result_type       = /obj/item/clothing/dress/gown
-	category          = "clothing"
+	result_type = /obj/item/clothing/dress/gown
+	category    = "clothing"
+	uid         = "stack_recipe_textile_gown"
 
 /decl/stack_recipe/textiles/trousers
 	result_type = /obj/item/clothing/pants/trousers
 	category    = "clothing"
+	uid         = "stack_recipe_textile_trousers"
 
 /decl/stack_recipe/textiles/braies
 	result_type = /obj/item/clothing/pants/trousers/braies
 	category    = "clothing"
+	uid         = "stack_recipe_textile_braies"
 
 /decl/stack_recipe/textiles/tunic
 	result_type = /obj/item/clothing/shirt/tunic
 	category    = "clothing"
+	uid         = "stack_recipe_textile_tunic"
 
 /decl/stack_recipe/textiles/tunic_short
 	result_type = /obj/item/clothing/shirt/tunic/short
 	category    = "clothing"
+	uid         = "stack_recipe_textile_tunic_short"

--- a/mods/content/fantasy/items/clothing/loincloth.dm
+++ b/mods/content/fantasy/items/clothing/loincloth.dm
@@ -8,4 +8,5 @@
 	material = /decl/material/solid/organic/skin/fur
 
 /decl/stack_recipe/textiles/loincloth
-	result_type       = /obj/item/clothing/pants/loincloth
+	result_type = /obj/item/clothing/pants/loincloth
+	uid         = "stack_recipe_textile_loincloth"

--- a/mods/content/fishing/fishing_recipes.dm
+++ b/mods/content/fishing/fishing_recipes.dm
@@ -1,2 +1,3 @@
 /decl/stack_recipe/planks/fishing_rod
 	result_type = /obj/item/fishing_rod
+	uid         = "stack_recipe_planks_fishingrod"

--- a/mods/content/psionics/datum/antagonists/beguiled.dm
+++ b/mods/content/psionics/datum/antagonists/beguiled.dm
@@ -3,6 +3,7 @@
 	name_plural = "Beguiled"
 	welcome_text = "Your mind is no longer solely your own..."
 	flags = ANTAG_IMPLANT_IMMUNE
+	uid = "special_role_beguiled"
 
 	var/list/minion_controllers = list()
 

--- a/mods/content/psionics/datum/antagonists/foundation.dm
+++ b/mods/content/psionics/datum/antagonists/foundation.dm
@@ -24,6 +24,7 @@
 	faction = "foundation"
 	default_outfit = /decl/outfit/foundation
 	id_title = "Foundation Agent"
+	uid = "special_role_foundation_agent"
 
 /decl/special_role/foundation/equip_role(var/mob/living/human/player)
 	. = ..()

--- a/mods/content/psionics/datum/antagonists/paramount.dm
+++ b/mods/content/psionics/datum/antagonists/paramount.dm
@@ -12,6 +12,7 @@
 	min_player_age = 18
 	faction = "paramount"
 	default_outfit = /decl/outfit/paramount
+	uid = "special_role_paramount"
 
 /decl/outfit/paramount
 	name =    "Special Role - Paramount Grandmaster"

--- a/mods/content/psionics/system/psionics/faculties/_faculty.dm
+++ b/mods/content/psionics/system/psionics/faculties/_faculty.dm
@@ -1,4 +1,5 @@
 /decl/psionic_faculty
+	abstract_type = /decl/psionic_faculty
 	var/id
 	var/name
 	var/associated_intent_flag

--- a/mods/content/psionics/system/psionics/null/material.dm
+++ b/mods/content/psionics/system/psionics/null/material.dm
@@ -30,3 +30,4 @@
 /decl/stack_recipe/tile/nullglass
 	result_type = /obj/item/stack/tile/floor_nullglass
 	required_material = /decl/material/nullglass
+	uid = "stack_recipe_nullglass_tile"

--- a/mods/content/response_team/datum/ert_special_role.dm
+++ b/mods/content/response_team/datum/ert_special_role.dm
@@ -23,6 +23,7 @@
 	default_outfit = /decl/outfit/ert
 
 	base_to_load = "ERT Base"
+	uid = "special_role_emergency_responder"
 
 /decl/special_role/ert/create_default(var/mob/source)
 	var/mob/living/human/M = ..()

--- a/mods/content/undead/traits.dm
+++ b/mods/content/undead/traits.dm
@@ -2,3 +2,4 @@
 	name = "Undead"
 	description = "Your body is dead, but remains animated through some supernatural force."
 	levels = list(TRAIT_LEVEL_MINOR, TRAIT_LEVEL_MODERATE) // Moderate means skeleton, minor means zombie.
+	uid = "trait_undead"

--- a/mods/content/xenobiology/colours/_colour.dm
+++ b/mods/content/xenobiology/colours/_colour.dm
@@ -1,4 +1,5 @@
 /decl/slime_colour
+	abstract_type = /decl/slime_colour
 	var/name
 	var/min_children = 4
 	var/max_children = 4

--- a/mods/content/xenobiology/slime/slime_commands.dm
+++ b/mods/content/xenobiology/slime/slime_commands.dm
@@ -1,4 +1,5 @@
 /decl/slime_command
+	abstract_type = /decl/slime_command
 	var/list/triggers
 
 /decl/slime_command/proc/resolve(var/speaker, var/spoken, var/datum/mob_controller/slime/holder)

--- a/mods/gamemodes/cult/special_role.dm
+++ b/mods/gamemodes/cult/special_role.dm
@@ -19,6 +19,7 @@
 	skill_setter = /datum/antag_skill_setter/station
 	faction = "cult"
 	blocked_job_event_categories = list(ASSIGNMENT_ROBOT, ASSIGNMENT_COMPUTER)
+	uid = "special_role_cultist"
 
 	var/allow_narsie = 1
 	var/powerless = 0

--- a/mods/gamemodes/heist/special_role.dm
+++ b/mods/gamemodes/heist/special_role.dm
@@ -16,6 +16,7 @@
 	base_to_load = "Heist Base"
 	default_outfit = /decl/outfit/raider
 	id_title = "Visitor"
+	uid = "special_role_raider"
 
 	var/list/outfits_per_species
 

--- a/mods/gamemodes/mercenary/mercenary_antagonist.dm
+++ b/mods/gamemodes/mercenary/mercenary_antagonist.dm
@@ -19,6 +19,7 @@
 
 	base_to_load = "Mercenary Base"
 	default_outfit = /decl/outfit/mercenary
+	uid = "special_role_mercenary"
 
 /decl/special_role/mercenary/create_global_objectives()
 	if(!..())

--- a/mods/gamemodes/ninja/datums/special_role.dm
+++ b/mods/gamemodes/ninja/datums/special_role.dm
@@ -16,6 +16,7 @@
 	default_outfit = /decl/outfit/ninja
 	id_title = "Infiltrator"
 	rig_type = /obj/item/rig/light/ninja
+	uid = "special_role_ninja"
 	var/list/ninja_titles
 	var/list/ninja_names
 

--- a/mods/gamemodes/revolution/loyalist.dm
+++ b/mods/gamemodes/revolution/loyalist.dm
@@ -20,6 +20,7 @@
 	blacklisted_jobs = list(/datum/job/submap)
 	skill_setter = /datum/antag_skill_setter/station
 	faction = "loyalist"
+	uid = "special_role_loyalist"
 	var/command_department_id
 
 /decl/special_role/loyalist/Initialize()

--- a/mods/gamemodes/revolution/revolutionary.dm
+++ b/mods/gamemodes/revolution/revolutionary.dm
@@ -21,6 +21,7 @@
 	faction_indicator = "hud_rev"
 	faction_invisible = 1
 	faction = "revolutionary"
+	uid = "special_role_revolutionary"
 
 	blacklisted_jobs = list(/datum/job/submap)
 	var/command_department_id

--- a/mods/gamemodes/spyvspy/special_role.dm
+++ b/mods/gamemodes/spyvspy/special_role.dm
@@ -22,6 +22,7 @@
 	antaghud_indicator = "hud_renegade"
 	skill_setter = /datum/antag_skill_setter/station
 	blocked_job_event_categories = list(ASSIGNMENT_COMPUTER)
+	uid = "special_role_renegade"
 
 	var/list/spawn_guns = list(
 		/obj/item/gun/projectile/revolver/lasvolver,

--- a/mods/gamemodes/traitor/special_role.dm
+++ b/mods/gamemodes/traitor/special_role.dm
@@ -7,6 +7,7 @@
 	flags = ANTAG_SUSPICIOUS | ANTAG_RANDSPAWN | ANTAG_VOTABLE
 	skill_setter = /datum/antag_skill_setter/station
 	blocked_job_event_categories = list(ASSIGNMENT_COMPUTER)
+	uid = "special_role_traitor"
 
 /decl/special_role/traitor/get_extra_panel_options(var/datum/mind/player)
 	return "<a href='byond://?src=\ref[player];common=crystals'>\[set crystals\]</a><a href='byond://?src=\ref[src];spawn_uplink=\ref[player.current]'>\[spawn uplink\]</a>"

--- a/mods/mobs/borers/datum/antagonist.dm
+++ b/mods/mobs/borers/datum/antagonist.dm
@@ -21,6 +21,7 @@
 
 	spawn_announcement_title = "Lifesign Alert"
 	spawn_announcement_delay = 5000
+	uid = "special_role_borer"
 
 /decl/special_role/borer/get_extra_panel_options(var/datum/mind/player)
 	return "<a href='byond://?src=\ref[src];move_to_spawn=\ref[player.current]'>\[put in host\]</a>"

--- a/mods/species/ascent/datum/antagonist.dm
+++ b/mods/species/ascent/datum/antagonist.dm
@@ -14,6 +14,7 @@
 	initial_spawn_req = 4
 	initial_spawn_target = 6
 	rig_type = /obj/item/rig/mantid
+	uid = "special_role_gyne_hunter"
 
 /decl/special_role/hunter/update_antag_mob(var/datum/mind/player, var/preserve_appearance)
 	. = ..()

--- a/mods/species/ascent/datum/traits.dm
+++ b/mods/species/ascent/datum/traits.dm
@@ -20,15 +20,18 @@
 	name = "Upgraded Support Systems"
 	description = "Coming soon!"
 	category = "Suit Upgrades"
+	uid = "trait_ascent_suit_upgrade"
 
 // Physical modifications like extra organs or different resistances.
 /decl/trait/ascent/adaptation
 	name = "Specialized Molt"
 	description = "Coming soon!"
 	category = "Adaptations"
+	uid = "trait_ascent_specialized_molt"
 
 // Behavioral compulsions enforced by AI
 /decl/trait/ascent/derangement
 	name = "Megalomania"
 	description = "Coming soon!"
 	category = "Derangements"
+	uid = "trait_ascent_megalomania"

--- a/mods/species/drakes/drake_traits.dm
+++ b/mods/species/drakes/drake_traits.dm
@@ -1,3 +1,4 @@
 /decl/trait/sivian_biochemistry
 	name = "Sivian Biochemistry"
 	description = "This creature is adapted to the complex bacteria of the garden world of Sif."
+	uid = "trait_sivian_biochemistry"

--- a/mods/species/neoavians/datum/loadout.dm
+++ b/mods/species/neoavians/datum/loadout.dm
@@ -1,5 +1,6 @@
 /decl/loadout_category/avian
 	name = "Avian"
+	uid = "loadout_category_avian"
 
 /decl/loadout_option/avian
 	whitelisted = list(/decl/species/neoavian::uid)

--- a/mods/species/utility_frames/traits.dm
+++ b/mods/species/utility_frames/traits.dm
@@ -15,15 +15,18 @@
 	name = "Heavy Frame"
 	description = "Coming soon!"
 	category = "Frame Customisation"
+	uid = "trait_utility_frame_heavy"
 
 // Additional augments, organs, better armour, robomodules
 /decl/trait/utility_frame/upgrade
 	name = "Upgraded Widget"
 	description = "Coming soon!"
 	category = "Upgrades"
+	uid = "trait_utility_frame_upgraded_widget"
 
 // Various maluses
 /decl/trait/utility_frame/fault
 	name = "Faulty Widget"
 	description = "Coming soon!"
 	category = "Faults"
+	uid = "trait_utility_frame_faulty_widget"

--- a/mods/species/vox/datum/traits.dm
+++ b/mods/species/vox/datum/traits.dm
@@ -15,9 +15,11 @@
 	name = "Apex-Edited"
 	description = "Coming soon!"
 	category = "Psyche"
+	uid = "trait_vox_apex_edited"
 
 // Perks for interacting with vox equipment.
 /decl/trait/vox/symbiosis
 	name = "Self-Maintaining Equipment"
 	description = "Coming soon!"
 	category = "Symbiosis"
+	uid = "trait_vox_self_maintaining"

--- a/mods/utility/prometheus_metrics/metric_family.dm
+++ b/mods/utility/prometheus_metrics/metric_family.dm
@@ -1,5 +1,6 @@
 // Datum used for gathering a set of prometheus metrics.
 /decl/metric_family
+	abstract_type = /decl/metric_family
 	var/name = null
 	var/metric_type = null
 	var/help = null


### PR DESCRIPTION
## Description of changes
Split out of #5420.
Adds UIDs to a lot of decl types.

## Why and what will this PR improve
This will let us replace some uses of `ref()`/`\ref\[]` and `locate()` with UIDs, which avoids string operation overhead and is overall more stable.

## Authorship
me