### PR TITLE
Fixes from Cynosure playtesting.

### DIFF
--- a/code/game/objects/item_mob_overlay.dm
+++ b/code/game/objects/item_mob_overlay.dm
@@ -157,6 +157,16 @@ var/global/list/icon_state_cache = list()
 /obj/item/proc/get_icon_for_bodytype(var/bodytype)
 	. = LAZYACCESS(sprite_sheets, bodytype) || icon
 
+#define OFFSET_MOB_IMAGES(TO_OFFSET, DEST, ORIG, ADJU)                                                                       \
+	for(var/thing in TO_OFFSET) {                                                                                            \
+		ORIG = thing;                                                                                                        \
+		ADJU = root_bodytype.get_offset_overlay_image(user_mob, ORIG.icon, ORIG.icon_state, ORIG.color, (bodypart || slot)); \
+		ADJU.appearance_flags = ORIG.appearance_flags;                                                                       \
+		ADJU.plane = ORIG.plane;                                                                                             \
+		ADJU.layer = ORIG.layer;                                                                                             \
+		DEST += ADJU;                                                                                                        \
+	}
+
 // Ensure ..() is called only at the end of this proc, and that `overlay` is mutated rather than replaced.
 // This is necessary to ensure that all the overlays are generated and tracked prior to being passed to
 // the bodytype offset proc, which can scrub icon/icon_state information as part of the offset process.
@@ -175,16 +185,14 @@ var/global/list/icon_state_cache = list()
 
 		var/decl/bodytype/root_bodytype = user_mob?.get_equipment_bodytype(slot, bodypart)
 		if(root_bodytype && root_bodytype.bodytype_category != bodytype)
-			var/list/overlays_to_offset = overlay.overlays
+			var/list/overlays_to_offset  = overlay.overlays
+			var/list/underlays_to_offset = overlay.underlays
 			overlay = root_bodytype.get_offset_overlay_image(user_mob, overlay.icon, overlay.icon_state, color, (bodypart || slot))
 			if(overlay)
-				for(var/thing in overlays_to_offset)
-					var/image/I = thing // Technically an appearance but don't think we can cast to those
-					var/image/adjusted_overlay = root_bodytype.get_offset_overlay_image(user_mob, I.icon, I.icon_state, I.color, (bodypart || slot))
-					adjusted_overlay.appearance_flags = I.appearance_flags
-					adjusted_overlay.plane =            I.plane
-					adjusted_overlay.layer =            I.layer
-					overlay.overlays += adjusted_overlay
+				var/image/original_image
+				var/image/adjusted_image
+				OFFSET_MOB_IMAGES(overlays_to_offset, overlay.overlays, original_image, adjusted_image)
+				OFFSET_MOB_IMAGES(underlays_to_offset, overlay.underlays, original_image, adjusted_image)
 
 	return overlay
 

--- a/code/game/objects/items/devices/oxycandle.dm
+++ b/code/game/objects/items/devices/oxycandle.dm
@@ -17,7 +17,7 @@
 	var/candle_volume = 4600
 	var/on = 0
 	var/activation_sound = 'sound/effects/flare.ogg'
-	var/brightness_on = 1 // Moderate-low bright.
+	var/headlamp_range = 1 // Moderate-low bright.
 
 /obj/item/oxycandle/Initialize()
 	. = ..()
@@ -72,7 +72,7 @@
 	if(on == 1)
 		icon_state = "oxycandle_on"
 		item_state = icon_state
-		set_light(brightness_on)
+		set_light(headlamp_range)
 	else if(on == 2)
 		icon_state = "oxycandle_burnt"
 		item_state = icon_state

--- a/code/game/objects/items/devices/oxycandle.dm
+++ b/code/game/objects/items/devices/oxycandle.dm
@@ -17,7 +17,7 @@
 	var/candle_volume = 4600
 	var/on = 0
 	var/activation_sound = 'sound/effects/flare.ogg'
-	var/headlamp_range = 1 // Moderate-low bright.
+	var/oxycandle_light_range = 1 // Moderate-low bright.
 
 /obj/item/oxycandle/Initialize()
 	. = ..()
@@ -72,7 +72,7 @@
 	if(on == 1)
 		icon_state = "oxycandle_on"
 		item_state = icon_state
-		set_light(headlamp_range)
+		set_light(oxycandle_light_range)
 	else if(on == 2)
 		icon_state = "oxycandle_burnt"
 		item_state = icon_state

--- a/code/game/objects/items/weapons/ecigs.dm
+++ b/code/game/objects/items/weapons/ecigs.dm
@@ -9,7 +9,7 @@
 	chem_volume = 0 //ecig has no storage on its own but has reagent container created by parent obj
 	material = /decl/material/solid/organic/plastic
 
