### PR TITLE
Codex simplification and consistency pass.

### DIFF
--- a/code/controllers/subsystems/initialization/codex.dm
+++ b/code/controllers/subsystems/initialization/codex.dm
@@ -63,15 +63,19 @@ SUBSYSTEM_DEF(codex)
 		string = replacetextEx(string, linkRegex.match, replacement)
 	return string
 
-/datum/controller/subsystem/codex/proc/get_codex_entry(entry, do_search = FALSE)
+/datum/controller/subsystem/codex/proc/get_codex_entry(entry, do_search = FALSE, skip_atom_codex = FALSE)
+
 	if(istype(entry, /atom))
 		var/atom/entity = entry
-		var/specific_codex_entry = entity.get_atom_codex_entry()
-		if(specific_codex_entry)
-			return specific_codex_entry
-		return get_entry_by_string(entity.name) || entries_by_path[entity.type]
+		if(!skip_atom_codex) // Avoids infinite loops when we enter here -from- get_atom_codex_entry()
+			var/specific_codex_entry = entity.get_atom_codex_entry()
+			if(specific_codex_entry)
+				return specific_codex_entry
+		return get_codex_entry(entity.type, do_search, skip_atom_codex) || get_codex_entry(entity.name, do_search, skip_atom_codex)
+
 	if(ispath(entry))
 		return entries_by_path[entry]
+
 	if(istext(entry))
 		entry = codex_sanitize(entry)
 		. = entries_by_string[entry]

--- a/code/controllers/subsystems/initialization/codex.dm
+++ b/code/controllers/subsystems/initialization/codex.dm
@@ -63,17 +63,22 @@ SUBSYSTEM_DEF(codex)
 		string = replacetextEx(string, linkRegex.match, replacement)
 	return string
 
-/datum/controller/subsystem/codex/proc/get_codex_entry(var/entry)
+/datum/controller/subsystem/codex/proc/get_codex_entry(entry, do_search = FALSE)
 	if(istype(entry, /atom))
 		var/atom/entity = entry
-		var/specific_codex_entry = entity.get_specific_codex_entry()
+		var/specific_codex_entry = entity.get_atom_codex_entry()
 		if(specific_codex_entry)
 			return specific_codex_entry
 		return get_entry_by_string(entity.name) || entries_by_path[entity.type]
 	if(ispath(entry))
 		return entries_by_path[entry]
 	if(istext(entry))
-		return entries_by_string[codex_sanitize(entry)]
+		entry = codex_sanitize(entry)
+		. = entries_by_string[entry]
+		if(!. && do_search)
+			var/list/entries = retrieve_entries_for_string(entry)
+			if(length(entries))
+				return entries[1]
 
 /datum/controller/subsystem/codex/proc/get_entry_by_string(var/string)
 	return entries_by_string[codex_sanitize(string)]

--- a/code/controllers/subsystems/initialization/codex.dm
+++ b/code/controllers/subsystems/initialization/codex.dm
@@ -8,7 +8,6 @@ SUBSYSTEM_DEF(codex)
 	var/regex/trailingLinebreakRegexEnd
 
 	var/list/datum/codex_entry/all_entries =       list()
-	var/list/datum/codex_entry/entries_by_path =   list()
 	var/list/datum/codex_entry/entries_by_string = list()
 	var/list/index_file =                          list()
 	var/list/search_cache =                        list()
@@ -63,7 +62,7 @@ SUBSYSTEM_DEF(codex)
 		string = replacetextEx(string, linkRegex.match, replacement)
 	return string
 
-/datum/controller/subsystem/codex/proc/get_codex_entry(entry, do_search = FALSE, skip_atom_codex = FALSE)
+/datum/controller/subsystem/codex/proc/get_codex_entry(atom/entry, do_search = FALSE, skip_atom_codex = FALSE)
 
 	if(istype(entry, /atom))
 		var/atom/entity = entry
@@ -71,10 +70,11 @@ SUBSYSTEM_DEF(codex)
 			var/specific_codex_entry = entity.get_atom_codex_entry()
 			if(specific_codex_entry)
 				return specific_codex_entry
-		return get_codex_entry(entity.type, do_search, skip_atom_codex) || get_codex_entry(entity.name, do_search, skip_atom_codex)
+		return get_codex_entry(entity.name, do_search, skip_atom_codex)
 
-	if(ispath(entry))
-		return entries_by_path[entry]
+	// As above for the skip_atom_codex check
+	if(ispath(entry, /atom) && TYPE_IS_SPAWNABLE(entry) && !TYPE_IS_ABSTRACT(entry) && !skip_atom_codex)
+		return atom_info_repository.get_codex_page_for(entry)
 
 	if(istext(entry))
 		entry = codex_sanitize(entry)
@@ -125,6 +125,11 @@ SUBSYSTEM_DEF(codex)
 					continue
 				if(findtext(entry.name, searching) || findtext(entry.lore_text, searching) || findtext(entry.mechanics_text, searching) || findtext(entry.antag_text, searching))
 					results |= entry
+				else
+					for(var/associated_string in entry.associated_strings)
+						if(findtext(associated_string, searching))
+							results |= entry
+							break
 		search_cache[searching] = sortTim(results, /proc/cmp_name_asc)
 	return search_cache[searching]
 

--- a/code/controllers/subsystems/initialization/codex_dump.dm
+++ b/code/controllers/subsystems/initialization/codex_dump.dm
@@ -148,7 +148,7 @@ TODO: work out how to implement an external search function.
 			atom = new atom_type
 			if(!istype(atom)) // Something went wrong, possibly a runtime in the atom info repo.
 				continue
-			var/datum/codex_entry/codex_entry = atom.get_specific_codex_entry()
+			var/datum/codex_entry/codex_entry = atom.get_atom_codex_entry()
 			if(istype(codex_entry))
 				var/link_name = codex_entry.get_dump_link_name()
 				if(ismob(atom))

--- a/code/datums/repositories/atom_info.dm
+++ b/code/datums/repositories/atom_info.dm
@@ -54,7 +54,7 @@ var/global/repository/atom_info/atom_info_repository = new()
 		origin_tech_cache[key] = cached_json_decode(item_instance.get_origin_tech())
 	if(cache_codex && !(key in codex_cache))
 		instance = instance || get_instance_of(_path, _mat, _amount)
-		codex_cache[key] = instance.get_atom_codex_entry() || FALSE
+		codex_cache[key] = instance.get_atom_codex_entry(permanent = TRUE) || FALSE
 
 	if(!QDELETED(instance))
 		qdel(instance)

--- a/code/datums/repositories/atom_info.dm
+++ b/code/datums/repositories/atom_info.dm
@@ -1,14 +1,15 @@
 var/global/repository/atom_info/atom_info_repository = new()
 
 /repository/atom_info
-	var/list/matter_cache         = list()
-	var/list/combined_worth_cache = list()
-	var/list/single_worth_cache   = list()
-	var/list/name_cache           = list()
-	var/list/description_cache    = list()
-	var/list/matter_mult_cache    = list()
-	var/list/origin_tech_cache    = list()
-	var/list/appearance_cache     = list()
+	var/alist/matter_cache         = alist()
+	var/alist/combined_worth_cache = alist()
+	var/alist/single_worth_cache   = alist()
+	var/alist/name_cache           = alist()
+	var/alist/description_cache    = alist()
+	var/alist/matter_mult_cache    = alist()
+	var/alist/origin_tech_cache    = alist()
+	var/alist/appearance_cache     = alist()
+	var/alist/codex_cache          = alist()
 
 /repository/atom_info/proc/create_key_for(var/_path, var/_mat, var/_amount)
 	. = "[_path]"
@@ -25,7 +26,7 @@ var/global/repository/atom_info/atom_info_repository = new()
 	else
 		. = new _path
 
-/repository/atom_info/proc/update_cached_info_for(var/_path, var/_mat, var/_amount, var/key, var/cache_appearance = FALSE)
+/repository/atom_info/proc/update_cached_info_for(var/_path, var/_mat, var/_amount, var/key, var/cache_appearance = FALSE, var/cache_codex = FALSE)
 	var/atom/instance
 	if(!matter_cache[key])
 		instance = get_instance_of(_path, _mat, _amount)
@@ -51,6 +52,10 @@ var/global/repository/atom_info/atom_info_repository = new()
 	if(!origin_tech_cache[key] && ispath(_path, /obj/item))
 		var/obj/item/item_instance = instance || get_instance_of(_path, _mat, _amount)
 		origin_tech_cache[key] = cached_json_decode(item_instance.get_origin_tech())
+	if(cache_codex && !(key in codex_cache))
+		instance = instance || get_instance_of(_path, _mat, _amount)
+		codex_cache[key] = instance.get_specific_codex_entry() || FALSE
+
 	if(!QDELETED(instance))
 		qdel(instance)
 
@@ -95,3 +100,11 @@ var/global/repository/atom_info/atom_info_repository = new()
 	var/key = create_key_for(_path, _mat, _amount)
 	update_cached_info_for(_path, _mat, _amount, key, cache_appearance = TRUE)
 	. = appearance_cache[key]
+
+// Bespoke proc; only cache codex page if and when this proc is called, not more generally.
+/repository/atom_info/proc/get_codex_page_for(var/_path, var/_mat, var/_amount)
+	var/key = create_key_for(_path, _mat, _amount)
+	update_cached_info_for(_path, _mat, _amount, key, cache_codex = TRUE)
+	. = codex_cache[key]
+	if(!istype(., /datum))
+		. = null

--- a/code/datums/repositories/atom_info.dm
+++ b/code/datums/repositories/atom_info.dm
@@ -54,7 +54,7 @@ var/global/repository/atom_info/atom_info_repository = new()
 		origin_tech_cache[key] = cached_json_decode(item_instance.get_origin_tech())
 	if(cache_codex && !(key in codex_cache))
 		instance = instance || get_instance_of(_path, _mat, _amount)
-		codex_cache[key] = instance.get_specific_codex_entry() || FALSE
+		codex_cache[key] = instance.get_atom_codex_entry() || FALSE
 
 	if(!QDELETED(instance))
 		qdel(instance)

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -319,7 +319,7 @@
 		article_name = ADD_ARTICLE_GENDER("[examine_prefix][name]", gender)
 	var/header_string = "[html_icon(src)] That's [article_name]"
 	if(user?.get_preference_value(/datum/client_preference/inquisitive_examine) == PREF_ON && user.can_use_codex())
-		var/datum/codex_entry/codex = get_atom_codex_entry(user)
+		var/datum/codex_entry/codex = get_atom_codex_entry(user, strict = TRUE)
 		if(codex)
 			header_string = "[header_string]<small><a href='byond://?src=\ref[SScodex];show_examined_info=\ref[codex];show_to=\ref[user]'>?</a></small>"
 	header_string = "[header_string][infix][get_examine_punctuation()] [suffix]"

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -317,13 +317,12 @@
 		if(examine_prefix)
 			examine_prefix += " " // add a space to the end to be polite
 		article_name = ADD_ARTICLE_GENDER("[examine_prefix][name]", gender)
-
-	var/header_string = "[html_icon(src)] That's [article_name][infix][get_examine_punctuation()] [suffix]"
+	var/header_string = "[html_icon(src)] That's [article_name]"
 	if(user?.get_preference_value(/datum/client_preference/inquisitive_examine) == PREF_ON && user.can_use_codex())
 		var/datum/codex_entry/codex = get_atom_codex_entry(user)
 		if(codex)
-			header_string = "[header_string]<sup><a href='byond://?src=\ref[SScodex];show_examined_info=\ref[codex];show_to=\ref[user]'>?</a></b> is available.</sup>"
-
+			header_string = "[header_string]<small><a href='byond://?src=\ref[SScodex];show_examined_info=\ref[codex];show_to=\ref[user]'>?</a></small>"
+	header_string = "[header_string][infix][get_examine_punctuation()] [suffix]"
 	return list(header_string)
 
 // Main body of examine, displayed after the header and before hints.

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -317,7 +317,14 @@
 		if(examine_prefix)
 			examine_prefix += " " // add a space to the end to be polite
 		article_name = ADD_ARTICLE_GENDER("[examine_prefix][name]", gender)
-	return list("[html_icon(src)] That's [article_name][infix][get_examine_punctuation()] [suffix]")
+
+	var/header_string = "[html_icon(src)] That's [article_name][infix][get_examine_punctuation()] [suffix]"
+	if(user?.get_preference_value(/datum/client_preference/inquisitive_examine) == PREF_ON && user.can_use_codex())
+		var/datum/codex_entry/codex = get_atom_codex_entry(user)
+		if(codex)
+			header_string = "[header_string]<sup><a href='byond://?src=\ref[SScodex];show_examined_info=\ref[codex];show_to=\ref[user]'>?</a></b> is available.</sup>"
+
+	return list(header_string)
 
 // Main body of examine, displayed after the header and before hints.
 /atom/proc/get_examine_strings(mob/user, distance, infix, suffix)
@@ -343,10 +350,7 @@
 
 	var/decl/interaction_handler/handler = get_quick_interaction_handler(user)
 	if(handler)
