### PR TITLE
Fix unmarked abstract decl types

### DIFF
--- a/code/datums/ai_holo.dm
+++ b/code/datums/ai_holo.dm
@@ -3,6 +3,7 @@
 * bypass_colorize: if false, the hologram will be decolorized.
 */
 /decl/ai_holo
+	abstract_type = /decl/ai_holo
 	var/requires_malf = FALSE
 	var/icon = 'icons/mob/hologram.dmi'
 	var/icon_state = "icon_state"

--- a/code/datums/appearances/automatic/cardborg.dm
+++ b/code/datums/appearances/automatic/cardborg.dm
@@ -49,6 +49,7 @@
 			appearances[ca.backpack_type] = ca
 
 /decl/cardborg_appearance
+	abstract_type = /decl/cardborg_appearance
 	var/backpack_type
 	var/icon_state = ICON_STATE_WORLD
 	var/icon = 'icons/mob/robots/robot.dmi'

--- a/code/datums/colors/color_generator.dm
+++ b/code/datums/colors/color_generator.dm
@@ -1,4 +1,5 @@
 /decl/color_generator
+	abstract_type = /decl/color_generator
 	var/color = COLOR_WHITE
 	var/min_random_span = -25
 	var/max_random_span = 25

--- a/code/datums/communication/channel.dm
+++ b/code/datums/communication/channel.dm
@@ -1,6 +1,7 @@
 #define plain_key_name(A) key_name(A, highlight_special_characters = 0)
 
 /decl/communication_channel
+	abstract_type = /decl/communication_channel
 	var/name
 	var/config_setting
 	var/expected_communicator_type = /datum

--- a/code/datums/extensions/scent/_scent.dm
+++ b/code/datums/extensions/scent/_scent.dm
@@ -6,6 +6,7 @@
 Scent intensity
 *****/
 /decl/scent_intensity
+	abstract_type = /decl/scent_intensity
 	var/cooldown = 5 MINUTES
 	var/intensity = 1
 

--- a/code/datums/footsteps.dm
+++ b/code/datums/footsteps.dm
@@ -1,4 +1,5 @@
 /decl/footsteps
+	abstract_type = /decl/footsteps
 	var/list/footstep_sounds
 
 /decl/footsteps/catwalk

--- a/code/datums/genetics/genetic_conditions.dm
+++ b/code/datums/genetics/genetic_conditions.dm
@@ -1,4 +1,5 @@
 /decl/genetic_condition
+	abstract_type = /decl/genetic_condition
 	/// Descriptive name, used in VV panel.
 	var/name
 	/// Verb to be added or removed on activate/deactivate

--- a/code/datums/hostility/hostility.dm
+++ b/code/datums/hostility/hostility.dm
@@ -1,4 +1,5 @@
 // A singleton useful for recycling hostility logic in things such as mobs or turrets.
+// intentionally NOT abstract
 /decl/hostility
 
 // Returns a value determining whether or not whatever is calling should attack the target.

--- a/code/datums/item_modifiers/item_modifier.dm
+++ b/code/datums/item_modifiers/item_modifier.dm
@@ -1,4 +1,5 @@
 /decl/item_modifier
+	abstract_type = /decl/item_modifier
 	var/name
 	var/list/type_setups
 

--- a/code/datums/licences/license.dm
+++ b/code/datums/licences/license.dm
@@ -1,4 +1,5 @@
 /decl/license
+	abstract_type = /decl/license
 	var/name
 	var/url
 	var/attribution_mandatory = TRUE

--- a/code/datums/mind/memory.dm
+++ b/code/datums/mind/memory.dm
@@ -125,6 +125,7 @@
 
 // General memory handling
 /decl/memory_options
+	abstract_type = /decl/memory_options
 	var/memory_type = /datum/memory
 
 /decl/memory_options/proc/validate_mind(var/datum/mind/target)

--- a/code/datums/move_intent/move_intent.dm
+++ b/code/datums/move_intent/move_intent.dm
@@ -6,6 +6,7 @@
 #define MOVE_INTENT_NEUTRAL    BITFLAG(3)
 
 /decl/move_intent
+	abstract_type = /decl/move_intent
 	var/name
 	var/flags = MOVE_INTENT_NONE
 	var/move_delay = 1

--- a/code/datums/observation/observation.dm
+++ b/code/datums/observation/observation.dm
@@ -57,6 +57,7 @@
 //		The first argument shall always be the event_source belonging to the event. Beyond that there are no restrictions.
 
 /decl/observ