-	var/brightness_on = 1
+	var/headlamp_range = 1
 	var/cartridge_type = /obj/item/chems/ecig_cartridge/med_nicotine
 	var/obj/item/chems/ecig_cartridge/ec_cartridge
 	var/power_usage = 450 //value for simple ecig, enough for about 1 cartridge, in JOULES!
@@ -122,7 +122,7 @@
 /obj/item/clothing/mask/smokable/ecig/on_update_icon()
 	. = ..()
 	if(lit)
-		set_light(brightness_on)
+		set_light(headlamp_range)
 	else
 		set_light(0)
 	if(ec_cartridge && check_state_in_icon("[icon_state]-loaded", icon))

--- a/code/game/objects/items/weapons/ecigs.dm
+++ b/code/game/objects/items/weapons/ecigs.dm
@@ -9,7 +9,7 @@
 	chem_volume = 0 //ecig has no storage on its own but has reagent container created by parent obj
 	material = /decl/material/solid/organic/plastic
 
-	var/headlamp_range = 1
+	var/ecig_light_range = 1
 	var/cartridge_type = /obj/item/chems/ecig_cartridge/med_nicotine
 	var/obj/item/chems/ecig_cartridge/ec_cartridge
 	var/power_usage = 450 //value for simple ecig, enough for about 1 cartridge, in JOULES!
@@ -122,7 +122,7 @@
 /obj/item/clothing/mask/smokable/ecig/on_update_icon()
 	. = ..()
 	if(lit)
-		set_light(headlamp_range)
+		set_light(ecig_light_range)
 	else
 		set_light(0)
 	if(ec_cartridge && check_state_in_icon("[icon_state]-loaded", icon))

--- a/code/game/objects/structures/fences/_fences.dm
+++ b/code/game/objects/structures/fences/_fences.dm
@@ -84,10 +84,13 @@
 		var/turf/neighbor = get_step_resolving_mimic(my_turf, check_dir)
 		if(!istype(neighbor))
 			continue
-		for(var/obj/structure/fence/fence in neighbor)
-			if(fence_data == RESOLVE_TO_DECL(fence.fence_data))
-				connected_dirs |= check_dir
-				break
+		if(neighbor.density)
+			connected_dirs |= check_dir
+		else
+			for(var/obj/structure/fence/fence in neighbor)
+				if(fence_data == RESOLVE_TO_DECL(fence.fence_data))
+					connected_dirs |= check_dir
+					break
 
 /obj/structure/fence/proc/update_fence_icon()
 
@@ -137,7 +140,7 @@
 				break
 
 /obj/structure/fence/proc/is_cuttable()
-	return icon_state == fence_data.straight_state && hole_size < MAX_HOLE_SIZE
+	return (connected_dirs == (NORTH | SOUTH) || connected_dirs == (EAST | WEST)) && hole_size < MAX_HOLE_SIZE
 
 /obj/structure/fence/get_examine_strings(mob/user, distance, infix, suffix)
 	. = ..()
@@ -210,24 +213,15 @@
 	return ..()
 
 /obj/structure/fence/proc/update_cut_status()
-	if(!is_cuttable())
-		return
-	density = TRUE
-	switch(hole_size)
-		if(NO_HOLE)
-			icon_state = initial(icon_state)
-		if(MEDIUM_HOLE)
-			icon_state = "[initial(icon_state)]-cut2"
-		if(LARGE_HOLE)
-			icon_state = "[initial(icon_state)]-cut3"
-			density = FALSE
+	set_density(hole_size != LARGE_HOLE)
+	update_icon()
 
 //FENCE DOORS
 /obj/structure/fence/door
 	name = "fence gate"
 	desc = "Much like a regular door, but thinner."
 	icon_state = "door-closed"
-	interaction_priority   = TRUE
+	interaction_priority = TRUE
 
 /obj/structure/fence/door/can_install_lock()
 	return TRUE
@@ -255,7 +249,7 @@
 
 /obj/structure/fence/door/opened
 	icon_state = "door-opened"
-	density = TRUE
+	density = FALSE
 
 /obj/structure/fence/door/locked/Initialize(mapload)
 	lock ||= "fence key #[random_id(type, 10000, 99999)]"
@@ -264,8 +258,8 @@
 /obj/structure/fence/door/attack_hand(mob/user, list/params)
 	SHOULD_CALL_PARENT(FALSE)
 	if(!density || can_open(user))
-		density = !density
-		visible_message(SPAN_NOTICE("\The [user] [density ? "opens" : "closes"] \the [src]."))
+		set_density(!density)
+		visible_message(SPAN_NOTICE("\The [user] [!density ? "opens" : "closes"] \the [src]."))
 		playsound(src, 'sound/machines/click.ogg', 100, 1)
 		update_icon()
 	else

