### PR TITLE
Staging fixes

### DIFF
--- a/code/_onclick/hud/screen/screen_gun.dm
+++ b/code/_onclick/hud/screen/screen_gun.dm
@@ -10,16 +10,14 @@
 /obj/screen/gun/on_update_icon()
 	if(toggle_flag && base_icon_state)
 		var/mob/living/owner = owner_ref?.resolve()
-		icon_state = "[base_icon_state][!!(istype(owner) && owner.aiming && (owner.aiming.target_permissions & toggle_flag))]"
+		icon_state = "[base_icon_state][!!(istype(owner) && (owner.get_aiming_overlay()?.target_permissions & toggle_flag))]"
 	..()
 
 /obj/screen/gun/handle_click(mob/user, params)
 	if(isliving(user))
 		var/mob/living/shooter = user
-		if(!shooter.aiming)
-			shooter.aiming = new(user)
 		if(toggle_flag)
-			shooter.aiming.toggle_permission(toggle_flag)
+			shooter.get_aiming_overlay(create_if_missing = TRUE).toggle_permission(toggle_flag)
 		return TRUE
 	return FALSE
 
@@ -52,12 +50,12 @@
 
 /obj/screen/gun/mode/on_update_icon()
 	var/mob/living/owner = owner_ref?.resolve()
-	icon_state = "[base_icon_state][!!(istype(owner) && owner.aiming?.active)]"
+	icon_state = "[base_icon_state][!!(istype(owner) && owner.get_aiming_overlay()?.active)]"
 	..()
 
 /obj/screen/gun/mode/handle_click(mob/user, params)
 	if(..())
 		var/mob/living/shooter = user
-		shooter.aiming.toggle_active()
+		shooter.get_aiming_overlay(create_if_missing = TRUE).toggle_active()
 		return TRUE
 	return FALSE

--- a/code/modules/fluids/_fluid.dm
+++ b/code/modules/fluids/_fluid.dm
@@ -117,7 +117,7 @@ var/global/list/_fluid_edge_mask_cache = list()
 	var/list/connections
 	for(var/checkdir in global.alldirs)
 		var/turf/neighbor = get_step_resolving_mimic(loc, checkdir)
-		if(!neighbor || neighbor.density || !istype(neighbor?.reagents) || REAGENT_TOTAL_VOLUME(neighbor?.reagents) > FLUID_PUDDLE)
+		if(!neighbor || neighbor.density || REAGENT_TOTAL_VOLUME(neighbor?.reagents) > FLUID_PUDDLE)
 			LAZYADD(connections, checkdir)
 		else
 			LAZYADD(ignored, checkdir)

--- a/code/modules/mob/living/human/human_movement.dm
+++ b/code/modules/mob/living/human/human_movement.dm
@@ -51,7 +51,7 @@
 	if(is_asystole())
 		tally += 10 // Heart attacks are kinda distracting.
 
-	if(aiming && aiming.aiming_at)
+	if(get_aiming_overlay()?.aiming_at)
 		tally += 5 // Iron sights make you slower, it's a well-known fact.
 
 	if(facing_dir && ((travel_dir & facing_dir) != facing_dir))

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -746,7 +746,7 @@ default behaviour is:
 
 /mob/living/Destroy()
 	clear_mob_modifiers()
-	QDEL_NULL(aiming)
+	QDEL_NULL(_aiming)
 	QDEL_NULL_LIST(_hallucinations)
 	QDEL_NULL_LIST(aimed_at_by)
 	LAZYCLEARLIST(smell_cooldown)

--- a/code/modules/projectiles/_gun.dm
+++ b/code/modules/projectiles/_gun.dm
@@ -187,10 +187,8 @@
 /obj/item/gun/afterattack(atom/A, mob/living/user, adjacent, params)
 	if(adjacent) return //A is adjacent, is the user, or is on the user's person
 
-	if(!user.aiming)
-		user.aiming = new(user)
-
-	if(user && user.client && user.aiming && user.aiming.active && user.aiming.aiming_at != A)
+	var/obj/abstract/aiming_overlay/aiming = user.get_aiming_overlay()
+	if(user && user.client && aiming && aiming.active && aiming.aiming_at != A)
 		PreFire(A,user,params) //They're using the new gun system, locate what they're aiming at.
 		return
 
@@ -202,8 +200,9 @@
 		handle_suicide(user)
 		return TRUE
 
-	if(!user.check_intent(I_FLAG_HARM) && user.aiming && user.aiming.active) //if aim mode, don't pistol whip
-		if (user.aiming.aiming_at != target)
+	var/obj/abstract/aiming_overlay/aiming = user.get_aiming_overlay(create_if_missing = TRUE)
+	if(!user.check_intent(I_FLAG_HARM) && aiming?.active) //if aim mode, don't pistol whip
+		if (aiming.aiming_at != target)
 			PreFire(target, user)
 		else
 			Fire(target, user, pointblank=1)