+	abstract_type = /decl/observ
 	var/name = "Unnamed Event"                // The name of this event, used mainly for debug/VV purposes. The list of event managers can be reached through the "Debug Controller" verb, selecting the "Observation" entry.
 	var/expected_type = /datum                // The expected event source for this event. register() will CRASH() if it receives an unexpected type.
 	var/list/list/list/event_sources = list() // Associative list of event sources, each with their own associative list. This associative list contains an instance/list of procs to call when the event is raised.

--- a/code/datums/outfits/equipment/backpacks.dm
+++ b/code/datums/outfits/equipment/backpacks.dm
@@ -45,6 +45,7 @@
 
 /* Code */
 /decl/backpack_outfit
+	abstract_type = /decl/backpack_outfit
 	var/flags
 	var/name
 	var/path

--- a/code/datums/scents/scent_decls.dm
+++ b/code/datums/scents/scent_decls.dm
@@ -1,4 +1,5 @@
 /decl/scent_type
+	abstract_type = /decl/scent_type
 	var/color
 	var/scent //this is for the desc, the actual scent goes in the datum
 	var/scent_datum

--- a/code/datums/state_machine/state.dm
+++ b/code/datums/state_machine/state.dm
@@ -1,6 +1,7 @@
 // An individual state, defined as a `/decl` to save memory.
 // On a directed graph, these would be the nodes themselves, connected to each other by unidirectional arrows.
 /decl/state
+	abstract_type = /decl/state
 	// Transition decl types, which get turned into refs to those types.
 	// Note that the order DOES matter, as decls earlier in the list have higher priority
 	// if more than one becomes 'open'.

--- a/code/datums/state_machine/transition.dm
+++ b/code/datums/state_machine/transition.dm
@@ -1,6 +1,7 @@
 // Used to connect `/decl/state`s together so the FSM knows what state to switch to, and on what conditions.
 // On a directed graph, these would be the arrows connecting the nodes representing states.
 /decl/state_transition
+	abstract_type = /decl/state_transition
 	var/list/from = null
 	var/decl/state/target = null
 

--- a/code/datums/uplink/uplink_sources.dm
+++ b/code/datums/uplink/uplink_sources.dm
@@ -9,6 +9,7 @@ var/global/list/default_uplink_source_priority = list(
 )
 
 /decl/uplink_source
+	abstract_type = /decl/uplink_source
 	var/name
 	var/desc
 

--- a/code/game/machinery/_machines_base/machine_construction/_construction.dm
+++ b/code/game/machinery/_machines_base/machine_construction/_construction.dm
@@ -25,6 +25,7 @@
 	return MCS_CHANGE
 
 /decl/machine_construction
+	abstract_type = /decl/machine_construction
 	var/needs_board  // Type of circuitboard expected, if any. Used in unit testing.
 	var/cannot_print // If false, unit testing will attempt to guarantee that the machine is buildable in-round. This inverts that behavior.
 	var/visible_components = TRUE // Whether user can see installed components on examine

--- a/code/game/machinery/_machines_base/machinery_public_vars.dm
+++ b/code/game/machinery/_machines_base/machinery_public_vars.dm
@@ -1,8 +1,10 @@
 /decl/public_access
+	abstract_type = /decl/public_access
 	var/name
 	var/desc
 
 /decl/public_access/public_variable
+	abstract_type = /decl/public_access/public_variable
 	var/expected_type
 	var/can_write = FALSE
 	var/var_type = IC_FORMAT_BOOLEAN // Reuses IC defines for better compatibility.
@@ -115,6 +117,7 @@ Public methods machines can expose. Pretty bare-bones; just wraps a proc and giv
 */
 
 /decl/public_access/public_method
+	abstract_type = /decl/public_access/public_method
 	var/call_proc
 	var/forward_args = FALSE
 

--- a/code/game/machinery/_machines_base/stock_parts/stock_parts_presets.dm
+++ b/code/game/machinery/_machines_base/stock_parts/stock_parts_presets.dm
@@ -8,6 +8,7 @@ Do not work with lazy-initialized parts.
 	var/list/stock_part_presets  // Format: assotiative list of decl path -> number to apply.
 
 /decl/stock_part_preset
+	abstract_type = /decl/stock_part_preset
 	var/expected_part_type
 
 /decl/stock_part_preset/proc/apply(obj/machinery/machine, obj/item/stock_parts/part)

