### PR TITLE
Adds a mob_mimic simple_animal type for complex mob NPCs.

### DIFF
--- a/code/datums/repositories/atom_info.dm
+++ b/code/datums/repositories/atom_info.dm
@@ -44,6 +44,7 @@ var/global/repository/atom_info/atom_info_repository = new()
 		description_cache[key] = instance.desc
 	if(cache_appearance && !appearance_cache[key])
 		instance = instance || get_instance_of(_path, _mat, _amount)
+		instance.compile_overlays()
 		appearance_cache[key] = instance.appearance
 	if(!matter_mult_cache[key] && ispath(_path, /obj))
 		var/obj/obj_instance = instance || get_instance_of(_path, _mat, _amount)

--- a/code/datums/repositories/atom_info.dm
+++ b/code/datums/repositories/atom_info.dm
@@ -44,7 +44,6 @@ var/global/repository/atom_info/atom_info_repository = new()
 		description_cache[key] = instance.desc
 	if(cache_appearance && !appearance_cache[key])
 		instance = instance || get_instance_of(_path, _mat, _amount)
-		instance.compile_overlays()
 		appearance_cache[key] = instance.appearance
 	if(!matter_mult_cache[key] && ispath(_path, /obj))
 		var/obj/obj_instance = instance || get_instance_of(_path, _mat, _amount)

--- a/code/game/objects/items/__item.dm
+++ b/code/game/objects/items/__item.dm
@@ -1365,3 +1365,6 @@ modules/mob/living/human/life.dm if you die, you will be zoomed out.
 // Called on mouse up event from wielding mob.
 /obj/item/proc/wielder_mouse_drag_up(mob/user, atom/target)
 	return FALSE
+
+/obj/item/proc/get_effective_obj()
+	return src

--- a/code/modules/bodytype/_bodytype.dm
+++ b/code/modules/bodytype/_bodytype.dm
@@ -91,6 +91,8 @@ var/global/list/bodytypes_by_category = list()
 	var/list/prone_overlay_offset
 	/// Set to TRUE to skip unit testing as a primary bodytype in a human. Generally for partial prosthetic models.
 	var/skip_organ_validation = FALSE
+	/// Simplified 'animal' version used by mob mimics.
+	var/simple_variant = /decl/bodytype/animal
 
 	/// Per-bodytype per-zone message strings, see /mob/proc/get_hug_zone_messages
 	var/list/default_hug_message
@@ -724,19 +726,10 @@ var/global/list/bodytypes_by_category = list()
 /decl/bodytype/proc/set_default_sprite_accessories(var/mob/living/setting)
 	if(!istype(setting))
 		return
-	for(var/obj/item/organ/external/E in setting.get_external_organs())
-		E.skin_colour = base_color
-		E.clear_sprite_accessories(skip_update = TRUE)
-	if(!length(default_sprite_accessories))
-		return
-	for(var/accessory_category in default_sprite_accessories)
-		for(var/accessory in default_sprite_accessories[accessory_category])
-			var/decl/sprite_accessory/accessory_decl = GET_DECL(accessory)
-			var/accessory_metadata = default_sprite_accessories[accessory_category][accessory]
-			for(var/bodypart in accessory_decl.body_parts)
-				var/obj/item/organ/external/O = GET_EXTERNAL_ORGAN(setting, bodypart)
-				if(O)
-					O.set_sprite_accessory(accessory, null, accessory_metadata, skip_update = TRUE)
+	setting.clear_sprite_accessories(base_color, skip_update = TRUE)
+	if(length(default_sprite_accessories))
+		setting.set_sprite_accessories(default_sprite_accessories, skip_update = TRUE)
+	setting.update_body(TRUE)
 
 /decl/bodytype/proc/customize_preview_mannequin(mob/living/human/dummy/mannequin/mannequin)
 	set_default_sprite_accessories(mannequin)

--- a/code/modules/bodytype/bodytype_quadruped.dm
+++ b/code/modules/bodytype/bodytype_quadruped.dm
@@ -16,6 +16,7 @@
 		BP_L_FOOT = list("path" = /obj/item/organ/external/foot/quadruped),
 		BP_R_FOOT = list("path" = /obj/item/organ/external/foot/right/quadruped)
 	)
+	simple_variant = /decl/bodytype/quadruped/animal
 	var/rideable = TRUE
 	var/riding_offset = @'{"x":0,"y":0,"z":8}'
 

--- a/code/modules/mechs/equipment/_equipment.dm
+++ b/code/modules/mechs/equipment/_equipment.dm
@@ -69,9 +69,6 @@
 	owner = null
 	canremove = TRUE
 
-/obj/item/mech_equipment/proc/get_effective_obj()
-	return src
-
 /obj/item/mech_equipment/mob_can_unequip(mob/user, slot, disable_warning = FALSE, dropping = FALSE)
 	. = ..()
 	if(. && owner)

--- a/code/modules/mechs/equipment/mounted_system.dm
+++ b/code/modules/mechs/equipment/mounted_system.dm
@@ -32,7 +32,7 @@
 	. = ..()
 
 /obj/item/mech_equipment/mounted_system/get_effective_obj()
-	return (holding ? holding : src)
+	return (holding ? holding : ..())
 
 /obj/item/mech_equipment/mounted_system/get_hardpoint_status_value()
 	return (holding ? holding.get_hardpoint_status_value() : null)

--- a/code/modules/mechs/mech_interaction.dm
+++ b/code/modules/mechs/mech_interaction.dm
@@ -40,6 +40,10 @@
 		return STATUS_INTERACTIVE
 	return ..()
 
+/mob/living/exosuit/get_held_items()
+	for(var/h in hardpoints)
+		LAZYADD(., hardpoints[h])
+
 /mob/living/exosuit/get_dexterity(var/silent)
 	return DEXTERITY_FULL
 

--- a/code/modules/mechs/mech_movement.dm
+++ b/code/modules/mechs/mech_movement.dm
@@ -6,11 +6,17 @@
 		/datum/movement_handler/mob/exosuit
 	)
 
+/mob/living/exosuit/get_turn_sound()
+	return mech_turn_sound
+
+/mob/living/exosuit/get_footstep_sound(turf/step_turf)
+	if(!isspaceturf(step_turf))
+		return mech_step_sound
+	return ..()
+
 /mob/living/exosuit/Move()
 	. = ..()
 	if(.)
-		if(!isspaceturf(loc))
-			playsound(src.loc, mech_step_sound, 40, 1)
 		for(var/mob/pilot as anything in pilots)
 			pilot.refresh_hud_element(HUD_UP_HINT)
 
@@ -101,7 +107,6 @@
 		exosuit.visible_message(SPAN_NOTICE("\The [exosuit] moves [txt_dir]."))
 
 	if(exosuit.dir != moving_dir && !(direction & (UP|DOWN)))
-		playsound(exosuit.loc, exosuit.mech_turn_sound, 40,1)
 		exosuit.set_dir(moving_dir)
 		exosuit.SetMoveCooldown(exosuit.legs.turn_delay)
 	else

--- a/code/modules/mechs/premade/_premade.dm
+++ b/code/modules/mechs/premade/_premade.dm
@@ -167,10 +167,12 @@
 	faction = "killbots"
 	ai = /datum/mob_controller/aggressive
 	abstract_type = /mob/living/simple_animal/mob_mimic/exosuit
