### PR TITLE
Fix issues with ambient light on staging

### DIFF
--- a/code/controllers/subsystems/ambience.dm
+++ b/code/controllers/subsystems/ambience.dm
@@ -101,13 +101,20 @@ SUBSYSTEM_DEF(ambience)
 			var/datum/daycycle/daycycle = SSdaycycle.get_daycycle(daycycle_id)
 			var/new_power = daycycle?.current_period?.power
 			if(!isnull(new_power))
+				new_power = clamp(new_power + ambient_light_modifier, 0, 1)
 				if(new_power > 0)
-					set_ambient_light(daycycle.current_period.color, clamp(new_power + ambient_light_modifier, 0, 1))
+					set_ambient_light(daycycle.current_period.color, new_power)
+				else
+					clear_ambient_light()
 				return TRUE
 
 		// Apply general level ambience.
-		if(level_data?.ambient_light_level)
-			set_ambient_light(level_data.ambient_light_color, clamp(level_data.ambient_light_level + ambient_light_modifier, 0, 1))
+		var/effective_power = isnull(level_data?.ambient_light_level) ? null : clamp(level_data.ambient_light_level + ambient_light_modifier, 0, 1)
+		if(!isnull(effective_power))
+			if(effective_power > 0)
+				set_ambient_light(level_data.ambient_light_color, effective_power)
+			else
+				clear_ambient_light()
 			return TRUE
 
 	return FALSE

--- a/code/modules/lighting/ambient_turf.dm
+++ b/code/modules/lighting/ambient_turf.dm
@@ -83,7 +83,7 @@
 	ambient_light_old_g += lg
 	ambient_light_old_b += lb
 
-	if (TURF_IS_DYNAMICALLY_LIT_UNSAFE(src) && (!corners || !lighting_corners_initialised))
+	if (!corners || !lighting_corners_initialised)
 		generate_missing_corners()
 
 	// This list can contain nulls on things like space turfs -- they only have their neighbors' corners.

--- a/code/modules/lighting/lighting_corner.dm
+++ b/code/modules/lighting/lighting_corner.dm
@@ -75,7 +75,7 @@ var/global/list/REVERSE_LIGHTING_CORNER_DIAGONAL = list(0, 0, 0, 0, 3, 4, 0, 0, 
 	z = t1.z
 	t1i = oi
 
-	if (TURF_IS_AMBIENT_LIT_UNSAFE(new_turf))
+	if (new_turf.ambient_light)
 		has_ambience = TRUE
 
 	var/vertical   = diagonal & ~(diagonal - 1) // The horizontal directions (4 and 8) are bigger than the vertical ones (1 and 2), so we can reliably say the lsb is the horizontal direction.
@@ -101,7 +101,7 @@ var/global/list/REVERSE_LIGHTING_CORNER_DIAGONAL = list(0, 0, 0, 0, 3, 4, 0, 0, 
 		t2 = T
 		t2i = REVERSE_LIGHTING_CORNER_DIAGONAL[diagonal]
 		T.corners[t2i] = src
-		if (TURF_IS_AMBIENT_LIT_UNSAFE(T))
+		if (T.ambient_light)
 			has_ambience = TRUE
 
 	// Now the horizontal one.
@@ -114,7 +114,7 @@ var/global/list/REVERSE_LIGHTING_CORNER_DIAGONAL = list(0, 0, 0, 0, 3, 4, 0, 0, 
 		t3 = T
 		t3i = REVERSE_LIGHTING_CORNER_DIAGONAL[((Tc > x) ? EAST : WEST) | ((t1.y > y) ? NORTH : SOUTH)] // Get the dir based on coordinates.
 		T.corners[t3i] = src
-		if (TURF_IS_AMBIENT_LIT_UNSAFE(T))
+		if (T.ambient_light)
 			has_ambience = TRUE
 
 	// And finally the vertical one.
@@ -127,7 +127,7 @@ var/global/list/REVERSE_LIGHTING_CORNER_DIAGONAL = list(0, 0, 0, 0, 3, 4, 0, 0, 
 		t4 = T
 		t4i = REVERSE_LIGHTING_CORNER_DIAGONAL[((t1.x > x) ? EAST : WEST) | ((Tc > y) ? NORTH : SOUTH)] // Get the dir based on coordinates.
 		T.corners[t4i] = src
-		if (TURF_IS_AMBIENT_LIT_UNSAFE(T))
+		if (T.ambient_light)
 			has_ambience = TRUE
 
 	if (has_ambience)


### PR DESCRIPTION
## Description of changes
ambient light set prior to corner init wasn't working properly because corners checked `ambient_active`, but that wasn't set. i don't know how to make it properly set in the right order and lohikar said a proper fix will take a while, so here's a stopgap

## Why and what will this PR improve
fixes issues with ambient light on staging, avoids issues with the partial revert of non-queueing ambience in #5470

## Authorship
some of this stuff is adapted from lohi talking about fixes on O7 but the code here was written by me