### PR TITLE
Interaction retrieval is slightly more robust.

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -335,7 +335,7 @@
 	if(LAZYLEN(alt_interactions))
 		var/list/interaction_strings = list()
 		for(var/interaction_type as anything in alt_interactions)
-			var/decl/interaction_handler/interaction = GET_DECL(interaction_type)
+			var/decl/interaction_handler/interaction = RESOLVE_TO_DECL(interaction_type)
 			if(interaction.examine_desc && (interaction.always_show_on_examine || interaction.is_possible(src, user, user?.get_active_held_item())))
 				interaction_strings += emote_replace_target_tokens(interaction.examine_desc, src)
 		if(length(interaction_strings))

--- a/code/modules/interactions/interactions_atom.dm
+++ b/code/modules/interactions/interactions_atom.dm
@@ -5,7 +5,7 @@
 
 	var/list/possibilities
 	for(var/interaction_type in interactions)
-		var/decl/interaction_handler/interaction = GET_DECL(interaction_type)
+		var/decl/interaction_handler/interaction = RESOLVE_TO_DECL(interaction_type)
 		if(interaction.is_possible(src, user, prop))
 			var/image/label = image(interaction.icon, interaction.icon_state)
 			label.name = interaction.name


### PR DESCRIPTION
Should allow a little more leeway with things like accidentally using GET_DECL() in an interaction proc.