+	VAR_PRIVATE/static/alist/_mob_mimic_type_to_mech_overlays = alist()
 
 /mob/living/simple_animal/mob_mimic/exosuit/update_mob_values()
 	. = ..()
 	SetName("autonomous [name]")
+	desc += " This one seems to be running autonomously, with no pilot inside."
 
 /mob/living/simple_animal/mob_mimic/exosuit/prepare_mimic(mob/living/mimic)
 	if(!istype(mimic, /mob/living/exosuit))
@@ -179,3 +181,13 @@
 	mimech.hatch_closed = TRUE
 	mimech.power = MECH_POWER_ON
 	mimech.update_icon()
+
+/mob/living/simple_animal/mob_mimic/exosuit/handle_additional_mimic(mob/living/mimic)
+	_mob_mimic_type_to_mech_overlays[mimic_mob] = mimic.overlays?.Copy()
+
+/mob/living/simple_animal/mob_mimic/exosuit/on_update_icon()
+	. = ..()
+	cut_overlays()
+	if(length(_mob_mimic_type_to_mech_overlays[mimic_mob]))
+		set_overlays(_mob_mimic_type_to_mech_overlays[mimic_mob])
+	compile_overlays()

--- a/code/modules/mechs/premade/_premade.dm
+++ b/code/modules/mechs/premade/_premade.dm
@@ -162,3 +162,20 @@
 
 /mob/living/exosuit/premade/random/extra/Initialize(mapload, var/obj/structure/heavy_vehicle_frame/source_frame)
 	. = ..(mapload, source_frame, super_random = TRUE)
+
+/mob/living/simple_animal/mob_mimic/exosuit
+	faction = "killbots"
+	ai = /datum/mob_controller/aggressive
+	abstract_type = /mob/living/simple_animal/mob_mimic/exosuit
+
+/mob/living/simple_animal/mob_mimic/exosuit/update_mob_values()
+	. = ..()
+	SetName("autonomous [name]")
+
+/mob/living/simple_animal/mob_mimic/exosuit/prepare_mimic(mob/living/mimic)
+	if(!istype(mimic, /mob/living/exosuit))
+		return
+	var/mob/living/exosuit/mimech = mimic
+	mimech.hatch_closed = TRUE
+	mimech.power = MECH_POWER_ON
+	mimech.update_icon()

--- a/code/modules/mechs/premade/combat.dm
+++ b/code/modules/mechs/premade/combat.dm
@@ -2,6 +2,9 @@
 	name = "combat exosuit"
 	desc = "A sleek, modern combat exosuit."
 
+/mob/living/simple_animal/mob_mimic/exosuit/combat
+	mimic_mob = /mob/living/exosuit/premade/combat
+
 /mob/living/exosuit/premade/combat/Initialize()
 	if(!arms)
 		arms = new /obj/item/mech_component/manipulators/combat/painted(src)
@@ -24,8 +27,14 @@
 /mob/living/exosuit/premade/combat/military
 	decal = "cammo1"
 
+/mob/living/simple_animal/mob_mimic/exosuit/military
+	mimic_mob = /mob/living/exosuit/premade/combat/military
+
 /mob/living/exosuit/premade/combat/military/alpine
 	decal = "cammo2"
+
+/mob/living/simple_animal/mob_mimic/exosuit/alpine
+	mimic_mob = /mob/living/exosuit/premade/combat/military/alpine
 
 /mob/living/exosuit/premade/combat/military/Initialize()
 	. = ..()

--- a/code/modules/mechs/premade/exploration.dm
+++ b/code/modules/mechs/premade/exploration.dm
@@ -2,6 +2,9 @@
 	name = "exploration mech"
 	desc = "It looks a bit charred."
 
+/mob/living/simple_animal/mob_mimic/exosuit/exploration
+	mimic_mob = /mob/living/exosuit/premade/light/exploration
+
 /obj/item/mech_component/manipulators/powerloader/exploration
 	color = COLOR_PURPLE
 

--- a/code/modules/mechs/premade/heavy.dm
+++ b/code/modules/mechs/premade/heavy.dm
@@ -1,5 +1,5 @@
 /mob/living/exosuit/premade/heavy
-	name = "Heavy exosuit"
+	name = "heavy exosuit"
 	desc = "A heavily armored combat exosuit."
 
 /mob/living/simple_animal/mob_mimic/exosuit/heavy

--- a/code/modules/mechs/premade/heavy.dm
+++ b/code/modules/mechs/premade/heavy.dm
@@ -2,6 +2,9 @@
 	name = "Heavy exosuit"
 	desc = "A heavily armored combat exosuit."
 
+/mob/living/simple_animal/mob_mimic/exosuit/heavy
+	mimic_mob = /mob/living/exosuit/premade/heavy
+
 /obj/item/mech_component/manipulators/heavy/painted
 	color = COLOR_TITANIUM
 
@@ -103,6 +106,9 @@
 		head.color = COLOR_RED
 	if(body)
 		body.color = COLOR_DARK_GUNMETAL
+
+/mob/living/simple_animal/mob_mimic/exosuit/merc
+	mimic_mob = /mob/living/exosuit/premade/heavy/merc
 
 /mob/living/exosuit/premade/heavy/merc/spawn_mech_equipment()
 	install_system(new /obj/item/mech_equipment/mounted_system/taser(src), HARDPOINT_LEFT_HAND)

--- a/code/modules/mechs/premade/light.dm
+++ b/code/modules/mechs/premade/light.dm
@@ -2,6 +2,9 @@
 	name = "light exosuit"
 	desc = "A light and agile exosuit."
 
+/mob/living/simple_animal/mob_mimic/exosuit/light
+	mimic_mob = /mob/living/exosuit/premade/light
+
 /obj/item/mech_component/manipulators/light/painted
 	color = COLOR_OFF_WHITE
 

--- a/code/modules/mechs/premade/powerloader.dm
+++ b/code/modules/mechs/premade/powerloader.dm
@@ -111,13 +111,13 @@
 	install_system(new /obj/item/mech_equipment/mounted_system/melee/machete(src), HARDPOINT_RIGHT_HAND)
 
 /mob/living/exosuit/premade/powerloader/flames_red
-	name = "APLU \"Firestarter\""
+	name = "\improper APLU \"Firestarter\""
 	desc = "An ancient, but well-liked cargo handling exosuit. This one has cool red flames."
 	decal = "flames_red"
 	decal_blend = BLEND_OVERLAY
 
 /mob/living/exosuit/premade/powerloader/flames_blue
-	name = "APLU \"Burning Chrome\""
+	name = "\improper APLU \"Burning Chrome\""
 	desc = "An ancient, but well-liked cargo handling exosuit. This one has cool blue flames."
 	decal = "flames_blue"
 	decal_blend = BLEND_OVERLAY

--- a/code/modules/mechs/premade/powerloader.dm
+++ b/code/modules/mechs/premade/powerloader.dm
@@ -2,6 +2,9 @@
 	name = "power loader"
 	desc = "An ancient, but well-liked cargo handling exosuit."
 
+/mob/living/simple_animal/mob_mimic/exosuit/powerloader
+	mimic_mob = /mob/living/exosuit/premade/powerloader
+
 /obj/item/mech_component/manipulators/powerloader/painted
 	color = "#ffbc37"
 
@@ -122,6 +125,9 @@
 /mob/living/exosuit/premade/firefighter
 	name = "firefighting exosuit"
 	desc = "A mix and match of industrial parts designed to withstand fires."