--- a/code/game/machinery/doors/airlock_control.dm
+++ b/code/game/machinery/doors/airlock_control.dm
@@ -206,10 +206,14 @@
 		"pressure" = /decl/public_access/public_variable/airlock_pressure
 	)
 
-/decl/public_access/public_variable/set_airlock_cycling/airlock_sensor
-	expected_type = /obj/machinery/airlock_sensor
+/decl/public_access/public_variable/set_airlock_cycling
 	can_write     = TRUE
 	var_type      = IC_FORMAT_BOOLEAN
+	abstract_type = /decl/public_access/public_variable/set_airlock_cycling
+
+/decl/public_access/public_variable/set_airlock_cycling/airlock_sensor
+	expected_type = /obj/machinery/airlock_sensor
+	uid           = "public_var_airlock_sensor_cycling"
 
 /decl/public_access/public_variable/set_airlock_cycling/airlock_sensor/access_var(obj/machinery/airlock_sensor/owner)
 	return owner.master_cycling
@@ -358,8 +362,6 @@
 //
 /decl/public_access/public_variable/set_airlock_cycling/access_button
 	expected_type = /obj/machinery/button/access
-	can_write     = TRUE
-	var_type      = IC_FORMAT_BOOLEAN
 
 /decl/public_access/public_variable/set_airlock_cycling/access_button/access_var(obj/machinery/button/access/owner)
 	return owner.master_cycling

--- a/code/game/objects/structures/crates_lockers/closets/_closet_appearance_definitions.dm
+++ b/code/game/objects/structures/crates_lockers/closets/_closet_appearance_definitions.dm
@@ -3,6 +3,7 @@
 	. = ..(maploading)
 
 /decl/closet_appearance
