### PR TITLE
Fix base scent intensity being marked as abstract

### DIFF
--- a/code/datums/extensions/scent/_scent.dm
+++ b/code/datums/extensions/scent/_scent.dm
@@ -6,7 +6,6 @@
 Scent intensity
 *****/
 /decl/scent_intensity
-	abstract_type = /decl/scent_intensity
 	var/cooldown = 5 MINUTES
 	var/intensity = 1
 


### PR DESCRIPTION
This is not actually abstract. Fixes a runtime.