+
+/mob/living/simple_animal/mob_mimic/exosuit/firefighter
+	mimic_mob = /mob/living/exosuit/premade/firefighter
 
 /mob/living/exosuit/premade/firefighter/Initialize()
 	if(!arms)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1641,6 +1641,17 @@ default behaviour is:
 
 	return TRUE
 
+/mob/living/set_dir()
+	var/lastdir = dir
+	. = ..()
+	if(. && dir != lastdir)
+		var/turn_sound = get_turn_sound()
+		if(turn_sound)
+			playsound(src, turn_sound, 50, 1)
+
+/mob/living/proc/get_turn_sound()
+	return
+
 /mob/living/proc/get_footstep_sound(turf/step_turf)
 	return step_turf?.get_footstep_sound(src)
 

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -749,6 +749,7 @@ default behaviour is:
 	QDEL_NULL(_aiming)
 	QDEL_NULL_LIST(_hallucinations)
 	QDEL_NULL_LIST(aimed_at_by)
+	QDEL_NULL_LIST(stat_organs)
 	LAZYCLEARLIST(smell_cooldown)
 	if(stressors) // Do not QDEL_NULL, keys are managed instances.
 		stressors = null

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -2023,3 +2023,23 @@ default behaviour is:
 
 /mob/living/proc/is_playing_dead()
 	return stat || current_posture?.prone || (status_flags & FAKEDEATH)
+
+/mob/living/proc/clear_sprite_accessories(set_color, skip_update)
+	for(var/obj/item/organ/external/E in get_external_organs())
+		if(set_color)
+			E.skin_colour = set_color
+		E.clear_sprite_accessories(skip_update = TRUE)
+	if(!skip_update)
+		update_body()
+
+/mob/living/proc/set_sprite_accessories(list/setting_accessories, skip_update)
+	for(var/accessory_category in setting_accessories)
+		for(var/accessory in setting_accessories[accessory_category])
+			var/decl/sprite_accessory/accessory_decl = GET_DECL(accessory)
+			var/accessory_metadata = setting_accessories[accessory_category][accessory]
+			for(var/bodypart in accessory_decl.body_parts)
+				var/obj/item/organ/external/O = GET_EXTERNAL_ORGAN(src, bodypart)
+				if(O)
+					O.set_sprite_accessory(accessory, null, accessory_metadata, skip_update = TRUE)
+	if(!skip_update)
+		update_body()

--- a/code/modules/mob/living/living_appearance.dm
+++ b/code/modules/mob/living/living_appearance.dm
@@ -48,6 +48,7 @@
 	return get_eye_colour() != new_color
 
 /mob/living/get_all_current_mob_overlays()
+	RETURN_TYPE(/list)
 	return mob_overlays
 
 /mob/living/set_current_mob_overlay(var/overlay_layer, var/image/overlay, var/redraw_mob = TRUE)
@@ -58,6 +59,7 @@
 	return mob_overlays[overlay_layer]
 
 /mob/living/get_all_current_mob_underlays()
+	RETURN_TYPE(/list)
 	return mob_underlays
 
 /mob/living/set_current_mob_underlay(var/underlay_layer, var/image/underlay, var/redraw_mob = TRUE)

--- a/code/modules/mob/living/simple_animal/friendly/crab.dm
+++ b/code/modules/mob/living/simple_animal/friendly/crab.dm
@@ -25,6 +25,7 @@
 // TODO
 /decl/bodytype/hexapod
 	abstract_type = /decl/bodytype/hexapod
+	simple_variant = /decl/bodytype/hexapod/animal
 
 /decl/bodytype/hexapod/animal
 	abstract_type = /decl/bodytype/hexapod/animal

--- a/code/modules/mob/living/simple_animal/mob_mimic/mob_mimic.dm
+++ b/code/modules/mob/living/simple_animal/mob_mimic/mob_mimic.dm
@@ -1,6 +1,7 @@
 /mob/living/simple_animal/mob_mimic
 	natural_weapon = null
 	projectiletype = null
+	faction        = null
 
 	var/copy_health = TRUE
 
@@ -65,11 +66,15 @@
 	cut_overlays()
 	try_refresh_visible_overlays()
 
+/mob/living/simple_animal/mob_mimic/proc/prepare_mimic(mob/living/mimic)
+	return
+
 // For some reason mobs like humans do not fully apply their appearance by the time this proc runs without sleep().
 // The sleep is only applied the first time this type is created so should not be a big issue in practice.
 /mob/living/simple_animal/mob_mimic/proc/cache_and_apply_mimic()
 	set waitfor = FALSE
 	var/mob/living/mimic = new mimic_mob
+	prepare_mimic(mimic)
 	sleep(5)
 	_mob_mimic_type_to_appearance[mimic_mob] = mimic.appearance
 	_mob_mimic_type_to_synthetic[mimic_mob]  = mimic.isSynthetic()

--- a/code/modules/mob/living/simple_animal/mob_mimic/mob_mimic.dm
+++ b/code/modules/mob/living/simple_animal/mob_mimic/mob_mimic.dm
@@ -33,6 +33,8 @@
 	var/copy_health = TRUE
 	var/mob/living/mimic_mob
 
+	VAR_PRIVATE/static/alist/_mob_mimic_being_prepared      = alist()
+
 	VAR_PRIVATE/static/alist/_mob_mimic_type_to_appearance  = alist()
 	VAR_PRIVATE/static/alist/_mob_mimic_type_to_synthetic   = alist()
 	VAR_PRIVATE/static/alist/_mob_mimic_type_to_overlays    = alist()
@@ -67,7 +69,6 @@
 /mob/living/simple_animal/mob_mimic/LateInitialize()
 	. = ..()
 	if(_mob_mimic_type_to_appearance[mimic_mob])
-		update_icon()
 		update_mob_values()
 	else
 		cache_and_apply_mimic()
@@ -113,12 +114,13 @@
 /mob/living/simple_animal/mob_mimic/proc/get_best_melee_weapon(mob/living/mimic)
 	var/obj/item/strongest
 	for(var/obj/item/thing in mimic.get_held_items())
-		thing = thing.get_effective_obj()
-		if(!strongest || thing.get_base_attack_force() > strongest.get_base_attack_force())
+		var/obj/item/weapon = thing.get_effective_obj()
+		if(!strongest || weapon.get_base_attack_force() > strongest.get_base_attack_force())
 			strongest = thing
-	. = strongest
-	if(.)
+	if(strongest)
 		mimic.drop_from_inventory(strongest)
+		strongest.forceMove(null)
+		return strongest.get_effective_obj()
 
 /mob/living/simple_animal/mob_mimic/proc/prepare_mimic(mob/living/mimic)
 	return
@@ -126,14 +128,20 @@
 /mob/living/simple_animal/mob_mimic/proc/handle_additional_mimic(mob/living/mimic)
 	return
 
-// For some reason mobs like humans do not fully apply their appearance by the time this proc runs without sleep().
-// The sleep is only applied the first time this type is created so should not be a big issue in practice.
+// For some reason mobs like humans do not fully apply their appearance by the time this proc runs without a delay.
+// The delay is only applied the first time this type is created so should not be a big issue in practice.
+// Atoms initialising in parallel will defer their update until hopefully the first one has completed.
 /mob/living/simple_animal/mob_mimic/proc/cache_and_apply_mimic()
