### PR TITLE
Add unit test for curtain item matter validation

### DIFF
--- a/code/game/objects/structures/curtain_decls.dm
+++ b/code/game/objects/structures/curtain_decls.dm
@@ -2,6 +2,7 @@
 // Curtain types declaration
 //
 /decl/curtain_kind
+	abstract_type = /decl/curtain_kind
 	var/name = "curtain"
 	var/color = COLOR_WHITE
 	var/alpha = 255

--- a/code/game/objects/structures/curtains.dm
+++ b/code/game/objects/structures/curtains.dm
@@ -5,7 +5,7 @@
 	icon_state = "curtain_rolled"
 	_base_attack_force = 3 //just plastic
 	w_class = ITEM_SIZE_HUGE //curtains, yeap
-	var/curtain_kind_path = /decl/curtain_kind //path to decl containing the curtain's details
+	var/curtain_kind_path //path to decl containing the curtain's details
 
 /obj/item/curtain/Initialize(ml, material_key)
 	. = ..()
@@ -73,7 +73,7 @@
 	opacity = TRUE
 	density = FALSE
 	anchored = TRUE
-	var/curtain_kind_path = /decl/curtain_kind
+	var/curtain_kind_path
 
 /obj/structure/curtain/open
 	icon_state = "open"
@@ -81,7 +81,10 @@
 	opacity = FALSE
 
 /obj/structure/curtain/Initialize(ml, _mat, _reinf_mat)
-	. = ..(ml)
+	if(curtain_kind_path) // these are overridden, don't initialize them early
+		_mat = null
+		_reinf_mat = null
+	. = ..()
 	set_extension(src, /datum/extension/turf_hand)
 	if(curtain_kind_path)
 		set_curtain_kind(GET_DECL(curtain_kind_path))

--- a/code/unit_tests/materials.dm
+++ b/code/unit_tests/materials.dm
@@ -90,3 +90,41 @@
 	else
 		pass("[length(passed_designs)] crafting recipes had consistent output materials.")
 	return 1
+
+/datum/unit_test/curtain_items_shall_have_consistent_matter
+	name = "MATERIALS: Curtain Items Shall Have Consistent Matter Lists"
+
+/datum/unit_test/curtain_items_shall_have_consistent_matter/start_test()
+	var/list/all_curtain_subtypes = subtypesof(/obj/item/curtain)
+	var/list/failed_curtains = list()
+	var/list/passed_curtains = list()
+
+	for(var/curtain_type in all_curtain_subtypes)
+		var/obj/item/curtain/curtain_subtype = curtain_type
+		var/decl/curtain_kind/curtain_kind = GET_DECL(curtain_subtype::curtain_kind_path)
+		if(!curtain_kind || TYPE_IS_ABSTRACT(curtain_subtype))
+			continue
+		var/list/failed = list()
+		curtain_subtype = new curtain_type // atom info repository was failing me here
+		var/used_matter = curtain_subtype.matter
+		var/expected_material = curtain_kind.material_key
+		switch(length(used_matter))
+			if(0)
+				failed += "did not have matter"
+			if(1)
+				if(!used_matter[expected_material])
+					failed += "did not have expected material (had [used_matter[1]], expected [expected_material])"
+			else
+				failed += "had too many materials ([length(used_matter)], expected 1)"
+		if(length(failed))
+			failed_curtains += "[curtain_type] - [english_list(failed)]"
+		else
+			passed_curtains += curtain_type
+		QDEL_NULL(curtain_subtype)
+
+	var/failed_count = length(failed_curtains)
+	if(failed_count)
+		fail("[failed_count] curtain items had inconsistent matter lists: [jointext(failed_curtains, "\n")].")
+	else
+		pass("[length(passed_curtains)] curtain items had consistent matter lists.")
+	return 1


### PR DESCRIPTION
adds a unit test to make sure curtains have correct matter, i noticed an issue and wanted to a) confirm it and b) make sure it doesn't ever regress