### PR TITLE
Readded unsim rock wall for natural maps.

### DIFF
--- a/code/game/turfs/unsimulated/walls.dm
+++ b/code/game/turfs/unsimulated/walls.dm
@@ -11,3 +11,8 @@
 	desc = "A secure airlock. Doesn't look like you can get through easily."
 	icon = 'icons/obj/doors/centcomm/door.dmi'
 	icon_state = "closed"
+
+/turf/unsimulated/wall/rock
+	name = "impenetrable stone"
+	desc = "Looks like bedrock - too dense and hard to dig through without days of work."
+	icon_state = "rock-dark"


### PR DESCRIPTION
The icon for this still existed, just lost the definition at some point. Useful for contained maps with rock walls.