-	set waitfor = FALSE
+	if(_mob_mimic_being_prepared[mimic_mob])
+		addtimer(CALLBACK(src, TYPE_PROC_REF(/mob/living/simple_animal/mob_mimic, update_mob_values)), 10)
+	else
+		_mob_mimic_being_prepared[mimic_mob] = TRUE
+		var/mob/living/mimic = new mimic_mob
+		prepare_mimic(mimic)
+		addtimer(CALLBACK(src, TYPE_PROC_REF(/mob/living/simple_animal/mob_mimic, process_mimic), mimic), 5)
 
-	var/mob/living/mimic = new mimic_mob
-	prepare_mimic(mimic)
-	sleep(5)
+/mob/living/simple_animal/mob_mimic/proc/process_mimic(mob/living/mimic)
+
 	handle_additional_mimic(mimic)
 
 	_mob_mimic_type_to_appearance[mimic_mob]  = mimic.appearance
@@ -167,7 +175,6 @@
 			_mob_mimic_type_to_melee[mimic_mob] = strongest
 
 	qdel(mimic)
-	update_icon()
 	update_mob_values()
 
 /mob/living/simple_animal/mob_mimic/get_turn_sound()
@@ -214,6 +221,8 @@
 		natural_weapon.set_base_attack_force(melee.get_base_attack_force())
 		natural_weapon.atom_damage_type = melee.atom_damage_type
 		UNLINT(natural_weapon.attack_verb = melee.attack_verb)
+
+	update_icon()
 
 /mob/living/simple_animal/mob_mimic/death(gibbed)
 

--- a/code/modules/mob/living/simple_animal/mob_mimic/mob_mimic.dm
+++ b/code/modules/mob/living/simple_animal/mob_mimic/mob_mimic.dm
@@ -1,0 +1,149 @@
+/mob/living/simple_animal/mob_mimic
+	natural_weapon = null
+	projectiletype = null
+
+	var/copy_health = TRUE
+
+	var/mob/living/mimic_mob
+	VAR_PRIVATE/static/alist/_mob_mimic_type_to_appearance = alist()
+	VAR_PRIVATE/static/alist/_mob_mimic_type_to_synthetic  = alist()
+	VAR_PRIVATE/static/alist/_mob_mimic_type_to_overlays   = alist()
+	VAR_PRIVATE/static/alist/_mob_mimic_type_to_underlays  = alist()
+	VAR_PRIVATE/static/alist/_mob_mimic_type_to_eyes       = alist()
+	VAR_PRIVATE/static/alist/_mob_mimic_type_to_eye_color  = alist()
+	VAR_PRIVATE/static/alist/_mob_mimic_type_to_projectile = alist()
+	VAR_PRIVATE/static/alist/_mob_mimic_type_to_melee      = alist()
+	VAR_PRIVATE/static/alist/_mob_mimic_type_to_health     = alist()
+	VAR_PRIVATE/static/alist/_mob_mimic_type_to_offset_x   = alist()
+	VAR_PRIVATE/static/alist/_mob_mimic_type_to_offset_y   = alist()
+	VAR_PRIVATE/static/alist/_mob_mimic_type_to_bodytype   = alist()
+
+/mob/living/simple_animal/mob_mimic/isSynthetic()
+	return !!_mob_mimic_type_to_synthetic[mimic_mob]
+
+/mob/living/simple_animal/mob_mimic/Initialize()
+	if(!ispath(mimic_mob, /mob/living))
+		return INITIALIZE_HINT_QDEL
+	..()
+	return INITIALIZE_HINT_LATELOAD
+
+/mob/living/simple_animal/mob_mimic/LateInitialize()
+	. = ..()
+	if(_mob_mimic_type_to_appearance[mimic_mob])
+		update_mob_values()
+		update_icon()
+	else
+		cache_and_apply_mimic()
+
+/mob/living/simple_animal/mob_mimic/add_additional_visible_overlays(list/accumulator)
+	SHOULD_CALL_PARENT(FALSE)
+
+/mob/living/simple_animal/mob_mimic/set_current_mob_overlay(var/overlay_layer, var/image/overlay, var/redraw_mob = TRUE)
+	SHOULD_CALL_PARENT(FALSE)
+
+/mob/living/simple_animal/mob_mimic/set_current_mob_underlay(var/underlay_layer, var/image/underlay, var/redraw_mob = TRUE)
+	SHOULD_CALL_PARENT(FALSE)
+
+/mob/living/simple_animal/mob_mimic/update_equipment_overlay(var/slot, var/redraw_mob = TRUE)
+	SHOULD_CALL_PARENT(FALSE)
+
+/mob/living/simple_animal/mob_mimic/apply_visible_overlays()
+	mob_overlays  = _mob_mimic_type_to_overlays[mimic_mob]
+	mob_underlays = _mob_mimic_type_to_underlays[mimic_mob]
+	return ..()
+
+/mob/living/simple_animal/mob_mimic/get_eye_overlay()
+	return _mob_mimic_type_to_eyes[mimic_mob]
+
+/mob/living/simple_animal/mob_mimic/on_update_icon()
+	SHOULD_CALL_PARENT(FALSE)
+	if(!_mob_mimic_type_to_appearance[mimic_mob])
+		cache_and_apply_mimic()
+		return
+	appearance = _mob_mimic_type_to_appearance[mimic_mob]
+	eye_color  = _mob_mimic_type_to_eye_color[mimic_mob]
+	cut_overlays()
+	try_refresh_visible_overlays()
+
+// For some reason mobs like humans do not fully apply their appearance by the time this proc runs without sleep().
+// The sleep is only applied the first time this type is created so should not be a big issue in practice.
+/mob/living/simple_animal/mob_mimic/proc/cache_and_apply_mimic()
+	set waitfor = FALSE
+	var/mob/living/mimic = new mimic_mob
+	sleep(5)
+	_mob_mimic_type_to_appearance[mimic_mob] = mimic.appearance
+	_mob_mimic_type_to_synthetic[mimic_mob]  = mimic.isSynthetic()
+	_mob_mimic_type_to_overlays[mimic_mob]   = mimic.get_all_current_mob_overlays()?.Copy()
+	_mob_mimic_type_to_underlays[mimic_mob]  = mimic.get_all_current_mob_underlays()?.Copy()
+	_mob_mimic_type_to_eyes[mimic_mob]       = mimic.get_eye_overlay()
+	_mob_mimic_type_to_eye_color[mimic_mob]  = mimic.get_eye_colour()
+	_mob_mimic_type_to_health[mimic_mob]     = mimic.get_max_health()
+	_mob_mimic_type_to_offset_x[mimic_mob]   = mimic.default_pixel_x
+	_mob_mimic_type_to_offset_y[mimic_mob]   = mimic.default_pixel_y
+
+	var/decl/bodytype/bodytype = mimic.get_bodytype()
+	_mob_mimic_type_to_bodytype[mimic_mob] = bodytype?.simple_variant
+
+	if(isnull(projectiletype))
+		var/obj/item/gun/gun = locate() in mimic.get_held_items()
+		_mob_mimic_type_to_projectile[mimic_mob] = gun?.consume_next_projectile(mimic)
+
+	if(isnull(natural_weapon))
+		var/obj/item/strongest
+		for(var/obj/item/thing in mimic.get_held_items())
+			if(!strongest || thing.get_base_attack_force() > strongest.get_base_attack_force())
+				strongest = thing
+		if(strongest)
+			_mob_mimic_type_to_melee[mimic_mob] = strongest
+			mimic.drop_from_inventory(strongest)
+
+	qdel(mimic)
+	update_mob_values()
+	update_icon()
+
+/mob/living/simple_animal/mob_mimic/proc/update_mob_values()
+
+	if(isnull(faction))
+		faction = mimic_mob::faction
+
+	if(_mob_mimic_type_to_bodytype[mimic_mob])
+		set_bodytype(_mob_mimic_type_to_bodytype[mimic_mob])
+
+	if(copy_health)
+		max_health = _mob_mimic_type_to_health[mimic_mob]
+		current_health = max_health
+		update_health()
+
+	default_pixel_x = _mob_mimic_type_to_offset_x[mimic_mob]
+	default_pixel_y = _mob_mimic_type_to_offset_y[mimic_mob]
+	reset_offsets()
+
+	var/obj/item/projectile/proj = _mob_mimic_type_to_projectile[mimic_mob]
+	if(istype(proj))
+		projectilesound = proj.fire_sound
+		projectiletype  = proj.type
+
+	var/obj/item/melee = _mob_mimic_type_to_melee[mimic_mob]
+	if(melee && !istype(natural_weapon))
+		natural_weapon = new(src)
+		natural_weapon.show_in_message = TRUE
+		natural_weapon.appearance = melee
+		natural_weapon.set_base_attack_force(melee.get_base_attack_force())
+		natural_weapon.atom_damage_type = melee.atom_damage_type
+		UNLINT(natural_weapon.attack_verb = melee.attack_verb)
+
+/mob/living/simple_animal/mob_mimic/death(gibbed)
+
+	if(gibbed)
+		return ..()
+
+	if(mimic_mob)
+		var/mob/living/corpse = new mimic_mob(loc)
+		corpse.death()
+		corpse.take_overall_damage(brute_damage, burn_damage)
+		if(gene_damage)
+			corpse.adjustCloneLoss(gene_damage)
+
+	forceMove(null)
+	..() // Remove from mob lists, etc. in a way that isn't visible and leaves no debris
+	qdel(src) // Clean ourselves up