@@ -449,7 +448,7 @@
 			disp_mod += 0.5
 
 		//accuracy bonus from aiming
-		if (user.aiming?.aiming_at == target)
+		if (user.get_aiming_overlay()?.aiming_at == target)
 			//If you aim at someone beforehead, it'll hit more often.
 			//Kinda balanced by fact you need like 2 seconds to aim
 			//As opposed to no-delay pew pew
@@ -687,8 +686,7 @@
 			M.setClickCooldown(DEFAULT_QUICK_COOLDOWN) // Spam prevention, essentially.
 			M.visible_message(SPAN_DANGER("\The [M] pulls the trigger reflexively!"))
 			Fire(aiming_at, M)
-			if(M.aiming)
-				M.aiming.toggle_active(FALSE, TRUE)
+			M.get_aiming_overlay()?.toggle_active(FALSE, TRUE)
 
 /obj/item/gun/get_quick_interaction_handler(mob/user)
 	return GET_DECL(/decl/interaction_handler/gun/toggle_safety)

--- a/code/modules/projectiles/guns/launcher/bows/_bow.dm
+++ b/code/modules/projectiles/guns/launcher/bows/_bow.dm
@@ -45,10 +45,17 @@
 	var/strung_w_class = ITEM_SIZE_HUGE
 	/// How big is this bow when unstrung? Uses initial w_class if unset.
 	var/unstrung_w_class
+	/// Set to TRUE to skip the default click fire behavior of guns.
+	var/bypass_afterattack = TRUE
 
 /obj/item/gun/launcher/bow/handle_click_empty(atom/movable/firer)
 	if(check_fire_message_spam("click"))
 		to_chat(firer, SPAN_WARNING("\The [src] has nothing loaded."))
+
+/obj/item/gun/launcher/bow/afterattack(atom/A, mob/living/user, adjacent, params)
+	if(bypass_afterattack)
+		return
+	. = ..()
 
 /obj/item/gun/launcher/bow/fancy
 	desc = "A projectile weapon of ancient design that turns elastic tension into long-range death. This one has decorative engraving and flourishes."
@@ -151,3 +158,12 @@
 	if(!length(strings))
 		return
 	. += "It [english_list(strings)]."
+
+/obj/item/gun/launcher/bow/get_examine_hints(mob/user, distance, infix, suffix)
+	. = ..()
+	var/hint = get_bow_usage_hints()
+	if(hint)
+		LAZYADD(., hint)
+
+/obj/item/gun/launcher/bow/proc/get_bow_usage_hints()
+	return SPAN_SUBTLE("Place an arrow into the bow, then click and hold on harm intent to draw it back. Release to fire.")

--- a/code/modules/projectiles/guns/launcher/bows/crossbow.dm
+++ b/code/modules/projectiles/guns/launcher/bows/crossbow.dm
@@ -13,6 +13,7 @@
 	autofire_enabled = FALSE
 	w_class = ITEM_SIZE_HUGE
 	strung_w_class = null
+	bypass_afterattack = FALSE
 
 /obj/item/gun/launcher/bow/crossbow/show_load_message(mob/user)
 	if(user)
@@ -20,3 +21,6 @@
 			SPAN_NOTICE("\The [user] slides \the [_loaded] into \the [src]."),
 			SPAN_NOTICE("You slide \the [_loaded] into \the [src].")
 		)
+
+/obj/item/gun/launcher/bow/crossbow/get_bow_usage_hints()
+	return SPAN_SUBTLE("Place a bolt into the crowwbow, then use the crossbow in hand to draw it back. Click a target to fire.")

--- a/code/modules/projectiles/guns/launcher/bows/sling.dm
+++ b/code/modules/projectiles/guns/launcher/bows/sling.dm
@@ -55,3 +55,6 @@
 
 /obj/item/gun/launcher/bow/sling/show_working_draw_message(mob/user)
 	return
+
+/obj/item/gun/launcher/bow/sling/get_bow_usage_hints()
+	return SPAN_SUBTLE("Place a stone into the sling, then click and hold on harm intent to start swinging it. Release to fire.")

--- a/code/modules/projectiles/targeting/targeting_mob.dm
+++ b/code/modules/projectiles/targeting/targeting_mob.dm
@@ -1,24 +1,29 @@
 /mob/living
-	var/obj/aiming_overlay/aiming
+	VAR_PRIVATE/obj/abstract/aiming_overlay/_aiming
 	var/list/aimed_at_by
 
