### PR TITLE
Map vote now shows full name rather than path.

### DIFF
--- a/maps/~mapsystem/maps.dm
+++ b/maps/~mapsystem/maps.dm
@@ -23,7 +23,7 @@ var/global/const/MAP_HAS_RANK   = 2		//Rank system, also togglable
 
 		global.all_maps[map_instance.path] = map_instance
 		if(map_instance.votable)
-			global.votable_maps[map_instance.path] = map_instance
+			global.votable_maps[map_instance.full_name] = map_instance
 
 	return 1
 


### PR DESCRIPTION
Scav has had issues where the map in the vote is `ministation` and players don't know that this means it's `Tradepost Mollusc`. `global.votable_maps` is not used anywhere else, so this should have minimal chance of regressions.