--- a/code/modules/mob/living/simple_animal/mob_mimic/mob_mimic.dm
+++ b/code/modules/mob/living/simple_animal/mob_mimic/mob_mimic.dm
@@ -1,23 +1,59 @@
+/mob/proc/get_armor_for_mimic()
+	RETURN_TYPE(/list)
+	return null
+
+/mob/living/human/get_armor_for_mimic()
+	return get_bodytype()?.natural_armour_values
+
+/mob/living/simple_animal/get_armor_for_mimic()
+	return natural_armor
+
+/mob/living/exosuit/get_armor_for_mimic()
+	if(body?.m_armour)
+		var/datum/extension/armor/armor = get_extension(body.m_armour, /datum/extension/armor)
+		return armor?.armor_values
+
+/mob/proc/get_movement_delay_for_mimic()
+	return 0
+
+/mob/living/simple_animal/get_movement_delay_for_mimic()
+	return base_movement_delay
+
+/mob/living/human/get_movement_delay_for_mimic()
+	return get_config_value(/decl/config/num/movement_run)
+
+/mob/living/exosuit/get_movement_delay_for_mimic()
+	return legs?.move_delay || /obj/item/mech_component/propulsion::move_delay
+
 /mob/living/simple_animal/mob_mimic
 	natural_weapon = null
 	projectiletype = null
 	faction        = null
 
 	var/copy_health = TRUE
-
 	var/mob/living/mimic_mob
-	VAR_PRIVATE/static/alist/_mob_mimic_type_to_appearance = alist()
-	VAR_PRIVATE/static/alist/_mob_mimic_type_to_synthetic  = alist()
-	VAR_PRIVATE/static/alist/_mob_mimic_type_to_overlays   = alist()
-	VAR_PRIVATE/static/alist/_mob_mimic_type_to_underlays  = alist()
-	VAR_PRIVATE/static/alist/_mob_mimic_type_to_eyes       = alist()
-	VAR_PRIVATE/static/alist/_mob_mimic_type_to_eye_color  = alist()
-	VAR_PRIVATE/static/alist/_mob_mimic_type_to_projectile = alist()
-	VAR_PRIVATE/static/alist/_mob_mimic_type_to_melee      = alist()
-	VAR_PRIVATE/static/alist/_mob_mimic_type_to_health     = alist()
-	VAR_PRIVATE/static/alist/_mob_mimic_type_to_offset_x   = alist()
-	VAR_PRIVATE/static/alist/_mob_mimic_type_to_offset_y   = alist()
-	VAR_PRIVATE/static/alist/_mob_mimic_type_to_bodytype   = alist()
+
+	VAR_PRIVATE/static/alist/_mob_mimic_type_to_appearance  = alist()
+	VAR_PRIVATE/static/alist/_mob_mimic_type_to_synthetic   = alist()
+	VAR_PRIVATE/static/alist/_mob_mimic_type_to_overlays    = alist()
+	VAR_PRIVATE/static/alist/_mob_mimic_type_to_underlays   = alist()
+	VAR_PRIVATE/static/alist/_mob_mimic_type_to_eyes        = alist()
+	VAR_PRIVATE/static/alist/_mob_mimic_type_to_eye_color   = alist()
+	VAR_PRIVATE/static/alist/_mob_mimic_type_to_projectile  = alist()
+	VAR_PRIVATE/static/alist/_mob_mimic_type_to_melee       = alist()
+	VAR_PRIVATE/static/alist/_mob_mimic_type_to_health      = alist()
+	VAR_PRIVATE/static/alist/_mob_mimic_type_to_offset_x    = alist()
+	VAR_PRIVATE/static/alist/_mob_mimic_type_to_offset_y    = alist()
+	VAR_PRIVATE/static/alist/_mob_mimic_type_to_slowdown    = alist()
+	VAR_PRIVATE/static/alist/_mob_mimic_type_to_turn_sound  = alist()
+	VAR_PRIVATE/static/alist/_mob_mimic_type_to_step_sound  = alist()
+	VAR_PRIVATE/static/alist/_mob_mimic_type_to_bodytype    = alist()
+	VAR_PRIVATE/static/alist/_mob_mimic_type_to_bump_flags  = alist()
+	VAR_PRIVATE/static/alist/_mob_mimic_type_to_swap_flags  = alist()
+	VAR_PRIVATE/static/alist/_mob_mimic_type_to_push_flags  = alist()
+	VAR_PRIVATE/static/alist/_mob_mimic_type_to_always_swap = alist()
+	VAR_PRIVATE/static/alist/_mob_mimic_type_to_anchored    = alist()
+	VAR_PRIVATE/static/alist/_mob_mimic_type_to_armor       = alist()
 
 /mob/living/simple_animal/mob_mimic/isSynthetic()
 	return !!_mob_mimic_type_to_synthetic[mimic_mob]
@@ -31,8 +67,8 @@
 /mob/living/simple_animal/mob_mimic/LateInitialize()
 	. = ..()
 	if(_mob_mimic_type_to_appearance[mimic_mob])
-		update_mob_values()
 		update_icon()
+		update_mob_values()
 	else
 		cache_and_apply_mimic()
 
@@ -66,45 +102,79 @@
 	cut_overlays()
 	try_refresh_visible_overlays()
 