-/mob/verb/toggle_gun_mode()
+/mob/living/proc/get_aiming_overlay(create_if_missing = TRUE)
+	RETURN_TYPE(/obj/abstract/aiming_overlay)
+	if(create_if_missing && !_aiming)
+		_aiming = new(src)
+	return _aiming
+
+//Needs to be a mob verb to prevent error messages when using hotkeys
+/mob/verb/toggle_gun_mode_verb()
 	set name = "Toggle Gun Mode"
 	set desc = "Begin or stop aiming."
 	set category = "IC"
+	toggle_gun_mode()
 
-	if(isliving(src)) //Needs to be a mob verb to prevent error messages when using hotkeys
-		var/mob/living/M = src
-		if(!M.aiming)
-			M.aiming = new(src)
-		M.aiming.toggle_active()
-	else
-		to_chat(src, "<span class='warning'>This verb may only be used by living mobs, sorry.</span>")
-	return
+/mob/proc/toggle_gun_mode()
+	to_chat(src, SPAN_WARNING("This verb may only be used by living mobs, sorry."))
+
+/mob/living/toggle_gun_mode()
+	var/obj/abstract/aiming_overlay/aiming = get_aiming_overlay(create_if_missing = TRUE)
+	aiming.toggle_active()
 
 /mob/living/proc/stop_aiming(var/obj/item/thing, var/no_message = 0)
-	if(!aiming)
-		aiming = new(src)
-	if(thing && aiming.aiming_with != thing)
+	var/obj/abstract/aiming_overlay/aiming = get_aiming_overlay()
+	if(!aiming || (thing && aiming.aiming_with != thing))
 		return
 	aiming.cancel_aiming(no_message)

--- a/code/modules/projectiles/targeting/targeting_overlay.dm
+++ b/code/modules/projectiles/targeting/targeting_overlay.dm
@@ -1,14 +1,12 @@
-/obj/aiming_overlay
+/obj/abstract/aiming_overlay
 	name = ""
 	desc = "Stick 'em up!"
 	icon = 'icons/effects/Targeted.dmi'
 	icon_state = "locking"
-	anchored = TRUE
-	density = FALSE
-	opacity = FALSE
 	layer = ABOVE_HUMAN_LAYER
-	simulated = 0
 	mouse_opacity = MOUSE_OPACITY_UNCLICKABLE
+	invisibility = 0
+	hide_on_init = FALSE
 
 	var/mob/living/aiming_at   // Who are we currently targeting, if anyone?
 	var/obj/item/aiming_with   // What are we targeting with?
@@ -18,13 +16,13 @@
 	var/active =    0          // Is our owner intending to take hostages?
 	var/target_permissions = TARGET_CAN_MOVE | TARGET_CAN_CLICK | TARGET_CAN_RADIO	// Permission bitflags.
 
-/obj/aiming_overlay/Initialize()
+/obj/abstract/aiming_overlay/Initialize()
 	. = ..()
 	owner = loc
 	forceMove(null)
 	verbs.Cut()
 
-/obj/aiming_overlay/proc/toggle_permission(var/perm)
+/obj/abstract/aiming_overlay/proc/toggle_permission(var/perm)
 
 	if(target_permissions & perm)
 		target_permissions &= ~perm
@@ -56,24 +54,28 @@
 	if(aiming_at)
 		to_chat(aiming_at, "<span class='[use_span]'>You are [message].</span>")
 
-/obj/aiming_overlay/Process()
+/obj/abstract/aiming_overlay/Process()
 	if(!owner)
 		qdel(src)
 		return
 	..()
 	update_aiming()
 
-/obj/aiming_overlay/Destroy()
+/obj/abstract/aiming_overlay/Destroy()
 	cancel_aiming(1)
+	if(UNLINT(owner._aiming == src))
+		UNLINT(owner._aiming = null)
 	owner = null
+	aiming_at = null
+	aiming_with = null
 	return ..()
 
-/obj/aiming_overlay/proc/update_aiming_deferred()
+/obj/abstract/aiming_overlay/proc/update_aiming_deferred()
 	set waitfor = 0
 	sleep(0)
 	update_aiming()
 
-/obj/aiming_overlay/proc/update_aiming()
+/obj/abstract/aiming_overlay/proc/update_aiming()
 
 	if(!owner)
 		qdel(src)
@@ -114,7 +116,7 @@
 		spawn(0)
 			owner.set_dir(get_dir(get_turf(owner), get_turf(src)))
 
-/obj/aiming_overlay/proc/aim_at(var/mob/target, var/obj/thing)
+/obj/abstract/aiming_overlay/proc/aim_at(var/mob/target, var/obj/thing)
 
 	if(!owner || !isliving(target))
 		return