--- a/code/game/objects/structures/fences/fence_types.dm
+++ b/code/game/objects/structures/fences/fence_types.dm
@@ -11,8 +11,8 @@
 	var/end_state         = "end"
 	var/three_way_state   = "three_way"
 	var/four_way_state    = "four_way"
-	var/door_state_closed = "door-opened"
-	var/door_state_opened = "door-closed"
+	var/door_state_closed = "door-closed"
+	var/door_state_opened = "door-opened"
 
 /decl/fence_type/validate()
 	. = ..()

--- a/code/modules/clothing/head/_head.dm
+++ b/code/modules/clothing/head/_head.dm
@@ -10,38 +10,32 @@
 	fallback_slot       = slot_head_str
 
 	var/protects_against_weather = FALSE
-	var/light_applied
-	var/brightness_on
-	var/on = 0
+	var/headlamp_range
+	var/headlamp_on = FALSE
 
 /obj/item/clothing/head/gives_weather_protection()
 	return protects_against_weather
 
 /obj/item/clothing/head/attack_self(mob/user)
-	if(brightness_on)
+	if(headlamp_range)
 		if(!isturf(user.loc))
-			to_chat(user, "You cannot turn the light on while in this [user.loc].")
+			to_chat(user, "You cannot turn \the [src]'s light on while in this [user.loc].")
 			return
-		on = !on
-		to_chat(user, "You [on ? "enable" : "disable"] the helmet light.")
+		headlamp_on = !headlamp_on
+		to_chat(user, "You [headlamp_on ? "enable" : "disable"] the light on \the [src].")
 		update_flashlight(user)
 	else
 		return ..(user)
 
 /obj/item/clothing/head/proc/update_flashlight(var/mob/user = null)
-	if(on && !light_applied)
-		set_light(brightness_on)
-		light_applied = 1
-	else if(!on && light_applied)
-		set_light(0)
-		light_applied = 0
+	set_light(headlamp_on ? headlamp_range : 0)
 	update_icon()
 	user.update_action_buttons()
 
 /obj/item/clothing/head/on_update_icon()
 	. = ..()
 	update_clothing_icon()
-	if(on)
+	if(headlamp_on)
 		var/light_state = "[icon_state]_light"
 		if(check_state_in_icon(light_state, icon))
 			var/image/light_overlay = image(icon, light_state)
@@ -49,11 +43,6 @@
 			add_overlay(light_overlay)
 
 /obj/item/clothing/head/apply_additional_mob_overlays(mob/living/user_mob, bodytype, image/overlay, slot, bodypart, use_fallback_if_icon_missing = TRUE)
-	if(overlay && on && check_state_in_icon("[overlay.icon_state]_light", overlay.icon))
-		var/light_overlay
-		if(user_mob?.get_bodytype_category() != bodytype)
-			light_overlay = user_mob?.get_bodytype()?.get_offset_overlay_image(user_mob, overlay.icon, "[overlay.icon_state]_light", null, slot)
-		if(!light_overlay)
-			light_overlay = image(overlay.icon, "[overlay.icon_state]_light")
-		overlay.overlays += light_overlay
+	if(overlay && headlamp_on && check_state_in_icon("[overlay.icon_state]_light", overlay.icon))
+		overlay.overlays += overlay_image(overlay.icon, "[overlay.icon_state]_light", COLOR_WHITE, RESET_COLOR)
 	. = ..()

--- a/code/modules/clothing/head/hardhat.dm
+++ b/code/modules/clothing/head/hardhat.dm
@@ -3,7 +3,7 @@
 	desc = "A piece of headgear used in dangerous working conditions to protect the head. Comes with a built-in flashlight."
 	icon = 'icons/clothing/head/hardhat/yellow.dmi'
 	action_button_name = "Toggle Headlamp"
