### PR TITLE
Fix holsters breaking alt-interactions on clothing

### DIFF
--- a/code/datums/extensions/holster/holster.dm
+++ b/code/datums/extensions/holster/holster.dm
@@ -206,7 +206,7 @@
 	for(var/obj/item/thing in accessories)
 		var/datum/extension/holster/holster = get_extension(thing, /datum/extension/holster)
 		if(holster?.holstered)
-			LAZYADD(., GET_DECL(/decl/interaction_handler/unholster_accessory))
+			LAZYADD(., /decl/interaction_handler/unholster_accessory)
 
 /obj/item/clothing/get_quick_interaction_handler(mob/user)
 	if(!(. = ..()))

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -904,10 +904,10 @@
 	return
 
 /**
-	Get a list of alt interactions for a user from this atom.
+	Get a list of alt interaction paths for a user from this atom.
 
 	- `user`: The mob that these alt interactions are for
-	- Return: A list containing the alt interactions
+	- Return: A list containing the typepaths of alt interactions
 */
 /atom/proc/get_alt_interactions(var/mob/user)
 	SHOULD_CALL_PARENT(TRUE)


### PR DESCRIPTION
## Description of changes
`get_alt_interactions()` should not use `GET_DECL()` on any of its entries, the doc comment has been updated to reflect this

## Why and what will this PR improve
fixes a runtime where a value returned from `get_alt_interactions()` would be null after `GET_DECL()` was run on it