@@ -157,17 +159,17 @@
 
 	update_icon()
 	lock_time = world.time + 35
-	events_repository.register(/decl/observ/moved, owner, src, TYPE_PROC_REF(/obj/aiming_overlay, update_aiming))
-	events_repository.register(/decl/observ/moved, aiming_at, src, TYPE_PROC_REF(/obj/aiming_overlay, target_moved))
-	events_repository.register(/decl/observ/destroyed, aiming_at, src, TYPE_PROC_REF(/obj/aiming_overlay, cancel_aiming))
+	events_repository.register(/decl/observ/moved, owner, src, TYPE_PROC_REF(/obj/abstract/aiming_overlay, update_aiming))
+	events_repository.register(/decl/observ/moved, aiming_at, src, TYPE_PROC_REF(/obj/abstract/aiming_overlay, target_moved))
+	events_repository.register(/decl/observ/destroyed, aiming_at, src, TYPE_PROC_REF(/obj/abstract/aiming_overlay, cancel_aiming))
 
-/obj/aiming_overlay/on_update_icon()
+/obj/abstract/aiming_overlay/on_update_icon()
 	if(locked)
 		icon_state = "locked"
 	else
 		icon_state = "locking"
 
-/obj/aiming_overlay/proc/toggle_active(var/force_state = null, var/no_message = FALSE)
+/obj/abstract/aiming_overlay/proc/toggle_active(var/force_state = null, var/no_message = FALSE)
 	if(!isnull(force_state))
 		if(active == force_state)
 			return
@@ -188,7 +190,7 @@
 				to_chat(owner, "<span class='notice'>You will no longer aim rather than fire.</span>")
 			owner.hud_used.remove_gun_icons()
 
-/obj/aiming_overlay/proc/cancel_aiming(var/no_message = 0)
+/obj/abstract/aiming_overlay/proc/cancel_aiming(var/no_message = 0)
 	if(!aiming_with || !aiming_at)
 		return
 	if(!no_message)
@@ -208,6 +210,6 @@
 	forceMove(null)
 	STOP_PROCESSING(SSobj, src)
 
-/obj/aiming_overlay/proc/target_moved()
+/obj/abstract/aiming_overlay/proc/target_moved()
 	update_aiming()
 	trigger(TARGET_CAN_MOVE)

--- a/code/modules/projectiles/targeting/targeting_triggers.dm
+++ b/code/modules/projectiles/targeting/targeting_triggers.dm
@@ -3,7 +3,7 @@
 	return
 
 /mob/living/trigger_aiming(var/trigger_type)
-	for(var/obj/aiming_overlay/AO as anything in aimed_at_by)
+	for(var/obj/abstract/aiming_overlay/AO as anything in aimed_at_by)
 		if(AO.aiming_at == src)
 			AO.update_aiming()
 			if(AO.aiming_at == src)
@@ -13,13 +13,12 @@
 /mob/living/proc/aim_at(var/atom/target, var/obj/item/with)
 	if(!ismob(target) || !istype(with) || incapacitated())
 		return FALSE
-	if(!aiming)
-		aiming = new(src)
 	face_atom(target)
+	var/obj/abstract/aiming_overlay/aiming = get_aiming_overlay(create_if_missing = TRUE)
 	aiming.aim_at(target, with)
 	return TRUE
 
-/obj/aiming_overlay/proc/trigger(var/perm)
+/obj/abstract/aiming_overlay/proc/trigger(var/perm)
 	if(!owner || !aiming_with || !aiming_at || !locked)
 		return FALSE
 	if(perm && (target_permissions & perm))

--- a/code/modules/status_conditions/definitions/status_weakened.dm
+++ b/code/modules/status_conditions/definitions/status_weakened.dm
@@ -6,12 +6,12 @@
 /decl/status_condition/weakened/handle_changed_amount(var/mob/living/victim, var/new_amount, var/last_amount)
 	. = ..()
 	victim.facing_dir = null
-	if(victim.aiming)
+	if(victim.get_aiming_overlay())
 		victim.stop_aiming(no_message=1)
 	victim.update_posture()
 
 /decl/status_condition/weakened/handle_status(mob/living/victim, amount)
 	. = ..()
-	if(victim.aiming)
+	if(victim.get_aiming_overlay())
 		victim.stop_aiming(no_message=1)
 	victim.update_posture()


### PR DESCRIPTION
- Removes `reagents` null check from water turf edge checking. Not sure why it as there at all, might have been a null guard for the old block prior to the reagent macros.
- Tidies some bow logic and adds usage hints to examine.
- Rewrites aiming overlay generation to use a getter to avoid unnecessary creation.