+// These procs use get_effective_obj() so they can mimic mechs.
+/mob/living/simple_animal/mob_mimic/proc/get_best_projectile(mob/living/mimic)
+	for(var/obj/item/thing in mimic.get_held_items())
+		var/obj/item/gun/gun = thing.get_effective_obj()
+		var/proj = istype(gun) && gun.consume_next_projectile(mimic)
+		if(proj)
+			return proj
+
+/mob/living/simple_animal/mob_mimic/proc/get_best_melee_weapon(mob/living/mimic)
+	var/obj/item/strongest
+	for(var/obj/item/thing in mimic.get_held_items())
+		thing = thing.get_effective_obj()
+		if(!strongest || thing.get_base_attack_force() > strongest.get_base_attack_force())
+			strongest = thing
+	. = strongest
+	if(.)
+		mimic.drop_from_inventory(strongest)
+
 /mob/living/simple_animal/mob_mimic/proc/prepare_mimic(mob/living/mimic)
+	return
+
+/mob/living/simple_animal/mob_mimic/proc/handle_additional_mimic(mob/living/mimic)
 	return
 
 // For some reason mobs like humans do not fully apply their appearance by the time this proc runs without sleep().
 // The sleep is only applied the first time this type is created so should not be a big issue in practice.
 /mob/living/simple_animal/mob_mimic/proc/cache_and_apply_mimic()
 	set waitfor = FALSE
+
 	var/mob/living/mimic = new mimic_mob
 	prepare_mimic(mimic)
 	sleep(5)
-	_mob_mimic_type_to_appearance[mimic_mob] = mimic.appearance
-	_mob_mimic_type_to_synthetic[mimic_mob]  = mimic.isSynthetic()
-	_mob_mimic_type_to_overlays[mimic_mob]   = mimic.get_all_current_mob_overlays()?.Copy()
-	_mob_mimic_type_to_underlays[mimic_mob]  = mimic.get_all_current_mob_underlays()?.Copy()
-	_mob_mimic_type_to_eyes[mimic_mob]       = mimic.get_eye_overlay()
-	_mob_mimic_type_to_eye_color[mimic_mob]  = mimic.get_eye_colour()
-	_mob_mimic_type_to_health[mimic_mob]     = mimic.get_max_health()
-	_mob_mimic_type_to_offset_x[mimic_mob]   = mimic.default_pixel_x
-	_mob_mimic_type_to_offset_y[mimic_mob]   = mimic.default_pixel_y
+	handle_additional_mimic(mimic)
+
+	_mob_mimic_type_to_appearance[mimic_mob]  = mimic.appearance
+	_mob_mimic_type_to_synthetic[mimic_mob]   = mimic.isSynthetic()
+	_mob_mimic_type_to_overlays[mimic_mob]    = mimic.get_all_current_mob_overlays()?.Copy()
+	_mob_mimic_type_to_underlays[mimic_mob]   = mimic.get_all_current_mob_underlays()?.Copy()
+	_mob_mimic_type_to_eyes[mimic_mob]        = mimic.get_eye_overlay()
+	_mob_mimic_type_to_eye_color[mimic_mob]   = mimic.get_eye_colour()
+	_mob_mimic_type_to_health[mimic_mob]      = mimic.get_max_health()
+	_mob_mimic_type_to_offset_x[mimic_mob]    = mimic.default_pixel_x
+	_mob_mimic_type_to_offset_y[mimic_mob]    = mimic.default_pixel_y
+	_mob_mimic_type_to_slowdown[mimic_mob]    = mimic.get_movement_delay_for_mimic()
+	_mob_mimic_type_to_step_sound[mimic_mob]  = mimic.get_footstep_sound()
+	_mob_mimic_type_to_turn_sound[mimic_mob]  = mimic.get_turn_sound()
+	_mob_mimic_type_to_bump_flags[mimic_mob]  = mimic.mob_bump_flag
+	_mob_mimic_type_to_swap_flags[mimic_mob]  = mimic.mob_swap_flags
+	_mob_mimic_type_to_push_flags[mimic_mob]  = mimic.mob_push_flags
+	_mob_mimic_type_to_always_swap[mimic_mob] = mimic.mob_always_swap
+	_mob_mimic_type_to_anchored[mimic_mob]    = mimic.anchored
+	_mob_mimic_type_to_armor[mimic_mob]       = mimic.get_armor_for_mimic()?.Copy()
 
 	var/decl/bodytype/bodytype = mimic.get_bodytype()
 	_mob_mimic_type_to_bodytype[mimic_mob] = bodytype?.simple_variant
 
 	if(isnull(projectiletype))
-		var/obj/item/gun/gun = locate() in mimic.get_held_items()
-		_mob_mimic_type_to_projectile[mimic_mob] = gun?.consume_next_projectile(mimic)
+		_mob_mimic_type_to_projectile[mimic_mob] = get_best_projectile(mimic)
 
 	if(isnull(natural_weapon))
-		var/obj/item/strongest
-		for(var/obj/item/thing in mimic.get_held_items())
-			if(!strongest || thing.get_base_attack_force() > strongest.get_base_attack_force())
-				strongest = thing
+		var/obj/item/strongest = get_best_melee_weapon(mimic)
 		if(strongest)
 			_mob_mimic_type_to_melee[mimic_mob] = strongest
-			mimic.drop_from_inventory(strongest)
 
 	qdel(mimic)
-	update_mob_values()
 	update_icon()
+	update_mob_values()
+
+/mob/living/simple_animal/mob_mimic/get_turn_sound()
+	return _mob_mimic_type_to_turn_sound[mimic_mob] || ..()
+
+/mob/living/simple_animal/mob_mimic/get_footstep_sound(turf/step_turf)
+	return _mob_mimic_type_to_step_sound[mimic_mob] || ..()
 
 /mob/living/simple_animal/mob_mimic/proc/update_mob_values()
 
@@ -122,6 +192,14 @@
 	default_pixel_x = _mob_mimic_type_to_offset_x[mimic_mob]
 	default_pixel_y = _mob_mimic_type_to_offset_y[mimic_mob]
 	reset_offsets()
+
+	mob_bump_flag       = _mob_mimic_type_to_bump_flags[mimic_mob]
+	mob_swap_flags      = _mob_mimic_type_to_swap_flags[mimic_mob]
+	mob_push_flags      = _mob_mimic_type_to_push_flags[mimic_mob]
+	mob_always_swap     = _mob_mimic_type_to_always_swap[mimic_mob]
+	anchored            = _mob_mimic_type_to_anchored[mimic_mob]
+	base_movement_delay = _mob_mimic_type_to_slowdown[mimic_mob]
+	natural_armor       = _mob_mimic_type_to_armor[mimic_mob]
 
 	var/obj/item/projectile/proj = _mob_mimic_type_to_projectile[mimic_mob]
 	if(istype(proj))

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -16,7 +16,7 @@
 	return ..() // Parent call should make the mob move.
 
 /mob/CanPass(atom/movable/mover, turf/target, height=0, air_group=0)
-	. = current_posture.prone || ..() || !mover.density
+	. = current_posture?.prone || ..() || !mover.density
 
 /mob/proc/SetMoveCooldown(var/timeout)
 	var/datum/movement_handler/mob/delay/delay = GetMovementHandler(/datum/movement_handler/mob/delay)

--- a/code/modules/mob/update_icons.dm
+++ b/code/modules/mob/update_icons.dm
@@ -39,6 +39,7 @@
 	return
 
 /mob/proc/get_all_current_mob_overlays()
+	RETURN_TYPE(/list)
 	return
 
 /mob/proc/set_current_mob_overlay(var/overlay_layer, var/image/overlay, var/redraw_mob = TRUE)
@@ -51,6 +52,7 @@
 	return
 
 /mob/proc/get_all_current_mob_underlays()