-		LAZYADD(., SPAN_NOTICE("<b>Ctrl-click</b> \the [src] while in your inventory to [lowertext(handler.name)]."))
-
-	if(user?.get_preference_value(/datum/client_preference/inquisitive_examine) == PREF_ON && user.can_use_codex() && SScodex.get_codex_entry(get_codex_value(user)))
-		LAZYADD(., SPAN_NOTICE("The codex has <b><a href='byond://?src=\ref[SScodex];show_examined_info=\ref[src];show_to=\ref[user]'>relevant information</a></b> available."))
+		LAZYADD(., SPAN_INFO("<b>Ctrl-click</b> \the [src] while in your inventory to [lowertext(handler.name)]."))
 
 /**
 	Relay movement to this atom.

--- a/code/game/atoms_init.dm
+++ b/code/game/atoms_init.dm
@@ -87,8 +87,8 @@
 	QDEL_NULL(light)
 	if(simulated && opacity)
 		updateVisibility(src)
-	if(atom_codex_ref && atom_codex_ref != TRUE) // may be null, TRUE or a datum instance
-		QDEL_NULL(atom_codex_ref)
+	if(istype(_atom_codex_ref) && !_atom_codex_ref.store_codex_entry) // may be null, TRUE or a datum instance
+		QDEL_NULL(_atom_codex_ref)
 	. = ..()
 	// This might need to be moved onto a Del() override at some point.
 	QDEL_NULL(storage)

--- a/code/game/machinery/OpTable.dm
+++ b/code/game/machinery/OpTable.dm
@@ -10,7 +10,7 @@
 	active_power_usage = 5
 	construct_state = /decl/machine_construction/default/panel_closed
 	uncreated_component_parts = null
-
+	_atom_codex_value = /datum/codex_entry/optable
 	var/suppressing = FALSE
 	var/mob/living/victim
 	var/obj/machinery/computer/operating/computer = null

--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -14,6 +14,7 @@
 	idle_power_usage = 15
 	active_power_usage = 1 KILOWATTS //builtin health analyzer, dialysis machine, injectors.
 	pixel_z = -8
+	_atom_codex_value = /datum/codex_entry/sleeper
 
 	var/mob/living/human/occupant
 	var/obj/item/chems/glass/beaker = null

--- a/code/game/machinery/_machines_base/machinery.dm
+++ b/code/game/machinery/_machines_base/machinery.dm
@@ -520,9 +520,5 @@ Class Procs:
 	id_tag = new_id_tag
 	//#TODO: Add handling for components, when we're sure it will work for any kind of machinery. Some machines do not use the same id_tag on receiver and transmitters for example.
 
-// Make sure that mapped subtypes get the right codex entry.
-/obj/machinery/get_codex_value()
-	return base_type || ..()
-
 /obj/machinery/solvent_can_melt(var/solvent_power = MAT_SOLVENT_STRONG)
 	return FALSE

--- a/code/game/machinery/_machines_base/stock_parts/power/battery.dm
+++ b/code/game/machinery/_machines_base/stock_parts/power/battery.dm
@@ -208,16 +208,18 @@
 	charge_wait_counter = 15
 
 /obj/item/stock_parts/power/battery/buildable/crap/get_lore_info()
-	return "The BAT84's debut on the battery backup market was greeted by universally negative reviews, \
+	. = ..()
+	LAZYADD(., "The BAT84's debut on the battery backup market was greeted by universally negative reviews, \
 	highlighting its slow recharge rate and exceptional lack of responsiveness to power changes.\
-	Nevertheless, it has been steadily gaining market share due to rock-bottom prices and a predatory marketing campaign."
+	Nevertheless, it has been steadily gaining market share due to rock-bottom prices and a predatory marketing campaign.")
 
 /obj/item/stock_parts/power/battery/buildable/stock
 	name = "battery backup (standard)"
 	desc = "The 3006915, or, as this part is colloquially known, model 15, is the workhorse battery backup solution of populated space."
 
 /obj/item/stock_parts/power/battery/buildable/stock/get_lore_info()
-	return "Combining tolerable recharge rate and high durability into a conveniently shaped package, the model 15 has dominated the market for over three decades."
+	. = ..()
+	LAZYADD(., "Combining tolerable recharge rate and high durability into a conveniently shaped package, the model 15 has dominated the market for over three decades.")
 
 /obj/item/stock_parts/power/battery/buildable/turbo
 	name = "battery backup (rapid)"
@@ -230,8 +232,9 @@
 	)
 
 /obj/item/stock_parts/power/battery/buildable/turbo/get_lore_info()
-	return "The latest in battery charging technology deploys advanced composites and semiorganic interfaces to attain previously unheard-of charge rates. \
-	The relevant marketing divisions, on the other hand, has been engaged in seeminly endless lawsuits over false advertising, having allegedly overstated said rates."
+	. = ..()
+	LAZYADD(., "The latest in battery charging technology deploys advanced composites and semiorganic interfaces to attain previously unheard-of charge rates. \
+	The relevant marketing divisions, on the other hand, has been engaged in seeminly endless lawsuits over false advertising, having allegedly overstated said rates.")
 
 /obj/item/stock_parts/power/battery/buildable/responsive
 	name = "battery backup (responsive)"
@@ -245,5 +248,6 @@
 	)
 
 /obj/item/stock_parts/power/battery/buildable/responsive/get_lore_info()
-	return "Unable to compete on price with the larger conglomerates, Focal Point's FOXUS instead sacrifices a bit of charge rate for drastically better responsiveness. \
-	While an instant cult classic in the high-performance market, the FOXUS's bewildering name, lackluster marketing effort, and steep price have kept it from becoming a household name."
+	. = ..()
+	LAZYADD(., "Unable to compete on price with the larger conglomerates, Focal Point's FOXUS instead sacrifices a bit of charge rate for drastically better responsiveness. \
+	While an instant cult classic in the high-performance market, the FOXUS's bewildering name, lackluster marketing effort, and steep price have kept it from becoming a household name.")

--- a/code/game/machinery/atmoalter/canister.dm
+++ b/code/game/machinery/atmoalter/canister.dm
@@ -15,6 +15,7 @@
 		/decl/material/solid/metal/steel = 10 * SHEET_MATERIAL_AMOUNT
 	)
 	uncreated_component_parts  = null
+	_atom_codex_value = /datum/codex_entry/atmos_canister
 	var/valve_open             = FALSE
 	var/release_pressure       = ONE_ATMOSPHERE
 	var/release_flow_rate      = ATMOS_DEFAULT_VOLUME_PUMP //in L/s

--- a/code/game/machinery/atmoalter/meter.dm
+++ b/code/game/machinery/atmoalter/meter.dm
@@ -8,6 +8,8 @@
 	power_channel = ENVIRON
 	idle_power_usage = 15
 
+	_atom_codex_value = /datum/codex_entry/atmos_meter
+
 	uncreated_component_parts = list(
 		/obj/item/stock_parts/power/apc
 	)

--- a/code/game/machinery/atmoalter/pump.dm
+++ b/code/game/machinery/atmoalter/pump.dm
@@ -8,6 +8,7 @@
 	base_type = /obj/machinery/portable_atmospherics/powered/pump
 	atom_flags = ATOM_FLAG_CLIMBABLE
 	movable_flags = MOVABLE_FLAG_WHEELED
+	_atom_codex_value = /datum/codex_entry/atmos_power_pump
 
 	var/direction_out = 0 //0 = siphoning, 1 = releasing
 	var/target_pressure = ONE_ATMOSPHERE

--- a/code/game/machinery/atmoalter/scrubber.dm
+++ b/code/game/machinery/atmoalter/scrubber.dm
@@ -1,6 +1,6 @@
 /obj/machinery/portable_atmospherics/powered/scrubber
 	name = "portable air scrubber"
-
+	_atom_codex_value = /datum/codex_entry/atmos_power_scrubber
 	icon = 'icons/obj/atmos.dmi'
 	icon_state = "pscrubber:0"
 	density = TRUE

--- a/code/game/machinery/bodyscanner.dm
+++ b/code/game/machinery/bodyscanner.dm
@@ -1,7 +1,5 @@
 // Pretty much everything here is stolen from the dna scanner FYI
 /obj/machinery/bodyscanner
-	var/mob/living/human/occupant
-	var/locked
 	name = "body scanner"
 	icon = 'icons/obj/Cryogenic2.dmi'
 	icon_state = "body_scanner_0"
@@ -11,8 +9,11 @@
 	active_power_usage = 10000	//10 kW. It's a big all-body scanner.
 	construct_state = /decl/machine_construction/default/panel_closed
 	uncreated_component_parts = null
+	_atom_codex_value = /datum/codex_entry/bodyscanner
 	var/open_sound = 'sound/machines/podopen.ogg'
 	var/close_sound = 'sound/machines/podclose.ogg'
+	var/mob/living/human/occupant
+	var/locked
 
 // Don't dump out the occupant!
 /obj/machinery/bodyscanner/proc/dump_obj_contents()

--- a/code/game/machinery/computer/Operating.dm
+++ b/code/game/machinery/computer/Operating.dm
@@ -6,6 +6,7 @@
 	anchored = TRUE
 	icon_keyboard = "med_key"
 	icon_screen = "crew"
+	_atom_codex_value = /datum/codex_entry/operating
 	var/mob/living/human/victim = null
 	var/obj/machinery/optable/table = null
 

--- a/code/game/machinery/computer/buildandrepair.dm
+++ b/code/game/machinery/computer/buildandrepair.dm
@@ -5,6 +5,7 @@
 	icon = 'icons/obj/items/stock_parts/stock_parts.dmi'
 	icon_state = "unwired"
 	expected_machine_type = "computer"
+	_atom_codex_value = /datum/codex_entry/computer
 
 /obj/machinery/constructable_frame/computerframe/on_update_icon()
 	overlays.Cut()

--- a/code/game/machinery/computer/computer.dm
+++ b/code/game/machinery/computer/computer.dm
@@ -10,14 +10,15 @@
 	uncreated_component_parts = null
 	stat_immune = 0
 	frame_type = /obj/machinery/constructable_frame/computerframe/deconstruct
+	atom_flags = ATOM_FLAG_CLIMBABLE
+	clicksound = "keyboard"
+	_atom_codex_value = /datum/codex_entry/computer
 
 	var/icon_keyboard = "generic_key"
 	var/icon_screen = "generic"
 	var/light_range_on = 2
 	var/light_power_on = 1
 	var/overlay_layer
-	atom_flags = ATOM_FLAG_CLIMBABLE
-	clicksound = "keyboard"
 
 /obj/machinery/computer/Initialize()
 	. = ..()

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -164,6 +164,7 @@
 	density = TRUE
 	anchored = TRUE
 	dir = WEST
+	_atom_codex_value = /datum/codex_entry/cryopod
 
 	var/base_icon_state = "body_scanner_0"
 	var/occupied_icon_state = "body_scanner_1"

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -21,6 +21,7 @@
 	icon_state_open   = "open"
 	icon_state_closed = "closed"
 	material = /decl/material/solid/metal/steel
+	_atom_codex_value = /datum/codex_entry/airlock
 
 	var/aiControlDisabled = 0 //If 1, AI control is disabled until the AI hacks back in and disables the lock. If 2, the AI has bypassed the lock. If -1, the control is enabled but the AI had bypassed it earlier, so if it is disabled again the AI would have no trouble getting back in.
 	var/hackProof = 0 // if 1, this door can't be hacked by the AI
@@ -88,6 +89,7 @@
 	var/sparks_broken_file  = 'icons/obj/doors/station/sparks_broken.dmi'
 	var/welded_file         = 'icons/obj/doors/station/welded.dmi'
 	var/emag_file           = 'icons/obj/doors/station/emag.dmi'
+
 
 /obj/machinery/door/airlock/Process()
 	if(main_power_lost_until > 0 && world.time >= main_power_lost_until)

--- a/code/game/machinery/emitter.dm
+++ b/code/game/machinery/emitter.dm
@@ -9,6 +9,7 @@
 	density = TRUE
 	initial_access = list(access_engine_equip)
 	active_power_usage = 100 KILOWATTS
+	_atom_codex_value = /datum/codex_entry/emitter
 
 	var/efficiency = 0.3	// Energy efficiency. 30% at this time, so 100kW load means 30kW laser pulses.
 	var/minimum_power = 10 KILOWATTS // The minimum power below which the emitter will turn off; different than the power needed to fire.

--- a/code/game/machinery/jukebox.dm
+++ b/code/game/machinery/jukebox.dm
@@ -3,7 +3,6 @@
 	desc = "An immense, standalone touchscreen on a swiveling base, equipped with phased array speakers. Embossed on one corner of the ultrathin bezel is the brand name, 'Leitmotif Enterprise Edition'."
 	icon = 'icons/obj/jukebox_new.dmi'
 	icon_state = "jukebox3-nopower"
-	var/state_base = "jukebox3"
 	anchored = TRUE
 	density = TRUE
 	power_channel = EQUIP
@@ -11,17 +10,16 @@
 	active_power_usage = 100
 	clicksound = 'sound/machines/buttonbeep.ogg'
 	pixel_x = -8
-
 	uncreated_component_parts = null
 	stat_immune = 0
 	construct_state = /decl/machine_construction/default/panel_closed
+	_atom_codex_value = /datum/codex_entry/jukebox
 
+	var/state_base = "jukebox3"
 	var/playing = 0
 	var/music_volume = 20
-
 	var/sound_id
 	var/datum/sound_token/sound_token
-
 	var/datum/track/current_track
 	var/list/datum/track/tracks
 

--- a/code/game/machinery/slide_projector.dm
+++ b/code/game/machinery/slide_projector.dm
@@ -24,7 +24,7 @@
 
 /obj/item/slide_projector/get_mechanics_info()
 	. = ..()
-	. += "Use in hand to open the interface."
+	LAZYADD(., "Use in hand to open the interface.")
 
 /obj/item/slide_projector/afterattack(atom/target, mob/user, proximity_flag, click_parameters)
 	if(!current_slide)

--- a/code/game/machinery/vending/_vending.dm
+++ b/code/game/machinery/vending/_vending.dm
@@ -19,6 +19,7 @@
 	emagged = 0 //Ignores if somebody doesn't have card access to that machine.
 	wires = /datum/wires/vending
 	required_interaction_dexterity = DEXTERITY_SIMPLE_MACHINES
+	_atom_codex_value = /datum/codex_entry/vending
 
 	// Power
 	var/vend_power_usage = 150 //actuators and stuff

--- a/code/game/machinery/vending_deconstruction.dm
+++ b/code/game/machinery/vending_deconstruction.dm
@@ -15,10 +15,12 @@
 	. = ..()
 
 /obj/structure/vending_refill/get_lore_info()
-	return "Vendor restock containers are notoriously difficult to open, representing the pinnacle of humanity's antitheft technologies."
+	. = ..()
+	LAZYADD(., "Vendor restock containers are notoriously difficult to open, representing the pinnacle of humanity's antitheft technologies.")
 
 /obj/structure/vending_refill/get_mechanics_info()
-	return "Drag to a vendor to restock. Generally can not be opened."
+	. = ..()
+	LAZYADD(., "Drag to a vendor to restock. Generally cannot be opened.")
 
 /obj/structure/vending_refill/handle_mouse_drop(atom/over, mob/user, params)
 	if(istype(over, /obj/machinery/vending))

--- a/code/game/objects/__objs.dm
+++ b/code/game/objects/__objs.dm
@@ -507,8 +507,3 @@
 	if(anchored)
 		return FALSE
 	return ..()
-
-/obj/get_lore_info()
-	. = list()
-	if(desc && simulated && !INSTANCE_IS_ABSTRACT(src))
-		LAZYADD(., desc)

--- a/code/game/objects/__objs.dm
+++ b/code/game/objects/__objs.dm
@@ -507,3 +507,8 @@
 	if(anchored)
 		return FALSE
 	return ..()
+
+/obj/get_lore_info()
+	. = list()
+	if(desc && simulated && !INSTANCE_IS_ABSTRACT(src))
+		LAZYADD(., desc)

--- a/code/game/objects/items/blades/spear.dm
+++ b/code/game/objects/items/blades/spear.dm
@@ -8,3 +8,4 @@
 	attack_verb   = list("attacked", "poked", "jabbed", "torn", "gored")
 	does_spin     = FALSE
 	abstract_type = /obj/item/bladed/polearm/spear
+	_atom_codex_value = /datum/codex_entry/spear

--- a/code/game/objects/items/books/_book.dm
+++ b/code/game/objects/items/books/_book.dm
@@ -8,6 +8,7 @@
 	attack_verb = list("bashed", "whacked", "educated")
 	material = /decl/material/solid/organic/plastic
 	matter = list(/decl/material/solid/organic/paper = MATTER_AMOUNT_REINFORCEMENT)
+	_atom_codex_value = /datum/codex_entry/writing
 
 	/// Actual page content
 	var/dat

--- a/code/game/objects/items/books/skill/_skill.dm
+++ b/code/game/objects/items/books/skill/_skill.dm
@@ -13,6 +13,7 @@ Skill books that increase your skills while you activate and hold them
 	material = /decl/material/solid/organic/plastic
 	matter = list(/decl/material/solid/organic/wood/oak = MATTER_AMOUNT_REINFORCEMENT)
 	abstract_type = /obj/item/book/skill
+	_atom_codex_value = /datum/codex_entry/textbook
 
 	var/decl/skill/skill       // e.g. SKILL_LITERACY
 	var/skill_req = SKILL_NONE           // The level the user needs in the skill to benefit from the book, e.g. SKILL_PROF

--- a/code/game/objects/items/cryobag.dm
+++ b/code/game/objects/items/cryobag.dm
@@ -13,6 +13,7 @@
 		/decl/material/solid/metal/gold = MATTER_AMOUNT_TRACE
 	)
 	bag_type = /obj/structure/closet/body_bag/cryobag
+	_atom_codex_value = /datum/codex_entry/cryobag
 	var/stasis_power
 
 /obj/item/bodybag/cryobag/get_cryogenic_power()
@@ -32,8 +33,8 @@
 	item_path = /obj/item/bodybag/cryobag
 	material = /decl/material/solid/organic/plastic
 	storage_types = CLOSET_STORAGE_MOBS
+	_atom_codex_value = /datum/codex_entry/cryobag
 	var/datum/gas_mixture/airtank
-
 	var/stasis_power = 20
 	var/degradation_time = 150 //ticks until stasis power degrades, ~5 minutes
 

--- a/code/game/objects/items/devices/auto_cpr.dm
+++ b/code/game/objects/items/devices/auto_cpr.dm
@@ -14,6 +14,7 @@
 		/decl/material/solid/metal/uranium   = MATTER_AMOUNT_TRACE,
 		/decl/material/solid/metal/lead      = MATTER_AMOUNT_TRACE,
 	)
+	_atom_codex_value = /datum/codex_entry/autopump
 	var/last_pump
 	var/skilled_setup
 

--- a/code/game/objects/items/devices/cable_painter.dm
+++ b/code/game/objects/items/devices/cable_painter.dm
@@ -3,9 +3,10 @@
 	desc = "A device for repainting cables."
 	icon = 'icons/obj/items/hand_labeler.dmi'
 	icon_state = ICON_STATE_WORLD
-	var/color_selection
 	w_class = ITEM_SIZE_SMALL
 	material = /decl/material/solid/organic/plastic
+	_atom_codex_value = /datum/codex_entry/cable_painter
+	var/color_selection
 
 /obj/item/cable_painter/Initialize()
 	. = ..()

--- a/code/game/objects/items/devices/geiger.dm
+++ b/code/game/objects/items/devices/geiger.dm
@@ -19,6 +19,8 @@
 		/decl/material/solid/metal/aluminium = MATTER_AMOUNT_REINFORCEMENT,
 		/decl/material/solid/glass           = MATTER_AMOUNT_TRACE,
 	)
+	_atom_codex_value = /datum/codex_entry/geiger_counter
+
 	var/scanning = 0
 	var/radiation_count = 0
 	var/datum/sound_token/sound_token

--- a/code/game/objects/items/devices/multitool.dm
+++ b/code/game/objects/items/devices/multitool.dm
@@ -17,7 +17,7 @@
 		/decl/material/solid/fiberglass = MATTER_AMOUNT_REINFORCEMENT,
 		/decl/material/solid/metal/steel = MATTER_AMOUNT_TRACE
 	)
-
+	_atom_codex_value = /datum/codex_entry/multitool
 	origin_tech = @'{"magnets":1,"engineering":1}'
 
 	var/buffer_name

--- a/code/game/objects/items/devices/paint_sprayer.dm
+++ b/code/game/objects/items/devices/paint_sprayer.dm
@@ -8,6 +8,8 @@
 	icon_state = ICON_STATE_WORLD
 	desc = "A slender and none-too-sophisticated device capable of applying paint on floors, walls, exosuits and certain airlocks."
 	material = /decl/material/solid/metal/stainlesssteel
+	_atom_codex_value = /datum/codex_entry/paint_sprayer
+
 	var/decal =        "Quarter-turf"
 	var/paint_dir =    "Precise"
 	var/spray_color = COLOR_GRAY15

--- a/code/game/objects/items/devices/suit_cooling.dm
+++ b/code/game/objects/items/devices/suit_cooling.dm
@@ -5,6 +5,7 @@
 	icon = 'icons/obj/items/suitcooler.dmi'
 	icon_state = ICON_STATE_WORLD
 	slot_flags = SLOT_BACK
+	_atom_codex_value = /datum/codex_entry/suitcooler
 
 	//copied from tank.dm
 	obj_flags = OBJ_FLAG_CONDUCTIBLE

--- a/code/game/objects/items/devices/t_scanner.dm
+++ b/code/game/objects/items/devices/t_scanner.dm
@@ -10,13 +10,12 @@
 	material = /decl/material/solid/metal/aluminium
 	origin_tech = @'{"magnets":1,"engineering":1}'
 	action_button_name = "Toggle T-Ray scanner"
+	_atom_codex_value = /datum/codex_entry/t_scanner
 
 	var/scan_range = 3
-
 	var/on = 0
 	var/list/active_scanned = list() //assoc list of objects being scanned, mapped to their overlay
 	var/client/user_client //since making sure overlays are properly added and removed is pretty important, so we track the current user explicitly
-
 	var/static/list/overlay_cache = list() //cache recent overlays
 
 /obj/item/t_scanner/Destroy()

--- a/code/game/objects/items/devices/transfer_valve.dm
+++ b/code/game/objects/items/devices/transfer_valve.dm
@@ -4,13 +4,15 @@
 	icon = 'icons/obj/assemblies.dmi'
 	icon_state = "valve_1"
 	material = /decl/material/solid/metal/stainlesssteel
+	movable_flags = MOVABLE_FLAG_PROXMOVE
+	_atom_codex_value = /datum/codex_entry/transfer_valve
+
 	var/obj/item/tank/tank_one
 	var/obj/item/tank/tank_two
 	var/obj/item/assembly/attached_device
 	var/weakref/attacher_ref = null
 	var/valve_open = 0
 	var/toggle = 1
-	movable_flags = MOVABLE_FLAG_PROXMOVE
 
 /obj/item/transfer_valve/Destroy()
 	if(!QDELETED(tank_one))

--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -34,6 +34,7 @@
 	desc = "You shouldn't be seeing this!"
 	icon = 'icons/obj/modules/module_cyborg_2.dmi'
 	require_module = 0
+	_atom_codex_value = /datum/codex_entry/uncertified_module
 	var/new_module = null
 
 /obj/item/borg/upgrade/uncertified/action(var/mob/living/silicon/robot/robot)

--- a/code/game/objects/items/stacks/rods.dm
+++ b/code/game/objects/items/stacks/rods.dm
@@ -19,6 +19,7 @@
 	crafting_stack_type  = /obj/item/stack/material/rods
 	pickup_sound         = 'sound/foley/tooldrop3.ogg'
 	drop_sound           = 'sound/foley/tooldrop2.ogg'
+	_atom_codex_value    = /datum/codex_entry/rods
 
 /obj/item/stack/material/rods/get_autopsy_descriptors()
 	. = ..()

--- a/code/game/objects/items/stacks/telecrystal.dm
+++ b/code/game/objects/items/stacks/telecrystal.dm
@@ -8,6 +8,7 @@
 	max_amount = 50
 	item_flags = ITEM_FLAG_NO_BLUDGEON
 	origin_tech = @'{"materials":6,"wormholes":4}'
+	_atom_codex_value = /datum/codex_entry/telecrystal
 
 /obj/item/stack/telecrystal/afterattack(var/obj/item/I, mob/user, proximity)
 	if(!proximity)

--- a/code/game/objects/items/tools/crowbar.dm
+++ b/code/game/objects/items/tools/crowbar.dm
@@ -14,6 +14,8 @@
 	material_alteration = MAT_FLAG_ALTERATION_COLOR
 	drop_sound = 'sound/foley/bardrop1.ogg'
 	item_flags = ITEM_FLAG_IS_WEAPON
+	_atom_codex_value = /datum/codex_entry/crowbar
+
 	var/static/valid_colours = list(COLOR_RED_GRAY, COLOR_MAROON, COLOR_DARK_BROWN, COLOR_GRAY20)
 	var/handle_color
 	var/shape_variations = 1

--- a/code/game/objects/items/tools/screwdriver.dm
+++ b/code/game/objects/items/tools/screwdriver.dm
@@ -12,6 +12,7 @@
 	sharp = TRUE
 	material_alteration = MAT_FLAG_ALTERATION_COLOR
 	drop_sound = 'sound/foley/singletooldrop2.ogg'
+	_atom_codex_value = /datum/codex_entry/screwdriver
 
 	var/static/valid_colours = list(COLOR_RED, COLOR_CYAN_BLUE, COLOR_PURPLE, COLOR_CHESTNUT, COLOR_ASSEMBLY_YELLOW, COLOR_BOTTLE_GREEN)
 	var/handle_color

--- a/code/game/objects/items/tools/wirecutter.dm
+++ b/code/game/objects/items/tools/wirecutter.dm
@@ -13,6 +13,7 @@
 	edge = TRUE
 	material_alteration = MAT_FLAG_ALTERATION_COLOR
 	drop_sound = 'sound/foley/singletooldrop1.ogg'
+	_atom_codex_value = /datum/codex_entry/wirecutters
 
 	var/handle_color
 	var/static/valid_colours = list(COLOR_RED, COLOR_MAROON, COLOR_SEDONA, PIPE_COLOR_YELLOW, COLOR_BABY_BLUE)

--- a/code/game/objects/items/tools/wrench.dm
+++ b/code/game/objects/items/tools/wrench.dm
@@ -11,6 +11,7 @@
 	attack_verb = list("bashed", "battered", "bludgeoned", "whacked")
 	material_alteration = MAT_FLAG_ALTERATION_COLOR
 	drop_sound = 'sound/foley/bardrop1.ogg'
+	_atom_codex_value = /datum/codex_entry/wrench
 	var/handle_color
 	var/static/list/valid_colours = list(COLOR_RED_GRAY, COLOR_MAROON, COLOR_DARK_BROWN, COLOR_GRAY20)
 

--- a/code/game/objects/items/weapons/RCD.dm
+++ b/code/game/objects/items/weapons/RCD.dm
@@ -16,6 +16,8 @@
 	origin_tech = @'{"engineering":4,"materials":2}'
 	material = /decl/material/solid/metal/steel
 	_base_attack_force = 10
+	_atom_codex_value = /datum/codex_entry/rcd
+
 	var/stored_matter = 0
 	var/max_stored_matter = 120
 	var/work_id = 0

--- a/code/game/objects/items/weapons/melee/energy_sword.dm
+++ b/code/game/objects/items/weapons/melee/energy_sword.dm
@@ -4,6 +4,7 @@
 	icon = 'icons/obj/items/weapon/e_sword.dmi'
 	origin_tech = @'{"magnets":3,"esoteric":4}'
 	active_parry_chance = 50
+	_atom_codex_value = /datum/codex_entry/energy_sword
 
 	var/blade_color
 	var/static/list/blade_colors = list(

--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -100,6 +100,7 @@
 	overlay_flags = BELT_OVERLAY_ITEMS
 	storage = /datum/storage/belt/utility
 	material = /decl/material/solid/organic/leather
+	_atom_codex_value = /datum/codex_entry/toolbelt
 
 /obj/item/belt/utility/full/WillContain()
 	return list(

--- a/code/game/objects/items/weapons/storage/toolbox.dm
+++ b/code/game/objects/items/weapons/storage/toolbox.dm
@@ -14,6 +14,7 @@
 	attack_verb = "robusted"
 	material = /decl/material/solid/metal/aluminium
 	_base_attack_force = 20
+	_atom_codex_value = /datum/codex_entry/toolbox
 
 /obj/item/toolbox/emergency
 	name = "emergency toolbox"

--- a/code/game/objects/items/weapons/stunbaton.dm
+++ b/code/game/objects/items/weapons/stunbaton.dm
@@ -17,6 +17,7 @@
 	)
 	item_flags = ITEM_FLAG_IS_WEAPON
 	_base_attack_force = 15
+	_atom_codex_value = /datum/codex_entry/baton
 	var/stunforce = 0
 	var/agonyforce = 30
 	var/status = 0		//whether the thing is on or not

--- a/code/game/objects/items/weapons/tanks/tanks.dm
+++ b/code/game/objects/items/weapons/tanks/tanks.dm
@@ -32,6 +32,7 @@ var/global/list/global/tank_gauge_cache = list()
 	throw_speed = 1
 	throw_range = 4
 	_base_attack_force = 15
+	_atom_codex_value = /datum/codex_entry/gas_tank
 
 	var/gauge_icon = "indicator_tank"
 	var/gauge_cap = 6

--- a/code/game/objects/items/welding/weldbackpack.dm
+++ b/code/game/objects/items/welding/weldbackpack.dm
@@ -70,6 +70,7 @@
 	w_class     = ITEM_SIZE_HUGE
 	atom_flags  = ATOM_FLAG_OPEN_CONTAINER
 	chem_volume = 350
+	_atom_codex_value = /datum/codex_entry/welding_pack
 	var/obj/item/weldingtool/weldpack/welder = /obj/item/weldingtool/weldpack
 
 // Duplicated from welder tanks.

--- a/code/game/objects/items/welding/weldingtool.dm
+++ b/code/game/objects/items/welding/weldingtool.dm
@@ -18,6 +18,8 @@
 	drop_sound                          = 'sound/foley/tooldrop1.ogg'
 	z_flags                             = ZMM_MANGLE_PLANES
 	attack_cooldown                     = DEFAULT_ATTACK_COOLDOWN
+	_atom_codex_value                   = /datum/codex_entry/welder
+
 	var/lit_colour                      = COLOR_PALE_ORANGE
 	var/waterproof                      = FALSE
 	var/welding                         = FALSE 	//Whether or not the welding tool is off(0), on(1) or currently welding(2)

--- a/code/game/objects/structures/barricade.dm
+++ b/code/game/objects/structures/barricade.dm
@@ -9,6 +9,7 @@
 	layer = ABOVE_WINDOW_LAYER
 	material_alteration = MAT_FLAG_ALTERATION_ALL
 	max_health = 100
+	_atom_codex_value = /datum/codex_entry/cheval
 
 	var/spike_damage //how badly it smarts when you run into this like a rube
 	var/list/poke_description = list("gored", "spiked", "speared", "stuck", "stabbed")

--- a/code/game/objects/structures/barsign.dm
+++ b/code/game/objects/structures/barsign.dm
@@ -7,6 +7,7 @@
 	anchored = TRUE
 	obj_flags = OBJ_FLAG_MOVES_UNSUPPORTED
 	directional_offset = @'{"NORTH":{"y":-32}, "SOUTH":{"y":32}, "EAST":{"x":-32}, "WEST":{"x":32}}'
+	_atom_codex_value = /datum/codex_entry/barsign
 	var/cult = 0
 
 /obj/structure/sign/double/barsign/proc/get_valid_states(initial=1)

--- a/code/game/objects/structures/beds/bed.dm
+++ b/code/game/objects/structures/beds/bed.dm
@@ -17,6 +17,7 @@
 	user_comfort = 1
 	obj_flags = OBJ_FLAG_SUPPORT_MOB
 	monetary_worth_multiplier = 2.5 // Utility structures should be worth more than their matter (wheelchairs, rollers, etc).
+	_atom_codex_value = /datum/codex_entry/bed
 	/// The padding extension type for this bed. If null, no extension is created and this bed cannot be padded.
 	var/padding_extension_type = /datum/extension/padding
 	var/decl/material/initial_padding_material

--- a/code/game/objects/structures/crematorium.dm
+++ b/code/game/objects/structures/crematorium.dm
@@ -15,7 +15,8 @@
 	var/id_tag
 
 /obj/structure/crematorium/get_mechanics_info()
-	return "[..()]<BR>Can be labeled once with a hand labeler."
+	. = ..()
+	LAZYADD(., "Can be labeled once with a hand labeler.")
 
 /obj/structure/crematorium/Initialize(ml, _mat, _reinf_mat)
 	. = ..()

--- a/code/game/objects/structures/girders.dm
+++ b/code/game/objects/structures/girders.dm
@@ -12,6 +12,7 @@
 	material = /decl/material/solid/metal/steel
 	parts_amount = 5
 	parts_type = /obj/item/stack/material/rods
+	_atom_codex_value = /datum/codex_entry/girder
 
 	var/cover = 50
 	var/prepped_for_fakewall

--- a/code/game/objects/structures/grille.dm
+++ b/code/game/objects/structures/grille.dm
@@ -13,6 +13,7 @@
 	material = /decl/material/solid/metal/steel
 	parts_type = /obj/item/stack/material/rods
 	parts_amount = 2
+	_atom_codex_value = /datum/codex_entry/grille
 
 	handle_generic_blending = TRUE
 	material_alteration = MAT_FLAG_ALTERATION_COLOR | MAT_FLAG_ALTERATION_NAME

--- a/code/game/objects/structures/inflatable.dm
+++ b/code/game/objects/structures/inflatable.dm
@@ -5,6 +5,7 @@
 	icon_state = "folded_wall"
 	material = /decl/material/solid/organic/plastic
 	w_class = ITEM_SIZE_NORMAL
+	_atom_codex_value = /datum/codex_entry/inflatable_item
 	var/deploy_path = /obj/structure/inflatable/wall
 	var/inflatable_health
 
@@ -45,6 +46,7 @@
 	hitsound = 'sound/effects/Glasshit.ogg'
 	atmos_canpass = CANPASS_DENSITY
 	material = /decl/material/solid/organic/plastic
+	_atom_codex_value = /datum/codex_entry/inflatable_item
 
 	var/undeploy_path = null
 	var/taped

--- a/code/game/objects/structures/lattice.dm
+++ b/code/game/objects/structures/lattice.dm
@@ -11,6 +11,7 @@
 	material = /decl/material/solid/metal/steel
 	obj_flags = OBJ_FLAG_NOFALL | OBJ_FLAG_MOVES_UNSUPPORTED
 	material_alteration = MAT_FLAG_ALTERATION_ALL
+	_atom_codex_value = /datum/codex_entry/lattice
 
 /obj/structure/lattice/Initialize(mapload)
 	. = ..()

--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -11,7 +11,8 @@
 	var/obj/structure/morgue_tray/connected_tray
 
 /obj/structure/morgue/get_mechanics_info()
-	return "[..()]<BR>Can be labeled once with a hand labeler."
+	. = ..()
+	LAZYADD(., "Can be labeled once with a hand labeler.")
 
 /obj/structure/morgue/Initialize(ml, _mat, _reinf_mat)
 	. = ..()

--- a/code/game/turfs/walls/_wall.dm
+++ b/code/game/turfs/walls/_wall.dm
@@ -31,6 +31,7 @@ var/global/list/wall_fullblend_objects = list(
 	initial_gas = GAS_STANDARD_AIRMIX
 	zone_membership_candidate = TRUE
 	layer = TURF_OVER_EDGE_LAYER
+	_atom_codex_value = /datum/codex_entry/wall
 
 	/// If set, will prevent merges between walls with different IDs.
 	var/unique_merge_identifier

--- a/code/modules/atmospherics/components/binary_devices/passive_gate.dm
+++ b/code/modules/atmospherics/components/binary_devices/passive_gate.dm
@@ -7,6 +7,8 @@
 	icon_state = "map_off"
 	level = LEVEL_BELOW_PLATING
 
+	_atom_codex_value = /datum/codex_entry/atmos_gate
+
 	name = "pressure regulator"
 	desc = "A one-way air valve that can be used to regulate input or output pressure, and flow rate. Does not require power."
 

--- a/code/modules/atmospherics/components/binary_devices/pump.dm
+++ b/code/modules/atmospherics/components/binary_devices/pump.dm
@@ -17,6 +17,8 @@ Thus, the two variables affect pump operation are set in New():
 	icon_state = "map_off"
 	level = LEVEL_BELOW_PLATING
 
+	_atom_codex_value = /datum/codex_entry/atmos_pump
+
 	name = "gas pump"
 	desc = "A pump that can pressurize gas and restrict flow to one direction."
 

--- a/code/modules/atmospherics/components/omni_devices/filter.dm
+++ b/code/modules/atmospherics/components/omni_devices/filter.dm
@@ -6,6 +6,7 @@
 	desc = "A device that can separate components of a gas mixture and redirect them to different pipes."
 	icon_state = "map_filter"
 	core_icon = "filter"
+	_atom_codex_value = /datum/codex_entry/atmos_omni_filter
 
 	var/list/gas_filters = new()
 	var/datum/omni_port/input

--- a/code/modules/atmospherics/components/omni_devices/mixer.dm
+++ b/code/modules/atmospherics/components/omni_devices/mixer.dm
@@ -6,6 +6,7 @@
 	desc = "A device that combines two or more gases to produce a mix with a specific ratio."
 	icon_state = "map_mixer"
 	core_icon = "mixer"
+	_atom_codex_value = /datum/codex_entry/atmos_omni_mixer
 
 	idle_power_usage = 150		//internal circuitry, friction losses and stuff
 	power_rating = 15000			// 15000 W ~ 20 HP

--- a/code/modules/atmospherics/components/tvalve.dm
+++ b/code/modules/atmospherics/components/tvalve.dm
@@ -1,6 +1,8 @@
 /obj/machinery/atmospherics/tvalve
 	icon = 'icons/atmos/tvalve.dmi'
 	icon_state = "map_tvalve0"
+	_atom_codex_value = /datum/codex_entry/atmos_tvalve
+
 	var/base_icon_state = "tvalve"
 
 	name = "manual switching valve"

--- a/code/modules/atmospherics/components/unary/cold_sink.dm
+++ b/code/modules/atmospherics/components/unary/cold_sink.dm
@@ -10,6 +10,7 @@
 	base_type = /obj/machinery/atmospherics/unary/temperature/freezer
 	ui_title = "Gas Cooling System"
 	performance_multiplier = FREEZER_PERF_MULT
+	_atom_codex_value = /datum/codex_entry/atmos_freezer
 	var/heatsink_temperature = T20C	// The constant temperature reservoir into which the freezer pumps heat. Probably the hull of the station or something.
 
 /obj/machinery/atmospherics/unary/temperature/freezer/get_temperature_class()

--- a/code/modules/atmospherics/components/unary/heat_source.dm
+++ b/code/modules/atmospherics/components/unary/heat_source.dm
@@ -9,6 +9,7 @@
 	base_icon_state = "heater"
 	base_type = /obj/machinery/atmospherics/unary/temperature/heater
 	performance_multiplier = HEATER_PERF_MULT
+	_atom_codex_value = /datum/codex_entry/atmos_heater
 
 /obj/machinery/atmospherics/unary/temperature/heater/should_modify_gas()
 	return air_contents.temperature < set_temperature

--- a/code/modules/atmospherics/components/unary/outlet_injector.dm
+++ b/code/modules/atmospherics/components/unary/outlet_injector.dm
@@ -3,11 +3,12 @@
 //When it receives the "inject" signal, it will try to pump its entire contents into the environment regardless of pressure, using power.
 
 /obj/machinery/atmospherics/unary/outlet_injector
+	name = "injector outlet"
+	desc = "Passively injects air into its surroundings. Has a valve attached to it that can control flow rate."
 	icon = 'icons/atmos/injector.dmi'
 	icon_state = "off"
 
-	name = "injector outlet"
-	desc = "Passively injects air into its surroundings. Has a valve attached to it that can control flow rate."
+	_atom_codex_value = /datum/codex_entry/atmos_injector
 
 	use_power = POWER_USE_OFF
 	idle_power_usage = 150		//internal circuitry, friction losses and stuff

--- a/code/modules/atmospherics/components/unary/vent_pump.dm
+++ b/code/modules/atmospherics/components/unary/vent_pump.dm
@@ -11,6 +11,8 @@
 	icon = 'icons/atmos/vent_pump.dmi'
 	icon_state = "map_vent"
 
+	_atom_codex_value = /datum/codex_entry/atmos_vent_pump
+
 	name = "air vent"
 	desc = "A vent that moves air into or out of the attached pipe system, and uses a valve and pump to prevent backflow."
 	use_power = POWER_USE_OFF

--- a/code/modules/atmospherics/components/unary/vent_scrubber.dm
+++ b/code/modules/atmospherics/components/unary/vent_scrubber.dm
@@ -2,6 +2,8 @@
 	icon = 'icons/atmos/vent_scrubber.dmi'
 	icon_state = "map_scrubber_off"
 
+	_atom_codex_value = /datum/codex_entry/atmos_vent_scrubber
+
 	name = "air scrubber"
 	desc = "Has a valve and pump attached to it."
 	use_power = POWER_USE_OFF

--- a/code/modules/atmospherics/components/valve.dm
+++ b/code/modules/atmospherics/components/valve.dm
@@ -2,6 +2,8 @@
 	icon = 'icons/atmos/valve.dmi'
 	icon_state = "map_valve0"
 
+	_atom_codex_value = /datum/codex_entry/atmos_valve
+
 	name = "manual valve"
 	desc = "A valve that controls flow through a pipe network, and must be operated by hand."
 

--- a/code/modules/atmospherics/pipes.dm
+++ b/code/modules/atmospherics/pipes.dm
@@ -4,6 +4,8 @@
 	name = "atmospherics pipe" // mostly for codex purposes, subtypes will override it
 	abstract_type = /obj/machinery/atmospherics/pipe
 
+	_atom_codex_value = /datum/codex_entry/atmos_pipe
+
 	use_power = POWER_USE_OFF
 	stat_immune = NOSCREEN | NOINPUT | NOPOWER
 	interact_offline = TRUE //Needs to be set so that pipes don't say they lack power in their description

--- a/code/modules/butchery/butchery_products.dm
+++ b/code/modules/butchery/butchery_products.dm
@@ -20,6 +20,9 @@
 	/// A multiplier for the number of slices, when autosetting from butchery_data.
 	var/slices_multiplier = 1
 
+/obj/item/food/butchery/get_mechanics_info()
+	return "Raw meat can be obtained by butchering dead animals on a table or meathook with a sharp object like a knife."
+
 // This contains, specifically, initialisation code that must run before the parent call in Initialize().
 /obj/item/food/butchery/proc/initialize_butchery_data(decl/butchery_data/new_data, new_meat_name)
 	if(new_data)

--- a/code/modules/butchery/butchery_products.dm
+++ b/code/modules/butchery/butchery_products.dm
@@ -21,7 +21,7 @@
 	var/slices_multiplier = 1
 
 /obj/item/food/butchery/get_mechanics_info()
-	return "Raw meat can be obtained by butchering dead animals on a table or meathook with a sharp object like a knife."
+	return "Raw meat can be obtained by butchering dead animals on a table or meathook with a sharp object like a knife.<br>Most butchery products can be sliced or chopped with a knife for use in other recipes."
 
 // This contains, specifically, initialisation code that must run before the parent call in Initialize().
 /obj/item/food/butchery/proc/initialize_butchery_data(decl/butchery_data/new_data, new_meat_name)

--- a/code/modules/butchery/butchery_products.dm
+++ b/code/modules/butchery/butchery_products.dm
@@ -21,7 +21,9 @@
 	var/slices_multiplier = 1
 
 /obj/item/food/butchery/get_mechanics_info()
-	return "Raw meat can be obtained by butchering dead animals on a table or meathook with a sharp object like a knife.<br>Most butchery products can be sliced or chopped with a knife for use in other recipes."
+	. = ..()
+	LAZYADD(., "Raw meat can be obtained by butchering dead animals on a table or meathook with a sharp object like a knife.")
+	LAZYADD(., "Most butchery products can be sliced or chopped with a knife for use in other recipes.")
 
 // This contains, specifically, initialisation code that must run before the parent call in Initialize().
 /obj/item/food/butchery/proc/initialize_butchery_data(decl/butchery_data/new_data, new_meat_name)

--- a/code/modules/butchery/butchery_products_cutlet.dm
+++ b/code/modules/butchery/butchery_products_cutlet.dm
@@ -12,7 +12,6 @@
 	color               = "#81492e"
 	material_alteration = MAT_FLAG_ALTERATION_NONE
 
-
 /obj/item/food/butchery/cutlet/raw
 	desc                           = "A thin piece of raw meat."
 	cooked_food                    = FOOD_RAW

--- a/code/modules/clothing/badges/_badge.dm
+++ b/code/modules/clothing/badges/_badge.dm
@@ -25,9 +25,9 @@
 /obj/item/clothing/badge/get_lore_info()
 	. = ..()
 	if(SScodex.get_codex_entry(badge_string))
-		. += "<br>Denotes affiliation to <l>[badge_string]</l>."
+		LAZYADD(., "Denotes affiliation to <l>[badge_string]</l>.")
 	else
-		. += "<br>Denotes affiliation to [badge_string]."
+		LAZYADD(., "Denotes affiliation to [badge_string].")
 
 /obj/item/clothing/badge/proc/set_name(var/new_name)
 	stored_name = new_name

--- a/code/modules/clothing/shoes/miscellaneous.dm
+++ b/code/modules/clothing/shoes/miscellaneous.dm
@@ -160,6 +160,7 @@
 	desc = "The height of fashion, and they're pre-polished. Upon further inspection, the soles appear to be on backwards. They look uncomfortable."
 	move_trail = /obj/effect/decal/cleanable/blood/tracks/footprints/reversed
 	item_flags = ITEM_FLAG_SILENT
+	_atom_codex_value = /datum/codex_entry/sneakies
 
 /obj/item/clothing/shoes/heels
 	name = "high heels"

--- a/code/modules/codex/categories/category_recipes.dm
+++ b/code/modules/codex/categories/category_recipes.dm
@@ -125,7 +125,11 @@
 			product_name = initial(recipe_product.name)
 			lore_text ||= initial(recipe_product.desc)
 		product_link ||= "\a [product_name]"
-		mechanics_text += "<br>This recipe takes [ceil(recipe.cooking_time/(1 SECOND))] second\s to cook in [english_list(cooking_methods, and_text = " or ")] and creates [product_link]."
+		var/cook_string = english_list(cooking_methods, and_text = " or ")
+		if(cook_string)
+			mechanics_text += "<br>This recipe takes [ceil(recipe.cooking_time/(1 SECOND))] second\s to cook in [cook_string] and creates [product_link]."
+		else
+			mechanics_text += "<br>This recipe takes [ceil(recipe.cooking_time/(1 SECOND))] second\s to cook in a microwave and creates [product_link]."
 
 		var/recipe_name = recipe.display_name || sanitize(product_name)
 		guide_html += "<h3>[capitalize(recipe_name)]</h3>Cook [english_list(ingredients)] for [ceil(recipe.cooking_time/(1 SECOND))] second\s."

--- a/code/modules/codex/categories/category_recipes.dm
+++ b/code/modules/codex/categories/category_recipes.dm
@@ -97,7 +97,7 @@
 			if(SScodex.get_entry_by_string(thing_name))
 				thing_name = "<l>[thing_name]</l>"
 			else
-				var/datum/codex_entry/result_entry = SScodex.get_codex_entry(thing)
+				var/datum/codex_entry/result_entry = SScodex.get_codex_entry(thing) || atom_info_repository.get_codex_page_for(thing)
 				if(result_entry)
 					thing_name = "<span codexlink='[result_entry.name]'>[thing_name]</span>"
 			ingredients += (count > 1) ? "[count]x [thing_name]" : "\a [thing_name]"

--- a/code/modules/codex/categories/category_recipes.dm
+++ b/code/modules/codex/categories/category_recipes.dm
@@ -94,21 +94,20 @@
 			var/count = recipe.items[thing]
 			var/thing_name = initial(thing.name)
 
-			var/datum/codex_entry/thing_entry = SScodex.get_codex_entry(thing)
+			var/datum/codex_entry/thing_entry
 			if(ispath(thing, /atom/movable) && TYPE_IS_SPAWNABLE(thing))
 				thing_name = atom_info_repository.get_name_for(thing)
-				thing_entry = atom_info_repository.get_codex_page_for(thing)
+				thing_entry ||= atom_info_repository.get_codex_page_for(thing)
 
-			if(SScodex.get_entry_by_string(thing_name))
-				thing_name = "<l>[thing_name]</l>"
-			else
-				thing_entry ||= SScodex.get_codex_entry(thing_name, do_search = TRUE)
-				if(thing_entry)
-					thing_name = "<span codexlink='[thing_entry.name]'>[thing_name]</span>"
+			thing_entry ||= SScodex.get_codex_entry(thing_name, do_search = TRUE)
+			if(thing_entry)
+				thing_name = "<span codexlink='[thing_entry.name]'>[thing_name]</span>"
 
 			ingredients += (count > 1) ? "[count]x [thing_name]" : "\a [thing_name]"
+
 		for(var/thing in recipe.fruit)
-			ingredients += "[recipe.fruit[thing]] [thing]\s"
+			ingredients += "[recipe.fruit[thing]] <span codexlink='[/datum/codex_entry/fruit_and_veg::name]'>[thing]\s</span>"
+
 		mechanics_text += "<ul><li>[jointext(ingredients, "</li><li>")]</li></ul>"
 
 		var/list/cooking_methods = list()
@@ -131,9 +130,8 @@
 			product_name = initial(recipe_product.name)
 			lore_text ||= initial(recipe_product.desc)
 		product_link ||= "\a [product_name]"
-		var/cook_string = english_list(cooking_methods, and_text = " or ")
-		if(cook_string)
-			mechanics_text += "<br>This recipe takes [ceil(recipe.cooking_time/(1 SECOND))] second\s to cook in [cook_string] and creates [product_link]."
+		if(length(cooking_methods))
+			mechanics_text += "<br>This recipe takes [ceil(recipe.cooking_time/(1 SECOND))] second\s to cook in [english_list(cooking_methods, and_text = " or ")] and creates [product_link]."
 		else
 			mechanics_text += "<br>This recipe takes [ceil(recipe.cooking_time/(1 SECOND))] second\s to cook in a microwave and creates [product_link]."
 

--- a/code/modules/codex/categories/category_recipes.dm
+++ b/code/modules/codex/categories/category_recipes.dm
@@ -89,17 +89,23 @@
 		for(var/thing in recipe.reagents)
 			var/decl/material/thing_reagent = GET_DECL(thing)
 			ingredients += "[recipe.reagents[thing]]u <span codexlink='[thing_reagent.codex_name || thing_reagent.name] (substance)'>[thing_reagent.name]</span>"
+
 		for(var/atom/thing as anything in recipe.items)
 			var/count = recipe.items[thing]
 			var/thing_name = initial(thing.name)
+
+			var/datum/codex_entry/thing_entry = SScodex.get_codex_entry(thing)
 			if(ispath(thing, /atom/movable) && TYPE_IS_SPAWNABLE(thing))
 				thing_name = atom_info_repository.get_name_for(thing)
+				thing_entry = atom_info_repository.get_codex_page_for(thing)
+
 			if(SScodex.get_entry_by_string(thing_name))
 				thing_name = "<l>[thing_name]</l>"
 			else
-				var/datum/codex_entry/result_entry = SScodex.get_codex_entry(thing) || atom_info_repository.get_codex_page_for(thing)
-				if(result_entry)
-					thing_name = "<span codexlink='[result_entry.name]'>[thing_name]</span>"
+				thing_entry ||= SScodex.get_codex_entry(thing_name, do_search = TRUE)
+				if(thing_entry)
+					thing_name = "<span codexlink='[thing_entry.name]'>[thing_name]</span>"
+
 			ingredients += (count > 1) ? "[count]x [thing_name]" : "\a [thing_name]"
 		for(var/thing in recipe.fruit)
 			ingredients += "[recipe.fruit[thing]] [thing]\s"

--- a/code/modules/codex/codex_atom.dm
+++ b/code/modules/codex/codex_atom.dm
@@ -1,41 +1,35 @@
 /atom
-	var/atom_codex_ref
-
-/obj
-	atom_codex_ref = TRUE
-
-/mob
-	atom_codex_ref = TRUE
-
-/turf
-	atom_codex_ref = TRUE
+	VAR_PROTECTED/datum/codex_entry/_atom_codex_value // /datum for initial()
+	VAR_PROTECTED/datum/codex_entry/_atom_codex_ref
 
 /atom/proc/get_codex_value()
-	return src
+	return ispath(_atom_codex_value, /datum/codex_entry) ? _atom_codex_value::name : src
 
-/atom/proc/get_atom_codex_entry(mob/user, permanent = FALSE)
+/atom/proc/get_atom_codex_entry(mob/user, permanent = FALSE, strict = TRUE)
 
-	if(!atom_codex_ref)
-		return SScodex.get_codex_entry(get_codex_value(user), skip_atom_codex = TRUE)
+	var/existing = SScodex.get_codex_entry(get_codex_value(user), do_search = !strict, skip_atom_codex = TRUE)
+	if(existing)
+		return existing
 
-	if(istype(atom_codex_ref, /datum/codex_entry))
-		return atom_codex_ref
+	if(istype(_atom_codex_ref, /datum/codex_entry))
+		return _atom_codex_ref
 
-	var/lore      = get_lore_info()
-	var/mechanics = get_mechanics_info()
-	var/antag     = get_antag_info()
-	if(!length(lore) && !length(mechanics) && !length(antag))
+	var/lore_text      = get_lore_info()
+	var/mechanics_text = get_mechanics_info()
+	var/antag_text     = get_antag_info()
+
+	if(!length(lore_text) && !length(mechanics_text) && !length(antag_text))
 		return
 
-	lore      = islist(lore)      ? jointext(lore,      "<br><br>") : null
-	mechanics = islist(mechanics) ? jointext(mechanics, "<br><br>") : null
-	antag     = islist(antag)     ? jointext(antag,     "<br><br>") : null
+	lore_text      = islist(lore_text)      ? jointext(lore_text,      "<br><br>") : null
+	mechanics_text = islist(mechanics_text) ? jointext(mechanics_text, "<br><br>") : null
+	antag_text     = islist(antag_text)     ? jointext(antag_text,     "<br><br>") : null
 
 	if(!permanent)
-		atom_codex_ref = new /datum/codex_entry/temporary(name, list(type), _lore_text = lore, _mechanics_text = mechanics, _antag_text = antag)
-		return atom_codex_ref
+		_atom_codex_ref = new /datum/codex_entry/temporary(name, _lore_text = lore_text, _mechanics_text = mechanics_text, _antag_text = antag_text)
+		return _atom_codex_ref
 
-	return SScodex.get_codex_entry(get_codex_value(user), skip_atom_codex = TRUE) || new /datum/codex_entry(name, list(type), _lore_text = lore, _mechanics_text = mechanics, _antag_text = antag)
+	return SScodex.get_codex_entry(get_codex_value(user), do_search = TRUE, skip_atom_codex = TRUE) || new /datum/codex_entry(name, _lore_text = lore_text, _mechanics_text = mechanics_text, _antag_text = antag_text)
 
 /atom/proc/get_mechanics_info()
 	return

--- a/code/modules/codex/codex_atom.dm
+++ b/code/modules/codex/codex_atom.dm
@@ -13,17 +13,17 @@
 /atom/proc/get_codex_value()
 	return src
 
-/atom/proc/get_specific_codex_entry()
+/atom/proc/get_atom_codex_entry(mob/user)
 	if(!atom_codex_ref)
-		return
+		return SScodex.get_codex_entry(get_codex_value(user))
 	if(!istype(atom_codex_ref, /datum/codex_entry))
 		var/lore = get_lore_info()
 		var/mechanics = get_mechanics_info()
 		var/antag = get_antag_info()
 		if(!lore && !mechanics && !antag)
-			return
+			return SScodex.get_codex_entry(get_codex_value(user))
 		atom_codex_ref = new /datum/codex_entry/temporary(name, list(type), _lore_text = lore, _mechanics_text = mechanics, _antag_text = antag)
-	return atom_codex_ref
+	return atom_codex_ref || SScodex.get_codex_entry(get_codex_value(user))
 
 /atom/proc/get_mechanics_info()
 	return

--- a/code/modules/codex/codex_atom.dm
+++ b/code/modules/codex/codex_atom.dm
@@ -21,11 +21,15 @@
 	if(istype(atom_codex_ref, /datum/codex_entry))
 		return atom_codex_ref
 
-	var/lore = get_lore_info()
+	var/lore      = get_lore_info()
 	var/mechanics = get_mechanics_info()
-	var/antag = get_antag_info()
-	if(!lore && !mechanics && !antag)
+	var/antag     = get_antag_info()
+	if(!length(lore) && !length(mechanics) && !length(antag))
 		return
+
+	lore      = islist(lore)      ? jointext(lore,      "<br><br>") : null
+	mechanics = islist(mechanics) ? jointext(mechanics, "<br><br>") : null
+	antag     = islist(antag)     ? jointext(antag,     "<br><br>") : null
 
 	if(!permanent)
 		atom_codex_ref = new /datum/codex_entry/temporary(name, list(type), _lore_text = lore, _mechanics_text = mechanics, _antag_text = antag)

--- a/code/modules/codex/codex_atom.dm
+++ b/code/modules/codex/codex_atom.dm
@@ -13,17 +13,25 @@
 /atom/proc/get_codex_value()
 	return src
 
-/atom/proc/get_atom_codex_entry(mob/user)
+/atom/proc/get_atom_codex_entry(mob/user, permanent = FALSE)
+
 	if(!atom_codex_ref)
-		return SScodex.get_codex_entry(get_codex_value(user))
-	if(!istype(atom_codex_ref, /datum/codex_entry))
-		var/lore = get_lore_info()
-		var/mechanics = get_mechanics_info()
-		var/antag = get_antag_info()
-		if(!lore && !mechanics && !antag)
-			return SScodex.get_codex_entry(get_codex_value(user))
+		return SScodex.get_codex_entry(get_codex_value(user), skip_atom_codex = TRUE)
+
+	if(istype(atom_codex_ref, /datum/codex_entry))
+		return atom_codex_ref
+
+	var/lore = get_lore_info()
+	var/mechanics = get_mechanics_info()
+	var/antag = get_antag_info()
+	if(!lore && !mechanics && !antag)
+		return
+
+	if(!permanent)
 		atom_codex_ref = new /datum/codex_entry/temporary(name, list(type), _lore_text = lore, _mechanics_text = mechanics, _antag_text = antag)
-	return atom_codex_ref || SScodex.get_codex_entry(get_codex_value(user))
+		return atom_codex_ref
+
+	return SScodex.get_codex_entry(get_codex_value(user), skip_atom_codex = TRUE) || new /datum/codex_entry(name, list(type), _lore_text = lore, _mechanics_text = mechanics, _antag_text = antag)
 
 /atom/proc/get_mechanics_info()
 	return

--- a/code/modules/codex/codex_client.dm
+++ b/code/modules/codex/codex_client.dm
@@ -1,5 +1,5 @@
 /client
-	var/codex_on_cooldown = FALSE
+	var/next_codex_action = FALSE
 	var/const/max_codex_entries_shown = 10
 
 /client/verb/search_codex(searching as text)
@@ -11,8 +11,8 @@
 	if(!mob || !SScodex)
 		return
 
-	if(codex_on_cooldown || !mob.can_use_codex())
-		to_chat(src, SPAN_WARNING("You cannot perform codex actions currently."))
+	if(world.time < next_codex_action || !mob.can_use_codex())
+		to_chat(src, SPAN_WARNING("You cannot perform codex actions for another [ceil((next_codex_action-world.time)/10)] second\s."))
 		return
 
 	if(!searching)
@@ -20,12 +20,11 @@
 		if(!searching)
 			return
 
-	if(codex_on_cooldown || !mob.can_use_codex())
-		to_chat(src, SPAN_WARNING("You cannot perform codex actions currently."))
+	if(world.time < next_codex_action || !mob.can_use_codex())
+		to_chat(src, SPAN_WARNING("You cannot perform codex actions for another [ceil((next_codex_action-world.time)/10)] second\s."))
 		return
 
-	codex_on_cooldown = TRUE
-	addtimer(CALLBACK(src, PROC_REF(reset_codex_cooldown)), 1 SECOND)
+	next_codex_action = world.time + 1 SECOND
 
 	var/list/all_entries = SScodex.retrieve_entries_for_string(searching)
 	if(mob && mob.mind && !player_is_antag(mob.mind))
@@ -67,11 +66,10 @@
 	if(!mob || !SScodex.initialized)
 		return
 
-	if(codex_on_cooldown || !mob.can_use_codex())
-		to_chat(src, SPAN_WARNING("You cannot perform codex actions currently."))
+	if(world.time < next_codex_action || !mob.can_use_codex())
+		to_chat(src, SPAN_WARNING("You cannot perform codex actions for another [ceil((next_codex_action-world.time)/10)] second\s."))
 		return
-	codex_on_cooldown = TRUE
-	addtimer(CALLBACK(src, PROC_REF(reset_codex_cooldown)), 1 SECOND)
+	next_codex_action = world.time + 1 SECOND
 
 	to_chat(mob, SPAN_NOTICE("The codex forwards you an index file."))
 
@@ -101,9 +99,6 @@
 	popup.set_content(jointext(codex_data, null))
 	popup.open()
 
-/client/proc/reset_codex_cooldown()
-	codex_on_cooldown = FALSE
-
 /client/verb/codex()
 	set name = "Codex"
 	set category = "IC"
@@ -112,12 +107,11 @@
 	if(!mob || !SScodex)
 		return
 
-	if(codex_on_cooldown || !mob.can_use_codex())
-		to_chat(src, SPAN_WARNING("You cannot perform codex actions currently."))
+	if(world.time < next_codex_action || !mob.can_use_codex())
+		to_chat(src, SPAN_WARNING("You cannot perform codex actions for another [ceil((next_codex_action-world.time)/10)] second\s."))
 		return
 
-	codex_on_cooldown = TRUE
-	addtimer(CALLBACK(src, PROC_REF(reset_codex_cooldown)), 1 SECOND)
+	next_codex_action = world.time + 1 SECOND
 
 	var/datum/codex_entry/entry = SScodex.get_codex_entry("nexus")
 	SScodex.present_codex_entry(mob, entry)

--- a/code/modules/codex/codex_scannable.dm
+++ b/code/modules/codex/codex_scannable.dm
@@ -20,7 +20,7 @@ var/global/list/unlocked_codex_scannables = list()
 	var/worth_points = 1
 	var/category
 
-/datum/codex_entry/scannable/New(var/_display_name, var/list/_associated_paths, var/list/_associated_strings, var/_lore_text, var/_mechanics_text, var/_antag_text)
+/datum/codex_entry/scannable/New(var/_display_name, var/list/_associated_strings, var/_lore_text, var/_mechanics_text, var/_antag_text)
 	..()
 	if(category)
 		var/decl/codex_category/cat = GET_DECL(category)

--- a/code/modules/codex/entries/_codex_entry.dm
+++ b/code/modules/codex/entries/_codex_entry.dm
@@ -7,8 +7,6 @@
 	var/store_codex_entry = TRUE
 	/// A list of string search terms associated with this entry.
 	var/list/associated_strings
-	/// A list of typepaths used to populate associated_strings.
-	var/list/associated_paths
 	/// IC text.
 	var/lore_text
 	/// OOC text.
@@ -21,8 +19,6 @@
 	var/list/categories
 	/// If TRUE, don't create this entry in codex init. Where possible, consider using abstract_type or store_codex_entry = FALSE instead.
 	var/skip_hardcoded_generation = FALSE
-	/// If TRUE, associated_paths is set to include each path's subtypes in New().
-	var/include_subtypes = FALSE
 	/// HTML returned when the entry is used to populate a guide manual.
 	var/guide_html
 	/// The map tech level this entry will appear for.
@@ -34,40 +30,15 @@
 /datum/codex_entry/temporary
 	store_codex_entry = FALSE
 
-/datum/codex_entry/New(var/_display_name, var/list/_associated_paths, var/list/_associated_strings, var/_lore_text, var/_mechanics_text, var/_antag_text)
+/datum/codex_entry/New(var/_display_name, var/list/_associated_strings, var/_lore_text, var/_mechanics_text, var/_antag_text)
 	if(global.using_map.map_tech_level < available_to_map_tech_level)
 		unsearchable = TRUE
 
 	if(_display_name)       name =               _display_name
-	if(_associated_paths)   associated_paths =   _associated_paths
 	if(_associated_strings) associated_strings = _associated_strings
 	if(_lore_text)          lore_text =          _lore_text
 	if(_mechanics_text)     mechanics_text =     _mechanics_text
 	if(_antag_text)         antag_text =         _antag_text
-
-	if(store_codex_entry && length(associated_paths))
-		for(var/atom/thing as anything in associated_paths)
-			var/thing_name = initial(thing.name)
-			if(ispath(thing, /atom/movable) && TYPE_IS_SPAWNABLE(thing))
-				thing_name = atom_info_repository.get_name_for(thing)
-			thing_name = codex_sanitize(thing_name)
-			if(disambiguator)
-				thing_name = "[thing_name] ([disambiguator])"
-			LAZYDISTINCTADD(associated_strings, thing_name)
-		// Don't move this any earlier, adding strings for subtypes can cause overlaps.
-		if(include_subtypes)
-			var/new_assoc_paths = list()
-			for(var/path in associated_paths)
-				new_assoc_paths |= typesof(path)
-			associated_paths = new_assoc_paths
-		for(var/associated_path in associated_paths)
-			// This fix assumes more specific codex entries always follow more general ones.
-			// TODO: Refactor to be order-agnostic.
-			var/datum/codex_entry/predecessor = SScodex.entries_by_path[associated_path]
-			if(predecessor)
-				log_debug("Trying to save codex entry for [name] by path [associated_path] but entry [predecessor.name] already uses it, overwriting.")
-				predecessor.associated_paths -= SScodex.entries_by_path[associated_path]
-			SScodex.entries_by_path[associated_path] = src
 
 	if(!name)
 		if(length(associated_strings))
@@ -101,8 +72,6 @@
 		SScodex.all_entries -= src
 		for(var/associated_string in associated_strings)
 			SScodex.entries_by_string -= associated_string
-		for(var/associated_path in associated_paths)
-			SScodex.entries_by_path -= associated_path
 		for(var/thing in SScodex.index_file)
 			if(src == SScodex.index_file[thing])
 				SScodex.index_file -= thing

--- a/code/modules/codex/entries/armor.dm
+++ b/code/modules/codex/entries/armor.dm
@@ -1,6 +1,5 @@
 /datum/extension/armor/proc/get_capabilities_description()
 	. = list()
-
 	var/list/descriptors = decls_repository.get_decls_of_type(/decl/protection_type)
 	for(var/T in descriptors)
 		var/decl/protection_type/armortype = descriptors[T]
@@ -14,7 +13,6 @@
 /datum/extension/armor/ablative/get_capabilities_description()
 	. = ..()
 	. += "It degrades as it blocks damage."
-
 
 // Generic non-bomb brute damage
 /decl/protection_type

--- a/code/modules/codex/entries/atmospherics.dm
+++ b/code/modules/codex/entries/atmospherics.dm
@@ -1,31 +1,30 @@
 /datum/codex_entry/atmos_pipe
-	associated_paths = list(/obj/machinery/atmospherics/pipe)
+	name = "atmospherics pipes"
 	mechanics_text = "All pipes can be connected or disconnected with a wrench.  The internal pressure of the pipe must be below 300 kPa to do this.  More pipes can be obtained from a pipe dispenser. \
 	<br>Some pipes, like scrubbers and supply pipes, do not connect to 'normal' pipes. If you want to connect them, use a universal adapter pipe. \
 	<br>Pipes generally do not exchange thermal energy with the environment (ie. they do not heat up or cool down their turf), but heat exchange pipes are an exception. \
 	<br>To join three or more pipe segments, you can use a pipe manifold.\
 	<br>To terminate a pipeline, use a cap to prevent the gas escaping into the environment."
-	include_subtypes = TRUE
 	disambiguator = "atmospherics"
 	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
 
 //T-shaped valves
 /datum/codex_entry/atmos_tvalve
-	associated_paths = list(/obj/machinery/atmospherics/tvalve)
+	name = "transfer valves"
 	mechanics_text = "Click this to toggle the mode.  The direction with the green light is where the gas will flow."
 	disambiguator = "atmospherics"
 	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
 
 //Normal valves
 /datum/codex_entry/atmos_valve
-	associated_paths = list(/obj/machinery/atmospherics/valve)
+	name = "atmospherics valve"
 	mechanics_text = "Click this to turn the valve.  If red, the pipes on each end are separated.  Otherwise, they are connected."
 	disambiguator = "atmospherics"
 	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
 
 //TEG ports
 /datum/codex_entry/atmos_circulator
-	associated_paths = list(/obj/machinery/atmospherics/binary/circulator)
+	name = "atmospherics circulator"
 	mechanics_text = "This generates electricity, depending on the difference in temperature between each side of the machine.  The meter in \
 	the center of the machine gives an indicator of how much elecrtricity is being generated."
 	disambiguator = "atmospherics"
@@ -33,28 +32,28 @@
 
 //Passive gates
 /datum/codex_entry/atmos_gate
-	associated_paths = list(/obj/machinery/atmospherics/binary/passive_gate)
+	name = "atmospherics regulator"
 	mechanics_text = "This is a one-way regulator, allowing gas to flow only at a specific pressure and flow rate.  If the light is green, it is flowing."
 	disambiguator = "atmospherics"
 	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
 
 //Normal pumps (high power one inherits from this)
 /datum/codex_entry/atmos_pump
-	associated_paths = list(/obj/machinery/atmospherics/binary/pump)
+	name = "atmospherics pump"
 	mechanics_text = "This moves gas from one pipe to another.  A higher target pressure demands more energy.  The side with the red end is the output."
 	disambiguator = "atmospherics"
 	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
 
 //Vents
 /datum/codex_entry/atmos_vent_pump
-	associated_paths = list(/obj/machinery/atmospherics/unary/vent_pump)
+	name = "atmospherics vent pump"
 	mechanics_text = "This pumps the contents of the attached pipe out into the atmosphere, if needed.  It can be controlled from an Air Alarm."
 	disambiguator = "atmospherics"
 	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
 
 //Freezers
 /datum/codex_entry/atmos_freezer
-	associated_paths = list(/obj/machinery/atmospherics/unary/temperature/freezer)
+	name = "atmospherics freezer"
 	mechanics_text = "Cools down the gas of the pipe it is connected to.  It uses massive amounts of electricity while on. \
 	It can be upgraded by replacing the capacitors, manipulators, and matter bins.  It can be deconstructed by screwing the maintenance panel open with a \
 	screwdriver, and then using a crowbar."
@@ -63,7 +62,7 @@
 
 //Heaters
 /datum/codex_entry/atmos_heater
-	associated_paths = list(/obj/machinery/atmospherics/unary/temperature/heater)
+	name = "atmospherics heater"
 	mechanics_text = "Heats up the gas of the pipe it is connected to.  It uses massive amounts of electricity while on. \
 	It can be upgraded by replacing the capacitors, manipulators, and matter bins.  It can be deconstructed by screwing the maintenance panel open with a \
 	screwdriver, and then using a crowbar."
@@ -72,7 +71,7 @@
 
 //Gas injectors
 /datum/codex_entry/atmos_injector
-	associated_paths = list(/obj/machinery/atmospherics/unary/outlet_injector)
+	name = "atmospherics injector"
 	mechanics_text = "Outputs the pipe's gas into the atmosphere, similar to an airvent.  It can be controlled by a nearby atmospherics computer. \
 	A green light on it means it is on."
 	disambiguator = "atmospherics"
@@ -80,7 +79,7 @@
 
 //Scrubbers
 /datum/codex_entry/atmos_vent_scrubber
-	associated_paths = list(/obj/machinery/atmospherics/unary/vent_scrubber)
+	name = "atmospherics vent scrubber"
 	mechanics_text = "This filters the atmosphere of harmful gas.  Filtered gas goes to the pipes connected to it, typically a scrubber pipe. \
 	It can be controlled from an Air Alarm.  It can be configured to drain all air rapidly with a 'panic syphon' from an air alarm."
 	disambiguator = "atmospherics"
@@ -88,7 +87,7 @@
 
 //Omni filters
 /datum/codex_entry/atmos_omni_filter
-	associated_paths = list(/obj/machinery/atmospherics/omni/filter)
+	name = "atmospherics omni filter"
 	mechanics_text = "Filters gas from a custom input direction, with up to two filtered outputs and a 'everything else' \
 	output.  The filtered output's arrows glow orange."
 	disambiguator = "atmospherics"
@@ -96,15 +95,14 @@
 
 //Omni mixers
 /datum/codex_entry/atmos_omni_mixer
-	associated_paths = list(/obj/machinery/atmospherics/omni/mixer)
+	name = "atmospherics omni mixer"
 	mechanics_text = "Combines gas from custom input and output directions.  The percentage of combined gas can be defined."
 	disambiguator = "atmospherics"
 	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
 
 //Canisters
 /datum/codex_entry/atmos_canister
-	name = "gas canister" // because otherwise it shows up as 'canister: [caution]'
-	associated_paths = list(/obj/machinery/portable_atmospherics/canister)
+	name = "atmospherics canister" // because otherwise it shows up as 'canister: [caution]'
 	mechanics_text = "The canister can be connected to a connector port with a wrench.  Tanks of gas (the kind you can hold in your hand) \
 	can be filled by the canister, by using the tank on the canister, increasing the release pressure, then opening the valve until it is full, and then close it.  \
 	*DO NOT* remove the tank until the valve is closed.  A gas analyzer can be used to check the contents of the canister."
@@ -114,7 +112,7 @@
 
 //Portable pumps
 /datum/codex_entry/atmos_power_pump
-	associated_paths = list(/obj/machinery/portable_atmospherics/powered/pump)
+	name = "atmospherics powered pump"
 	mechanics_text = "Invaluable for filling air in a room rapidly after a breach repair.  The internal gas container can be filled by \
 	connecting it to a connector port.  The pump can pump the air in (sucking) or out (blowing), at a specific target pressure.  The powercell inside can be \
 	replaced by using a screwdriver, and then adding a new cell.  A tank of gas can also be attached to the air pump."
@@ -123,7 +121,7 @@
 
 //Portable scrubbers
 /datum/codex_entry/atmos_power_scrubber
-	associated_paths = list(/obj/machinery/portable_atmospherics/powered/scrubber)
+	name = "atmospherics power scrubber"
 	mechanics_text = "Filters the air, placing harmful gases into the internal gas container.  The container can be emptied by \
 	connecting it to a connector port.  The pump can pump the air in (sucking) or out (blowing), at a specific target pressure.  The powercell inside can be \
 	replaced by using a screwdriver, and then adding a new cell.  A tank of gas can also be attached to the scrubber. "
@@ -132,27 +130,27 @@
 
 //Meters
 /datum/codex_entry/atmos_meter
-	associated_paths = list(/obj/machinery/meter)
+	name = "atmospherics meter"
 	mechanics_text = "Measures the volume and temperature of the pipe under the meter."
 	disambiguator = "atmospherics"
 	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
 
 //Pipe dispensers
 /datum/codex_entry/atmos_pipe_dispenser
-	associated_paths = list(/obj/machinery/fabricator/pipe)
+	name = "atmospherics pipe dispenser"
 	mechanics_text = "This can be moved by using a wrench.  You will need to wrench it again when you want to use it.  You can put \
 	excess (atmospheric) pipes into the dispenser, as well.  The dispenser requires electricity to function."
 	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
 
 /datum/codex_entry/transfer_valve
-	associated_paths = list(/obj/item/transfer_valve)
+	name = "atmospherics transfer valve"
 	mechanics_text = "This machine is used to merge the contents of two different gas tanks. Plug the tanks into the transfer, then open the valve to mix them together. You can also attach various assembly devices to trigger this process."
 	antag_text = "With a tank of hot accelerant and cold oxidiser, this benign little atmospheric device becomes an incredibly deadly bomb. You don't want to be anywhere near it when it goes off."
 	disambiguator = "component"
 	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
 
 /datum/codex_entry/gas_tank
-	associated_paths = list(/obj/item/tank)
+	name = "gas tank"
 	mechanics_text = "These tanks are utilised to store any of the various types of gaseous substances. \
 	They can be attached to various portable atmospheric devices to be filled or emptied. <br>\
 	<br>\
@@ -168,7 +166,7 @@
 	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
 
 /datum/codex_entry/gas_analyzer
-	associated_paths = list(/obj/item/scanner/gas)
+	name = "gas analyzer"
 	mechanics_text = "A device that analyzes the gas contents of a tile or atmospherics devices. Has 3 modes: Default operates without \
 	additional output data; Moles and volume shows the moles per gas in the mixture and the total moles and volume; Gas \
 	traits and data describes the traits per gas, how it interacts with the world, and some of its property constants."

--- a/code/modules/codex/entries/clothing.dm
+++ b/code/modules/codex/entries/clothing.dm
@@ -1,7 +1,3 @@
-
-/obj/item/clothing/get_lore_info()
-	return desc
-
 /obj/item/clothing/get_mechanics_info()
 	var/list/armor_strings = list()
 	var/datum/extension/armor/A = get_extension(src, /datum/extension/armor)
@@ -47,8 +43,9 @@
 	if(slots.len)
 		armor_strings += "It can be worn on your [english_list(slots)]."
 
-	return jointext(armor_strings, "<br>")
+	. = ..()
+	LAZYADD(., jointext(armor_strings, "<br>"))
 
 /obj/item/clothing/suit/armor/pcarrier/get_mechanics_info()
 	. = ..()
-	. += "<br>Its protection is provided by the plate inside, examine it for details on armor.<br>"
+	LAZYADD(., "Its protection is provided by the plate inside, examine it for details on armor.")

--- a/code/modules/codex/entries/engineering.dm
+++ b/code/modules/codex/entries/engineering.dm
@@ -1,5 +1,6 @@
 /datum/codex_entry/apc
-	associated_paths = list(/obj/machinery/apc)
+	name = "area power controller"
+	associated_strings = list("apc")
 	mechanics_text = "An APC (Area Power Controller) regulates and supplies backup power for the area they are in. Their power channels are divided \
 	out into 'environmental' (items that manipulate airflow and temperature), 'lighting' (the lights), and 'equipment' (everything else that consumes power).  \
 	Power consumption and backup power cell charge can be seen from the interface, further controls (turning a specific channel on, off or automatic, \
@@ -10,12 +11,13 @@
 	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
 
 /datum/codex_entry/inflatable_item
-	associated_paths = list(/obj/item/inflatable, /obj/structure/inflatable, /obj/structure/inflatable/door)
+	name = "inflatables"
 	mechanics_text = "Inflate by using it in your hand.  The inflatable barrier will inflate on your tile.  To deflate it, use the 'deflate' verb. Hitting this with any object will probably puncture and break it forever.<br>Walls are static, but doors may be clicked to open or close them. They only stop air while closed."
 	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
 
 /datum/codex_entry/welding_pack
-	associated_paths = list(/obj/item/chems/weldpack, /obj/item/chems/weldpack/empty)
+	name = "welding pack"
+	associated_strings = list("welder pack")
 	mechanics_text = "This pack acts as a portable source of welding fuel. Use a welder on it to refill its tank - but make sure it's not lit! You can use this kit on a fuel tank or appropriate reagent dispenser to replenish its reserves."
 	lore_text = "The Shenzhen Chain of 2133 was an industrial accident of noteworthy infamy that occurred at Earth's L3 Lagrange Point. An apprentice welder, working for the Shenzhen Space Fabrication Group, failed to properly seal her fuel port, triggering a chain reaction that spread from laborer to laborer, instantly vaporizing a crew of fourteen. Don't let this happen to you!"
 	antag_text = "In theory, you could hold an open flame to this pack and produce some pretty catastrophic results. The trick is getting out of the blast radius."
@@ -23,21 +25,20 @@
 	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
 
 /datum/codex_entry/gripper
-	associated_paths = list(/obj/item/gripper)
+	name = "gripper"
 	mechanics_text = "Click an item to pick it up with your gripper. Use it as you would normally use anything in your hand. The Drop Item verb will allow you to release the item."
 	disambiguator = "equipment"
-	include_subtypes = TRUE
 	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
 
 /datum/codex_entry/diffuser_item
-	associated_paths = list(/obj/item/shield_diffuser)
+	name = "shield diffuser"
 	mechanics_text = "This device disrupts shields on directly adjacent tiles (in a + shaped pattern), in a similar way the floor mounted variant does. It is, however, portable and run by an internal battery. Can be recharged with a regular recharger."
 	disambiguator = "equipment"
 	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
 
 /datum/codex_entry/solars
-	associated_paths = list(/obj/item/solar_assembly, /obj/machinery/power/solar, /obj/machinery/power/tracker, /obj/machinery/power/solar_control)
-	associated_strings = list("solar array")
+	name = "solars"
+	associated_strings = list("solar array", "solar panel", "solar power")
 	lore_text = "'At Greencorps we love the environment, and space. With this package you are able to help mother nature and produce energy without any usage of fossil fuels! Singularity energy is dangerous while solar energy is safe, which is why it's better. Now here is how you set up your own solar array...''"
 	mechanics_text = "A solar array is a source of power for your ship or station, utalizing a series of panels on the outside of the ship/station. A computer console is used to control the array, with the help of a solar tracker.<BR> \
 	<BR><b>Using the console</b><BR> \
@@ -53,8 +54,8 @@
 	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
 
 /datum/codex_entry/cable
-	associated_paths = list(/obj/structure/cable, /obj/item/stack/cable_coil)
-	associated_strings = list("cables")
+	name = "power cable"
+	associated_strings = list("cable", "cables")
 	mechanics_text = "Cables are used to transfer power and form power networks. Usually power is transfered via cables from a SMES to an APC for the majority of the ship/station. Cables also serve a purpose in constructing machinery, as a component. <BR>Hold a cable coil in one hand, and click it with the other to split the stack. Cables come in a variety of colours and can be painted using a cable painter. Right click on a cable coil to make cable restraints using 15 cables.<BR><BR> \
 	<B>Laying Cables</B><ul> \
 	<li>Cables can only be placed on plating. Tiles must be removed using a crowbar, if any.</li> \
@@ -64,5 +65,4 @@
 	<li>Knots are also used for certain machines to connect directly to a power network, usually by having the machine secured to the same plating as the knot is on, like the SMES. However, knots shouldn't exist within the network otherwise. Try to smooth those out.</li> \
 	<li>To lay a cable between decks (z-levels), use a cable on an open space from the deck above, dropping it down to the level below.</li></ul>"
 	antag_text = "Sometimes a carefully cut cable in the right place can cause power issues over a wide area once APCs start to run out. Just make sure to hide it after."
-	include_subtypes = TRUE
 	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE

--- a/code/modules/codex/entries/guns.dm
+++ b/code/modules/codex/entries/guns.dm
@@ -11,21 +11,21 @@
 	general_codex_key = "magnetic weapons"
 
 /obj/item/gun/get_antag_info()
+	. = ..()
 	var/list/entries = SScodex.retrieve_entries_for_string(general_codex_key)
 	var/datum/codex_entry/general_entry = LAZYACCESS(entries, 1)
 	if(general_entry && general_entry.antag_text)
-		return general_entry.antag_text
+		LAZYADD(., general_entry.antag_text)
 
 /obj/item/gun/get_lore_info()
+	. = ..()
 	var/list/entries = SScodex.retrieve_entries_for_string(general_codex_key)
 	var/datum/codex_entry/general_entry = LAZYACCESS(entries, 1)
-	. = "[desc]<br>"
 	if(general_entry && general_entry.lore_text)
-		. += general_entry.lore_text
+		LAZYADD(., general_entry.lore_text)
 
 /obj/item/gun/get_mechanics_info()
 	var/list/traits = list()
-
 	var/list/entries = SScodex.retrieve_entries_for_string(general_codex_key)
 	var/datum/codex_entry/general_entry = LAZYACCESS(entries, 1)
 	if(general_entry && general_entry.mechanics_text)
@@ -46,7 +46,8 @@
 	if(LAZYLEN(firemodes) > 1)
 		traits += "It has multiple firemodes. Click it in hand to cycle them."
 
-	return jointext(traits, "<br>")
+	. = ..()
+	LAZYADD(., jointext(traits, "<br>"))
 
 /obj/item/gun/projectile/get_mechanics_info()
 	. = ..()
@@ -70,44 +71,40 @@
 	if(jam_chance)
 		traits += "It's prone to jamming."
 
-	. += jointext(traits, "<br>")
+	LAZYADD(., jointext(traits, "<br>"))
 
 /obj/item/gun/energy/get_mechanics_info()
 	. = ..()
 	var/list/traits = list()
-
-	traits += "<br>Its maximum capacity is [max_shots] shots worth of power."
-
+	traits += "Its maximum capacity is [max_shots] shots worth of power."
 	if(self_recharge)
 		traits += "It recharges itself over time."
-
-	. += jointext(traits, "<br>")
+	LAZYADD(., jointext(traits, "<br>"))
 
 /obj/item/gun/projectile/shotgun/pump/get_mechanics_info()
 	. = ..()
-	. += "<br>To pump it, click it in hand.<br>"
+	LAZYADD(., "To pump it, click it in hand.")
 
 /obj/item/gun/energy/crossbow/get_antag_info()
 	. = ..()
-	. += "This is a stealthy weapon which fires poisoned bolts at your target. When it hits someone, they will suffer a stun effect, in \
-	addition to toxins. The energy crossbow recharges itself slowly, and can be concealed in your pocket or bag.<br>"
+	LAZYADD(., "This is a stealthy weapon which fires poisoned bolts at your target. When it hits someone, they will suffer a stun effect, in \
+	addition to toxins. The energy crossbow recharges itself slowly, and can be concealed in your pocket or bag.")
 
 /obj/item/gun/energy/chameleon/get_antag_info()
 	. = ..()
-	. += "This gun is actually a hologram projector that can alter its appearance to mimick other weapons. To change the appearance, use \
+	LAZYADD(., "This gun is actually a hologram projector that can alter its appearance to mimick other weapons. To change the appearance, use \
 	the appropriate verb in the chameleon items tab. Any beams or projectiles fired from this gun are actually holograms and useless for actual combat. \
-	Projecting these holograms over distance uses a little bit of charge.<br>"
+	Projecting these holograms over distance uses a little bit of charge.")
 
 /obj/item/gun/magnetic/get_mechanics_info()
 	. = ..()
 	if (removable_components)
-		. += "<p>Its cell and capacitor can be removed and replaced. You can remove the components by clicking the gun with an empty hand while it's unloaded.</p>"
+		LAZYADD(., "<p>Its cell and capacitor can be removed and replaced. You can remove the components by clicking the gun with an empty hand while it's unloaded.</p>")
 	if (load_type)
 		var/load_item = new load_type()
-		. += "<p>It accepts [load_item] as ammunition, with a maximum capacity of [load_sheet_max].</p>"
+		LAZYADD(., "<p>It accepts [load_item] as ammunition, with a maximum capacity of [load_sheet_max].</p>")
 	if (gun_unreliable)
-		. += "<p>This weapon is unreliable and has a chance of exploding in your hands when you fire it.</p>"
-
+		LAZYADD(., "<p>This weapon is unreliable and has a chance of exploding in your hands when you fire it.</p>")
 
 /datum/codex_entry/energy_weapons
 	name = "energy weapons"

--- a/code/modules/codex/entries/jukebox.dm
+++ b/code/modules/codex/entries/jukebox.dm
@@ -1,11 +1,6 @@
 /datum/codex_entry/jukebox
-	associated_paths = list(/obj/machinery/media/jukebox)
+	name = "jukebox"
 	mechanics_text = "Click the jukebox and then select a track on the interface. You can choose to play or stop the track, or set the volume. Use a wrench to attach or detach the jukebox to the floor. The room it is installed in must have power for it to operate!"
 	lore_text = "The Leitmotif is Auraliving's most popular brand of retro jukebox, putting a modern spin on the ancient curved plasmascreen design. The Enterprise Edition allows an indefinite number of users to sync music from their devices simultaneously... of course the Expeditionary Corps made sure to lock down the selection before they installed this one."
 	antag_text = "Slide a cryptographic sequencer into the jukebox to overload its speakers. Instead of music, it'll produce a hellish blast of noise and explode!"
-	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
-
-/datum/codex_entry/jukebox/old
-	associated_paths = list(/obj/machinery/media/jukebox/old)
-	lore_text = "No one these days knows what civilization is responsible for this machine's design - various alien species have been credited on more than one occasion."
 	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE

--- a/code/modules/codex/entries/machinery.dm
+++ b/code/modules/codex/entries/machinery.dm
@@ -1,12 +1,12 @@
 /datum/codex_entry/airlock
-	associated_paths = list(/obj/machinery/door/airlock)
+	name = "airlock"
 	mechanics_text = "An airtight mechanical door. Most airlocks require an ID to open (wearing it on your ID slot is enough), and many have special access requirements to be on your ID. You can open an airlock by clicking on one, or simply walking into it, and clicking on an open airlock will close it. If the lights on the door flash red, you don't have the required access to open the airlock, and if they're consistently red, the door is bolted. Airlocks also require power to operate. In a situation without power, a crowbar can be used to force it open. <BR><BR>Airlocks can also be <span codexlink='hacking'>hacked</span>.<BR>Airlock hacking information:<BR>* Door bolts will lock the door, preventing it from being opened by any means until the bolts are raised again. Pulsing the correct wire will toggle the bolts, but cutting it will only drop them.<BR>* IDscan light indicates the door can scan ID cards. If the wire for this is pulsed it will cause the door to flash red, and cutting it will cause doors with restricted access to be unable to scan ID, essentially locking it.<BR>* The AI control light shows whether or not AI and robots can control the door. Pulsing is only temporary, while cutting is more permanent.<BR>* The test light shows whether the door has power or not. When turned off, the door can be opened with a crowbar.<BR>* If the door sparks, it is electrified. Pulsing the corresponding wire causes this to happen for 30 seconds, and cutting it electrifies the door until mended.<BR>* The check wiring light will turn on if the safety is turned off. This causes the airlock to close even when someone is standing on it, crushing them.<BR>* If the Check Timing Mechanism light is on then the door will close much faster than normal. Dangerous in conjuction with the Check Wiring light.<BR><BR><B>Deconstruction</B><BR>To pull apart an airlock, you must open the maintenance panel, disable the power via hacking (or any other means), weld the door shut, and crowbar the electroncs out, cut the wires with a wirecutter, unsecure the whole assembly with a wrench, and then cut it into metal sheets with a welding tool."
 	antag_text = "Electrifying a door makes for a good trap, hurting and stunning whoever touches it. The same goes for a combination of disabling the safety and timing mechanisms. Bolting a door can also help ensure privacy, or slow down those in search of you. It's also a good idea to disable AI interaction when needed."
 	disambiguator = "machine"
 	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
 
 /datum/codex_entry/computer
-	associated_paths = list(/obj/machinery/computer, /obj/machinery/constructable_frame/computerframe)
+	name = "computer"
 	mechanics_text = "(This entry refers to the older single-purpose computers, not <span codexlink='modular console (machine)'>modular computers</span>.)<BR><BR> \
 	Computers are used primarily for controlling other machines and systems, or for providing information about said systems. They require power to function and run off the Equipment power channel on an APC. and sometimes requries ID access. \
 	<BR><BR><b>Constructing a computer:</b><BR> \
@@ -25,11 +25,10 @@
 	4.) Use a wrench on to take the frame apart.<BR> \
 	5.) Use a welder to cut the frame into sheets."
 	disambiguator = "machine"
-	include_subtypes = TRUE
 	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
 
 /datum/codex_entry/computer/modular
-	associated_paths = list(/obj/machinery/computer/modular)
+	name = "modular computers"
 	lore_text = "Modular computers allow for customized hardware and downloadable software, enabling users to create their own workplace experience."
 	mechanics_text = "(This entry is for modular computers. Modular computers are not the same as regular computers.)<BR><BR> \
 	Modular computers can have a variety of functions depending on the installed hardware and software. They also come available as tablets, laptops, wallscreens and PDA.<BR>\
@@ -43,38 +42,39 @@
 	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
 
 /datum/codex_entry/conveyor_construct
-	associated_paths = list(/obj/machinery/conveyor, /obj/item/conveyor_construct)
+	name = "conveyor belt"
 	mechanics_text = "This device must be connected to a switch assembly before placement by clicking the switch on the conveyor belt assembly. When active it will move objects on top of it to the adjacent space based on its direction and if it is runnnig in forward or reverse mode. Can be removed with a crowbar."
 	disambiguator = "machine"
 	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
 
 /datum/codex_entry/conveyor_switch
-	associated_paths = list(/obj/machinery/conveyor_switch, /obj/machinery/conveyor_switch/oneway, /obj/item/conveyor_switch_construct, /obj/item/conveyor_switch_construct/oneway)
+	name = "conveyor switch"
 	mechanics_text = "This device can connect to a number of conveyor belts and control their movement. A two-way switch will allow you to make the conveyors run in forward and reverse mode, the one-way switch will only allow one direction. Can be removed with a crowbar."
 	disambiguator = "machine"
 	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
 
 /datum/codex_entry/cryopod
-	associated_paths = list(/obj/machinery/cryopod)
+	name = "cryopod"
 	mechanics_text = "To enter a cryopod, or put someone in a cryopod, click+drag. When someone is in a cryopod, and they use the <i>ghost</i> verb, their character will despawn, be removed from the game round along with all their belongings, and freeing their job slot for someone else to take. This also occurs if a character is inside a cryopod for 15 minutes. Any particularly important belongings that the game can't do without will be stored. The item can then be retrieved from the nearby oversight console."
 	disambiguator = "machine"
 	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
 
 /datum/codex_entry/diffuser_machine
-	associated_paths = list(/obj/machinery/shield_diffuser)
+	name = "shield diffuser"
 	mechanics_text = "This device disrupts shields on directly adjacent tiles (in a + shaped pattern). They are commonly installed around exterior airlocks to prevent shields from blocking EVA access."
 	disambiguator = "machine"
 	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
 
 /datum/codex_entry/disposal
-	associated_paths = list(/obj/machinery/disposal/buildable)
+	name = "disposal bin"
+	associated_strings = list("disposals")
 	mechanics_text = "A high-tech garbage bin. Inserting an item causes the disposal unit (after a delay) to pneumatically launch the item through a series of pipes leading to either a garbage processing room, or space, depending on the ship/station. Larger objects can be inserted via click+drag. <BR> You can remove a disposal unit by turning it off, using a screwdriver, then a welding tool, and removing the floor tile underneath it."
 	antag_text = "People can be inserted into the disposal unit. If they're capable of moving however, it's easy for them to get out. Be careful though, putting things in disposal units doesn't always mean they're gone forever. <BR>If you turn it off, it can be used to hide in. Just be careful no one turns it back on while you're still in there!"
 	disambiguator = "machine"
 	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
 
 /datum/codex_entry/emitter
-	associated_paths = list(/obj/machinery/emitter)
+	name = "emitter"
 	mechanics_text = "You must secure this in place with a wrench and weld it to the floor before using it. Using cables on the emitter will allow you to connect it to the powernet with a terminal, placed over a cable node. Clicking will toggle it on and off, at which point, so long as it remains powered, it will fire in a single direction in bursts of four."
 	lore_text = "Lasers like this one have been in use for ages, in applications such as mining, cutting, and in the startup sequence of many advanced space station and starshipn engines."
 	antag_text = "This baby is capable of slicing through walls, sealed lockers, and people."
@@ -82,14 +82,14 @@
 	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
 
 /datum/codex_entry/fusion_fuel_injector
-	associated_paths = list(/obj/machinery/fusion_fuel_injector, /obj/machinery/computer/fusion/fuel_control)
+	name = "fusion fuel injector"
 	lore_text = "A simple magnetic accelerator used to inject small pellets of fuel into a fusion field."
 	mechanics_text = "Accepts a fuel rod produced by the fuel compressor and regularly fires fuel pellets into the fusion field. Rods can be swapped by hand when the injector is not firing. Power outages will require the injector to be turned on again. If there is no electromagnetic field active to catch the injected fuel, the results can be very unhealthy for anyone standing in the firing path. <BR>Controlled via the fuel injection control computer."
 	disambiguator = "machine"
 	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
 
 /datum/codex_entry/fusion_core
-	associated_paths = list(/obj/machinery/fusion_core, /obj/machinery/computer/fusion/core_control)
+	name = "fusion core"
 	lore_text = "An old but more or less reliable fusion field generator. Probably sourced from a retired cargo freighter."
 	mechanics_text = "Generates the field used to contain reaction material from fuel injectors, and dumps power into the power network under it based on plasma heat. Needs 500W or more in the network to start the field. Field will become unstable if it intersects with windows or other objects, and from some reactions, and will eventually rupture violently if not stabilized by a gyrotron. Turning the field off without letting it cool below 1000K will cause a violent explosion and EMP depending on the contents of the field. <BR>Controlled via the R-UST Mk. 8 core control. Make careful note of the instability."
 	antag_text = "Be careful when blowing this thing up. The blast is fairly large and can happen instantly depending how you do it."
@@ -97,57 +97,57 @@
 	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
 
 /datum/codex_entry/fuel_compressor
-	associated_paths = list(/obj/machinery/fuel_compressor)
+	name = "fuel compressor"
 	lore_text = "A highly secret design that can compress many varieties of solid and liquid matter into fuel rods for nuclear power production."
 	mechanics_text = "Uses sheets of material or units of reagents to produce fuel rods. Material/units are inserted by hand. Can also have some objects click-dragged onto it for more exotic fuel."
 	disambiguator = "machine"
 	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
 
 /datum/codex_entry/gyrotron
-	associated_paths = list(/obj/machinery/emitter/gyrotron, /obj/machinery/computer/fusion/gyrotron)
+	name = "gyrotron"
 	lore_text = "A high-power industrial laser used to excite plasma for fusion reactions. Also used to excite careless engineers, usually fatally."
 	mechanics_text = "Fires in pulses and will heat up a plasma toroid that is below 1000K. Mostly used to lower field instability after heating it to ignition point. Very power hungry, uses 20k per point of power. <BR>Controlled via the gyrotron control console."
 	disambiguator = "machine"
 	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
 
 /datum/codex_entry/pacman
-	associated_paths = list(/obj/machinery/port_gen/pacman)
+	name = "generator"
+	associated_strings = list("pacman")
 	mechanics_text = "Lends itself to being portable thanks to the small size and ease of use. Some versions use radioactive fuel and as such produces radiation, while others may produce dangerous byproducts as gasses. Ideally one should wear protective gear while interacting with an active generator. While active it also produces heat and will eventually overheat and explode. While the power output can be increased, doing this causes it to heat up faster. Must be secured using a wrench before use."
 	antag_text = "Can be used as a makeshift delayed explosive when power output is set to unsafe levels, though it may take some time to go off."
 	disambiguator = "machine"
 	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
 
 /datum/codex_entry/replicator
-	associated_paths = list(/obj/machinery/fabricator/replicator)
+	name = "replicator"
 	mechanics_text = "The food replicator is operated through voice commands. To inquire available dishes on the menu, say 'menu'. To dispense a dish, say the name of the dish listed in its menu. Dishes can only be produced as long as the replicator has biomass. To check on the biomass level of the replicator, say 'status'. Various food items or plants may be inserted to refill biomass."
 	disambiguator = "machine"
 	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
 
 /datum/codex_entry/vending
-	associated_paths = list(/obj/machinery/vending)
-	associated_strings = list("vending machine", "vendor")
+	name = "vendor"
+	associated_strings = list("vending machine")
 	mechanics_text = "A machine that dispenses items from a category of items at the user's selection.<BR>Vending machines sometimes require payment via an ID card, cash or charge card. Some dispense items for free, and such vending machines are usually access restricted. Items that have been dispensed can sometimes be returned simply by inserting it back into the vending machine by hand. Vending machines can also be restocked with an appropriate Vendor Restock, usually ordered via supply management, and then click+dragged onto the vending machine.<BR><BR>Vending machines can be <span codexlink='hacking'>hacked</span>.<BR><b>Vending machine hacking</b><BR>* The orange light shows if the vending machine is electrified.<BR>* The red light indicates whether or not the vending machine is firing out its contents randomly. Sometimes this can happen as a random event.<BR>* The green light indicates whether or not the vending machine is dispensing its hidden inventory. Nearly every vending machine has a list of secret goods that are usually considered to be contraband.<BR>* The purple or yellow light shows whether or not the ID scanner for the vending machine is working. When this function is disabled, anyone can access the vending machine, even if it normally has restricted access."
 	antag_text = "Accessing the secret inventory of a vending machine can sometimes be very useful, especially for department-focused machines."
 	disambiguator = "machine"
-	include_subtypes = TRUE
 	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
 
 /datum/codex_entry/internet_uplink
-	associated_paths = list(/obj/machinery/internet_uplink, /obj/machinery/computer/internet_uplink)
+	name = "internet uplink"
 	lore_text = "A complex internet uplink, capable of communicating near instantaneously with other uplinks through wormhole technology. It can also communicate with PLEXUS repeaters within a local range using hyperintense radio waves."
 	mechanics_text = "Allows for PLEXUS receivers in a set range on the overmap to function, permitting internetwork functions in the sector. The PLEXUS uplink can restrict access to certain networks. The uplink requires massive amounts of power and atmospheric cooling, scaling with the desired range. <BR>Maximum range can be inreased by installing SMES coils. <BR>Can be controlled via the PLEXUS uplink computer."
 	disambiguator = "machine"
 	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
 
 /datum/codex_entry/internet_repeater
-	associated_paths = list(/obj/machinery/internet_repeater)
+	name = "internet repeater"
 	lore_text = "A signal repeater, capable of transmitting and decoding hyperintense radio waves to and from PLEXUS uplinks."
 	mechanics_text = "Allows for network devices in its sector to connect to and communicate with distant networks over PLEXUS.<BR>Networks requires a modem to utilize PLEXUS connections."
 	disambiguator = "machine"
 	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
 
 /datum/codex_entry/mining_drill
-	associated_paths = list(/obj/machinery/mining_drill)
+	name = "mining drill"
 	mechanics_text = "When properly supported by two adjacent braces, the mining drill can automatically mine underground mineral deposits.<br>\
 	You can empty the ore storage by click-dragging the drill onto an ore box, or using the <b>Unload Drill</b> verb.<br>\
 	The drill head can be upgraded using a number of different components:<br>\

--- a/code/modules/codex/entries/medical.dm
+++ b/code/modules/codex/entries/medical.dm
@@ -1,5 +1,6 @@
 /datum/codex_entry/bodyscanner
-	associated_paths = list(/obj/machinery/bodyscanner)
+	name = "body scanner"
+	associated_strings = list("bodyscanner")
 	mechanics_text = "The advanced scanner detects and reports internal injuries such as bone fractures, internal bleeding, and organ damage. \
 	This is useful if you are about to perform surgery.<br>\
 	<br>\
@@ -10,19 +11,20 @@
 	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
 
 /datum/codex_entry/optable
-	associated_paths = list(/obj/machinery/optable)
+	name = "operating table"
+	associated_strings = list("optable")
 	mechanics_text = "Click your target with Grab intent, then click on the table with an empty hand, to place them on it.<br>Click on table after that to enable knockout function."
 	disambiguator = "machinery"
 	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
 
 /datum/codex_entry/operating
-	associated_paths = list(/obj/machinery/computer/operating)
+	name = "operating console"
 	mechanics_text = "This console gives information on the status of the patient on the adjacent operating table, notably their consciousness."
 	disambiguator = "machinery"
 	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
 
 /datum/codex_entry/sleeper
-	associated_paths = list(/obj/machinery/sleeper)
+	name = "sleeper"
 	mechanics_text = "The sleeper allows you to clean the blood by means of dialysis, and to administer medication in a controlled environment.<br>\
 	<br>\
 	Click your target with Grab intent, then click on the sleeper to place them in it. Click the green console, with an empty hand, to open the menu. \
@@ -38,7 +40,7 @@
 	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
 
 /datum/codex_entry/cryobag
-	associated_paths = list(/obj/item/bodybag/cryobag, /obj/structure/closet/body_bag/cryobag)
+	name = "cryobag"
 	mechanics_text = "This stasis bag will preserve the occupant, stopping most forms of harm from occuring, such as from oxygen \
 	deprivation, irradiation, shock, and chemicals inside the occupant, at least until the bag is opened again.<br>\
 	<br>\
@@ -48,11 +50,10 @@
 	occupant will not use up the bag, and you can pick it back up.<br>\
 	<br>\
 	You can use a health analyzer to scan the occupant's vitals without opening the bag by clicking the occupied bag with the analyzer."
-	include_subtypes = TRUE
 	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
 
 /datum/codex_entry/autopump
-	associated_paths = list(/obj/item/auto_cpr/)
+	name = "autopump"
 	mechanics_text = "This automatic pump will help a patient whose heart is stopped, much like CPR, when put in the patient's suit slot.<br>\
 	<br>\
 	There are several things to keep in mind when using it. First off, you need Basic Medicine AND Anatomy skills to align it properly, otherwise it'll hurt patient. \

--- a/code/modules/codex/entries/misc.dm
+++ b/code/modules/codex/entries/misc.dm
@@ -1,24 +1,23 @@
 /datum/codex_entry/suitcooler
-	associated_paths = list(/obj/item/suit_cooling_unit)
+	name = "suit cooler"
 	mechanics_text = "You may wear this instead of your backpack to cool yourself down. It is commonly used by full-body prosthetic users, \
 	as it allows them to go into low pressure environments for more than few seconds without overhating. It runs off energy provided by internal power cell. \
 	Remember to turn it on by clicking it when it's your in your hand before you put it on."
 	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
 
 /datum/codex_entry/barsign
-	associated_paths = list(/obj/structure/sign/double/barsign)
+	name = "bar sign"
 	mechanics_text = "If your ID has bar access, you may swipe it on this sign to alter its display."
 	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
 
 /datum/codex_entry/sneakies
-	associated_paths = list(/obj/item/clothing/shoes/dress/sneakies)
+	name = "sneakies"
 	lore_text =  "Originally designed to confuse Terran troops on the swamp moon of Nabier XI, where they were proven somewhat effective. Not bad on a space vessel, either."
 	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
 
 /datum/codex_entry/moneygun
-	associated_paths = list(/obj/item/gun/launcher/money)
+	name = "money cannon"
 	mechanics_text = "Load money into the cannon by picking it up with the gun, or feeding it directly by hand. Use in your hand to configure how much money you want to fire per shot."
 	lore_text = "These devices were invented several centuries ago and are a distinctly human cultural infection. They have produced knockoffs as timeless and as insipid as the potato gun and the paddle ball, showing up in all corners of the galaxy. The Money Cannon variation is noteworthy for its sturdiness and build quality, but is, at the end of the day, just another knockoff of the ancient originals."
 	antag_text = "Sliding a cryptographic sequencer into the receptacle will short the motors and override their speed. If you set the cannon to dispense 100 units or more, this might make a handy weapon."
-	include_subtypes = TRUE
 	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE

--- a/code/modules/codex/entries/mobs.dm
+++ b/code/modules/codex/entries/mobs.dm
@@ -1,5 +1,6 @@
 /datum/codex_entry/maint_drone
-	associated_paths = list(/mob/living/silicon/robot/drone)
+	name = "maintenance drone"
+	associated_strings = list("maint drone")
 	mechanics_text = "Drones are player-controlled synthetics which are lawed to maintain their assigned vessel and not \
 	interfere with anyone else, except for other drones. They hold a wide array of tools to build, repair, maintain, and clean. \
 	They function similarly to other synthetics, in that they require recharging regularly, have laws, and are resilient to many hazards, \
@@ -8,11 +9,10 @@
 	Maintenance drone presence can be requested to specific areas from any maintenance drone control console."
 	antag_text = "A cryptographic sequencer, available via a traitor uplink, can be used to subvert the drone to your cause."
 	disambiguator = "synthetic"
-	include_subtypes = TRUE
 	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
 
 /datum/codex_entry/uncertified_module
-	associated_paths = list(/obj/item/borg/upgrade/uncertified)
+	name = "party module"
 	mechanics_text = "This special chip will forcibly change a robot's module to a new one. In most cases, this is the only way for the robot to obtain these modules. Once you've unlocked the robot's maintenance hatch with an ID card and opened it with a crowbar, click the bot to install this chip."
 	lore_text = "No TSC, industrial concern, or military organization worth their salt would dare install uncertified hardware on their robotic platforms. Nevertheless, in backwater sectors of the universe, there is a thriving grey market for third-party modular configurations such as this one."
 	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE

--- a/code/modules/codex/entries/paperwork.dm
+++ b/code/modules/codex/entries/paperwork.dm
@@ -1,8 +1,7 @@
 /datum/codex_entry/writing
+	name = "writing"
 	associated_strings = list("pencode")
-	associated_paths = list(/obj/item/pen, /obj/item/paper, /obj/item/book)
 	disambiguator = "writing"
-
 	mechanics_text = {"Used for writing down your thoughts, on paper or elsewhere. The following special commands are available:<br><br>
 \[br\] : Creates a linebreak.<br>
 \[center\] - \[/center\] : Centers the text.<br>
@@ -33,10 +32,9 @@
 \[redacted\] : Adds R E D A C T E D in black font on a black background.<br><br>"}
 
 /datum/codex_entry/textbook
-	associated_paths = list(/obj/item/book/skill)
+	name = "textbook"
 	associated_strings = list("skillbook","skill book")
 	lore_text = "Education, written down and made overly expensive."
 	mechanics_text = "Textbooks provide <span codexlink='Skills (category)'>skill</span> buffs, raising the relevant skill by one level. In order to use textbook, you must have the matching skill that the textbook teaches, at the level it can buff. To use a textbook, simply hold it in your active hand and click it. You must then wait for a short period of time, after which you will have the skill buff indefinitely. However, the skill buff will be removed the moment the textbook is closed (used again) or removed from your hand in any way (dropped, put in a container, destroyed, etc). This process can be repeated without consequence, though only one textbook can be used at any one time. <BR><BR> \
 	<h4>Custom Skill Books</h4> \
 	Those with Master level <span codexlink='Literacy (skill)'>Literacy</span> can create a textbook with the use of an autobinder and a suitable writing implement. This works much the same way as writing a normal book(use pen on book) but rather than manually writing the contents, the Skill option is selected from the menu. To imbue the book with any given skill, the writer must possess the relevant skill at the level they desire. After successfully selecting the skill and level, the writer must then repeatedly use the pen on the book until it is complete. Only once complete can it be used as a skill book. <b>Important note</b>: You may only write two skill books during a round. If a textbook you wrote gets destroyed, it does not enable you to write another to replace it."
-	include_subtypes = TRUE

--- a/code/modules/codex/entries/stacks.dm
+++ b/code/modules/codex/entries/stacks.dm
@@ -1,35 +1,35 @@
 /datum/codex_entry/telecrystal
-	associated_paths = list(/obj/item/stack/telecrystal)
+	name = "telecrystal"
 	antag_text = "Telecrystals can be activated by utilizing them on devices with an actively running uplink. They will not activate on unactivated uplinks."
 	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
 
 /datum/codex_entry/rods
-	associated_paths = list(/obj/item/stack/material/rods)
+	name = "metal rods"
 	mechanics_text = "Made from steel sheets.  You can build a grille by using it in your hand. \
 	Clicking on a floor without any tiles will reinforce the floor.  You can make reinforced glass by combining rods and normal glass sheets."
 
 /datum/codex_entry/glass
-	associated_paths = list(/obj/item/stack/material/pane)
+	name = "glass pane"
 	mechanics_text = "Use in your hand to build a window. Glass can be upgraded to reinforced glass by adding metal rods, which are made from metal sheets. Reinforced glass is much stronger against damage."
 
 /datum/codex_entry/glass_borg
-	associated_paths = list(/obj/item/stack/material/cyborg/glass)
+	name = "glass pane dispenser"
 	mechanics_text = "Use in your hand to build a window.  Can be upgraded to reinforced glass by adding metal rods, which are made from metal sheets.<br>\
 	As a synthetic, you can acquire more sheets of glass by recharging."
 	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
 
 /datum/codex_entry/glass_reinf_borg
-	associated_paths = list(/obj/item/stack/material/cyborg/glass/reinforced)
+	name = "reinforced glass pane dispenser"
 	mechanics_text = "Use in your hand to build a window. Reinforced glass is much stronger against damage.<br>\
 	As a synthetic, you can gain more reinforced glass by recharging."
 	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
 
 /datum/codex_entry/steel_borg
-	associated_paths = list(/obj/item/stack/material/cyborg/steel)
+	name = "steel sheet dispenser"
 	mechanics_text = "Use in your hand to bring up the recipe menu.  If you have enough sheets, click on something on the list to build it.<br>\
 	You can replenish your supply of metal as a synthetic by recharging."
 	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
 
 /datum/codex_entry/material_sheet
-	associated_paths = list(/obj/item/stack/material)
+	name = "raw material"
 	mechanics_text = "Use in your hand to bring up the recipe menu.  If you have enough sheets, click on something on the list to build it."

--- a/code/modules/codex/entries/storage.dm
+++ b/code/modules/codex/entries/storage.dm
@@ -1,6 +1,3 @@
-/obj/item/get_lore_info()
-	return desc
-
 /obj/item/get_mechanics_info()
 	. = ..()
 	var/list/storage_info_list = list()
@@ -43,16 +40,15 @@
 		storage_info_list += "* It can be worn on your [english_list(slots)] by holding the item and clicking on the appropriate slot."
 		if (("back" || "waist") in slots)
 			storage_info_list += "* Storage items worn on the back or waist can be accessed with a simple empty handed click. To remove storage items in these slots, drag the storage item to an empty hand."
-	else
-		storage_info_list += "* It cannot be worn on your body. Please don't try."
+	//else // Keeping this in because it's funny, but it's a bit silly to see it on every /obj/item codex page.
+	//	storage_info_list += "* It cannot be worn on your body. Please don't try."
 
-	return jointext(storage_info_list, "<BR>")
-
-
+	LAZYADD(., jointext(storage_info_list, "<BR>"))
 
 /obj/item/plate/tray/get_mechanics_info()
 	. = ..()
-	. += "<BR><BR>Trays, when put down on a tables, drop all their contents onto the table. If you drop the tray in any other way or hit someone with it, all the items it holds will fall off and scatter. You can also examine a tray to see the contents."
+	LAZYADD(., "Trays, when put down on a tables, drop all their contents onto the table. If you drop the tray in any other way or hit someone with it, all the items it holds will fall off and scatter. You can also examine a tray to see the contents.")
+
 /obj/item/plate/tray/get_lore_info()
 	. = ..()
-	. += "<BR><BR>A simple tool allowing for multiple items to be carried at once while keeping the load more accessible than a box or bag. Used primarily by hospitality workers and other service staff."
+	LAZYADD(., "A simple tool allowing for multiple items to be carried at once while keeping the load more accessible than a box or bag. Used primarily by hospitality workers and other service staff.")

--- a/code/modules/codex/entries/structures.dm
+++ b/code/modules/codex/entries/structures.dm
@@ -1,26 +1,25 @@
 /datum/codex_entry/girder
-	associated_paths = list(/obj/structure/girder)
+	name = "wall support"
+	associated_strings = list("girder")
 	mechanics_text = "Use material sheets on this while anchored to build a wall. Adding sheets while unanchored will reinforce it.<br>\
 	A false wall can be made by using a screwdriver on this girder, and then adding material sheets.<br>\
 	You can dismantle the grider with a wrench."
 	disambiguator = "structure"
 
 /datum/codex_entry/grille
-	associated_paths = list(/obj/structure/grille)
+	name = "grille"
 	mechanics_text = "A powered and knotted wire underneath this will cause the grille (provided it is made of a conductive material) to shock anyone not wearing insulated gloves.<br>\
 	Wirecutters will turn the grille into rods instantly.  Grilles are typically made with steel rods."
 	disambiguator = "structure"
-	include_subtypes = TRUE
 
 /datum/codex_entry/lattice
-	associated_paths = list(/obj/structure/lattice)
+	name = "lattice"
 	mechanics_text = "Add a metal floor tile to build a floor on top of the lattice.<br>\
 	Lattices can be made by applying rods to a space tile."
 	disambiguator = "structure"
-	include_subtypes = TRUE
 
 /datum/codex_entry/bed
-	associated_paths = list(/obj/structure/bed)
+	name = "bed"
 	mechanics_text = "Click and drag yourself (or anyone) to this to buckle in. Click on this with an empty hand to undo the buckles.<br>\
 	<br>\
 	Anyone with restraints, such as handcuffs, will not be able to unbuckle themselves. They must use the Resist button, or verb, to break free of \
@@ -28,7 +27,8 @@
 	disambiguator = "structure"
 
 /datum/codex_entry/cheval
-	associated_paths = list(/obj/structure/barricade, /obj/structure/barricade/spike)
+	name = "barricade"
+	associated_strings = list("cheval")
 	lore_text = "The cheval de frise (Frisian horse) is an ancient anti-cavalry barricade so named because they were widely deployed by the Frisians, who lacked easy access to horses to field their own cavalry."
 	mechanics_text = "A simple barricade is crafted from any material. You can make it a cheval de frise by adding rods of any material to a barricade constructed of any material, this structure will injure anyone who moves into it."
 	disambiguator = "structure"

--- a/code/modules/codex/entries/tools.dm
+++ b/code/modules/codex/entries/tools.dm
@@ -29,32 +29,32 @@
 	antag_text = "Need to bypass a bolted door? You can use a crowbar to pry the electronics out of an airlock, provided that it has no power and has been welded shut."
 
 /datum/codex_entry/toolbelt
-	associated_paths = list(/obj/item/belt/utility)
+	name = "toolbelt"
 	mechanics_text = "The tool-belt has enough slots to carry a full engineer's toolset: screwdriver, crowbar, wrench, welder, cable coil, and multitool. Simply click the belt to move a tool to one of its slots."
 	lore_text = "Good hide is hard to come by in certain regions of the galaxy. When they can't come across it, most TSCs will outfit their crews with toolbelts made of synthesized leather."
 	antag_text = "Only amateurs skip grabbing a tool-belt."
 
 /datum/codex_entry/cable_painter
-	associated_paths = list(/obj/item/cable_painter)
+	name = "cable painter"
 	mechanics_text = "Use this device to select a preferred cable color. Apply it to a bundle of cables on your person, or use it on installed cabling on the floor to paint it in your chosen color."
 	lore_text = "A device often used by spacefaring engineers to color-code their electrical systems. An experienced technician can identify traditional installations by color alone."
 	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
 
 /datum/codex_entry/paint_sprayer
-	associated_paths = list(/obj/item/paint_sprayer)
+	name = "paint sprayer"
 	mechanics_text = "Use the paint sprayer to set decal, color and direction used for painting or to switch into the color picking mode. Ctrl+Click for quickly switching modes and Alt+Click for quickly selecting a preset color."
 	lore_text = "This ubiquitous maintenance-grade paint sprayer isn't as fancy or convenient as modern consumer models, but with an internal synthesizer it never runs out of pigment!"
 	antag_text = "This thing would be perfect for vandalism. Could you write your name in the halls?"
 	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
 
 /datum/codex_entry/geiger_counter
-	associated_paths = list(/obj/item/geiger)
+	name = "Geiger counter"
 	mechanics_text = "By using this item, you may toggle its scanning mode on and off. Examine it while it's on to check for ambient radiation."
 	lore_text = "For centuries geiger counters have been saving the lives of unsuspecting laborers and technicians. You can never be too careful around radiation."
 	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
 
 /datum/codex_entry/light_replacer
-	associated_paths = list(/obj/item/lightreplacer)
+	name = "light replacer"
 	mechanics_text = "Examine or use this item to see how many lights are remaining. You can feed it lightbulbs or sheets of glass to refill it."
 	lore_text = "Can you believe they used to have to screw lightbulbs in by hand?"
 	antag_text = "Using a cryptographic sequencer on this device will cause it to overload each light it replaces; when turned on, the new lights will explode!"
@@ -68,20 +68,21 @@
 	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
 
 /datum/codex_entry/t_scanner
-	associated_paths = list(/obj/item/t_scanner)
+	name = "T-ray scanner"
 	mechanics_text = "Use this to toggle its scanning capabilities on and off. While on, it will expose the layout of cabling and pipework in a 7x7 area around you."
 	lore_text = "The T-ray scanner is a modern spectroscopy solution and labor-saving device. Why work yourself to the bone removing floor panels when you can simply look through them with submillimeter radiation?"
 	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
 
 /datum/codex_entry/rcd
-	associated_paths = list(/obj/item/rcd)
+	name = "rapid construction device"
+	associated_strings = list("rcd")
 	mechanics_text = "On use, this device will toggle between various types of structures (or their removal). You can examine it to see its current mode. It must be loaded with compressed matter cartridges, which can be obtained from an autolathe. Click an adjacent tile to use the device."
 	lore_text = "Advents in material printing and synthesis technology have produced everyday miracles, such as the RCD, which in certain industries has single-handedly put entire construction crews out of a job."
 	antag_text = "RCDs can be incredibly dangerous in the wrong hands. Use them to swiftly block off corridors, or instantly breach the ship wherever you want."
 	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
 
 /datum/codex_entry/toolbox
-	associated_paths = list(/obj/item/toolbox)
+	name = "toolbox"
 	mechanics_text = "The toolbox is a general-purpose storage item with lots of space. With an item in your hand, click on it to store it inside."
 	lore_text = "No one remembers which company designed this particular toolbox. It's been mass-produced, retired, brought out of retirement, and counterfeited for decades."
 	antag_text = "Carrying one of these and being bald tends to instill a certain primal fear in most people."

--- a/code/modules/codex/entries/turfs.dm
+++ b/code/modules/codex/entries/turfs.dm
@@ -1,5 +1,6 @@
 /datum/codex_entry/wall
-	associated_paths = list(/turf/wall)
+	name = "wall"
+	associated_strings = list("bulkhead")
 	mechanics_text = "You can deconstruct this by welding it, and then wrenching the girder.<br>\
 	You can build a wall by using metal sheets to make a girder, then adding almost any material as plating.<br>\
 	Walls are typically made of steel girders, plated with steel or plasteel."

--- a/code/modules/codex/entries/weapons.dm
+++ b/code/modules/codex/entries/weapons.dm
@@ -1,19 +1,18 @@
 /datum/codex_entry/baton
-	associated_paths = list(/obj/item/baton, /obj/item/baton/loaded)
+	name = "baton"
 	mechanics_text = "The baton needs to be turned on to apply the stunning effect. Use it in your hand to toggle it on or off. If your intent is \
 	set to 'harm', you will inflict damage when using it, regardless if it is on or not. Each stun reduces the baton's charge, which can be replenished by \
 	putting it inside a weapon recharger."
 	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
 
 /datum/codex_entry/energy_sword
-	associated_paths = list(/obj/item/energy_blade/sword)
+	name = "energy sword"
 	antag_text = "The energy sword is a very strong melee weapon, capable of severing limbs easily, if they are targeted. It can also has a chance \
 	to block projectiles and melee attacks while it is on and being held. The sword can be toggled on or off by using it in your hand. While it is off, \
 	it can be concealed in your pocket or bag."
 	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
 
 /datum/codex_entry/spear
-	associated_paths = list(/obj/item/bladed/polearm/spear)
-	associated_strings = list("spear")
+	name = "spear"
 	mechanics_text = "Spears are automatically held with two hands if the other hand is free to do so. Holding with both hands increases damage dealt. \
 	<BR><BR>You can start crafting a spear by making cable cuffs and applying them to a rod. After, examining the spear assembly will give details on how to proceed."

--- a/code/modules/crafting/metalwork/metalwork_items.dm
+++ b/code/modules/crafting/metalwork/metalwork_items.dm
@@ -18,6 +18,7 @@
 	storage = /datum/storage/crucible
 	obj_flags = OBJ_FLAG_NO_STORAGE
 	chem_volume = 300 * REAGENT_UNITS_PER_MATERIAL_SHEET
+	_atom_codex_value = /datum/codex_entry/material_sheet
 
 /obj/item/chems/crucible/attackby(obj/item/used_item, mob/user)
 

--- a/code/modules/fabrication/fabricator_food.dm
+++ b/code/modules/fabrication/fabricator_food.dm
@@ -7,6 +7,7 @@
 	base_icon_state = "replicator"
 	base_storage_capacity_mult = 5
 	base_type = /obj/machinery/fabricator/replicator
+	_atom_codex_value = /datum/codex_entry/replicator
 
 /obj/machinery/fabricator/replicator/Initialize()
 	. = ..()

--- a/code/modules/fabrication/fabricator_pipe.dm
+++ b/code/modules/fabrication/fabricator_pipe.dm
@@ -10,6 +10,7 @@
 	anchored = FALSE
 	use_power = POWER_USE_OFF
 	color_selectable = TRUE
+	_atom_codex_value = /datum/codex_entry/atmos_pipe_dispenser
 
 /obj/machinery/fabricator/pipe/on_update_icon()
 	return // no icons

--- a/code/modules/fuel_assembly/fuel_compressor.dm
+++ b/code/modules/fuel_assembly/fuel_compressor.dm
@@ -9,6 +9,7 @@
 	anchored = TRUE
 	layer = 4
 	construct_state = /decl/machine_construction/default/panel_closed
+	_atom_codex_value = /datum/codex_entry/fuel_compressor
 	var/list/stored_material = list()
 	var/list/rod_makeup = list()
 

--- a/code/modules/fusion/consoles/core_control.dm
+++ b/code/modules/fusion/consoles/core_control.dm
@@ -1,6 +1,7 @@
 /obj/machinery/computer/fusion/core_control
 	name = "\improper R-UST Mk. 8 core control"
 	ui_template = "fusion_core_control.tmpl"
+	_atom_codex_value = /datum/codex_entry/fusion_core
 
 /obj/machinery/computer/fusion/core_control/OnTopic(var/mob/user, var/href_list, var/datum/topic_state/state)
 

--- a/code/modules/fusion/consoles/gyrotron_control.dm
+++ b/code/modules/fusion/consoles/gyrotron_control.dm
@@ -4,6 +4,7 @@
 	icon_screen = "gyrotron_screen"
 	light_color = COLOR_BLUE
 	ui_template = "fusion_gyrotron_control.tmpl"
+	_atom_codex_value = /datum/codex_entry/gyrotron
 
 /obj/machinery/computer/fusion/gyrotron/OnTopic(var/mob/user, var/href_list, var/datum/topic_state/state)
 

--- a/code/modules/fusion/consoles/injector_control.dm
+++ b/code/modules/fusion/consoles/injector_control.dm
@@ -3,6 +3,7 @@
 	icon_keyboard = "rd_key"
 	icon_screen = "fuel_screen"
 	ui_template = "fusion_injector_control.tmpl"
+	_atom_codex_value = /datum/codex_entry/fusion_fuel_injector
 
 /obj/machinery/computer/fusion/fuel_control/OnTopic(var/mob/user, var/href_list, var/datum/topic_state/state)
 	var/datum/local_network/lan = get_local_network()

--- a/code/modules/fusion/core/_core.dm
+++ b/code/modules/fusion/core/_core.dm
@@ -17,6 +17,7 @@
 	stat_immune = NOINPUT
 	base_type = /obj/machinery/fusion_core
 	stock_part_presets = list(/decl/stock_part_preset/terminal_setup)
+	_atom_codex_value = /datum/codex_entry/fusion_core
 
 	var/obj/effect/fusion_em_field/owned_field
 	var/field_strength = 1//0.01
@@ -103,13 +104,13 @@
 		anchored = !anchored
 		playsound(src.loc, 'sound/items/Ratchet.ogg', 75, 1)
 		if(anchored)
-			user.visible_message("\The [user] secures \the [src] to the floor.", 
-				"You secure \the [src] to the floor.", 
+			user.visible_message("\The [user] secures \the [src] to the floor.",
+				"You secure \the [src] to the floor.",
 				"You hear a ratchet."
 			)
 		else
-			user.visible_message("\The [user] unsecures \the [src] from the floor.", 
-				"You unsecure \the [src] from the floor.", 
+			user.visible_message("\The [user] unsecures \the [src] from the floor.",
+				"You unsecure \the [src] from the floor.",
 				"You hear a ratchet."
 			)
 		return TRUE

--- a/code/modules/fusion/fuel_injector/fuel_injector.dm
+++ b/code/modules/fusion/fuel_injector/fuel_injector.dm
@@ -10,6 +10,7 @@
 	construct_state = /decl/machine_construction/default/panel_closed
 	uncreated_component_parts = null
 	base_type = /obj/machinery/fusion_fuel_injector
+	_atom_codex_value = /datum/codex_entry/fusion_fuel_injector
 
 	var/fuel_usage = 0.001
 	var/initial_id_tag

--- a/code/modules/fusion/gyrotron/gyrotron.dm
+++ b/code/modules/fusion/gyrotron/gyrotron.dm
@@ -8,6 +8,7 @@
 	initial_access = list(access_engine)
 	use_power = POWER_USE_IDLE
 	active_power_usage = GYRO_POWER
+	_atom_codex_value = /datum/codex_entry/gyrotron
 
 	var/initial_id_tag
 	/// Time between shots, in SECONDS, NOT DECISECONDS

--- a/code/modules/hydroponics/grown.dm
+++ b/code/modules/hydroponics/grown.dm
@@ -1,3 +1,7 @@
+/datum/codex_entry/fruit_and_veg
+	name = "fruits and vegetables"
+	mechanics_text = "Fruits and vegetables are grown from seeds in hydroponics or farm plots. Some can have seeds extracted using a sharp knife to grow more.<br>Chopping, slicing or crushing growns with a knife is used to prepare them for other recipes."
+
 //Grown foods.
 /obj/item/food/grown
 	name = "produce"
@@ -16,6 +20,9 @@
 	var/work_skill = SKILL_BOTANY
 	var/seeds_extracted = FALSE
 	var/datum/seed/seed
+
+/obj/item/food/grown/get_codex_value()
+	return /datum/codex_entry/fruit_and_veg::name
 
 // This is sort of pointless while food is a valid input on the ChemMaster but maybe
 // in the future there will be some more interesting ways to process growns/food.

--- a/code/modules/hydroponics/grown.dm
+++ b/code/modules/hydroponics/grown.dm
@@ -15,14 +15,13 @@
 	drying_wetness = 45
 	dried_type = /obj/item/food/grown/dry
 	allergen_flags = ALLERGEN_VEGETABLE
+	_atom_codex_value = /datum/codex_entry/fruit_and_veg
 
 	var/plant_segment_type = PLANT_SEG_BODY // Used for growns produced via plant dissection.
 	var/work_skill = SKILL_BOTANY
 	var/seeds_extracted = FALSE
 	var/datum/seed/seed
 
-/obj/item/food/grown/get_codex_value()
-	return /datum/codex_entry/fruit_and_veg::name
 
 // This is sort of pointless while food is a valid input on the ChemMaster but maybe
 // in the future there will be some more interesting ways to process growns/food.

--- a/code/modules/hydroponics/processed_grown.dm
+++ b/code/modules/hydroponics/processed_grown.dm
@@ -18,6 +18,9 @@
 	/// Used in recipes to distinguish between general types.
 	var/processed_grown_tag
 
+/obj/item/food/processed_grown/get_codex_value()
+	return /datum/codex_entry/fruit_and_veg::name
+
 /obj/item/food/processed_grown/Initialize(mapload, material_key, skip_plate = FALSE, _seed)
 
 	if(isnull(seed) && _seed)

--- a/code/modules/hydroponics/processed_grown.dm
+++ b/code/modules/hydroponics/processed_grown.dm
@@ -6,6 +6,7 @@
 	center_of_mass    = @'{"x":16,"y":16}'
 	bitesize          = 2
 	material          = /decl/material/solid/organic/plantmatter
+	_atom_codex_value = /datum/codex_entry/fruit_and_veg
 
 	// We get these from being sliced.
 	nutriment_type = null
@@ -18,8 +19,6 @@
 	/// Used in recipes to distinguish between general types.
 	var/processed_grown_tag
 
-/obj/item/food/processed_grown/get_codex_value()
-	return /datum/codex_entry/fruit_and_veg::name
 
 /obj/item/food/processed_grown/Initialize(mapload, material_key, skip_plate = FALSE, _seed)
 

--- a/code/modules/hydroponics/seed.dm
+++ b/code/modules/hydroponics/seed.dm
@@ -1,4 +1,6 @@
 /datum/codex_entry/scannable/flora
+
+	abstract_type = /datum/codex_entry/scannable/flora
 	category = /decl/codex_category/flora
 
 /datum/seed

--- a/code/modules/lights/light_replacer.dm
+++ b/code/modules/lights/light_replacer.dm
@@ -45,6 +45,7 @@
 	obj_flags = OBJ_FLAG_CONDUCTIBLE
 	slot_flags = SLOT_LOWER_BODY
 	origin_tech = @'{"magnets":3,"materials":2}'
+	_atom_codex_value = /datum/codex_entry/light_replacer
 
 	var/max_uses = 32
 	var/uses = 32

--- a/code/modules/materials/material_stack_synth.dm
+++ b/code/modules/materials/material_stack_synth.dm
@@ -28,6 +28,7 @@
 	name = "cyborg steel synthesiser"
 	icon_state = "sheet"
 	material = /decl/material/solid/metal/steel
+	_atom_codex_value = /datum/codex_entry/steel_borg
 
 /obj/item/stack/material/cyborg/plasteel
 	name = "cyborg plasteel synthesiser"
@@ -43,6 +44,7 @@
 	name = "cyborg glass synthesiser"
 	icon_state = "sheet"
 	material = /decl/material/solid/glass
+	_atom_codex_value = /datum/codex_entry/glass_borg
 
 /obj/item/stack/material/cyborg/fiberglass
 	name = "cyborg fiberglass synthesiser"
@@ -55,6 +57,7 @@
 	material = /decl/material/solid/glass
 	reinf_material = /decl/material/solid/metal/steel
 	charge_costs = list(500, 1000)
+	_atom_codex_value = /datum/codex_entry/glass_reinf_borg
 
 /obj/item/stack/material/cyborg/aluminium
 	name = "cyborg aluminium synthesiser"

--- a/code/modules/materials/stack_types/material_stack_misc.dm
+++ b/code/modules/materials/stack_types/material_stack_misc.dm
@@ -37,6 +37,7 @@
 	stack_merge_type = /obj/item/stack/material/pane
 	crafting_stack_type = /obj/item/stack/material/pane
 	can_be_reinforced = TRUE
+	_atom_codex_value = /datum/codex_entry/glass
 
 /obj/item/stack/material/pane/update_state_from_amount()
 	if(reinf_material)

--- a/code/modules/mining/drilling/drill.dm
+++ b/code/modules/mining/drilling/drill.dm
@@ -14,6 +14,7 @@
 	uncreated_component_parts = null
 	base_type = /obj/machinery/mining_drill
 	z_flags = ZMM_WIDE_LOAD
+	_atom_codex_value = /datum/codex_entry/mining_drill
 
 	/// The drill's FSM, keeping track of which state the drill is currently in.
 	var/datum/state_machine/drill/state_machine = null

--- a/code/modules/mob/living/human/examine.dm
+++ b/code/modules/mob/living/human/examine.dm
@@ -4,12 +4,6 @@
 	var/list/mob_intro = "[user == src ? "You are" : "This is"] <EM>[name]</EM>"
 	if(!(hideflags & HIDEJUMPSUIT) || !(hideflags & HIDEFACE))
 
-		var/show_codex = user.get_preference_value(/datum/client_preference/inquisitive_examine) == PREF_ON && user.can_use_codex()
-		if(show_codex)
-			var/datum/codex_entry/mob_codex = get_atom_codex_entry(user)
-			if(mob_codex)
-				mob_intro += "<sup><a href='byond://?src=\ref[SScodex];show_examined_info=\ref[mob_codex];show_to=\ref[user]'>?</a></sup>"
-
 		var/species_name = "\improper "
 		if(isSynthetic() && species.cyborg_noun)
 			species_name += "[species.cyborg_noun] [species.name]"
@@ -17,10 +11,10 @@
 			species_name += "[species.name]"
 		mob_intro += ", <b><font color='[species.get_species_flesh_color(src)]'>\a [species_name]</font></b>"
 
-		if(show_codex)
+		if(user.get_preference_value(/datum/client_preference/inquisitive_examine) == PREF_ON && user.can_use_codex())
 			var/datum/codex_entry/species_codex = SScodex.get_codex_entry("[species.name] (species)")
 			if(species_codex)
-				mob_intro += "<sup><a href='byond://?src=\ref[SScodex];show_examined_info=\ref[species_codex];show_to=\ref[user]'>?</a></sup>"
+				mob_intro += "<small><a href='byond://?src=\ref[SScodex];show_examined_info=\ref[species_codex];show_to=\ref[user]'>?</a></sup>"
 
 	. += SPAN_INFO(JOINTEXT(mob_intro))
 	var/extra_species_text = species.get_additional_examine_text(src)

--- a/code/modules/mob/living/human/examine.dm
+++ b/code/modules/mob/living/human/examine.dm
@@ -3,12 +3,25 @@
 	. = list(SPAN_INFO("*---------*"))
 	var/list/mob_intro = "[user == src ? "You are" : "This is"] <EM>[name]</EM>"
 	if(!(hideflags & HIDEJUMPSUIT) || !(hideflags & HIDEFACE))
+
+		var/show_codex = user.get_preference_value(/datum/client_preference/inquisitive_examine) == PREF_ON && user.can_use_codex()
+		if(show_codex)
+			var/datum/codex_entry/mob_codex = get_atom_codex_entry(user)
+			if(mob_codex)
+				mob_intro += "<sup><a href='byond://?src=\ref[SScodex];show_examined_info=\ref[mob_codex];show_to=\ref[user]'>?</a></sup>"
+
 		var/species_name = "\improper "
 		if(isSynthetic() && species.cyborg_noun)
 			species_name += "[species.cyborg_noun] [species.name]"
 		else
 			species_name += "[species.name]"
-		mob_intro += ", <b><font color='[species.get_species_flesh_color(src)]'>\a [species_name]!</font></b>[(user.can_use_codex() && SScodex.get_codex_entry(get_codex_value(user))) ?  SPAN_NOTICE(" \[<a href='byond://?src=\ref[SScodex];show_examined_info=\ref[src];show_to=\ref[user]'>?</a>\]") : ""]"
+		mob_intro += ", <b><font color='[species.get_species_flesh_color(src)]'>\a [species_name]</font></b>"
+
+		if(show_codex)
+			var/datum/codex_entry/species_codex = SScodex.get_codex_entry("[species.name] (species)")
+			if(species_codex)
+				mob_intro += "<sup><a href='byond://?src=\ref[SScodex];show_examined_info=\ref[species_codex];show_to=\ref[user]'>?</a></sup>"
+
 	. += SPAN_INFO(JOINTEXT(mob_intro))
 	var/extra_species_text = species.get_additional_examine_text(src)
 	if(extra_species_text)

--- a/code/modules/mob/living/silicon/robot/drone/drone.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone.dm
@@ -17,6 +17,7 @@
 	local_transmit = 1
 	possession_candidate = TRUE
 	speed = -1
+	_atom_codex_value = /datum/codex_entry/maint_drone
 
 	can_pull_size = ITEM_SIZE_NORMAL
 	can_pull_mobs = MOB_PULL_SMALLER

--- a/code/modules/mob/living/silicon/robot/drone/drone_items.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_items.dm
@@ -7,6 +7,7 @@
 	icon_state = "gripper"
 	max_health = ITEM_HEALTH_NO_DAMAGE
 	item_flags = ITEM_FLAG_NO_BLUDGEON
+	_atom_codex_value = /datum/codex_entry/gripper
 
 	//Has a list of items that it can hold.
 	var/list/can_hold = list(

--- a/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
+++ b/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
@@ -303,6 +303,9 @@ var/global/chicken_count = 0
 	var/decl/skill/examine_skill = SKILL_BOTANY // for maps that change the default skills, or for alien eggs that need science/medical/anatomy instead
 	var/examine_difficulty = SKILL_ADEPT
 
+/obj/item/food/egg/get_mechanics_info()
+	return "Eggs are usually obtained from birds. Feeding fowl like chickens with wheat can encourage egg-laying, and if you leave an egg alone for long enough it might hatch."
+
 /obj/item/food/egg/get_examine_strings(mob/user, distance, infix, suffix)
 	. = ..()
 	if(isnull(examine_difficulty) || !ispath(examine_skill))

--- a/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
+++ b/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
@@ -304,7 +304,8 @@ var/global/chicken_count = 0
 	var/examine_difficulty = SKILL_ADEPT
 
 /obj/item/food/egg/get_mechanics_info()
-	return "Eggs are usually obtained from birds. Feeding fowl like chickens with wheat can encourage egg-laying, and if you leave an egg alone for long enough it might hatch."
+	. = ..()
+	LAZYADD(., "Eggs are usually obtained from birds. Feeding fowl like chickens with wheat can encourage egg-laying, and if you leave an egg alone for long enough it might hatch.")
 
 /obj/item/food/egg/get_examine_strings(mob/user, distance, infix, suffix)
 	. = ..()

--- a/code/modules/mob/living/simple_animal/simple_animal_codex.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal_codex.dm
@@ -1,2 +1,3 @@
 /datum/codex_entry/scannable/fauna
+	abstract_type = /datum/codex_entry/scannable/fauna
 	category = /decl/codex_category/fauna

--- a/code/modules/modular_computers/computers/subtypes/dev_console.dm
+++ b/code/modules/modular_computers/computers/subtypes/dev_console.dm
@@ -3,10 +3,12 @@
 	maximum_component_parts   = list(/obj/item/stock_parts = 14)	//There's a lot of stuff that goes in these
 	icon = 'icons/obj/modular_computers/modular_console.dmi'
 	icon_state = "console-off"
+	_atom_codex_value = /datum/codex_entry/computer/modular
 	var/list/interact_sounds  = list("keyboard", "keystroke")
 	var/wired_connection      = FALSE // Whether or not this console will start with a wired connection beneath it.
 	var/tmp/max_hardware_size = 3 //Enum to tell whether computer parts are too big to fit in this machine.
 	var/tmp/os_type           = /datum/extension/interactive/os/console //The type of the OS extension to create for this machine.
+
 
 /obj/machinery/computer/modular/Initialize()
 	set_extension(src, os_type)
@@ -94,7 +96,7 @@
 			to_chat(user, "This component is too large for \the [src].")
 			return 0
 	. = ..()
-	
+
 /obj/machinery/computer/modular/verb/emergency_shutdown()
 	set name = "Forced Shutdown"
 	set category = "Object"

--- a/code/modules/overmap/internet/internet_repeater.dm
+++ b/code/modules/overmap/internet/internet_repeater.dm
@@ -17,6 +17,7 @@ var/global/list/internet_repeaters = list()
 	uncreated_component_parts = list(
 		/obj/item/stock_parts/power/terminal,
 	)
+	_atom_codex_value = /datum/codex_entry/internet_repeater
 
 /obj/machinery/internet_repeater/Initialize()
 	. = ..()

--- a/code/modules/overmap/internet/internet_uplink.dm
+++ b/code/modules/overmap/internet/internet_uplink.dm
@@ -15,6 +15,7 @@ var/global/list/internet_uplinks = list()
 	stock_part_presets = list(
 		/decl/stock_part_preset/terminal_setup,
 	)
+	_atom_codex_value = /datum/codex_entry/internet_uplink
 
 	var/overmap_range = BASE_INTERNET_RANGE
 	var/max_overmap_range = BASE_INTERNET_RANGE
@@ -163,6 +164,7 @@ var/global/list/internet_uplinks = list()
 	light_color = COLOR_GREEN
 	idle_power_usage = 250
 	active_power_usage = 500
+	_atom_codex_value = /datum/codex_entry/internet_uplink
 	var/initial_id_tag = "plexus"
 
 /obj/machinery/computer/internet_uplink/Initialize()

--- a/code/modules/paperwork/_paper.dm
+++ b/code/modules/paperwork/_paper.dm
@@ -21,6 +21,8 @@
 	drop_sound             = 'sound/foley/paperpickup1.ogg'
 	pickup_sound           = 'sound/foley/paperpickup2.ogg'
 	item_flags             = ITEM_FLAG_CAN_TAPE
+	_atom_codex_value      = /datum/codex_entry/writing
+
 	//#TODO: Fonts probably should be stored in the pens or something?
 	var/tmp/deffont        = PEN_FONT_DEFAULT
 	var/tmp/signfont       = PEN_FONT_SIGNATURE

--- a/code/modules/paperwork/pen/pen.dm
+++ b/code/modules/paperwork/pen/pen.dm
@@ -9,6 +9,7 @@
 	throw_range           = 15
 	material              = /decl/material/solid/organic/plastic
 	_base_attack_force    = 1
+	_atom_codex_value     = /datum/codex_entry/writing
 	var/pen_flag          = PEN_FLAG_ACTIVE                     //Properties/state of the pen used.
 	var/stroke_color      = "black"                             //What colour the ink is! Can be hexadecimal colour or a colour name string.
 	var/stroke_color_name = "black"                             //Human readable name of the stroke colour. Used in text strings, and to identify the nearest colour to the stroke colour.

--- a/code/modules/power/apc/_apc.dm
+++ b/code/modules/power/apc/_apc.dm
@@ -27,6 +27,7 @@ var/global/list/all_apcs = list()
 	clicksound = "switch"
 	layer = ABOVE_WINDOW_LAYER
 	directional_offset = @'{"NORTH":{"y":22}, "SOUTH":{"y":-22}, "EAST":{"x":22}, "WEST":{"x":-22}}'
+	_atom_codex_value = /datum/codex_entry/apc
 
 	var/powered_down = FALSE
 	var/area/area

--- a/code/modules/power/cable/cable.dm
+++ b/code/modules/power/cable/cable.dm
@@ -35,6 +35,7 @@ var/global/list/obj/structure/cable/all_cables = list()
 	anchored = TRUE
 	obj_flags = OBJ_FLAG_MOVES_UNSUPPORTED
 	level = LEVEL_BELOW_PLATING
+	_atom_codex_value = /datum/codex_entry/cable
 
 	/// The base cable stack that should be produced, not including color.
 	/// cable_type::stack_merge_type should equal cable_type, ideally

--- a/code/modules/power/cable/cable_coil.dm
+++ b/code/modules/power/cable/cable_coil.dm
@@ -34,6 +34,8 @@
 	attack_verb = list("whipped", "lashed", "disciplined", "flogged")
 	stack_merge_type = /obj/item/stack/cable_coil
 	matter_multiplier = 0.15
+	_atom_codex_value = /datum/codex_entry/cable
+
 	/// Whether or not this cable coil can even have a color in the first place.
 	var/can_have_color = TRUE
 	/// The type of cable structure produced when laying down this cable.

--- a/code/modules/power/port_gen.dm
+++ b/code/modules/power/port_gen.dm
@@ -121,6 +121,7 @@
 	construct_state = /decl/machine_construction/default/panel_closed
 	uncreated_component_parts = null
 	stat_immune = 0
+	_atom_codex_value = /datum/codex_entry/pacman
 
 	var/sheet_path                                     // Base object type that it will accept, set in Initialize() if null
 	var/sheet_material = /decl/material/solid/graphite // Material type that the fuel needs to match.

--- a/code/modules/power/solar/solar_control.dm
+++ b/code/modules/power/solar/solar_control.dm
@@ -14,6 +14,8 @@
 	construct_state = /decl/machine_construction/default/panel_closed/computer
 	base_type = /obj/machinery/power/solar_control
 	frame_type = /obj/machinery/constructable_frame/computerframe/deconstruct
+	_atom_codex_value = /datum/codex_entry/solars
+
 	var/cdir = 0
 	var/targetdir = 0		// target angle in manual tracking (since it updates every game minute)
 	var/gen = 0

--- a/code/modules/power/solar/solar_panel.dm
+++ b/code/modules/power/solar/solar_panel.dm
@@ -26,6 +26,8 @@ var/global/list/solars_list = list()
 	idle_power_usage = 0
 	active_power_usage = 0
 	max_health = 10
+	_atom_codex_value = /datum/codex_entry/solars
+
 	var/obscured = 0
 	var/sunfrac = 0
 	var/efficiency = 1
@@ -229,6 +231,7 @@ var/global/list/solars_list = list()
 	w_class = ITEM_SIZE_HUGE // Pretty big!
 	anchored = FALSE
 	material = /decl/material/solid/metal/steel
+	_atom_codex_value = /datum/codex_entry/solars
 	var/tracker = 0
 	var/glass_type
 	var/glass_reinforced

--- a/code/modules/power/solar/tracker.dm
+++ b/code/modules/power/solar/tracker.dm
@@ -10,6 +10,7 @@
 	icon_state = "tracker"
 	anchored = TRUE
 	density = TRUE
+	_atom_codex_value = /datum/codex_entry/solars
 
 	var/sun_angle = 0		// sun angle as set by sun datum
 	var/obj/machinery/power/solar_control/control = null

--- a/code/modules/projectiles/guns/launcher/money_cannon.dm
+++ b/code/modules/projectiles/guns/launcher/money_cannon.dm
@@ -10,6 +10,7 @@
 	fire_sound_text = "a whoosh and a crisp, papery rustle"
 	fire_delay = 1
 	fire_sound = 'sound/weapons/gunshot/money_launcher.ogg'
+	_atom_codex_value = /datum/codex_entry/moneygun
 
 	var/emagged = 0
 	var/receptacle_value = 0

--- a/code/modules/reagents/reagent_containers/food/baking/leavened_dough.dm
+++ b/code/modules/reagents/reagent_containers/food/baking/leavened_dough.dm
@@ -12,7 +12,8 @@
 	backyard_grilling_announcement = "is baked into a simple bun."
 
 /obj/item/food/dough/get_mechanics_info()
-	return "Dough is made by <span codexlink='[/decl/chemical_reaction/recipe/food/dough::name]'>mixing water and flour</span>, with yeast added for leavening, then applying heat. It can be flattened with a rolling pin or divided with sharp object like a knife."
+	. = ..()
+	LAZYADD(., "Dough is made by <span codexlink='[/decl/chemical_reaction/recipe/food/dough::name]'>mixing water and flour</span>, with yeast added for leavening, then applying heat. It can be flattened with a rolling pin or divided with sharp object like a knife.")
 
 // Dough + rolling pin = flat dough
 /obj/item/food/dough/attackby(obj/item/used_item, mob/user)

--- a/code/modules/reagents/reagent_containers/food/baking/leavened_dough.dm
+++ b/code/modules/reagents/reagent_containers/food/baking/leavened_dough.dm
@@ -11,6 +11,9 @@
 	backyard_grilling_product = /obj/item/food/bun
 	backyard_grilling_announcement = "is baked into a simple bun."
 
+/obj/item/food/dough/get_mechanics_info()
+	return "Dough is made by <span codexlink='[/decl/chemical_reaction/recipe/food/dough::name]'>mixing water and flour</span>, with yeast added for leavening, then applying heat. It can be flattened with a rolling pin or divided with sharp object like a knife."
+
 // Dough + rolling pin = flat dough
 /obj/item/food/dough/attackby(obj/item/used_item, mob/user)
 	if(!istype(used_item,/obj/item/rollingpin))

--- a/code/modules/reagents/reagent_containers/food/dairy/_dairy.dm
+++ b/code/modules/reagents/reagent_containers/food/dairy/_dairy.dm
@@ -6,6 +6,15 @@
 	var/data_name_field  = DATA_MILK_NAME
 	var/data_color_field = DATA_MILK_COLOR
 
+/obj/item/food/dairy/get_mechanics_info()
+	return "Dairy products are made from milk, either by skimming or from mixing milk with enzymes or rennet and applying heat. Rennet can be obtained from the stomachs of grazing animals."
+
+// Set default strings so it shows as 'a wedge of cheese' in recipes instead of 'a wedge'.
+/obj/item/food/dairy/Initialize(ml, material_key, skip_plate)
+	set_dairy_name(get_default_dairy_name())
+	set_color(get_default_dairy_color())
+	. = ..()
+
 /obj/item/food/dairy/proc/get_default_dairy_color()
 	return COLOR_WHITE
 

--- a/code/modules/reagents/reagent_containers/food/dairy/_dairy.dm
+++ b/code/modules/reagents/reagent_containers/food/dairy/_dairy.dm
@@ -7,7 +7,8 @@
 	var/data_color_field = DATA_MILK_COLOR
 
 /obj/item/food/dairy/get_mechanics_info()
-	return "Dairy products are made from milk, either by skimming or from mixing milk with enzymes or rennet and applying heat. Rennet can be obtained from the stomachs of grazing animals."
+	. = ..()
+	LAZYADD(., "Dairy products are made from milk, either by skimming or from mixing milk with enzymes or rennet and applying heat. Rennet can be obtained from the stomachs of grazing animals.")
 
 // Set default strings so it shows as 'a wedge of cheese' in recipes instead of 'a wedge'.
 /obj/item/food/dairy/Initialize(ml, material_key, skip_plate)

--- a/code/modules/recycling/conveyor2.dm
+++ b/code/modules/recycling/conveyor2.dm
@@ -11,6 +11,7 @@ var/global/list/all_conveyor_switches = list()
 	desc = "A conveyor belt."
 	layer = BELOW_OBJ_LAYER	// so they appear under stuff
 	anchored = TRUE
+	_atom_codex_value = /datum/codex_entry/conveyor_construct
 	var/operating = 0  // 1 if running forward, -1 if backwards, 0 if off
 	var/operable = 1   // true if can operate (no broken segments in this belt run)
 	var/forwards       // this is the default (forward) direction, set by the map dir
@@ -130,6 +131,7 @@ var/global/list/all_conveyor_switches = list()
 	icon = 'icons/obj/recycling.dmi'
 	icon_state = "switch-off"
 	anchored = TRUE
+	_atom_codex_value = /datum/codex_entry/conveyor_switch
 	var/position = 0			// 0 off, -1 reverse, 1 forward
 	var/last_pos = -1			// last direction setting
 	var/operated = 1			// true if just operated
@@ -236,6 +238,7 @@ var/global/list/all_conveyor_switches = list()
 	w_class = ITEM_SIZE_HUGE
 	material = /decl/material/solid/metal/steel
 	matter = list(/decl/material/solid/organic/plastic = MATTER_AMOUNT_REINFORCEMENT)
+	_atom_codex_value = /datum/codex_entry/conveyor_construct
 	var/id_tag
 
 /obj/item/conveyor_construct/attackby(obj/item/used_item, mob/user, params)
@@ -272,6 +275,7 @@ var/global/list/all_conveyor_switches = list()
 	icon_state = "switch-off"
 	w_class = ITEM_SIZE_HUGE
 	material = /decl/material/solid/metal/steel
+	_atom_codex_value = /datum/codex_entry/conveyor_switch
 	var/id_tag
 
 /obj/item/conveyor_switch_construct/Initialize()

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -18,6 +18,18 @@ var/global/list/diversion_junctions = list()
 	icon_state = "disposal"
 	anchored = TRUE
 	density = TRUE
+	active_power_usage = 2200	//the pneumatic pump power. 3 HP ~ 2200W
+	idle_power_usage = 100
+	atom_flags = ATOM_FLAG_CLIMBABLE
+	throwpass = TRUE
+	construct_state = /decl/machine_construction/default/panel_closed/item_chassis
+	uncreated_component_parts = list(
+		/obj/item/stock_parts/power/apc/buildable
+	)
+	frame_type = /obj/structure/disposalconstruct/machine
+	base_type = /obj/machinery/disposal/buildable
+	_atom_codex_value = /datum/codex_entry/disposal
+
 	var/datum/gas_mixture/air_contents	// internal reservoir
 	var/mode = 1	// item mode 0=off 1=charging 2=charged
 	var/flush = 0	// true if flush handle is pulled
@@ -27,18 +39,7 @@ var/global/list/diversion_junctions = list()
 	var/flush_count = 0 //this var adds 1 once per tick. When it reaches flush_every_ticks it resets and tries to flush.
 	var/last_sound = 0
 	var/list/allowed_objects = list(/obj/structure/closet)
-	active_power_usage = 2200	//the pneumatic pump power. 3 HP ~ 2200W
-	idle_power_usage = 100
-	atom_flags = ATOM_FLAG_CLIMBABLE
 	var/turn = DISPOSAL_FLIP_NONE
-	throwpass = TRUE
-
-	construct_state = /decl/machine_construction/default/panel_closed/item_chassis
-	uncreated_component_parts = list(
-		/obj/item/stock_parts/power/apc/buildable
-	)
-	frame_type = /obj/structure/disposalconstruct/machine
-	base_type = /obj/machinery/disposal/buildable
 
 /obj/machinery/disposal/buildable
 	uncreated_component_parts = null

--- a/code/modules/recycling/wrapped_package.dm
+++ b/code/modules/recycling/wrapped_package.dm
@@ -83,8 +83,8 @@
 
 /obj/item/parcel/get_mechanics_info()
 	. = ..()
-	. += "<BR/>It can be opened by applying any sharp item, with help intent."
-	. += "<BR/>It can opened by using it while held, if its small enough."
+	LAZYADD(., "It can be opened by applying any sharp item, with help intent.")
+	LAZYADD(., "It can opened by using it while held, if its small enough.")
 
 /obj/item/parcel/proc/make_parcel(var/atom/movable/AM, var/mob/user)
 	if(!is_type_in_list(AM, get_whitelist()))

--- a/code/modules/scanners/gas.dm
+++ b/code/modules/scanners/gas.dm
@@ -9,6 +9,7 @@
 	origin_tech = @'{"magnets":1,"engineering":1}'
 	window_width = 350
 	window_height = 400
+	_atom_codex_value = /datum/codex_entry/gas_analyzer
 	var/mode = DEFAULT_MODE
 
 /obj/item/scanner/gas/get_header()

--- a/code/modules/shield_generators/floor_diffuser.dm
+++ b/code/modules/shield_generators/floor_diffuser.dm
@@ -12,6 +12,7 @@
 	construct_state = /decl/machine_construction/default/panel_closed
 	uncreated_component_parts = null
 	stat_immune = 0
+	_atom_codex_value = /datum/codex_entry/diffuser_machine
 
 	var/alarm = 0
 	var/enabled = 1

--- a/code/modules/shield_generators/handheld_diffuser.dm
+++ b/code/modules/shield_generators/handheld_diffuser.dm
@@ -10,6 +10,7 @@
 		/decl/material/solid/metal/gold = MATTER_AMOUNT_TRACE,
 		/decl/material/solid/metal/silver = MATTER_AMOUNT_TRACE
 	)
+	_atom_codex_value = /datum/codex_entry/diffuser_item
 	var/enabled = 0
 
 /obj/item/shield_diffuser/on_update_icon()

--- a/code/modules/smes/_smes.dm
+++ b/code/modules/smes/_smes.dm
@@ -19,6 +19,7 @@
 	stat = BROKEN         // Should be removed if the terminals initialize fully.
 	reason_broken = MACHINE_BROKEN_GENERIC
 	abstract_type = /obj/machinery/power/smes
+	_atom_codex_value = /datum/codex_entry/smes
 
 	var/capacity = 5e6 // maximum charge
 	var/charge = 1e6 // actual charge

--- a/code/modules/smes/smes_codex.dm
+++ b/code/modules/smes/smes_codex.dm
@@ -1,5 +1,6 @@
 /datum/codex_entry/smes
-	associated_paths = list(/obj/machinery/power/smes)
+	name = "power storage"
+	associated_strings = list("smes")
 	mechanics_text = "It's a big battery. An important part of the power network that ensures that you still have power when your generators eventually explode. Maximum input and output settings are available. <BR>The lights on the front show the status of the SMES: The column on the left shows stored power, a blinking red light at top right shows that it's on but receiving no power, blinking yellow shows that the SMES is charging, and the little light on the middle right shows whether it's outputting power or not. <BR>A floor terminal puts power into the SMES, and power is output to a wire underneath."
 	disambiguator = "machine"
 	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE

--- a/code/modules/thermoelectric_generator/circulator.dm
+++ b/code/modules/thermoelectric_generator/circulator.dm
@@ -10,6 +10,7 @@
 	connect_types = CONNECT_TYPE_REGULAR|CONNECT_TYPE_FUEL
 	obj_flags = OBJ_FLAG_ANCHORABLE | OBJ_FLAG_ROTATABLE
 	layer = STRUCTURE_LAYER
+	_atom_codex_value = /datum/codex_entry/atmos_circulator
 
 	var/kinetic_efficiency = 0.04 //combined kinetic and kinetic-to-electric efficiency
 	var/volume_ratio = 0.2

--- a/mods/content/fantasy/datum/overrides.dm
+++ b/mods/content/fantasy/datum/overrides.dm
@@ -73,3 +73,12 @@
 		"The pain is overwhelming!"
 	)
 	return custom_pain_strings
+
+// Removes references to hydroponics.
+/datum/codex_entry/fruit_and_veg
+	mechanics_text = "Fruits and vegetables are grown from seeds in farm plots, or harvested wild from plants in nature. Some can have seeds extracted using a sharp knife to grow more.<br>Chopping, slicing or crushing growns with a knife is used to prepare them for other recipes."
+
+// Removes references to universal enzyme.
+
+/obj/item/food/dairy/get_mechanics_info()
+	return "Dairy products are made from milk, either by skimming or from mixing milk with rennet and applying heat. Rennet can be obtained from the stomachs of grazing animals."

--- a/mods/content/fantasy/datum/overrides.dm
+++ b/mods/content/fantasy/datum/overrides.dm
@@ -81,4 +81,5 @@
 // Removes references to universal enzyme.
 
 /obj/item/food/dairy/get_mechanics_info()
-	return "Dairy products are made from milk, either by skimming or from mixing milk with rennet and applying heat. Rennet can be obtained from the stomachs of grazing animals."
+	. = ..()
+	LAZYADD(., "Dairy products are made from milk, either by skimming or from mixing milk with rennet and applying heat. Rennet can be obtained from the stomachs of grazing animals.")

--- a/mods/content/fantasy/props/signpost.dm
+++ b/mods/content/fantasy/props/signpost.dm
@@ -41,7 +41,7 @@
 
 /obj/effect/departure_signpost/get_mechanics_info()
 	. = ..()
-	. += "By clicking on the signpost, you can choose to remove your character from the round in order to free your job slot and respawn. This will delete your character's worn and held items, so make sure not to take any important items with you."
+	LAZYADD(., "By clicking on the signpost, you can choose to remove your character from the round in order to free your job slot and respawn. This will delete your character's worn and held items, so make sure not to take any important items with you.")
 
 // Premade types for mapping.
 /obj/effect/departure_signpost/north

--- a/mods/content/psionics/datum/codex.dm
+++ b/mods/content/psionics/datum/codex.dm
@@ -1,13 +1,5 @@
 /datum/codex_entry/cuchulain_foundation
 	name = "Cuchulain Foundation"
-	associated_paths = list(
-		/obj/item/briefcase/foundation,
-		/obj/item/gun/projectile/revolver/foundation,
-		/obj/item/card/id/foundation,
-		/obj/item/card/id/foundation_civilian,
-		/obj/item/clothing/suit/toggle/labcoat/foundation,
-		/obj/item/chems/drinks/glass2/coffeecup/foundation
-	)
 	lore_text = "The Cuchulain Foundation is a non-profit body based out of Neptune orbit. Their logo is \
 	an upward-facing radio telescope dish, usually printed in green. They perform niche research on behalf \
 	of private parties, the government, and their own interests. They are also the single largest psionic registration \
@@ -22,14 +14,27 @@
 	researching or understanding them, and the depth and nature of their connections to other major \
 	bodies are unclear."
 
+/obj/item/briefcase/foundation
+	_atom_codex_value = /datum/codex_entry/cuchulain_foundation
+
+/obj/item/gun/projectile/revolver/foundation
+	_atom_codex_value = /datum/codex_entry/cuchulain_foundation
+
+/obj/item/card/id/foundation
+	_atom_codex_value = /datum/codex_entry/cuchulain_foundation
+
+/obj/item/card/id/foundation_civilian
+	_atom_codex_value = /datum/codex_entry/cuchulain_foundation
+
+/obj/item/clothing/suit/toggle/labcoat/foundation
+	_atom_codex_value = /datum/codex_entry/cuchulain_foundation
+
+/obj/item/chems/drinks/glass2/coffeecup/foundation
+	_atom_codex_value = /datum/codex_entry/cuchulain_foundation
+
 /datum/codex_entry/psionics
 	name = "Psionics"
 	associated_strings = list("psychic powers")
-	associated_paths = list(
-		/obj/item/book/fluff/psionics,
-		/obj/item/clothing/head/helmet/space/psi_amp,
-		/obj/item/clothing/head/helmet/space/psi_amp/lesser
-	)
 	lore_text = "Psionics are a relatively new phenomenon theorized to be linked to long-term exposure \
 	to deep, uninhabited space. A tiny, tiny subset of people exposed to such conditions can develop the \
 	ability to perform small feats like levitating coins or removing a headache with nothing but their mind. \
@@ -45,3 +50,12 @@
 	made of nullglass will stop the use of powers, and overuse of powers can cause lethal brain damage."
 	antag_text = "Psionic amplifiers are illegal equipment, but can boost your psionics to massive levels at the cost \
 	of occupying your hat slot permanently."
+
+/obj/item/book/fluff/psionics
+	_atom_codex_value = /datum/codex_entry/psionics
+
+/obj/item/clothing/head/helmet/space/psi_amp
+	_atom_codex_value = /datum/codex_entry/psionics
+
+/obj/item/clothing/head/helmet/space/psi_amp/lesser
+	_atom_codex_value = /datum/codex_entry/psionics

--- a/mods/content/supermatter/datums/sm_codex.dm
+++ b/mods/content/supermatter/datums/sm_codex.dm
@@ -4,7 +4,7 @@
 	available_to_map_tech_level = MAP_TECH_LEVEL_SPACE
 
 /datum/codex_entry/supermatter
-	associated_paths = list(/obj/structure/supermatter)
+	name = "supermatter engine"
 	mechanics_text = "When energized by a laser (or something hitting it), it emits radiation and heat.  If the heat reaches above 7000 kelvin, it will send an alert and start taking damage. \
 	After integrity falls to zero percent, it will delaminate, causing a massive explosion, station-wide radiation spikes, and hallucinations. \
 	Supermatter reacts badly to oxygen in the atmosphere.  It'll also heat up really quick if it is in vacuum.<br>\

--- a/mods/content/supermatter/structures/supermatter_crystal.dm
+++ b/mods/content/supermatter/structures/supermatter_crystal.dm
@@ -117,6 +117,7 @@ var/global/list/supermatter_delam_accent_sounds = list(
 		/decl/material/solid/metal/steel =   MATTER_AMOUNT_REINFORCEMENT
 	)
 	w_class = ITEM_SIZE_LARGE_STRUCTURE
+	_atom_codex_value = /datum/codex_entry/supermatter
 
 	var/nitrogen_retardation_factor = 0.15 // Higher == N2 slows reaction more
 	var/thermal_release_modifier = 10000   // Higher == more heat released during reaction

--- a/mods/content/xenobiology/slime/slime_codex.dm
+++ b/mods/content/xenobiology/slime/slime_codex.dm
@@ -1,12 +1,17 @@
 
 /datum/codex_entry/slimes
-	associated_paths = list(
-		/mob/living/slime,
-		/obj/machinery/smartfridge/secure/extract,
-		/obj/item/slime_extract
-	)
+	name = "slimes"
 	lore_text = "The strange, hydrophobic, single-celled organisms called 'slimes' are frequently the focus of xenobiological science, due to their fascinating internal chemistry and their incredible hardiness. However, they are frequently underestimated or mishandled, and slime-related genetic decay is a leading cause of death for xenoscientists."
 	mechanics_text = "Slimes will happily feed on any human, humanoid or monkey that wanders into their sight. You can wrestle them off their victim or spray them with a fire extinguisher to neutralize them. If a slime is well-fed, it might grow into an adult, and then split into up to four baby slimes of various colours, depending on the colour of the parent.<br><br>Slime cores can have a variety of effects when injected with either blood or uranium powder. For more information on slime xenobiology, consult the <span codexlink='Guide to Slime Handling'>guide</span>."
+
+/mob/living/slime
+	_atom_codex_value = /datum/codex_entry/slimes
+
+/obj/machinery/smartfridge/secure/extract
+	_atom_codex_value = /datum/codex_entry/slimes
+
+/obj/item/slime_extract
+	_atom_codex_value = /datum/codex_entry/slimes
 
 /datum/codex_entry/slime_handling
 	name = "Guide to Slime Handling"
@@ -21,7 +26,7 @@
 		<p>Slimes are intelligent, social creatures, even if they don't look like it. Physical affection (click a slime on help intent) will start an enduring friendship that will last until you attack the slime, or it gets hungry enough to see you as food. Saying hello to a friendly slime will also make them regard you more fondly. Slimes that regard you well enough may even listen to commands like 'stop', 'stay' or 'follow'.</p>
 	"}
 
-/datum/codex_entry/slime_handling/New(_display_name, list/_associated_paths, list/_associated_strings, _lore_text, _mechanics_text, _antag_text)
+/datum/codex_entry/slime_handling/New(_display_name, list/_associated_strings, _lore_text, _mechanics_text, _antag_text)
 	. = ..()
 	var/list/extra_mechanics_text = list()
 	extra_mechanics_text += "<h2>Slime colours</h2><br><table border = '1px'>"

--- a/mods/gamemodes/cult/codex.dm
+++ b/mods/gamemodes/cult/codex.dm
@@ -1,3 +1,0 @@
-/datum/codex_entry/cultblade
-	associated_paths = list(/obj/item/sword/cultblade)
-	antag_text = "This sword is a powerful weapon, capable of severing limbs easily, if they are targeted. Nonbelievers are unable to use this weapon."

--- a/mods/gamemodes/cult/items.dm
+++ b/mods/gamemodes/cult/items.dm
@@ -4,6 +4,10 @@
 	icon = 'icons/obj/items/weapon/swords/cult.dmi'
 	material_alteration = MAT_FLAG_ALTERATION_COLOR | MAT_FLAG_ALTERATION_NAME
 
+/obj/item/sword/cultblade/get_antag_info()
+	. = ..()
+	LAZYADD(., "This sword is a powerful weapon, capable of severing limbs easily, if they are targeted. Nonbelievers are unable to use this weapon.")
+
 // separated into a proc so that modpacks can modify it
 /obj/item/sword/cultblade/proc/can_use_safely(mob/living/user)
 	return iscultist(user)

--- a/mods/species/ascent/datum/codex.dm
+++ b/mods/species/ascent/datum/codex.dm
@@ -1,14 +1,21 @@
 /datum/codex_entry/ascent
 	name = "The Ascent"
-	associated_paths = list(
-		/mob/living/silicon/robot/flying/ascent,
-		/obj/item/multitool/mantid,
-		/obj/item/weldingtool/electric/mantid,
-		/obj/item/cell/mantid,
-		/obj/item/gun/energy/particle,
-		/obj/item/gun/energy/particle/small
-	)
 	lore_text = "The Ascent is a hostile alien culture located rimward of the settled territories.\
 	Little is known about them, and diplomatic channels do not currently exist outside of informal \
 	contacts with individual seedships or warships. They are insectoid, crystalline, and seem to have \
 	a rigid heirarchial society structured around their massive queen 'gynes'."
+
+/mob/living/silicon/robot/flying/ascent
+	_atom_codex_value = /datum/codex_entry/ascent
+
+/obj/item/multitool/mantid
+	_atom_codex_value = /datum/codex_entry/ascent
+
+/obj/item/weldingtool/electric/mantid
+	_atom_codex_value = /datum/codex_entry/ascent
+
+/obj/item/cell/mantid
+	_atom_codex_value = /datum/codex_entry/ascent
+
+/obj/item/gun/energy/particle
+	_atom_codex_value = /datum/codex_entry/ascent


### PR DESCRIPTION
## Description of changes
Initial intent of this PR was just to fix some issues Scav reported with the codex, but it turned into a general-purpose codex rewrite.
- Removes `associated_paths` in favour of putting references on the atoms instead.
- Rewrites how codex pages are generated/retrieved.
- Moves the codex link in examine from the bottom of the examine to a `?` by the atom name.
- Other stuff that I will document when this is further along.

## Why and what will this PR improve
Codex works better, slightly more obvious.

## Authorship
Myself.

## Changelog
TODO