+	// this is NOT abstract
 	var/color = COLOR_GRAY40
 	var/decals = list(
 		"upper_vent",

--- a/code/modules/admin/view_variables/vv_set_handlers.dm
+++ b/code/modules/admin/view_variables/vv_set_handlers.dm
@@ -1,4 +1,5 @@
 /decl/vv_set_handler
+	abstract_type = /decl/vv_set_handler
 	var/handled_type
 	var/predicates
 	var/list/handled_vars

--- a/code/modules/client/preference_setup/global/prefixes.dm
+++ b/code/modules/client/preference_setup/global/prefixes.dm
@@ -1,4 +1,5 @@
 /decl/prefix
+	abstract_type = /decl/prefix
 	var/name
 	var/default_key
 	var/is_locked = FALSE

--- a/code/modules/codex/categories/_category.dm
+++ b/code/modules/codex/categories/_category.dm
@@ -1,4 +1,5 @@
 /decl/codex_category
+	abstract_type = /decl/codex_category
 	var/name = "Generic Category"
 	var/desc = "Some description for category's codex entry"
 	var/list/items = list()

--- a/code/modules/crafting/slapcrafting/_crafting_stage.dm
+++ b/code/modules/crafting/slapcrafting/_crafting_stage.dm
@@ -1,4 +1,5 @@
 /decl/crafting_stage
+	abstract_type = /decl/crafting_stage
 	var/descriptor = "undefined crafted item"
 	var/item_desc = "It's an unfinished item of some sort."
 	var/item_icon = 'icons/obj/crafting_icons.dmi'

--- a/code/modules/departments/department.dm
+++ b/code/modules/departments/department.dm
@@ -2,11 +2,12 @@
 	. = b.display_priority - a.display_priority
 
 /decl/department
+	// this isn't abstract because it's used as a fallback
 	var/name
 	var/noun = "department"
 	var/noun_adj = "departmental"
 	var/announce_channel = "Common" // The Channel for spawn annoncement. Leave as common if unsure. The channel will be selected based of the first deparment listed in a jobs .department_types
-	var/list/goals = list() 
+	var/list/goals = list()
 	var/min_goals = 1
 	var/max_goals = 2
 	var/colour = "#808080"

--- a/code/modules/ghosttrap/trap.dm
+++ b/code/modules/ghosttrap/trap.dm
@@ -1,5 +1,6 @@
 // This system is used to grab a ghost from observers with the required preferences and lack of bans set.
 /decl/ghosttrap
+	abstract_type = /decl/ghosttrap
 	var/name
 	var/minutes_since_death = 0     // If non-zero the ghost must have been dead for this many minutes to be allowed to spawn
 	var/list/ban_checks

--- a/code/modules/materials/geology/_strata.dm
+++ b/code/modules/materials/geology/_strata.dm
@@ -1,4 +1,5 @@
 /decl/strata
+	abstract_type = /decl/strata
 	var/name
 	var/list/base_materials
 	var/list/ores_sparse

--- a/code/modules/mob/grab/grab_datum.dm
+++ b/code/modules/mob/grab/grab_datum.dm
@@ -1,4 +1,5 @@
 /decl/grab
+	abstract_type = /decl/grab
 	var/name                    = "generic grab"
 	/// Whether or not the grabbed person can move out of the grab
 	var/stop_move               = 0

--- a/code/modules/organs/external/diagnostics.dm
+++ b/code/modules/organs/external/diagnostics.dm
@@ -178,6 +178,7 @@
 	return sounds
 
 /decl/diagnostic_sign
+	abstract_type = /decl/diagnostic_sign
 	var/name = "Some symptom"
 	var/descriptor
 	var/explanation

--- a/code/modules/power/fusion/fusion_reactions.dm
+++ b/code/modules/power/fusion/fusion_reactions.dm
@@ -1,6 +1,7 @@
 #define FUSION_PROCESSING_TIME_MULT 2 // SSmachines.wait / (1 SECOND) - previous values were intended for SSobj 1-second wait.
 
 /decl/fusion_reaction
+	abstract_type = /decl/fusion_reaction
 	var/p_react // Primary reactant.
 	var/s_react // Secondary reactant.
 	var/minimum_energy_level = 1

--- a/code/modules/projectiles/guns/energy/capacitor.dm
+++ b/code/modules/projectiles/guns/energy/capacitor.dm
@@ -1,6 +1,7 @@
 var/global/list/laser_wavelengths
 
 /decl/laser_wavelength
+	abstract_type = /decl/laser_wavelength
 	var/name
 	var/color
 	var/light_color

--- a/code/modules/projectiles/guns/projectile/random_pistol.dm
+++ b/code/modules/projectiles/guns/projectile/random_pistol.dm
@@ -59,6 +59,7 @@
 	safety.pixel_x = safety_offset[base_state][1]
 	safety.pixel_y = safety_offset[base_state][2]
 	return safety
+
 /decl/gun_look/cover
 	icon =  'icons/obj/guns/random_pistol/looks/cover.dmi'
 	ammo_offset = list(

--- a/code/modules/prometheus_metrics/metric_family.dm
+++ b/code/modules/prometheus_metrics/metric_family.dm
@@ -17,7 +17,7 @@
 // suitable for encoding as a JSON protobuf mapping.
 /datum/metric_family/proc/_to_proto()
 	var/list/collected = collect()
-	
+
 	var/list/out = list(
 		"name" = name,
 		"type" = metric_type,
@@ -36,7 +36,7 @@
 			label_pairs[++label_pairs.len] = list("name" = k, "value" = m[1][k])
 
 		metrics[++metrics.len] = list("label" = label_pairs, PROMETHEUS_METRIC_NAME(metric_type) = list("value" = m[2]))
-	
+
 	if(metrics.len == 0)
 		return null
 	out["metric"] = metrics

--- a/code/modules/reagents/chems/random/random_effects.dm
+++ b/code/modules/reagents/chems/random/random_effects.dm
@@ -3,6 +3,7 @@
 #define RANDOM_CHEM_EFFECT_FLOAT 3
 
 /decl/random_chem_effect
+	abstract_type = /decl/random_chem_effect
 	var/minimum = 0
 	var/maximum = 1
 	var/mode = RANDOM_CHEM_EFFECT_TRUE

--- a/code/modules/research/research_fields.dm
+++ b/code/modules/research/research_fields.dm
@@ -1,4 +1,5 @@
 /decl/research_field
+	abstract_type = /decl/research_field
 	var/name
 	var/desc
 	var/id

--- a/code/modules/status_conditions/_status.dm
+++ b/code/modules/status_conditions/_status.dm
@@ -3,6 +3,7 @@ var/global/list/status_marker_holders = list()
 // Check code/modules/mob/mob_status.dm code/modules/mob/living/living_status.dm 
 // for the procs that check/set/process these status conditions. 
 /decl/status_condition
+	abstract_type = /decl/status_condition
 	var/name
 	var/check_flags = 0
 	var/list/victim_data

--- a/code/modules/submaps/submap_archetype.dm
+++ b/code/modules/submaps/submap_archetype.dm
@@ -1,4 +1,5 @@
 /decl/submap_archetype
+	abstract_type = /decl/submap_archetype
 	var/descriptor = "generic ship archetype"
 	var/list/whitelisted_species = list()
 	var/list/blacklisted_species = list()

--- a/code/modules/webhooks/_webhook.dm
+++ b/code/modules/webhooks/_webhook.dm
@@ -1,4 +1,5 @@
 /decl/webhook
+	abstract_type = /decl/webhook
 	var/id
 	var/list/urls
 	var/list/mentions

--- a/code/modules/xenoarcheaology/artifacts/artifact_appearance.dm
+++ b/code/modules/xenoarcheaology/artifacts/artifact_appearance.dm
@@ -3,12 +3,15 @@
 
 /decl/artifact_appearance
 	var/name = "alien artifact"
+
 /decl/artifact_appearance/proc/apply_to(obj/structure/artifact/A)
 	A.SetName(name)
 	adjust_desc(A)
 	adjust_icon(A)
 	A.update_icon()
+
 /decl/artifact_appearance/proc/adjust_desc(obj/structure/artifact/A)
+
 /decl/artifact_appearance/proc/adjust_icon(obj/structure/artifact/A)
 	var/icon_num = rand(0, 6)
 	A.base_icon = "ano[icon_num]"
@@ -17,8 +20,10 @@
 
 /decl/artifact_appearance/vents
 	name = "alien artifact"
+
 /decl/artifact_appearance/vents/adjust_desc(obj/structure/artifact/A)
 	A.desc = "A large alien device, there appear to be some kind of vents in the side."
+
 /decl/artifact_appearance/vents/adjust_icon(obj/structure/artifact/A)
 	A.base_icon = "ano10"
 
@@ -26,21 +31,25 @@
 
 /decl/artifact_appearance/computer
 	name = "alien computer"
+
 /decl/artifact_appearance/computer/adjust_desc(obj/structure/artifact/A)
 	A.desc = "It is covered in strange markings."
+
 /decl/artifact_appearance/computer/adjust_icon(obj/structure/artifact/A)
 	A.base_icon = "ano9"
-	
+
 // Sealed pod
 
 /decl/artifact_appearance/pod
 	name = "sealed alien pod"
+
 /decl/artifact_appearance/pod/adjust_icon(obj/structure/artifact/A)
 	A.base_icon = "ano11"
 
 // Crystals
 /decl/artifact_appearance/crystal
 	name = "large crystal"
+
 /decl/artifact_appearance/crystal/adjust_desc(obj/structure/artifact/A)
 	A.desc = pick(
 		"It shines faintly as it catches the light.",
@@ -48,5 +57,6 @@
 		"It seems to draw you inward as you look it at.",
 		"Something twinkles faintly as you look at it.",
 		"It's mesmerizing to behold.")
+
 /decl/artifact_appearance/crystal/adjust_icon(obj/structure/artifact/A)
 	A.base_icon = "ano[pick(7,8)]"

--- a/mods/_modpack.dm
+++ b/mods/_modpack.dm
@@ -1,4 +1,5 @@
 /decl/modpack
+	abstract_type = /decl/modpack
 	/// A string name for the modpack. Used for looking up other modpacks in init.
 	var/name
 	/// A string desc for the modpack. Can be used for modpack verb list as description.

--- a/mods/content/psionics/system/psionics/faculties/_faculty.dm
+++ b/mods/content/psionics/system/psionics/faculties/_faculty.dm
@@ -1,4 +1,5 @@
 /decl/psionic_faculty
+	abstract_type = /decl/psionic_faculty
 	var/id
 	var/name
 	var/associated_intent

--- a/mods/content/xenobiology/colours/_colour.dm
+++ b/mods/content/xenobiology/colours/_colour.dm
@@ -1,4 +1,5 @@
 /decl/slime_colour
+	abstract_type = /decl/slime_colour
 	var/name
 	var/min_children = 4
 	var/max_children = 4

--- a/mods/content/xenobiology/slime/slime_commands.dm
+++ b/mods/content/xenobiology/slime/slime_commands.dm
@@ -1,4 +1,5 @@
 /decl/slime_command
+	abstract_type = /decl/slime_command
 	var/list/triggers
 
 /decl/slime_command/proc/resolve(var/speaker, var/spoken, var/datum/mob_controller/slime/holder)


### PR DESCRIPTION
## Description of changes
some decl types were abstract but not marked as such, so they got instantiated when they didn't need to be or, worse, should not have been

## Why and what will this PR improve
avoid instantiating stuff that shouldn't be, and also make sure stuff doesn't break with unit test improvements. this is part 1, part 2 goes to dev

## Authorship
me