+	RETURN_TYPE(/list)
 	return
 
 /mob/proc/set_current_mob_underlay(var/underlay_layer, var/image/underlay, var/redraw_mob = TRUE)

--- a/code/modules/organs/organ.dm
+++ b/code/modules/organs/organ.dm
@@ -67,6 +67,10 @@
 		owner = null
 	else
 		do_uninstall(TRUE, FALSE, FALSE, FALSE) //Don't ignore children here since we might own/contain them
+	if(has_stat_info)
+		var/mob/living/holder = loc
+		if(istype(holder))
+			LAZYREMOVE(holder.stat_organs, src)
 	species = null
 	bodytype = null
 	QDEL_NULL(organ_appearance)

--- a/mods/species/drakes/mobs.dm
+++ b/mods/species/drakes/mobs.dm
@@ -1,3 +1,20 @@
+/obj/item/natural_weapon/claws/drake
+	_base_attack_force = 25
+
+/obj/item/natural_weapon/claws/drake/apply_hit_effect(mob/living/target, mob/living/user, hit_zone)
+	if(!(. = ..()))
+		return
+	var/obj/item/organ/external/limb = target.get_organ(hit_zone)
+	if(istype(limb))
+		drake_infect_wounds(limb)
+
+/obj/item/natural_weapon/claws/drake/hatchling
+	_base_attack_force = 5
+	attack_verb = list("clawed", "scratched")
+
+/mob/living/human/grafadreka
+	faction = "grafadreka"
+
 /mob/living/human/grafadreka/Initialize(mapload, species_uid, datum/mob_snapshot/supplied_appearance)
 	species_uid = /decl/species/grafadreka::uid
 	. = ..()
@@ -5,3 +22,16 @@
 /mob/living/human/grafadreka/hatchling/Initialize(mapload, species_uid, datum/mob_snapshot/supplied_appearance)
 	. = ..()
 	set_bodytype(/decl/bodytype/quadruped/grafadreka/hatchling)
+
+/mob/living/simple_animal/mob_mimic/grafadreka
+	ai = /datum/mob_controller/aggressive
+	mimic_mob = /mob/living/human/grafadreka
+	natural_weapon = /obj/item/natural_weapon/claws/drake
+	projectiletype = /obj/item/projectile/drake_spit
+	projectilesound = /obj/item/projectile/drake_spit::fire_sound
+
+/mob/living/simple_animal/mob_mimic/grafadreka/hatchling
+	mimic_mob = /mob/living/human/grafadreka/hatchling
+	natural_weapon = /obj/item/natural_weapon/claws/drake/hatchling
+	projectiletype = /obj/item/projectile/drake_spit/weak
+	projectilesound = /obj/item/projectile/drake_spit/weak::fire_sound

--- a/mods/species/drakes/mobs.dm
+++ b/mods/species/drakes/mobs.dm
@@ -18,20 +18,28 @@
 /mob/living/human/grafadreka/Initialize(mapload, species_uid, datum/mob_snapshot/supplied_appearance)
 	species_uid = /decl/species/grafadreka::uid
 	. = ..()
+	set_eye_colour(COLOR_SILVER)
 
 /mob/living/human/grafadreka/hatchling/Initialize(mapload, species_uid, datum/mob_snapshot/supplied_appearance)
 	. = ..()
 	set_bodytype(/decl/bodytype/quadruped/grafadreka/hatchling)
+	set_eye_colour(COLOR_SILVER)
+
+/datum/mob_controller/aggressive/grafadreka
+	emote_speech = list("Chff!", "Skhh.", "Rrrss...")
+	emote_see    = list("scratches its ears","grooms its spines", "sways its tail", "claws at the ground")
+	emote_hear   = list("hisses", "rattles", "rasps", "barks", "warbles")
 
 /mob/living/simple_animal/mob_mimic/grafadreka
-	ai = /datum/mob_controller/aggressive
-	mimic_mob = /mob/living/human/grafadreka
-	natural_weapon = /obj/item/natural_weapon/claws/drake
-	projectiletype = /obj/item/projectile/drake_spit
+	ai              = /datum/mob_controller/aggressive/grafadreka
+	mimic_mob       = /mob/living/human/grafadreka
+	natural_weapon  = /obj/item/natural_weapon/claws/drake
+	projectiletype  = /obj/item/projectile/drake_spit
 	projectilesound = /obj/item/projectile/drake_spit::fire_sound
+	fire_desc       = "spits"
 
 /mob/living/simple_animal/mob_mimic/grafadreka/hatchling
-	mimic_mob = /mob/living/human/grafadreka/hatchling
-	natural_weapon = /obj/item/natural_weapon/claws/drake/hatchling
-	projectiletype = /obj/item/projectile/drake_spit/weak
+	mimic_mob       = /mob/living/human/grafadreka/hatchling
+	natural_weapon  = /obj/item/natural_weapon/claws/drake/hatchling
+	projectiletype  = /obj/item/projectile/drake_spit/weak
 	projectilesound = /obj/item/projectile/drake_spit/weak::fire_sound

--- a/mods/species/utility_frames/_utility_frames.dme
+++ b/mods/species/utility_frames/_utility_frames.dme
@@ -4,6 +4,7 @@
 // BEGIN_INCLUDE
 #include "_utility_frames.dm"
 #include "markings.dm"
+#include "mobs.dm"
 #include "species.dm"
 #include "species_bodytypes.dm"
 #include "traits.dm"