-	brightness_on = 4 //luminosity when on
+	headlamp_range = 4 //luminosity when on
 	w_class = ITEM_SIZE_NORMAL
 	armor = list(
 		ARMOR_MELEE = ARMOR_MELEE_RESISTANT,

--- a/code/modules/clothing/head/misc_special.dm
+++ b/code/modules/clothing/head/misc_special.dm
@@ -143,7 +143,7 @@
 	icon = 'icons/clothing/head/pumpkin.dmi'
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE|BLOCK_ALL_HAIR
 	body_parts_covered = SLOT_HEAD|SLOT_FACE|SLOT_EYES
-	brightness_on = 2
+	headlamp_range = 2
 	w_class = ITEM_SIZE_NORMAL
 	material = /decl/material/solid/organic/plantmatter
 	valid_accessory_slots = list(ACCESSORY_SLOT_OVER_HELMET)

--- a/code/modules/clothing/spacesuits/rig/rig_pieces.dm
+++ b/code/modules/clothing/spacesuits/rig/rig_pieces.dm
@@ -19,7 +19,7 @@
 	body_parts_covered = SLOT_HEAD|SLOT_FACE|SLOT_EYES
 	heat_protection =    SLOT_HEAD|SLOT_FACE|SLOT_EYES
 	cold_protection =    SLOT_HEAD|SLOT_FACE|SLOT_EYES
-	brightness_on = 4
+	headlamp_range = 4
 	light_wedge = LIGHT_WIDE
 	bodytype_equip_flags = null
 

--- a/code/modules/clothing/spacesuits/spacesuits.dm
+++ b/code/modules/clothing/spacesuits/spacesuits.dm
@@ -23,9 +23,8 @@
 	randpixel = 0
 	flash_protection = FLASH_PROTECTION_MAJOR
 	action_button_name = "Toggle Helmet Light"
-	brightness_on = 4
+	headlamp_range = 4
 	light_wedge = LIGHT_WIDE
-	on = 0
 	replaced_in_loadout = LOADOUT_CONFLICT_KEEP
 
 	var/obj/machinery/camera/camera

--- a/code/modules/clothing/suits/cloaks.dm
+++ b/code/modules/clothing/suits/cloaks.dm
@@ -34,26 +34,13 @@
 // Cloaks should layer over and under everything, so set the layer directly rather
 // than relying on overlay order. This also overlays over inhands but it looks ok.
 /obj/item/clothing/suit/cloak/adjust_mob_overlay(mob/living/user_mob, bodytype, image/overlay, slot, bodypart, use_fallback_if_icon_missing = TRUE)
-
-	if(slot == slot_wear_suit_str || slot == slot_w_uniform_str)
-
-		var/image/underlay
-		var/image/cloverlay
-
-		var/bodyicon = get_icon_for_bodytype(bodytype)
-		var/decl/bodytype/root_bodytype = user_mob?.get_bodytype()
-		if(root_bodytype && bodytype != root_bodytype.bodytype_category)
-			underlay =  root_bodytype.get_offset_overlay_image(user_mob, bodyicon, "[bodytype]-underlay", color, slot)
-			cloverlay = root_bodytype.get_offset_overlay_image(user_mob, bodyicon, "[bodytype]-overlay", color, slot)
-		else
-			underlay = image(bodyicon, "[bodytype]-underlay")
-			cloverlay = image(bodyicon, "[bodytype]-overlay")
-
-		underlay.layer = MOB_LAYER-0.01
-		overlay.underlays = list(underlay)
+	if(overlay && (slot == slot_wear_suit_str || slot == slot_w_uniform_str))
+		var/image/cunderlay  = image(overlay.icon, "[bodytype]-underlay")
+		cunderlay.layer = MOB_LAYER-0.01
+		overlay.underlays = list(cunderlay)
+		var/image/cloverlay = image(overlay.icon, "[bodytype]-overlay")
 		cloverlay.layer = MOB_LAYER+0.01
 		overlay.overlays = list(cloverlay)
-
 	. = overlay
 
 /obj/item/clothing/suit/cloak/captain

--- a/code/modules/multiz/level_data.dm
+++ b/code/modules/multiz/level_data.dm
@@ -368,6 +368,10 @@
 		var/decl/flooring/base_flooring = above.get_base_flooring()
 		if(!base_flooring || base_flooring.constructed)
 			continue
+		// If we only have the one layer, bump it up so we're not entirely replacing it with plating.
+		var/top_flooring = above.get_topmost_flooring()
+		if(top_flooring == base_flooring)
+			above.add_flooring(top_flooring, skip_update = TRUE)
 		above.set_base_flooring(/decl/flooring/plating) // TODO: check if we can skip update here.
 
 ///Calculate the bounds of the level, the border area, and the inner accessible area.

--- a/code/modules/reagents/reagent_containers/food/sliceable/pizza/pizza_box.dm
+++ b/code/modules/reagents/reagent_containers/food/sliceable/pizza/pizza_box.dm
@@ -70,6 +70,7 @@
 	while(LAZYLEN(stacked_boxes))
 		var/obj/item/pizzabox/top_box = stacked_boxes[LAZYLEN(stacked_boxes)]
 		LAZYREMOVE(stacked_boxes, top_box)
+		top_box.dropInto(our_turf)
 		top_box.throw_at(get_edge_target_turf(our_turf, pick(global.alldirs)), 1, 1) // just enough to bonk people
 	update_strings()
 	update_icon()


### PR DESCRIPTION
- Fixes inverted open/close state for fence gates.
- Fixes inverted density checking for some fence logic.
- Fixes fence cutting.
- Fixes fences not blending with walls.
- Fixes level data ceilings replacing dirt paths with plating.
- Fixes headlamp lighting overlays being offset twice on nonstandard humanmobs.
- Fixes cloak overlays/underlays being offset twice on nonstandard humanmobs.
- Fixes pizzas being banished to the Shadow Realm if stacked and thrown.