--- a/mods/species/utility_frames/mobs.dm
+++ b/mods/species/utility_frames/mobs.dm
@@ -1,0 +1,136 @@
+/decl/outfit/utility_frame
+	abstract_type = /decl/outfit/utility_frame
+	name          = "Utility Frame"
+	uniform       = /obj/item/clothing/shirt/harness
+
+/decl/outfit/utility_frame/combat
+	name  = "Utility Frame - Combat"
+	hands = list(/obj/item/knife/combat)
+
+/decl/outfit/utility_frame/scientist
+	name  = "Utility Frame - Scientist"
+	hands = list(/obj/item/gun/energy/gun)
+
+/decl/outfit/utility_frame/melee
+	name  = "Utility Frame - Melee Baton"
+	hands = list(/obj/item/baton)
+
+/decl/outfit/utility_frame/melee/sword
+	name  = "Utility Frame - Melee Sword"
+	hands = list(/obj/item/tool/machete/unbreakable)
+
+/decl/outfit/utility_frame/ranged
+	name  = "Utility Frame - Ranged Laser"
+	hands = list(/obj/item/gun/energy/laser)
+
+/decl/outfit/utility_frame/ranged/ionrifle
+	name  = "Utility Frame - Ranged Ion Rifle"
+	hands = list(/obj/item/gun/energy/ionrifle)
+
+/decl/outfit/utility_frame/ranged/smg
+	name  = "Utility Frame - SMG"
+	hands = list(/obj/item/gun/projectile/automatic/smg)
+
+/decl/outfit/utility_frame/ranged/grenadier
+	name  = "Utility Frame - Ranged Grenadier"
+	hands = list(/obj/item/gun/launcher/grenade)
+
+/mob/living/human/frame
+	var/spawn_outfit
+	var/spawn_color = COLOR_GUNMETAL
+	var/spawn_eye_color = COLOR_RED
+
+/mob/living/human/frame/Initialize(mapload, species_uid, datum/mob_snapshot/supplied_appearance)
+	species_uid = /decl/species/utility_frame::uid
+	. = ..()
+	if(spawn_outfit)
+		dressup_human(src, RESOLVE_TO_DECL(spawn_outfit))
+	var/list/spawn_markings = get_frame_spawn_markings()
+	if(spawn_markings)
+		clear_sprite_accessories(spawn_color, skip_update = TRUE)
+		set_sprite_accessories(spawn_markings)
+	if(spawn_eye_color)
+		set_eye_colour(spawn_eye_color)
+
+/mob/living/human/frame/proc/get_frame_spawn_markings()
+	return
+
+/mob/living/human/frame/malf
+	faction = "killbots"
+	var/spawn_stripe_color = COLOR_RED_GRAY
+
+/mob/living/human/frame/malf/get_frame_spawn_markings()
+	var/list/malf_frame_markings = list(
+		SAC_MARKINGS = list(
+			/decl/sprite_accessory/marking/frame/plating         = list(SAM_COLOR = COLOR_SILVER),
+			/decl/sprite_accessory/marking/frame/plating/legs    = list(SAM_COLOR = COLOR_SILVER),
+			/decl/sprite_accessory/marking/frame/plating/head    = list(SAM_COLOR = COLOR_SILVER),
+			/decl/sprite_accessory/marking/frame/head_stripe     = list(SAM_COLOR = spawn_stripe_color),
+			/decl/sprite_accessory/marking/frame/shoulder_stripe = list(SAM_COLOR = spawn_stripe_color)
+		)
+	)
+	return malf_frame_markings
+
+/mob/living/human/frame/malf/combat
+	spawn_outfit = /decl/outfit/utility_frame/combat
+	spawn_color = COLOR_BLUE_GRAY
+	spawn_stripe_color = COLOR_ORANGE
+	spawn_eye_color = COLOR_ORANGE
+
+/mob/living/human/frame/malf/scientist
+	spawn_outfit = /decl/outfit/utility_frame/scientist
+	spawn_color = COLOR_BLUE_GRAY
+	spawn_stripe_color = COLOR_CYAN
+	spawn_eye_color = COLOR_ORANGE
+
+/mob/living/human/frame/malf/melee
+	spawn_outfit = /decl/outfit/utility_frame/melee
+	spawn_stripe_color = COLOR_RED
+
+/mob/living/human/frame/malf/melee/sword
+	spawn_outfit = /decl/outfit/utility_frame/melee/sword
+	spawn_stripe_color = COLOR_RED_LIGHT
+
+/mob/living/human/frame/malf/ranged
+	spawn_outfit = /decl/outfit/utility_frame/ranged
+	spawn_stripe_color = COLOR_PALE_GOLD
+
+/mob/living/human/frame/malf/ranged/ionrifle
+	spawn_outfit = /decl/outfit/utility_frame/ranged/ionrifle
+	spawn_stripe_color = COLOR_GOLD
+
+/mob/living/human/frame/malf/ranged/smg
+	spawn_outfit = /decl/outfit/utility_frame/ranged/smg
+	spawn_stripe_color = COLOR_YELLOW_GRAY
+
+/mob/living/human/frame/malf/ranged/grenadier
+	spawn_outfit = /decl/outfit/utility_frame/ranged/grenadier
+	spawn_stripe_color = COLOR_BROWN
+
+/mob/living/simple_animal/mob_mimic/malf_frame
+	ai = /datum/mob_controller/aggressive
+	abstract_type = /mob/living/simple_animal/mob_mimic/malf_frame
+
+/mob/living/simple_animal/mob_mimic/malf_frame/combat
+	mimic_mob = /mob/living/human/frame/malf/combat
+
+/mob/living/simple_animal/mob_mimic/malf_frame/scientist
+	mimic_mob = /mob/living/human/frame/malf/scientist
+
+/mob/living/simple_animal/mob_mimic/malf_frame/melee
+	mimic_mob = /mob/living/human/frame/malf/melee
+
+/mob/living/simple_animal/mob_mimic/malf_frame/melee_sword
+	mimic_mob = /mob/living/human/frame/malf/melee/sword
+
+/mob/living/simple_animal/mob_mimic/malf_frame/ranged
+	mimic_mob = /mob/living/human/frame/malf/ranged
+
+/mob/living/simple_animal/mob_mimic/malf_frame/ranged_ionrifle
+	mimic_mob = /mob/living/human/frame/malf/ranged/ionrifle
+
+/mob/living/simple_animal/mob_mimic/malf_frame/ranged_smg
+	mimic_mob = /mob/living/human/frame/malf/ranged/smg
+
+/mob/living/simple_animal/mob_mimic/malf_frame/ranged_grenadier
+	mimic_mob = /mob/living/human/frame/malf/ranged/grenadier

--- a/mods/species/utility_frames/mobs.dm
+++ b/mods/species/utility_frames/mobs.dm
@@ -1,3 +1,7 @@
+/datum/mob_controller/aggressive/malf_frame
+	emote_speech = list("ALERT.","Hostile-ile-ile entities dee-twhoooo-wected.","Threat parameterszzzz- szzet.","Bring sub-sub-sub-systems uuuup to combat alert alpha-a-a.")
+	emote_see    = list("beeps menacingly","whirrs threateningly","scans its immediate vicinity")
+
 /decl/outfit/utility_frame
 	abstract_type = /decl/outfit/utility_frame
 	name          = "Utility Frame"
@@ -108,7 +112,7 @@
 	spawn_stripe_color = COLOR_BROWN
 
 /mob/living/simple_animal/mob_mimic/malf_frame
-	ai = /datum/mob_controller/aggressive
+	ai = /datum/mob_controller/aggressive/malf_frame
 	abstract_type = /mob/living/simple_animal/mob_mimic/malf_frame
 
 /mob/living/simple_animal/mob_mimic/malf_frame/combat

--- a/mods/species/utility_frames/species.dm
+++ b/mods/species/utility_frames/species.dm
@@ -28,7 +28,6 @@
 	body_temperature =      null
 	passive_temp_gain =     5  // stabilize at ~80 C in a 20 C environment.
 	blood_volume = 0
-
 	preview_outfit = null
 
 	available_pronouns = list(

--- a/nebula.dme
+++ b/nebula.dme
@@ -3110,6 +3110,7 @@
 #include "code\modules\mob\living\simple_animal\hostile\retaliate\parrot.dm"
 #include "code\modules\mob\living\simple_animal\hostile\retaliate\giant_parrot\giant_parrot.dm"
 #include "code\modules\mob\living\simple_animal\hostile\retaliate\giant_parrot\giant_parrot_species.dm"
+#include "code\modules\mob\living\simple_animal\mob_mimic\mob_mimic.dm"
 #include "code\modules\mob\living\simple_animal\passive\_passive.dm"
 #include "code\modules\mob\living\simple_animal\passive\deer.dm"
 #include "code\modules\mob\living\simple_animal\passive\fox.dm"


### PR DESCRIPTION
## Description of changes
- Adds `/mob/living/simple_animal/mob_mimic` which caches appearance, weapons, etc. from a more complex mob and applies them to spawns.
- Adds NPC grafadreka.
- Adds NPC utility frame variants.
- Adds NPC autonomous exosuit variants.

The AI is currently extremely lacklustre but with the other AI changes sitting in dev PRs I will be able to revisit it later and give them more interesting behavior (drakes spitting until the target is stunned then switching to claws, for example).

## Why and what will this PR improve
Expands our ability to make NPCs for exoplanets, ruins, etc. without needing to produce bespoke sprites. 

## Authorship
Myself.

## Changelog
Nothing player-facing.